### PR TITLE
chore(ffe-formatters): Fix non-deterministic tests

### DIFF
--- a/packages/ffe-formatters/src/formatPercentage.spec.js
+++ b/packages/ffe-formatters/src/formatPercentage.spec.js
@@ -14,7 +14,6 @@ describe('format percentage', () => {
 
     test('formats numbers as percentages', () => {
         expect(formatPercentage(30)).toBe(`30${NON_BREAKING_SPACE}%`);
-        expect(formatPercentage(-73.2)).toBe(`-73,2${NON_BREAKING_SPACE}%`);
         expect(formatPercentage(125)).toBe(`125${NON_BREAKING_SPACE}%`);
     });
 
@@ -33,13 +32,28 @@ describe('format percentage', () => {
         expect(formatPercentage(12.3456, { maxDecimals: 1 })).toBe(
             `12,3${NON_BREAKING_SPACE}%`,
         );
-        expect(formatPercentage(-98.7654321, { maxDecimals: 3 })).toBe(
-            `-98,765${NON_BREAKING_SPACE}%`,
-        );
     });
 
     test('rounds numbers correctly', () => {
         expect(formatPercentage(54.545)).toBe(`54,55${NON_BREAKING_SPACE}%`);
         expect(formatPercentage(54.544)).toBe(`54,54${NON_BREAKING_SPACE}%`);
+    });
+
+    test('formats negative numbers with prefix', () => {
+        const HYPHEN_MINUS = String.fromCharCode(45);
+        const MINUS_SIGN = String.fromCharCode(8722);
+        const ANY_MINUS_SIGN = `(${HYPHEN_MINUS}|${MINUS_SIGN})`;
+
+        expect(formatPercentage(-73.2)).toMatch(
+            new RegExp(`^${ANY_MINUS_SIGN}73,2${NON_BREAKING_SPACE}%$`),
+        );
+
+        expect(
+            formatPercentage(-98.7654321, {
+                maxDecimals: 3,
+            }),
+        ).toMatch(
+            new RegExp(`^${ANY_MINUS_SIGN}98,765${NON_BREAKING_SPACE}%$`),
+        );
     });
 });


### PR DESCRIPTION
On some environments the tests for formatPercentage with negative numbers fail because the minus sign is represented by different characters (char code 45 or 8722).

Fixes #23