### PR TITLE
docs: Add issue and pull request templates

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,0 +1,18 @@
+<!-- 
+Thanks for opening an issue with us! 🎉
+
+If you have a question about usage, please remove the following template, and 
+state your question with as much detail and context as possible.
+
+If you want to request a feature or report a bug, please use the following 
+template:
+-->
+#### Which package is this issue related to?
+
+#### Describe your issue (screenshots welcome!)
+
+#### What is the expected behavior? 
+
+#### What is the actual behavior?
+
+#### Steps to reproduce

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+<!-- 
+Thanks for opening a pull request! 🎉
+
+If your changes include some kind of UI element, please attach a screenshot of 
+how it looks.
+
+Before submitting a pull request, please have a look through the CONTRIBUTING.md
+document. TL;DR:
+
+- Follow the conventional commit standard
+- Write full, explanatory commit messages
+- Follow our code standards
+- Write tests where applicable
+- Be courteous and respect our code of conduct
+-->


### PR DESCRIPTION
This pull request adds an issue template that asks some basic questions that will help the user write a descriptive issue.

I'm open for discussing the contents - but I think this is one of those things we improve by using it a lot.

Fixes #9 