### PR TITLE
fix(ffe-icons): Fixed cwd in build script to compensate for package-s…

### DIFF
--- a/packages/ffe-icons-react/package.json
+++ b/packages/ffe-icons-react/package.json
@@ -16,7 +16,7 @@
     "build:babel": "babel jsx -d lib",
     "build:jsx-components": "babel-node ./src/build-jsx-components.js",
     "clean": "rimraf tmp jsx lib",
-    "ffe:icons": "ffe-icons --opts=packages/ffe-icons-react/svg.sprite.config.json",
+    "ffe:icons": "ffe-icons --opts=designsystem/packages/ffe-icons-react/svg.sprite.config.json",
     "lint": "eslint src/.",
     "test": "npm run lint"
   },

--- a/packages/ffe-icons-react/svg.sprite.config.json
+++ b/packages/ffe-icons-react/svg.sprite.config.json
@@ -1,5 +1,5 @@
 {
-    "dest": "packages/ffe-icons-react/tmp/",
+    "dest": "designsystem/packages/ffe-icons-react/tmp/",
     "icons": ["*"],
     "config": {
         "mode": {

--- a/packages/ffe-icons/bin/build.js
+++ b/packages/ffe-icons/bin/build.js
@@ -38,8 +38,8 @@ let options = {
 };
 
 if (argv.opts) {
-    options.cwd = '../../../';
-    const opts = require(`../../../${argv.opts}`);
+    options.cwd = '../../../../';
+    const opts = require(`../../../../${argv.opts}`);
 
     // deepAssign does not handle arrays, so copy the icon array and delete it from opts before assigning the rest
     options.icons = opts.icons.slice(0);


### PR DESCRIPTION
Added another level to the current working directory in the ffe-icons build script to compensate for @sb1-scoping.