### PR TITLE
fix: Correct peerDependencies after breaking change

### DIFF
--- a/packages/ffe-accordion-react/package.json
+++ b/packages/ffe-accordion-react/package.json
@@ -35,8 +35,7 @@
     "jest": "^22.4.0"
   },
   "peerDependencies": {
-    "@sb1/ffe-accordion": "^3.0.10",
-    "@sb1/ffe-core": "^11.0.2",
+    "@sb1/ffe-accordion": "^4.0.0",
     "react": "^15.0.0 || ^16.0.0"
   },
   "publishConfig": {

--- a/packages/ffe-accordion/package.json
+++ b/packages/ffe-accordion/package.json
@@ -22,7 +22,7 @@
     "@sb1/ffe-core": "^12.0.0"
   },
   "peerDependencies": {
-    "@sb1/ffe-core": "^11.0.3"
+    "@sb1/ffe-core": "^12.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ffe-account-selector-react/package.json
+++ b/packages/ffe-account-selector-react/package.json
@@ -44,8 +44,8 @@
     "jest": "^22.4.0"
   },
   "peerDependencies": {
-    "@sb1/ffe-form": "^8.1.12",
-    "@sb1/ffe-spinner": "^2.0.9"
+    "@sb1/ffe-form": "^9.0.0",
+    "@sb1/ffe-spinner": "^3.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ffe-buttons/package.json
+++ b/packages/ffe-buttons/package.json
@@ -19,7 +19,7 @@
     "stylelint": "^8.4.0"
   },
   "peerDependencies": {
-    "@sb1/ffe-core": "^11.0.3"
+    "@sb1/ffe-core": "^12.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ffe-cards-react/package.json
+++ b/packages/ffe-cards-react/package.json
@@ -26,7 +26,7 @@
     "jest": "^22.4.0"
   },
   "peerDependencies": {
-    "@sb1/ffe-cards": "^5.0.12"
+    "@sb1/ffe-cards": "^6.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ffe-cards/package.json
+++ b/packages/ffe-cards/package.json
@@ -17,7 +17,7 @@
     "@sb1/ffe-core": "^12.0.0"
   },
   "peerDependencies": {
-    "@sb1/ffe-core": "^11.0.2"
+    "@sb1/ffe-core": "^12.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ffe-checkbox-react/package.json
+++ b/packages/ffe-checkbox-react/package.json
@@ -34,7 +34,7 @@
     "react-dom": "^16.2.0"
   },
   "peerDependencies": {
-    "@sb1/ffe-form": "^8.1.5"
+    "@sb1/ffe-form": "^9.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ffe-context-message-react/package.json
+++ b/packages/ffe-context-message-react/package.json
@@ -32,7 +32,7 @@
     "jest": "^22.4.0"
   },
   "peerDependencies": {
-    "@sb1/ffe-context-message": "^2.0.11"
+    "@sb1/ffe-context-message": "^3.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ffe-context-message/package.json
+++ b/packages/ffe-context-message/package.json
@@ -22,7 +22,7 @@
     "@sb1/ffe-core": "^12.0.0"
   },
   "peerDependencies": {
-    "@sb1/ffe-core": "^11.0.2"
+    "@sb1/ffe-core": "^12.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ffe-core-react/package.json
+++ b/packages/ffe-core-react/package.json
@@ -40,7 +40,7 @@
     "rimraf": "^2.6.2"
   },
   "peerDependencies": {
-    "@sb1/ffe-core": "^11.0.3",
+    "@sb1/ffe-core": "^12.0.0",
     "react": "^15.4.0 || ^16.1.1"
   },
   "publishConfig": {

--- a/packages/ffe-datepicker-react/package.json
+++ b/packages/ffe-datepicker-react/package.json
@@ -36,8 +36,8 @@
     "react-dom": "^16.2.0"
   },
   "peerDependencies": {
-    "@sb1/ffe-datepicker": "^4.2.14",
-    "@sb1/ffe-form": "^8.1.12",
+    "@sb1/ffe-datepicker": "^5.0.0",
+    "@sb1/ffe-form": "^9.0.0",
     "react": "15.x || 16.x"
   },
   "publishConfig": {

--- a/packages/ffe-datepicker/package.json
+++ b/packages/ffe-datepicker/package.json
@@ -18,8 +18,8 @@
     "@sb1/ffe-form": "^9.0.0"
   },
   "peerDependencies": {
-    "@sb1/ffe-core": "^11.0.3",
-    "@sb1/ffe-form": "^8.1.12"
+    "@sb1/ffe-core": "^12.0.0",
+    "@sb1/ffe-form": "^9.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ffe-details-list/package.json
+++ b/packages/ffe-details-list/package.json
@@ -18,7 +18,7 @@
     "stylelint": "^8.4.0"
   },
   "peerDependencies": {
-    "@sb1/ffe-core": "^11.0.3"
+    "@sb1/ffe-core": "^12.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ffe-dropdown-react/package.json
+++ b/packages/ffe-dropdown-react/package.json
@@ -33,7 +33,7 @@
     "react-dom": "^16.2.0"
   },
   "peerDependencies": {
-    "@sb1/ffe-form": "^8.1.12"
+    "@sb1/ffe-form": "^9.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ffe-file-upload-react/package.json
+++ b/packages/ffe-file-upload-react/package.json
@@ -27,8 +27,8 @@
     "jest": "^22.4.0"
   },
   "peerDependencies": {
-    "@sb1/ffe-core": "^11.0.3",
-    "@sb1/ffe-form": "^8.1.12",
+    "@sb1/ffe-core": "^12.0.0",
+    "@sb1/ffe-form": "^9.0.0",
     "react": "^16.2.0",
     "react-dom": "^16.2.0"
   },

--- a/packages/ffe-form-react/package.json
+++ b/packages/ffe-form-react/package.json
@@ -40,8 +40,8 @@
     "sinon": "^4.2.1"
   },
   "peerDependencies": {
-    "@sb1/ffe-core": "^11.0.3",
-    "@sb1/ffe-form": "^8.1.12",
+    "@sb1/ffe-core": "^12.0.0",
+    "@sb1/ffe-form": "^9.0.0",
     "classnames": "2.x",
     "react": "15.x || 16.x"
   },

--- a/packages/ffe-form/package.json
+++ b/packages/ffe-form/package.json
@@ -21,8 +21,8 @@
     "stylelint": "^8.4.0"
   },
   "optionalDependencies": {
-    "@sb1/ffe-buttons": "^5.2.3",
-    "@sb1/ffe-core": "^11.0.3"
+    "@sb1/ffe-buttons": "^6.0.0",
+    "@sb1/ffe-core": "^12.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ffe-grid-react/package.json
+++ b/packages/ffe-grid-react/package.json
@@ -32,7 +32,7 @@
     "react-dom": "^16.2.0"
   },
   "peerDependencies": {
-    "@sb1/ffe-grid": "^6.0.12"
+    "@sb1/ffe-grid": "^7.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ffe-grid/package.json
+++ b/packages/ffe-grid/package.json
@@ -23,7 +23,7 @@
     "stylelint": "^8.4.0"
   },
   "peerDependencies": {
-    "@sb1/ffe-core": "^11.0.3"
+    "@sb1/ffe-core": "^12.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ffe-header/package.json
+++ b/packages/ffe-header/package.json
@@ -24,8 +24,8 @@
     "stylelint": "^8.4.0"
   },
   "peerDependencies": {
-    "@sb1/ffe-buttons": "^5.2.3",
-    "@sb1/ffe-core": "^11.0.3"
+    "@sb1/ffe-buttons": "^6.0.0",
+    "@sb1/ffe-core": "^12.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ffe-lists-react/package.json
+++ b/packages/ffe-lists-react/package.json
@@ -34,7 +34,7 @@
     "react-dom": "^16.2.0"
   },
   "peerDependencies": {
-    "@sb1/ffe-lists": "^4.1.8"
+    "@sb1/ffe-lists": "^5.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ffe-lists/package.json
+++ b/packages/ffe-lists/package.json
@@ -20,7 +20,7 @@
     "@sb1/ffe-core": "^12.0.0"
   },
   "peerDependencies": {
-    "@sb1/ffe-core": "^11.0.3"
+    "@sb1/ffe-core": "^12.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ffe-message-box-react/package.json
+++ b/packages/ffe-message-box-react/package.json
@@ -36,7 +36,7 @@
     "react-dom": "^16.2.0"
   },
   "peerDependencies": {
-    "@sb1/ffe-message-box": "^4.2.7"
+    "@sb1/ffe-message-box": "^5.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ffe-message-box/package.json
+++ b/packages/ffe-message-box/package.json
@@ -17,7 +17,7 @@
     "stylelint": "^8.4.0"
   },
   "peerDependencies": {
-    "@sb1/ffe-core": "^11.0.3"
+    "@sb1/ffe-core": "^12.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ffe-searchable-dropdown-react/package.json
+++ b/packages/ffe-searchable-dropdown-react/package.json
@@ -41,8 +41,8 @@
     "react-dom": "^16.2.0"
   },
   "peerDependencies": {
-    "@sb1/ffe-core": "^11.0.3",
-    "@sb1/ffe-form": "^8.1.12",
+    "@sb1/ffe-core": "^12.0.0",
+    "@sb1/ffe-form": "^9.0.0",
     "react": "^15.4.0 || ^16.0.0"
   },
   "publishConfig": {

--- a/packages/ffe-spinner-react/package.json
+++ b/packages/ffe-spinner-react/package.json
@@ -32,7 +32,7 @@
     "react-dom": "^16.2.0"
   },
   "peerDependencies": {
-    "@sb1/ffe-spinner": "^2.0.9"
+    "@sb1/ffe-spinner": "^3.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ffe-spinner/package.json
+++ b/packages/ffe-spinner/package.json
@@ -20,7 +20,7 @@
     "@sb1/ffe-core": "^12.0.0"
   },
   "peerDependencies": {
-    "@sb1/ffe-core": "^11.0.3"
+    "@sb1/ffe-core": "^12.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ffe-system-message-react/package.json
+++ b/packages/ffe-system-message-react/package.json
@@ -33,8 +33,8 @@
     "react-dom": "^16.2.0"
   },
   "peerDependencies": {
-    "@sb1/ffe-icons-react": "^4.0.7",
-    "@sb1/ffe-system-message": "^2.0.8"
+    "@sb1/ffe-icons-react": "^5.0.0",
+    "@sb1/ffe-system-message": "^3.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ffe-system-message/package.json
+++ b/packages/ffe-system-message/package.json
@@ -19,7 +19,7 @@
     "@sb1/ffe-core": "^12.0.0"
   },
   "peerDependencies": {
-    "@sb1/ffe-core": "^11.0.3"
+    "@sb1/ffe-core": "^12.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ffe-tables-react/package.json
+++ b/packages/ffe-tables-react/package.json
@@ -37,7 +37,7 @@
     "sinon": "^4.2.1"
   },
   "peerDependencies": {
-    "@sb1/ffe-tables": "^8.1.9"
+    "@sb1/ffe-tables": "^9.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ffe-tables/package.json
+++ b/packages/ffe-tables/package.json
@@ -19,7 +19,7 @@
     "stylelint": "^8.4.0"
   },
   "peerDependencies": {
-    "@sb1/ffe-core": "^11.0.3"
+    "@sb1/ffe-core": "^12.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ffe-tabs-react/package.json
+++ b/packages/ffe-tabs-react/package.json
@@ -32,8 +32,8 @@
     "react-dom": "^16.2.0"
   },
   "peerDependencies": {
-    "@sb1/ffe-core": "^11.0.3",
-    "@sb1/ffe-tabs": "^3.0.9",
+    "@sb1/ffe-core": "^12.0.0",
+    "@sb1/ffe-tabs": "^4.0.0",
     "react": "^15.0.0 || ^16.0.0"
   },
   "publishConfig": {

--- a/packages/ffe-tabs/package.json
+++ b/packages/ffe-tabs/package.json
@@ -18,7 +18,7 @@
     "@sb1/ffe-core": "^12.0.0"
   },
   "peerDependencies": {
-    "@sb1/ffe-core": "^11.0.3"
+    "@sb1/ffe-core": "^12.0.0"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
The peerDependencies were not updated after the version bump when we
added scopes to the packages, so users get spammed with peer dependency
warnings. This version fixes the peerDependencies so installing the
package should no longer produce a warning that another sb1 package is
missing (granted it's actually there).
