### PR TITLE
doc: Add indicator for current page to top navigation

### DIFF
--- a/src/templates/header.hbs
+++ b/src/templates/header.hbs
@@ -52,7 +52,10 @@
 						class="sb1ds-top-menu__list"
 					>
 						{{#each sections}}
-							<li class="sb1ds-top-menu__item">
+							<li class="
+								sb1ds-top-menu__item
+								{{#if (eq ../currentTarget this.target)}}sb1ds-top-menu__item--active{{/if}}
+							">
 								<a class="
 									ffe-link-text
 									ffe-link-text--no-underline
@@ -62,7 +65,10 @@
 								 href="/{{this.target}}.html">{{this.name}}</a>
 							</li>
 						{{/each}}
-						<li class="sb1ds-top-menu__item">
+							<li class="
+								sb1ds-top-menu__item
+								{{#if (eq currentTarget "styleguidist")}}sb1ds-top-menu__item--active{{/if}}
+							">
 							<a
 								class="
 									ffe-link-text

--- a/src/templates/helpers.js
+++ b/src/templates/helpers.js
@@ -8,3 +8,5 @@ Handlebars.registerHelper('preformat', obj => {
         `<pre>${Handlebars.escapeExpression(str)}</pre>`
     );
 });
+
+Handlebars.registerHelper('eq', (a, b) => a == b); // eslint-disable-line eqeqeq

--- a/src/templates/page.hbs
+++ b/src/templates/page.hbs
@@ -9,7 +9,7 @@
 </head>
 
 <body>
-  {{> header }}
+  {{> header currentTarget=section.target }}
 
   <div class="sb1ds ffe-grid ffe-grid--no-top-padding">
     <div class="ffe-grid__row">

--- a/src/templates/styleguidist.hbs
+++ b/src/templates/styleguidist.hbs
@@ -6,7 +6,7 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	</head>
 	<body>
-    {{> header }}
+    {{> header currentTarget="styleguidist" }}
 
 		<div id="app"></div>
 	</body>


### PR DESCRIPTION
The css class `sb1ds-top-menu__item--active` is added to the navigation item for the current page at build time.

Fixes #54

<!-- 
Thanks for opening a pull request! 🎉

If your changes include some kind of UI element, please attach a screenshot of 
how it looks.

Before submitting a pull request, please have a look through the CONTRIBUTING.md
document. TL;DR:

- Follow the conventional commit standard
- Write full, explanatory commit messages
- Follow our code standards
- Write tests where applicable
- Be courteous and respect our code of conduct
-->
