### PR TITLE
infra: Add coverage reporting to CI build (#7)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 node_modules
 
 # Built files
+coverage/
 dist/
 lib/
 src/styleguidist.html

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,4 @@ cache:
     - "node_modules"
 script:
   - npm run build
-  - npm test
+  - npm run test:ci

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
         "styleguidist:server": "styleguidist server",
         "styleguidist:build": "styleguidist build",
         "test": "jest",
+        "test:ci": "jest --ci --coverage && cat ./coverage/lcov.info | coveralls && rimraf ./coverage",
         "test:watch": "jest --watch"
     },
     "devDependencies": {
@@ -41,6 +42,7 @@
         "babel-preset-react": "^6.24.1",
         "babel-preset-stage-3": "^6.24.1",
         "case": "^1.5.4",
+        "coveralls": "^3.0.0",
         "css-loader": "^0.28.7",
         "enzyme": "^3.3.0",
         "enzyme-adapter-react-16": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
         "styleguidist:server": "styleguidist server",
         "styleguidist:build": "styleguidist build",
         "test": "jest",
-        "test:ci": "jest --ci --coverage && cat ./coverage/lcov.info | coveralls && rimraf ./coverage",
+        "test:ci": "npm run lint && jest --ci --coverage && cat ./coverage/lcov.info | coveralls && rimraf ./coverage",
         "test:watch": "jest --watch"
     },
     "devDependencies": {


### PR DESCRIPTION
This commit introduces a new test script for CI that includes coverage
reporting with Jest and Coveralls. It also uses Jests `--ci` option.
From the docs:

> When this option is provided, Jest will assume it is running in a CI
> environment. This changes the behavior when a new snapshot is
> encountered. Instead of the regular behavior of storing a new
> snapshot automatically, it will fail the test and require Jest to be
> run with `--updateSnapshot`.

Travis will use this new CI script so we get Coveralls reporting on
pull requests.
