### PR TITLE
61 center button texts

### DIFF
--- a/packages/ffe-buttons-react/src/ActionButton.js
+++ b/packages/ffe-buttons-react/src/ActionButton.js
@@ -35,6 +35,8 @@ ActionButton.propTypes = {
     disabled: bool,
     /** The rendered element, like an `<a />` or `<Link />` */
     element: oneOfType([func, string]),
+    /** Applies the ghost modifier if true. */
+    ghost: bool,
     /** Ref-setting function passed to the button element */
     innerRef: func,
     /** Shows a loader if true */
@@ -43,6 +45,4 @@ ActionButton.propTypes = {
     leftIcon: node,
     /** Icon shown to the right of the label */
     rightIcon: node,
-    /** Applies the ghost modifier if true. */
-    ghost: bool,
 };

--- a/packages/ffe-buttons-react/src/ActionButton.md
+++ b/packages/ffe-buttons-react/src/ActionButton.md
@@ -17,7 +17,7 @@ Denne knappen er hvit med grønn outline og grønn tekst.
 ```js
 <ActionButton
     onClick={() => { alert('Bø!'); }}
-    className="ffe-action-button--ghost"
+    ghost={true}
 >
     Spooky!
 </ActionButton>

--- a/packages/ffe-buttons/less/base-button.less
+++ b/packages/ffe-buttons/less/base-button.less
@@ -8,6 +8,7 @@
     cursor: pointer;
     display: flex;
     font-family: "MuseoSansRounded-500", arial, sans-serif;
+    justify-content: center;
     line-height: 24px;
     overflow: hidden;
     padding: 8px 30px;


### PR DESCRIPTION
This pull request fixes a bug with ffe-buttons that doesn't center the text.

In addition, this pull request fixes an issue in the button docs that stopped us from adding a ghost modifier example.

Fixes #61 