### PR TITLE
docs: Reduce to one blank line between list items

### DIFF
--- a/styleguide-content/merkevare/stil-og-tone.md
+++ b/styleguide-content/merkevare/stil-og-tone.md
@@ -6,13 +6,11 @@
 
    Vi kommuniserer ærlig og med et reelt ønske om at kundene skal få mest mulig igjen for pengene sine.
 
-
 2. ##### Relevant
 
    **Vi ser hverdagen fra kundens ståsted**
 
    Vi snakker med kundene om deres økonomi - ikke bare om våre produkter. Lytt og bruk spørreord aktivt. Forsøk å bruke din innsikt om hva folk er opptatt av og del av vår kunnskap om hverdagsøkonomi.
-
 
 3. ##### Til stede hver dag
 
@@ -20,13 +18,11 @@
 
    Alle ønsker å bli sett og få gode tilbakemeldinger, også kunder og lokalsamfunn.
 
-
 4. ##### Tydelig
 
    **Vi er modige, og fremstår som et tydelig alternativ i markedet**
 
    Vi tør å være ubankske og å bruke det lokale og regionale til vår fordel når vi kommuniserer.
-
 
 5. ##### Jordnær
 


### PR DESCRIPTION
Fixes #49 

The transformation from Markdown to HTML considers the items to be
separate lists if there is more than one blank line between the items.
The result would be fire ordered lists with one item, each being given
the number 1. by the browser.

This commit reduces the spacing between items to one blank line so they
all become part of the same ordered list, ranging from 1 to 5.

![screen shot 2018-03-08 at 18 03 01](https://user-images.githubusercontent.com/1223410/37164585-07f5d7d2-22fb-11e8-8a30-30b2c9ae085e.png)

