### PR TITLE
Have ffe-icon resolve the path of --opt relative to current working directory

### DIFF
--- a/packages/ffe-icons-react/package.json
+++ b/packages/ffe-icons-react/package.json
@@ -16,7 +16,7 @@
     "build:babel": "babel jsx -d lib",
     "build:jsx-components": "babel-node ./src/build-jsx-components.js",
     "clean": "rimraf tmp jsx lib",
-    "ffe:icons": "ffe-icons --opts=designsystem/packages/ffe-icons-react/svg.sprite.config.json",
+    "ffe:icons": "ffe-icons --opts=svg.sprite.config.json",
     "lint": "eslint src/.",
     "test": "npm run lint"
   },

--- a/packages/ffe-icons-react/svg.sprite.config.json
+++ b/packages/ffe-icons-react/svg.sprite.config.json
@@ -1,6 +1,6 @@
 {
-    "dest": "designsystem/packages/ffe-icons-react/tmp/",
-    "icons": ["*"],
+    "dest": "tmp",
+    "icons": "*",
     "config": {
         "mode": {
             "view": {

--- a/packages/ffe-icons/bin/build.js
+++ b/packages/ffe-icons/bin/build.js
@@ -1,10 +1,6 @@
 #!/usr/bin/env node
+'use strict'; // eslint-disable-line strict
 
-/* eslint-disable strict */
-// Jenkins version of Node dislikes features like let and const outside of strict mode
-'use strict';
-
-const argv = require('yargs').argv;
 const deepAssign = require('deep-assign');
 const fs = require('fs');
 const mkdirp = require('mkdirp');
@@ -13,92 +9,101 @@ const SVGSpriter = require('svg-sprite');
 const Vinyl = require('vinyl');
 
 const ICONS_PATH = path.join(__dirname, '..', 'icons');
-
-let options = {
-    icons: '**/*.svg',
-    dest: 'dist/',
-    cwd: '../',
-    config: {
-        log: 'info',
-        svg: {
-            dimensionAttributes: false
+const defaultSVGOptions = {
+    log: 'info',
+    svg: {
+        dimensionAttributes: false,
+    },
+    shape: {
+        dimension: {
+            maxWidth: 150,
         },
-        shape: {
-            dimension: {
-                maxWidth: 150
-            }
+    },
+    mode: {
+        symbol: {
+            sprite: 'ffe-icons.svg',
+            example: true,
         },
-        mode: {
-            symbol: {
-                sprite: 'ffe-icons.svg',
-                example: true
-            }
-        }
-    }
+    },
 };
 
-if (argv.opts) {
-    options.cwd = '../../../../';
-    const opts = require(`../../../../${argv.opts}`);
+// convenience to avoid having file extension in config
+const appendSvgExtension = icons =>
+    icons.map(name => (name.endsWith('.svg') ? name : `${name}.svg`));
 
-    // deepAssign does not handle arrays, so copy the icon array and delete it from opts before assigning the rest
-    options.icons = opts.icons.slice(0);
-    if (opts.projectIcons) {options.projectIcons = opts.projectIcons.slice(0);}
-    delete opts.icons;
-    delete opts.projectIcons;
+const options = require('yargs')
+    .config('opts')
+    .options({
+        icons: {
+            default: '**/*.svg',
+            type: 'array',
+            coerce: appendSvgExtension,
+        },
+        projectIcons: {
+            type: 'array',
+            coerce: appendSvgExtension,
+        },
+        dest: {
+            default: 'dist',
+            normalize: true,
+            coerce: path.resolve,
+        },
+        config: {
+            default: defaultSVGOptions,
+            coerce: config => deepAssign(defaultSVGOptions, config),
+        },
+    }).argv;
 
-    options = deepAssign(options, opts);
+options.config.dest = options.dest;
 
-    // convenience to avoid having file extension in config
-    options.icons = options.icons.map(icon => `${icon}.svg`);
-    if (options.projectIcons) {options.projectIcons = options.projectIcons.map(icon => `${icon}.svg`);}
-
-    if (!options.dest) {
-        throw Error('ffe-icons was given an options object, but no destination for the generated sprite! Update your ' +
-            'config file (e.g. icons.json) to include a "dest" property with a path to where you want the generated sprite.');
-    }
-}
-
-options.config.dest = path.join(__dirname, options.cwd, options.dest);
+const matchesIcon = icons =>
+    icons.includes('*.svg') || icons.includes('**/*.svg')
+        ? () => true
+        : fileName => icons.includes(path.basename(fileName));
 
 // https://github.com/jkphl/svg-sprite#usage-pattern
 const spriter = new SVGSpriter(options.config);
 
-fs.readdirSync(ICONS_PATH)
+fs
+    .readdirSync(ICONS_PATH)
     .filter(fileName => fileName.match(/\.svg$/))
-    .filter(fileName => {
-        return options.icons === '**/*.svg'
-            || options.icons.includes('*.svg')
-            || options.icons.includes(fileName.substring(fileName.lastIndexOf('/')));
-    })
-    .forEach((fileName) => {
+    .filter(matchesIcon(options.icons))
+    .forEach(fileName => {
         const iconPath = path.join(ICONS_PATH, fileName);
-        spriter.add(new Vinyl({
-            path: iconPath,
-            base: ICONS_PATH,
-            contents: fs.readFileSync(iconPath)
-        }));
+        spriter.add(
+            new Vinyl({
+                path: iconPath,
+                base: ICONS_PATH,
+                contents: fs.readFileSync(iconPath),
+            }),
+        );
     });
 
 if (options.projectIcons) {
-    options.projectIcons
-        .forEach((fileName) => {
-            const iconPath = path.join(fileName);
-            spriter.add(new Vinyl({
+    options.projectIcons.forEach(fileName => {
+        const iconPath = path.join(fileName);
+        spriter.add(
+            new Vinyl({
                 path: fileName.substring(fileName.lastIndexOf('/') - 1),
-                base: options.cwd,
-                contents: fs.readFileSync(iconPath)
-            }));
-        });
+                base: process.cwd(),
+                contents: fs.readFileSync(iconPath),
+            }),
+        );
+    });
 }
 
 spriter.compile(function(error, result) {
     for (const mode in result) {
         if (Object.prototype.hasOwnProperty.call(result, mode)) {
             for (const resource in result[mode]) {
-                if (Object.prototype.hasOwnProperty.call(result[mode], resource)) {
+                if (
+                    Object.prototype.hasOwnProperty.call(result[mode], resource)
+                ) {
                     mkdirp.sync(path.dirname(result[mode][resource].path));
-                    fs.writeFileSync(result[mode][resource].path, result[mode][resource].contents);
+                    fs.writeFileSync(
+                        result[mode][resource].path,
+                        result[mode][resource].contents,
+                    );
                 }
             }
         }


### PR DESCRIPTION
Breaking changes in ffe-icons: The path passed to `--opt` is treated as relative to the current working directory, determined by `process.cwd()`.
