### PR TITLE
fix: Limit to 2 concurrent tasks when linting

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
         "styleguidist:server": "cross-env NODE_ENV=development styleguidist server",
         "styleguidist:build": "cross-env NODE_ENV=production styleguidist build",
         "test": "jest",
-        "test:ci": "npm run lint && jest --ci --coverage && cat ./coverage/lcov.info | coveralls && rimraf ./coverage",
+        "test:ci": "npm run lint -- --concurrency 2 && jest --ci --coverage && cat ./coverage/lcov.info | coveralls && rimraf ./coverage",
         "test:watch": "jest --watch"
     },
     "devDependencies": {


### PR DESCRIPTION
We had issues with Travis CI killing random lint tasks, likely due to
the number of parallel tasks. Limit to 2 (default is 4) when on CI.

Attempted fix for #69 
