### PR TITLE
docs: Add Coveralls badge to root README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Felles Front End i SpareBank 1
 
 [![Build Status](https://travis-ci.org/SpareBank1/designsystem.svg?branch=master)](https://travis-ci.org/SpareBank1/designsystem)
+[![Coverage Status](https://coveralls.io/repos/github/SpareBank1/designsystem/badge.svg?branch=master)](https://coveralls.io/github/SpareBank1/designsystem?branch=master)
 
 Dette repositoryet inneholder designdokumentasjon, teknisk dokumentasjon, og kode for SpareBank 1 sitt designsystem og
 implementasjonen av det - Felles frontend (FFE).


### PR DESCRIPTION
Fixes #7 

Coveralls has been set up with a limit of 0 % coverage reduction (as discussed in #7), and Travis is set up to build `master` daily so this coverage badge is updated. PRs should now be rejected if coverage is reduced.