### PR TITLE
infra: Set up deploy to gh-pages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,16 @@ cache:
   directories:
     - "node_modules"
 script:
-  - npm run build
+  - npm run build:htdocs
   - npm run test:ci
+deploy:
+  provider: pages
+  github-token: $GITHUB_TOKEN   # Set in travis-ci.org dashboard, marked secure
+  skip-cleanup: true            # Set so Travis CI does not delete the files we are trying to deploy
+  local-dir: dist
+  fqdn: design.sparebank1.no
+  project-name: "SpareBank 1 Designsystem"
+  commiter-from-gh: true        # Set so Travis will pose as the owner of the access token. Only this account is allowed to push to gh-pages.
+  target-branch: gh-pages
+  on:
+    branch: master


### PR DESCRIPTION
Following the documentation from [1], this commit introduces a proposed
setup for automatically building and deploying the design system to
`gh-pages` when `master` is built, which is done daily by Travis CI and
can be triggered manually through travis-ci.org

[1]: https://docs.travis-ci.com/user/deployment/pages/