### PR TITLE
chore(ffe-message-box): Remove action message box

### DIFF
--- a/packages/ffe-message-box/less/ffe-message-box.less
+++ b/packages/ffe-message-box/less/ffe-message-box.less
@@ -20,10 +20,6 @@
         &--error {
             background-color: @ffe-orange-salmon;
         }
-
-        &--action {
-            background-color: @ffe-grey-cloud;
-        }
     }
 
     &__title {


### PR DESCRIPTION
BREAKING CHANGE: This commit removes the `action` message box type,
as it was never a part of the design system.

Consumers of the action message box type should instead use the tips
message box.

Fixes #22 

<!-- 
Thanks for opening a pull request! 🎉

If your changes include some kind of UI element, please attach a screenshot of 
how it looks.

Before submitting a pull request, please have a look through the CONTRIBUTING.md
document. TL;DR:

- Follow the conventional commit standard
- Write full, explanatory commit messages
- Follow our code standards
- Write tests where applicable
- Be courteous and respect our code of conduct
-->
