### PR TITLE
Add ButtonGroup component, fix vertical align issues with certain elements

### DIFF
--- a/packages/ffe-buttons-react/src/ButtonGroup.js
+++ b/packages/ffe-buttons-react/src/ButtonGroup.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import { bool, string } from 'prop-types';
+import classNames from 'classnames';
+
+const ButtonGroup = ({ className, thin, ...rest }) =>
+    (
+        <div
+            className={classNames(
+                'ffe-button-group',
+                { 'ffe-button-group--thin': thin },
+                className
+            )}
+            {...rest}
+        />
+    );
+
+ButtonGroup.propTypes = {
+    /** Extra class name applied in addition to the FFE classes */
+    className: string,
+    /** Applies the thin modifier to remove margins */
+    thin: bool,
+};
+
+export default ButtonGroup;

--- a/packages/ffe-buttons-react/src/ButtonGroup.md
+++ b/packages/ffe-buttons-react/src/ButtonGroup.md
@@ -1,0 +1,35 @@
+For å plassere knapper ved siden av hverandre på riktig måte har vi en såkalt
+knappegruppe. Denne sørger for å gi riktige marginer mellom knappene.
+
+```js
+<ButtonGroup>
+    <PrimaryButton>
+        Neste
+    </PrimaryButton>
+    <SecondaryButton
+        element="a"
+    >
+        Avbryt
+    </SecondaryButton>
+</ButtonGroup>
+```
+
+Det finnes også en tynnere variant.
+
+```js
+<ButtonGroup thin={true}>
+    <PrimaryButton>
+        Neste
+    </PrimaryButton>
+    <SecondaryButton>
+        Avbryt
+    </SecondaryButton>
+    <TertiaryButton
+        element="a"
+        href="#"
+    >
+        Til toppen av siden
+    </TertiaryButton>
+</ButtonGroup>
+```
+

--- a/packages/ffe-buttons-react/src/ButtonGroup.spec.js
+++ b/packages/ffe-buttons-react/src/ButtonGroup.spec.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import ButtonGroup from './ButtonGroup';
+
+const defaultProps = {
+    thin: false,
+};
+
+const getWrapper = props => shallow(<ButtonGroup {...defaultProps} {...props} />);
+
+describe('<ButtonGroup />', () => {
+    it('renders without exploding', () => {
+        const wrapper = getWrapper();
+        expect(wrapper.exists()).toBe(true);
+    });
+
+    it('renders without the the --thin modifier if thin is false', () => {
+        const wrapper = getWrapper({
+            thin: false,
+        });
+        expect(wrapper.hasClass('ffe-button-group--thin')).toBe(false);
+    });
+
+    it('applies the --thin modifier if thin is true', () => {
+        const wrapper = getWrapper({
+            thin: true,
+        });
+        expect(wrapper.hasClass('ffe-button-group--thin')).toBe(true);
+    });
+
+    it('applies the given className prop', () => {
+        const wrapper = getWrapper({
+            className: 'my-class',
+        });
+        expect(wrapper.hasClass('my-class')).toBe(true);
+    });
+});

--- a/packages/ffe-buttons-react/src/index.js
+++ b/packages/ffe-buttons-react/src/index.js
@@ -1,5 +1,6 @@
 export { default as ActionButton } from './ActionButton';
 export { default as BackButton } from './BackButton';
+export { default as ButtonGroup } from './ButtonGroup';
 export { default as ExpandButton } from './ExpandButton';
 export { default as InlineExpandButton } from './InlineExpandButton';
 export { default as PrimaryButton } from './PrimaryButton';

--- a/packages/ffe-buttons/less/button-group.less
+++ b/packages/ffe-buttons/less/button-group.less
@@ -1,8 +1,11 @@
 .ffe-button-group {
+    display: flex;
     padding: 40px 0;
 
     .ffe-button,
     .ffe-inline-button {
+        flex-direction: column;
+        justify-content: center;
         margin: 0 auto 10px;
     }
 
@@ -26,7 +29,7 @@
     @media screen and (min-width: @breakpoint-sm) {
         .ffe-button,
         .ffe-inline-button {
-            display: inline-block;
+            display: inline-flex;
             margin: 0 0 10px 10px;
             width: auto;
 

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -13,6 +13,13 @@ module.exports = {
         path.join(__dirname, 'src/styles/styles.less'),
     ],
     components: 'packages/ffe-*-react/src/**/[A-Z]+([A-Za-z]).js',
+    ignore: [
+        '**/__tests__/**',
+        '**/*.test.{js,jsx,ts,tsx}',
+        '**/*.spec.{js,jsx,ts,tsx}',
+        '**/Base*.js',
+        '**/InlineBase*.js',
+    ],
     styleguideComponents: components,
     styleguideDir: 'dist/styleguidist',
     theme: {


### PR DESCRIPTION
For non-`button` elements such as `a` the vertical alignment was broken.
For inline buttons such as `TertiaryButton` the vertical alignment was
also broken, and the button would be missing its underline.

See #87 for screenshot examples of the bug.

This commit solves both issues by applying flex styles to the button
group in key locations.

To help local development and for documentation purposes this PR also includes an implementation of `ButtonGroup` in React.

I also add an ignore config to the styleguide so we don't expose internal implementation details in the main docs.