### PR TITLE
fix: Make top menu render properly in IE

### DIFF
--- a/src/styles/components/top-menu.less
+++ b/src/styles/components/top-menu.less
@@ -16,6 +16,7 @@
 
         @media screen and (min-width: @breakpoint-lg) {
             height: 40px;
+            width: 182px;
             margin: 10px 20px 10px 10px;
         }
     }
@@ -92,6 +93,7 @@
 
         @media screen and (min-width: @breakpoint-md) {
             height: 28px;
+            width: 28px;
 
             &__text {
                 display: none;
@@ -217,5 +219,5 @@
 }
 
 .sb1ds-header-grid__row {
-    flex: 1;
+    flex: auto;
 }


### PR DESCRIPTION
Fixes a bug (#93) in which the top menu of the styleguide would not render properly ie IE, due to lacking support of `flex: 1` and unspecified width of inline svgs.