### PR TITLE
chore: Add React 16.2.0 as a peerDependency

### DIFF
--- a/packages/ffe-accordion-react/package.json
+++ b/packages/ffe-accordion-react/package.json
@@ -32,11 +32,13 @@
   "devDependencies": {
     "enzyme": "^3.3.0",
     "enzyme-adapter-react-16": "^1.1.1",
-    "jest": "^22.4.0"
+    "jest": "^22.4.0",
+    "react": "^16.2.0",
+    "react-dom": "^16.2.0"
   },
   "peerDependencies": {
     "@sb1/ffe-accordion": "^4.0.0",
-    "react": "^15.0.0 || ^16.0.0"
+    "react": "^16.2.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ffe-account-selector-react/package.json
+++ b/packages/ffe-account-selector-react/package.json
@@ -41,11 +41,14 @@
     "enzyme": "^3.3.0",
     "enzyme-adapter-react-16": "^1.1.1",
     "eslint": "^4.13.1",
-    "jest": "^22.4.0"
+    "jest": "^22.4.0",
+    "react": "^16.2.0",
+    "react-dom": "^16.2.0"
   },
   "peerDependencies": {
     "@sb1/ffe-form": "^9.0.0",
-    "@sb1/ffe-spinner": "^3.0.0"
+    "@sb1/ffe-spinner": "^3.0.0",
+    "react": "^16.2.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ffe-buttons-react/package.json
+++ b/packages/ffe-buttons-react/package.json
@@ -38,6 +38,10 @@
     "react": "^16.2.0",
     "react-dom": "^16.2.0"
   },
+  "peerDependencies": {
+    "@sb1/ffe-buttons": "^7.0.2",
+    "react": "^16.2.0"
+  },
   "publishConfig": {
     "access": "public"
   }

--- a/packages/ffe-cards-react/package.json
+++ b/packages/ffe-cards-react/package.json
@@ -23,10 +23,13 @@
     "@sb1/ffe-icons-react": "^5.0.3",
     "enzyme": "^3.3.0",
     "enzyme-adapter-react-16": "^1.1.1",
-    "jest": "^22.4.0"
+    "jest": "^22.4.0",
+    "react": "^16.2.0",
+    "react-dom": "^16.2.0"
   },
   "peerDependencies": {
-    "@sb1/ffe-cards": "^6.0.0"
+    "@sb1/ffe-cards": "^6.0.0",
+    "react": "^16.2.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ffe-chart-donut-react/package.json
+++ b/packages/ffe-chart-donut-react/package.json
@@ -33,10 +33,11 @@
     "enzyme": "^3.3.0",
     "enzyme-adapter-react-16": "^1.1.1",
     "jest": "^22.4.0",
-    "react": "^16.2.0"
+    "react": "^16.2.0",
+    "react-dom": "^16.2.0"
   },
   "peerDependencies": {
-    "react": "^15.4.0 || ^16.0.0"
+    "react": "^16.2.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ffe-checkbox-react/package.json
+++ b/packages/ffe-checkbox-react/package.json
@@ -34,7 +34,8 @@
     "react-dom": "^16.2.0"
   },
   "peerDependencies": {
-    "@sb1/ffe-form": "^9.0.0"
+    "@sb1/ffe-form": "^9.0.0",
+    "react": "^16.2.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ffe-context-message-react/package.json
+++ b/packages/ffe-context-message-react/package.json
@@ -29,10 +29,13 @@
   "devDependencies": {
     "enzyme": "^3.3.0",
     "enzyme-adapter-react-16": "^1.1.1",
-    "jest": "^22.4.0"
+    "jest": "^22.4.0",
+    "react": "^16.2.0",
+    "react-dom": "^16.2.0"
   },
   "peerDependencies": {
-    "@sb1/ffe-context-message": "^3.0.0"
+    "@sb1/ffe-context-message": "^3.0.0",
+    "react": "^16.2.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ffe-context-message/package.json
+++ b/packages/ffe-context-message/package.json
@@ -19,10 +19,13 @@
     "test": "npm run lint"
   },
   "devDependencies": {
-    "@sb1/ffe-core": "^12.0.2"
+    "@sb1/ffe-core": "^12.0.2",
+    "react": "^16.2.0",
+    "react-dom": "^16.2.0"
   },
   "peerDependencies": {
-    "@sb1/ffe-core": "^12.0.0"
+    "@sb1/ffe-core": "^12.0.0",
+    "react": "^16.2.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ffe-core-react/package.json
+++ b/packages/ffe-core-react/package.json
@@ -41,7 +41,7 @@
   },
   "peerDependencies": {
     "@sb1/ffe-core": "^12.0.0",
-    "react": "^15.4.0 || ^16.1.1"
+    "react": "^16.2.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ffe-datepicker-react/package.json
+++ b/packages/ffe-datepicker-react/package.json
@@ -38,7 +38,7 @@
   "peerDependencies": {
     "@sb1/ffe-datepicker": "^5.0.0",
     "@sb1/ffe-form": "^9.0.0",
-    "react": "15.x || 16.x"
+    "react": "^16.2.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ffe-decorators-react/package.json
+++ b/packages/ffe-decorators-react/package.json
@@ -37,7 +37,7 @@
     "sinon": "^4.2.1"
   },
   "peerDependencies": {
-    "react": "^15.4.2 || ^16.0.0"
+    "react": "^16.2.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ffe-details-list-react/package.json
+++ b/packages/ffe-details-list-react/package.json
@@ -35,6 +35,10 @@
     "react": "^16.2.0",
     "react-dom": "^16.2.0"
   },
+  "peerDependencies": {
+    "@sb1/ffe-details-list": "^9.0.2",
+    "react": "^16.2.0"
+  },
   "publishConfig": {
     "access": "public"
   }

--- a/packages/ffe-dropdown-react/package.json
+++ b/packages/ffe-dropdown-react/package.json
@@ -33,7 +33,8 @@
     "react-dom": "^16.2.0"
   },
   "peerDependencies": {
-    "@sb1/ffe-form": "^9.0.0"
+    "@sb1/ffe-form": "^9.0.0",
+    "react": "^16.2.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ffe-file-upload-react/package.json
+++ b/packages/ffe-file-upload-react/package.json
@@ -24,13 +24,14 @@
   "devDependencies": {
     "enzyme": "^3.3.0",
     "enzyme-adapter-react-16": "^1.1.1",
-    "jest": "^22.4.0"
+    "jest": "^22.4.0",
+    "react": "^16.2.0",
+    "react-dom": "^16.2.0"
   },
   "peerDependencies": {
     "@sb1/ffe-core": "^12.0.0",
     "@sb1/ffe-form": "^9.0.0",
-    "react": "^16.2.0",
-    "react-dom": "^16.2.0"
+    "react": "^16.2.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ffe-form-react/package.json
+++ b/packages/ffe-form-react/package.json
@@ -42,8 +42,7 @@
   "peerDependencies": {
     "@sb1/ffe-core": "^12.0.0",
     "@sb1/ffe-form": "^9.0.0",
-    "classnames": "2.x",
-    "react": "15.x || 16.x"
+    "react": "^16.2.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ffe-grid-react/package.json
+++ b/packages/ffe-grid-react/package.json
@@ -32,7 +32,8 @@
     "react-dom": "^16.2.0"
   },
   "peerDependencies": {
-    "@sb1/ffe-grid": "^7.0.0"
+    "@sb1/ffe-grid": "^7.0.0",
+    "react": "^16.2.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ffe-icons-react/package.json
+++ b/packages/ffe-icons-react/package.json
@@ -34,6 +34,9 @@
     "react-dom": "^16.2.0",
     "rimraf": "^2.6.2"
   },
+  "peerDependencies": {
+    "react": "^16.2.0"
+  },
   "publishConfig": {
     "access": "public"
   }

--- a/packages/ffe-lists-react/package.json
+++ b/packages/ffe-lists-react/package.json
@@ -34,7 +34,8 @@
     "react-dom": "^16.2.0"
   },
   "peerDependencies": {
-    "@sb1/ffe-lists": "^5.0.0"
+    "@sb1/ffe-lists": "^5.0.0",
+    "react": "^16.2.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ffe-message-box-react/package.json
+++ b/packages/ffe-message-box-react/package.json
@@ -36,7 +36,8 @@
     "react-dom": "^16.2.0"
   },
   "peerDependencies": {
-    "@sb1/ffe-message-box": "^5.0.0"
+    "@sb1/ffe-message-box": "^5.0.0",
+    "react": "^16.2.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ffe-radio-button-react/package.json
+++ b/packages/ffe-radio-button-react/package.json
@@ -31,6 +31,9 @@
     "react": "^16.2.0",
     "react-dom": "^16.2.0"
   },
+  "peerDependencies": {
+    "react": "^16.2.0"
+  },
   "publishConfig": {
     "access": "public"
   }

--- a/packages/ffe-searchable-dropdown-react/package.json
+++ b/packages/ffe-searchable-dropdown-react/package.json
@@ -43,7 +43,7 @@
   "peerDependencies": {
     "@sb1/ffe-core": "^12.0.0",
     "@sb1/ffe-form": "^9.0.0",
-    "react": "^15.4.0 || ^16.0.0"
+    "react": "^16.2.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ffe-spinner-react/package.json
+++ b/packages/ffe-spinner-react/package.json
@@ -32,7 +32,8 @@
     "react-dom": "^16.2.0"
   },
   "peerDependencies": {
-    "@sb1/ffe-spinner": "^3.0.0"
+    "@sb1/ffe-spinner": "^3.0.0",
+    "react": "^16.2.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ffe-system-message-react/package.json
+++ b/packages/ffe-system-message-react/package.json
@@ -34,7 +34,8 @@
   },
   "peerDependencies": {
     "@sb1/ffe-icons-react": "^5.0.0",
-    "@sb1/ffe-system-message": "^3.0.0"
+    "@sb1/ffe-system-message": "^3.0.0",
+    "react": "^16.2.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ffe-tables-react/package.json
+++ b/packages/ffe-tables-react/package.json
@@ -37,7 +37,8 @@
     "sinon": "^4.2.1"
   },
   "peerDependencies": {
-    "@sb1/ffe-tables": "^9.0.0"
+    "@sb1/ffe-tables": "^9.0.0",
+    "react": "^16.2.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ffe-tabs-react/package.json
+++ b/packages/ffe-tabs-react/package.json
@@ -34,7 +34,7 @@
   "peerDependencies": {
     "@sb1/ffe-core": "^12.0.0",
     "@sb1/ffe-tabs": "^4.0.0",
-    "react": "^15.0.0 || ^16.0.0"
+    "react": "^16.2.0"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Remove 15.x as a valid peerDependency so people get warnings to upgrade
since we may use 16.2 features such as Fragment at any time (and already
have for some components).

Fixes #44 

I'm unsure, but this may be a breaking change if npm throws errors for these unmet/wrong versions. Anybody know for sure?

BTW: I'm going on easter holiday so I won't be available for a while :)