### PR TITLE
feat(ffe-tables): modifier to preserve whitespace

### DIFF
--- a/packages/ffe-tables/less/table.less
+++ b/packages/ffe-tables/less/table.less
@@ -72,6 +72,10 @@
             vertical-align: top;
         }
 
+        &--preserve-white-space {
+            white-space: pre;
+        }
+
         @media screen and (min-width: @breakpoint-md) {
             display: table-cell;
             padding: 19px 10px;


### PR DESCRIPTION
Added a `--preserve-white-space` modifier to the table cell
class `ffe-table__cell`. Using this will add `white-space: pre`
to the cell it's used on.

<!-- 
Thanks for opening a pull request! 🎉

If your changes include some kind of UI element, please attach a screenshot of 
how it looks.

Before submitting a pull request, please have a look through the CONTRIBUTING.md
document. TL;DR:

- Follow the conventional commit standard
- Write full, explanatory commit messages
- Follow our code standards
- Write tests where applicable
- Be courteous and respect our code of conduct
-->
