### PR TITLE
Fix icons and button groups bug

### DIFF
--- a/packages/ffe-buttons/less/button-group.less
+++ b/packages/ffe-buttons/less/button-group.less
@@ -30,6 +30,7 @@
         .ffe-button,
         .ffe-inline-button {
             display: inline-flex;
+            flex-direction: row;
             margin: 0 0 10px 10px;
             width: auto;
 

--- a/packages/ffe-buttons/less/inline-base-button.less
+++ b/packages/ffe-buttons/less/inline-base-button.less
@@ -53,11 +53,13 @@
 
     &--tertiary {
         color: @ffe-blue-azure;
+        flex-wrap: wrap;
 
         &::after {
             border-bottom: solid 1px currentColor;
             content: ' ';
             display: block;
+            flex: 1 0 100%;
         }
 
         &:hover {


### PR DESCRIPTION
This commit makes buttons with icons behave correctly when they are put
inside a `ffe-button-group` container.

Previously, this would happen.
![image](https://user-images.githubusercontent.com/1307267/37962036-34ca56a2-31ba-11e8-869a-ca4a5a5dbbc8.png)

With these fixes - the same example would look like this:
![image](https://user-images.githubusercontent.com/1307267/37962279-ed0bd416-31ba-11e8-8a8a-cf799cdd7d35.png)

I know the icon is looking weird, but that's due to my non-existing manual svg writing skills.

<!-- 
Thanks for opening a pull request! 🎉

If your changes include some kind of UI element, please attach a screenshot of 
how it looks.

Before submitting a pull request, please have a look through the CONTRIBUTING.md
document. TL;DR:

- Follow the conventional commit standard
- Write full, explanatory commit messages
- Follow our code standards
- Write tests where applicable
- Be courteous and respect our code of conduct
-->
