### PR TITLE
docs: Restore scroll on navigation

### DIFF
--- a/src/components/style-guide/StyleGuide.js
+++ b/src/components/style-guide/StyleGuide.js
@@ -1,40 +1,55 @@
-import React, { Fragment } from 'react';
-import { node, shape, string } from 'prop-types';
+import React, { Component, Fragment } from 'react';
+import { bool, node, shape, string } from 'prop-types';
 
-import TopMenu from '../top-menu';
 import Sidebar from '../sidebar';
 import { Grid, GridRow, GridCol } from '../../../packages/ffe-grid-react';
 
-export default function StyleGuide(props) {
-    const { children, title, toc } = props;
+class StyleGuide extends Component {
+    componentDidUpdate(prevProps) {
+        if (
+            prevProps.displayMode === 'all' &&
+            this.props.displayMode === 'component'
+        ) {
+            window.scrollTo(0, 0);
+        }
+    }
+    render() {
+        const { children, title, toc } = this.props;
 
-    return (
-        <Fragment>
-            <Grid noTopPadding={true} className="sb1ds">
-                <GridRow>
-                    <GridCol lg={3} md={4} sm={12} noBottomPadding={true}>
-                        <Sidebar toc={toc} title={title} />
-                    </GridCol>
-                    <GridCol lg={9} md={8} sm={12} noBottomPadding={true}>
-                        <main className="sb1ds-main">
-                            <h1 className="ffe-h1 sb1ds-intro__heading">Komponenter</h1>
-                            <div className="sb1ds-intro sb1ds-intro--section">
-                                <p className="ffe-lead-paragraph sb1ds-intro__paragraph">
-                                    Vårt bibliotek av felles komponenter, implementert i Less og React.
-                                </p>
-                            </div>
+        return (
+            <Fragment>
+                <Grid noTopPadding={true} className="sb1ds">
+                    <GridRow>
+                        <GridCol lg={3} md={4} sm={12} noBottomPadding={true}>
+                            <Sidebar toc={toc} title={title} />
+                        </GridCol>
+                        <GridCol lg={9} md={8} sm={12} noBottomPadding={true}>
+                            <main className="sb1ds-main">
+                                <h1 className="ffe-h1 sb1ds-intro__heading">
+                                    Komponenter
+                                </h1>
+                                <div className="sb1ds-intro sb1ds-intro--section">
+                                    <p className="ffe-lead-paragraph sb1ds-intro__paragraph">
+                                        Vårt bibliotek av felles komponenter,
+                                        implementert i Less og React.
+                                    </p>
+                                </div>
 
-                            {children}
-                        </main>
-                    </GridCol>
-                </GridRow>
-            </Grid>
-        </Fragment>
-    );
+                                {children}
+                            </main>
+                        </GridCol>
+                    </GridRow>
+                </Grid>
+            </Fragment>
+        );
+    }
 }
 
 StyleGuide.propTypes = {
     children: node.isRequired,
+    displayMode: bool,
     title: string.isRequired,
     toc: shape({}).isRequired,
 };
+
+export default StyleGuide;


### PR DESCRIPTION
This commit makes the browser scroll to the top of the page whenever
the user goes from a list view to a details view in the app.

<!-- 
Thanks for opening a pull request! 🎉

If your changes include some kind of UI element, please attach a screenshot of 
how it looks.

Before submitting a pull request, please have a look through the CONTRIBUTING.md
document. TL;DR:

- Follow the conventional commit standard
- Write full, explanatory commit messages
- Follow our code standards
- Write tests where applicable
- Be courteous and respect our code of conduct
-->
