### PR TITLE
fix(ffe-header): Fix logo position to ensure it is properly horizontally centered

### DIFF
--- a/packages/ffe-header/less/ffe-header.less
+++ b/packages/ffe-header/less/ffe-header.less
@@ -287,11 +287,17 @@
 
         &__secondary-nav {
             display: block;
+            flex-basis: 30%;
 
             .ffe-header__list-item {
                 display: inline-block;
                 margin: 0 5px 0 0;
             }
+        }
+
+        &__user-nav-toggle {
+            flex-basis: 30%;
+            text-align: right;
         }
 
         &__user-nav {


### PR DESCRIPTION
Fixes #146