### PR TITLE
fix(ffe-buttons): Fix issue with back button top padding

### DIFF
--- a/packages/ffe-buttons/less/inline-base-button.less
+++ b/packages/ffe-buttons/less/inline-base-button.less
@@ -25,10 +25,6 @@
         line-height: 26px;
         padding-left: 1em;
 
-        a& {
-            padding-top: 2px; // Hack to make the button look similar for <a /> elements
-        }
-
         &:focus,
         &:hover {
             background-color: transparent;


### PR DESCRIPTION
The markup for inline `a`-tag back button have some weird top padding that results in unaligned text and icon. This only happens if the tag is an `a`-tag (and not `button`), as seen below.

```html
<a class="ffe-inline-button ffe-inline-button--back">
    <span class="ffe-inline-button__label">Tilbake til innstillinger</span>
</a>
```

Simply removing the top padding solves the problem. I am not sure why the padding is there. Perhaps some legacy code or something?

**Before:**

![back_before](https://user-images.githubusercontent.com/2326278/38557321-f66537f6-3ccc-11e8-8483-9629b0542cc4.png)


**After:**

![back_after](https://user-images.githubusercontent.com/2326278/38557085-316b4526-3ccc-11e8-856a-ab8d1cd8b2a9.png)
