### PR TITLE
Increase test coverage for various packages

### DIFF
--- a/packages/ffe-accordion-react/src/AccordionItem.spec.js
+++ b/packages/ffe-accordion-react/src/AccordionItem.spec.js
@@ -67,6 +67,14 @@ describe('<AccordionItem />', () => {
             }); // esc
             expect(wrapper.find('Collapse').prop('isOpened')).toBe(false);
         });
+        it('is not toggled by other keys', () => {
+            const wrapper = getWrapperWithExpandedContent();
+            wrapper.find('.ffe-accordion-item__toggler').simulate('keyup', {
+                target: { nodeName: 'div' },
+                keyCode: 14,
+            }); // not enter
+            expect(wrapper.find('Collapse').prop('isOpened')).toBe(false);
+        });
         it('toggling onToggle prop', () => {
             const onToggleOpenSpy = jest.fn();
 

--- a/packages/ffe-accordion-react/src/BlueAccordion.spec.js
+++ b/packages/ffe-accordion-react/src/BlueAccordion.spec.js
@@ -1,0 +1,22 @@
+import { AccordionItem, BlueAccordion } from '.';
+import { mount } from 'enzyme';
+import React from 'react';
+
+const getWrapper = () =>
+    mount(
+        <BlueAccordion>
+            <AccordionItem>Foo</AccordionItem>
+            <AccordionItem>Bar</AccordionItem>
+        </BlueAccordion>,
+    );
+
+describe('<Accordion />', () => {
+    it('provides the blue type property to each AccordionItem', () => {
+        const wrapper = getWrapper();
+        expect(
+            wrapper
+                .find('AccordionItem')
+                .everyWhere(item => item.prop('type') === 'blue'),
+        ).toBe(true);
+    });
+});

--- a/packages/ffe-buttons-react/src/ExpandButton.spec.js
+++ b/packages/ffe-buttons-react/src/ExpandButton.spec.js
@@ -1,7 +1,10 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 
+import BamseIkon from '@sb1/ffe-icons-react/lib/bamse-ikon';
+import BestikkIkon from '@sb1/ffe-icons-react/lib/bestikk-ikon';
 import KryssIkon from '@sb1/ffe-icons-react/lib/kryss-ikon';
+
 import ExpandButton from './ExpandButton';
 
 const defaultProps = {
@@ -22,11 +25,28 @@ describe('<ExpandButton />', () => {
         const wrapper = getWrapper({ 'aria-label': 'some label' });
         expect(wrapper.props()).toHaveProperty('aria-label', 'some label');
     });
+    it('renders leftIcon and rightIcon', () => {
+        const wrapper = getWrapper({
+            leftIcon: (<BestikkIkon />),
+            rightIcon: (<BamseIkon />),
+        });
+        expect(wrapper.find(BestikkIkon).exists()).toBe(true);
+        expect(wrapper.find(BamseIkon).exists()).toBe(true);
+    });
     describe('when expanded', () => {
         it('does not render children', () => {
             const wrapper = getWrapper({ isExpanded: true });
             expect(wrapper.text()).not.toContain('Click me');
-        });;
+        });
+        it('does not render leftIcon and rightIcon', () => {
+            const wrapper = getWrapper({
+                leftIcon: (<BestikkIkon />),
+                isExpanded: true,
+                rightIcon: (<BamseIkon />),
+            });
+            expect(wrapper.find(BestikkIkon).exists()).toBe(false);
+            expect(wrapper.find(BamseIkon).exists()).toBe(false);
+        });
         it('sets correct class', () => {
             const wrapper = getWrapper({ isExpanded: true });
             expect(wrapper.hasClass('ffe-button--expanded')).toBe(true);

--- a/packages/ffe-form-react/src/ErrorFieldMessage.spec.js
+++ b/packages/ffe-form-react/src/ErrorFieldMessage.spec.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import ErrorFieldMessage from './ErrorFieldMessage';
+
+const getWrapper = () =>
+    shallow(<ErrorFieldMessage>Field message</ErrorFieldMessage>);
+
+describe('<ErrorFieldMessage>', () => {
+    it('renders the correct class name based on type prop', () => {
+        const wrapper = getWrapper();
+        expect(wrapper.exists()).toBe(true);
+        expect(wrapper.hasClass('ffe-field-error-message'));
+    });
+});

--- a/packages/ffe-form-react/src/FieldMessage.spec.js
+++ b/packages/ffe-form-react/src/FieldMessage.spec.js
@@ -7,8 +7,18 @@ const getWrapper = props =>
 
 describe('<FieldMessage>', () => {
     it('renders the correct class name based on type prop', () => {
+        const wrapper = getWrapper({ type: 'error' });
+        expect(wrapper.exists()).toBe(true);
+        expect(wrapper.hasClass('ffe-field-error-message'));
+    });
+    it('renders the correct class name based on type prop', () => {
         const wrapper = getWrapper({ type: 'info' });
         expect(wrapper.exists()).toBe(true);
         expect(wrapper.hasClass('ffe-field-info-message'));
+    });
+    it('renders the correct class name based on type prop', () => {
+        const wrapper = getWrapper({ type: 'success' });
+        expect(wrapper.exists()).toBe(true);
+        expect(wrapper.hasClass('ffe-field-success-message'));
     });
 });

--- a/packages/ffe-form-react/src/InfoFieldMessage.spec.js
+++ b/packages/ffe-form-react/src/InfoFieldMessage.spec.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import InfoFieldMessage from './InfoFieldMessage';
+
+const getWrapper = () =>
+    shallow(<InfoFieldMessage>Field message</InfoFieldMessage>);
+
+describe('<InfoFieldMessage>', () => {
+    it('renders the correct class name based on type prop', () => {
+        const wrapper = getWrapper();
+        expect(wrapper.exists()).toBe(true);
+        expect(wrapper.hasClass('ffe-field-info-message'));
+    });
+});

--- a/packages/ffe-form-react/src/InputGroup.spec.js
+++ b/packages/ffe-form-react/src/InputGroup.spec.js
@@ -112,6 +112,30 @@ describe('<InputGroup>', () => {
         );
     });
 
+    it('throws error when receiving a <Tooltip /> and onTooltipToggle is used', () => {
+        const wrapper = () =>
+            getWrapper({
+                tooltip: (<Tooltip>Message</Tooltip>),
+                onTooltipToggle: f => f,
+            });
+
+        expect(wrapper).toThrowError(
+            /Only use the "onTooltipToggle" prop if you're not sending a component/,
+        );
+    });
+
+    it('renders a <Tooltip /> with onTooltipToggle as an onClick if tooltip is true', () => {
+        const onTooltipToggle = jest.fn();
+        const wrapper = getWrapper({
+            tooltip: true,
+            onTooltipToggle,
+        });
+        const tooltip = wrapper.find(Tooltip);
+        expect(tooltip.exists()).toBe(true);
+        tooltip.simulate('click');
+        expect(onTooltipToggle).toHaveBeenCalled();
+    });
+
     it('supplies id and aria-invalid to function when child is a function', () => {
         const wrapper = getWrapper({
             children: props => (

--- a/packages/ffe-form-react/src/SuccessFieldMessage.spec.js
+++ b/packages/ffe-form-react/src/SuccessFieldMessage.spec.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import SuccessFieldMessage from './SuccessFieldMessage';
+
+const getWrapper = () =>
+    shallow(<SuccessFieldMessage>Field message</SuccessFieldMessage>);
+
+describe('<SuccessFieldMessage>', () => {
+    it('renders the correct class name based on type prop', () => {
+        const wrapper = getWrapper();
+        expect(wrapper.exists()).toBe(true);
+        expect(wrapper.hasClass('ffe-field-success-message'));
+    });
+});

--- a/packages/ffe-grid-react/src/Grid.js
+++ b/packages/ffe-grid-react/src/Grid.js
@@ -6,6 +6,7 @@ import { checkForNestedComponent } from './utils';
 
 export default class Grid extends Component {
     componentDidMount() {
+        /* istanbul ignore else: there is no else  */
         if (process.env.NODE_ENV !== 'production') {
             checkForNestedComponent(this.props.children, Grid);
         }

--- a/packages/ffe-grid-react/src/GridCol.js
+++ b/packages/ffe-grid-react/src/GridCol.js
@@ -9,9 +9,6 @@ import {
 } from './utils';
 
 function camelCaseToDashCase(str) {
-    if (!str) {
-        return str;
-    }
     return str
         .split('')
         .reduce(
@@ -61,6 +58,7 @@ const modifiers = props =>
 
 export default class GridCol extends Component {
     componentDidMount() {
+        /* istanbul ignore else: there is no else  */
         if (process.env.NODE_ENV !== 'production') {
             checkForDeprecatedModifiers(this.props);
             checkForNestedComponent(this.props.children, GridCol);

--- a/packages/ffe-grid-react/src/GridRow.js
+++ b/packages/ffe-grid-react/src/GridRow.js
@@ -17,6 +17,7 @@ export const VALID_BACKGROUND_COLORS = [
 
 export default class GridRow extends Component {
     componentDidMount() {
+        /* istanbul ignore else: there is no else */
         if (process.env.NODE_ENV !== 'production') {
             checkForNestedComponent(this.props.children, GridRow);
         }

--- a/packages/ffe-grid-react/src/utils.js
+++ b/packages/ffe-grid-react/src/utils.js
@@ -1,3 +1,4 @@
+/* istanbul ignore if: I don't see any good way of getting around NODE_ENV */
 if (process.env.NODE_ENV === 'production') {
     const emptyFn = () => {};
     module.exports = {

--- a/packages/ffe-radio-button-react/src/RadioButtonInputGroup.js
+++ b/packages/ffe-radio-button-react/src/RadioButtonInputGroup.js
@@ -31,7 +31,7 @@ const RadioButtonInputGroup = props => {
         'aria-invalid': ariaInvalid || String(!!fieldMessage),
         inline,
         name,
-        onChange: f => f,
+        onChange: /* istanbul ignore next */ f => f,
         selectedValue,
     };
 


### PR DESCRIPTION
Increase test coverage. Should make Coveralls happy :purple_heart: 

The new test files are there to cover the actual export and props sent to the base component (such as the various FieldMessages).

I simply ignore the `NODE_ENV` blocks and their `else` cases.