### PR TITLE
feat(ffe-checkbox-react): Add optional prop stopPropagation

### DIFF
--- a/packages/ffe-checkbox-react/src/Checkbox.js
+++ b/packages/ffe-checkbox-react/src/Checkbox.js
@@ -1,12 +1,19 @@
 import React from 'react';
-import { bool, node, string } from 'prop-types';
+import { bool, node, string, func } from 'prop-types';
 import { v4 as hash } from 'uuid';
 import classNames from 'classnames';
 
 export default function CheckBox(props) {
-    const { children, inline, invalid, label, noMargins, ...rest } = props;
+    const { children, inline, invalid, label, noMargins, onClick, stopPropagation, ...rest } = props;
 
     const id = props.id || `checkbox-${hash()}`;
+
+    const onClickInput = event => {
+        if (stopPropagation) {
+            event.stopPropagation();
+        }
+        onClick(event);
+    };
 
     return (
         <span>
@@ -15,6 +22,7 @@ export default function CheckBox(props) {
                 id={id}
                 type="checkbox"
                 aria-invalid={String(invalid)}
+                onClick={ onClickInput }
                 {...rest}
             />
             <label
@@ -24,6 +32,8 @@ export default function CheckBox(props) {
                     'ffe-checkbox--no-margin': noMargins,
                 })}
                 htmlFor={id}
+                role="presentation"
+                onClick={ event => { if (stopPropagation) { event.stopPropagation() } } }
             >
                 {label || children}
             </label>
@@ -49,9 +59,14 @@ CheckBox.propTypes = {
     invalid: bool,
     /** The label for the checkbox */
     children: node,
+    onClick: func,
+    /** Stops onClick from bubbling from the checkbox/label */
+    stopPropagation: bool,
 };
 
 CheckBox.defaultProps = {
     inline: true,
     invalid: false,
+    onClick: () => {},
+    stopPropagation: false,
 };

--- a/packages/ffe-checkbox-react/src/Checkbox.md
+++ b/packages/ffe-checkbox-react/src/Checkbox.md
@@ -38,7 +38,7 @@ Du kan merke at et felt er ugyldig ved å sette `aria-invalid="true"`:
 </CheckBox>
 ```
 
-Du kan kan sende inn en callback-funksjon som blir kalt hver gang verdien i checkboxen endrer
+Du kan sende inn en callback-funksjon som blir kalt hver gang verdien i checkboxen endrer
 seg med `onChange`:
 
 ```js
@@ -48,6 +48,20 @@ seg med `onChange`:
 >
     Trykk for å lære litt om meg
 </CheckBox>
+```
+
+Du kan forhindre at click-event bobler opp fra checkboxen.
+Dette kan være nyttig dersom området rundt checkboxen er klikkbart.
+
+```js
+<div style={ { background: '#ccc', width: '150px' } } onClick={ () => alert('Jeg skal ikke komme frem når du bruker checkboxen') }>
+    <CheckBox
+        name="clicked"
+        stopPropagation
+    >
+        Trykk utenfor label for en alert
+    </CheckBox>
+</div>
 ```
 
 Komponenten videresender alle udokumenterte props til `<input />`-elementet.

--- a/packages/ffe-checkbox-react/src/Checkbox.spec.js
+++ b/packages/ffe-checkbox-react/src/Checkbox.spec.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 
 import Checkbox from './Checkbox';
 
@@ -105,5 +105,23 @@ describe('<Checkbox />', () => {
             'false',
         );
         expect(wrapper.find('input').prop('tabIndex')).toBe(-1);
+    });
+
+    it('should stop event propagation when stopPropagation is true', () => {
+        const onClickOfWrapper = jest.fn();
+        const onClickOfCheckbox = jest.fn();
+        const wrapper = mount(
+            <div onClick={onClickOfWrapper} role="presentation">
+                <Checkbox
+                    onClick={onClickOfCheckbox}
+                    stopPropagation={true}
+                />
+            </div>
+        );
+
+        wrapper.find('div').find('input').simulate('click');
+
+        expect(onClickOfWrapper).toHaveBeenCalledTimes(0);
+        expect(onClickOfCheckbox).toHaveBeenCalled();
     });
 });


### PR DESCRIPTION
This commit adds a new optional prop to ffe-checkbox-react. When this is
set to `true` the internal `<input>` and `<label>` of the Checkbox will
stop propagation of their onClick events.

Resolves #158 