### PR TITLE
fix(ffe-header): Extend all necessary modifiers in order to render logout button correctly

### DIFF
--- a/packages/ffe-header/less/ffe-header.less
+++ b/packages/ffe-header/less/ffe-header.less
@@ -135,10 +135,14 @@
         &:extend(.ffe-button--condensed);
 
         margin: 8px 10px;
+        border-radius: 20px;
 
         &:focus:extend(.ffe-button:focus) {}
+        &:focus:extend(.ffe-button--secondary:focus) {}
         &:hover:extend(.ffe-button:hover) {}
+        &:hover:extend(.ffe-button--secondary:hover) {}
         &:active:extend(.ffe-button:active) {}
+        &:active:extend(.ffe-button--secondary:active) {}
 
         &--loading {
             &:extend(.ffe-button--loading);


### PR DESCRIPTION
Fixes a bug in which the logout button didn't extend all necessary classes/modifiers, and therefore was rendered with only parts of the styling needed (Font-family, hover/focus/active states, etc)

![screenshot from 2018-04-13 10-59-54](https://user-images.githubusercontent.com/463847/38726470-85f3fe7c-3f0a-11e8-8af1-016cfbeda85a.png)
