### PR TITLE
docs: Update README.md

### DIFF
--- a/packages/ffe-core/README.md
+++ b/packages/ffe-core/README.md
@@ -34,4 +34,6 @@ I noe tilfeller trenger man kanskje kun deler av ffe-core. Derfor kan hver fil i
 @import '~@sb1/ffe-core/less/dimensions';
 @import '~@sb1/ffe-core/less/motion';
 @import '~@sb1/ffe-core/less/font-sizes';
+@import '~@sb1/ffe-core/less/typography';
+@import '~@sb1/ffe-core/less/accessibility';
 ```


### PR DESCRIPTION
Add the two remaining "non-destructive" files to the example. Consumers that want core without any element styling (without normalize) can use this list as a reference.
