### PR TITLE
fix(ffe-header): Make logout button properly centered on small screens

### DIFF
--- a/packages/ffe-header/less/ffe-header.less
+++ b/packages/ffe-header/less/ffe-header.less
@@ -134,7 +134,7 @@
         &:extend(.ffe-button--secondary);
         &:extend(.ffe-button--condensed);
 
-        margin: 8px 10px;
+        margin: 8px 0;
         border-radius: 20px;
 
         &:focus:extend(.ffe-button:focus) {}
@@ -364,6 +364,10 @@
             background: @ffe-white;
             border: 2px solid @ffe-blue-azure;
             outline: 2px solid @ffe-blue-focus;
+        }
+
+        &__logout-button {
+            margin: 8px 10px;
         }
 
         &__icon-button--user-nav {


### PR DESCRIPTION
Removes horizontal margin on small screens in order to ensure the log out button is centered.

![screenshot from 2018-04-13 13-57-37](https://user-images.githubusercontent.com/463847/38733727-47623f16-3f23-11e8-8933-ed5ece48e951.png)
