### PR TITLE
fix(ffe-buttons): Align button group contents with container

### DIFF
--- a/packages/ffe-buttons/less/button-group.less
+++ b/packages/ffe-buttons/less/button-group.less
@@ -14,7 +14,7 @@
 //
 // Styleguide ffe-buttons.button-group
 .ffe-button-group {
-    display: flex;
+    display: inline-flex;
     padding: 40px 0;
 
     .ffe-button,


### PR DESCRIPTION
Fixes a regression where the button group would always be left aligned,
regardless of its parent. With this the button group will be centered if
the contents of its container is centered, like it used to.

Fixes #173 