### PR TITLE
 fix(ffe-buttons): Properly align tertiary button anchors 

### DIFF
--- a/packages/ffe-buttons-react/src/ButtonGroup.md
+++ b/packages/ffe-buttons-react/src/ButtonGroup.md
@@ -1,35 +1,95 @@
 For å plassere knapper ved siden av hverandre på riktig måte har vi en såkalt
-knappegruppe. Denne sørger for å gi riktige marginer mellom knappene.
+knappegruppe. Denne sørger for å gi riktige marginer mellom knappene. Knapper i
+grupper kan være vanlige knapper eller lenker til andre steder.
 
 ```js
-<ButtonGroup>
-    <PrimaryButton>
-        Neste
-    </PrimaryButton>
-    <SecondaryButton
-        element="a"
-    >
-        Avbryt
-    </SecondaryButton>
-</ButtonGroup>
+<React.Fragment>
+    <ButtonGroup>
+        <ActionButton>
+            Neste
+        </ActionButton>
+        <ActionButton element="a" href="#buttongroup">
+            Lenke
+        </ActionButton>
+        <SecondaryButton>
+            Avbryt
+        </SecondaryButton>
+        <SecondaryButton element="a" href="#buttongroup">
+            Lenke
+        </SecondaryButton>
+        <TertiaryButton>
+            Hopp over
+        </TertiaryButton>
+        <TertiaryButton element="a" href="#buttongroup">
+            Lenke
+        </TertiaryButton>
+    </ButtonGroup>
+    <ButtonGroup>
+        <PrimaryButton>
+            Neste
+        </PrimaryButton>
+        <PrimaryButton element="a" href="#buttongroup">
+            Lenke
+        </PrimaryButton>
+        <SecondaryButton>
+            Avbryt
+        </SecondaryButton>
+        <SecondaryButton element="a" href="#buttongroup">
+            Lenke
+        </SecondaryButton>
+        <TertiaryButton>
+            Hopp over
+        </TertiaryButton>
+        <TertiaryButton element="a" href="#buttongroup">
+            Lenke
+        </TertiaryButton>
+    </ButtonGroup>
+</React.Fragment>
 ```
 
 Det finnes også en tynnere variant.
 
 ```js
-<ButtonGroup thin={true}>
-    <PrimaryButton>
-        Neste
-    </PrimaryButton>
-    <SecondaryButton>
-        Avbryt
-    </SecondaryButton>
-    <TertiaryButton
-        element="a"
-        href="#"
-    >
-        Til toppen av siden
-    </TertiaryButton>
-</ButtonGroup>
+<React.Fragment>
+    <ButtonGroup thin={true}>
+        <ActionButton>
+            Neste
+        </ActionButton>
+        <ActionButton element="a" href="#buttongroup">
+            Lenke
+        </ActionButton>
+        <SecondaryButton>
+            Avbryt
+        </SecondaryButton>
+        <SecondaryButton element="a" href="#buttongroup">
+            Lenke
+        </SecondaryButton>
+        <TertiaryButton>
+            Hopp over
+        </TertiaryButton>
+        <TertiaryButton element="a" href="#buttongroup">
+            Lenke
+        </TertiaryButton>
+    </ButtonGroup>
+    <ButtonGroup thin={true}>
+        <PrimaryButton>
+            Neste
+        </PrimaryButton>
+        <PrimaryButton element="a" href="#buttongroup">
+            Lenke
+        </PrimaryButton>
+        <SecondaryButton>
+            Avbryt
+        </SecondaryButton>
+        <SecondaryButton element="a" href="#buttongroup">
+            Lenke
+        </SecondaryButton>
+        <TertiaryButton>
+            Hopp over
+        </TertiaryButton>
+        <TertiaryButton element="a" href="#buttongroup">
+            Lenke
+        </TertiaryButton>
+    </ButtonGroup>
+</React.Fragment>
 ```
-

--- a/packages/ffe-buttons/less/inline-base-button.less
+++ b/packages/ffe-buttons/less/inline-base-button.less
@@ -63,14 +63,14 @@
 }
 
 .ffe-inline-button--tertiary {
+    align-content: center;
     color: @ffe-blue-azure;
     flex-wrap: wrap;
 
     &::after {
         border-bottom: solid 1px currentColor;
         content: ' ';
-        display: block;
-        flex: 1 0 100%;
+        width: 100%;
     }
 
     &:hover {


### PR DESCRIPTION
We had a bug where the border and label of the tertiary button would be
rendered at the top and bottom of the button group if the button was an
anchor element (or !button, really). This commit adds the proper flex
attibute to make sure the content inside the container is vertically
centered. It also adjusts the CSS for the ::after element now that the
container takes care of the details.

Fixes #178 