### PR TITLE
fix(ffe-account-selector-react): Adds support for filtering on accoun…

### DIFF
--- a/packages/ffe-account-selector-react/src/filter/filters.js
+++ b/packages/ffe-account-selector-react/src/filter/filters.js
@@ -1,4 +1,4 @@
-const COMMON_SEPARATORS = new RegExp(/[ .]/g);
+const COMMON_SEPARATORS = new RegExp(/[\s.]/g);
 
 export function accountFilter(query = '') {
     const nameQuery = query.toLowerCase();

--- a/packages/ffe-account-selector-react/src/filter/filters.spec.js
+++ b/packages/ffe-account-selector-react/src/filter/filters.spec.js
@@ -64,6 +64,9 @@ describe('accountFilter', () => {
         expect(accounts.filter(accountFilter('1286 7318 345'))).toEqual([
             accounts[1],
         ]);
+        const NON_BREAKING_SPACE = '\u00A0';
+        expect(accounts.filter(accountFilter(`1286${NON_BREAKING_SPACE}7318${NON_BREAKING_SPACE}345`))).toEqual([
+            accounts[1]]);
     });
 
     it('should filter by partial account number', () => {


### PR DESCRIPTION
…t numbers with unicode spaces

We have unitcode spaces in our account numbers. Copying an account number and pasting it into the account selector yields 'Not Found'

<!-- 
Thanks for opening a pull request! 🎉

If your changes include some kind of UI element, please attach a screenshot of 
how it looks.

Before submitting a pull request, please have a look through the CONTRIBUTING.md
document. TL;DR:

- Follow the conventional commit standard
- Write full, explanatory commit messages
- Follow our code standards
- Write tests where applicable
- Be courteous and respect our code of conduct
-->
