### PR TITLE
fix(ffe-buttons): button group direction on small screen

### DIFF
--- a/packages/ffe-buttons/less/button-group.less
+++ b/packages/ffe-buttons/less/button-group.less
@@ -14,12 +14,12 @@
 //
 // Styleguide ffe-buttons.button-group
 .ffe-button-group {
-    display: inline-flex;
+    display: flex;
+    flex-direction: column;
     padding: 40px 0;
 
     .ffe-button,
     .ffe-inline-button {
-        flex-direction: column;
         justify-content: center;
         margin: 0 auto 10px;
     }
@@ -42,10 +42,11 @@
     }
 
     @media screen and (min-width: @breakpoint-sm) {
+        display: inline-flex;
+        flex-direction: row;
         .ffe-button,
         .ffe-inline-button {
             display: inline-flex;
-            flex-direction: row;
             margin: 0 0 10px 10px;
             width: auto;
 


### PR DESCRIPTION
This commit changes the styling of `ffe-button-group` on small screen
(below @breakpoint-sm): our full-width buttons now wraps vertically,
as intended.

Fixes #114 