### PR TITLE
fix(ffe-buttons): tertiary button underline on small screens

### DIFF
--- a/packages/ffe-buttons/less/button-group.less
+++ b/packages/ffe-buttons/less/button-group.less
@@ -46,7 +46,6 @@
         flex-direction: row;
         .ffe-button,
         .ffe-inline-button {
-            display: inline-flex;
             margin: 0 0 10px 10px;
             width: auto;
 

--- a/packages/ffe-buttons/less/inline-base-button.less
+++ b/packages/ffe-buttons/less/inline-base-button.less
@@ -18,7 +18,7 @@
     border: none;
     border-radius: 6px;
     cursor: pointer;
-    display: inline-block;
+    display: inline-flex;
     font-family: 'MuseoSansRounded-500', arial, sans-serif;
     margin: 0 -4px; // Hack to allow box-shadow to float outside content on focus
     overflow: hidden;
@@ -40,6 +40,10 @@
     line-height: 26px;
     padding-left: 1em;
 
+    .ffe-inline-button__label {
+        border-bottom: 1px solid transparent;
+    }
+
     &:focus,
     &:hover {
         background-color: transparent;
@@ -50,7 +54,7 @@
     }
 
     &:hover .ffe-inline-button__label {
-        border-bottom: 1px solid @ffe-grey-charcoal;
+        border-bottom-color: @ffe-grey-charcoal;
     }
 }
 


### PR DESCRIPTION
This commit fixes the underline of the tertiary button on small screens.

The changes made to `.ffe-inline-button--back` were necessary because the
hover border pushed the rest of the page downwards after giving all
`.ffe-inline-button`s `display: inline-flex;`.

Fixes #191 