### PR TITLE
feat(ffe-account-selector-react): Adds expand/collapse button to inpu…

### DIFF
--- a/packages/ffe-account-selector-react/less/base-selector.less
+++ b/packages/ffe-account-selector-react/less/base-selector.less
@@ -10,6 +10,27 @@
         }
     }
 
+    &__expand-button {
+        position: absolute;
+        right: 7px;
+        margin: auto;
+        top: 13px;
+        background: transparent;
+        border: none;
+        cursor: pointer;
+
+        &-icon {
+            fill: @ffe-blue-azure;
+            @size: 17px;
+            width: @size;
+            height: @size;
+        }
+
+        &-icon--invalid {
+            fill: @ffe-orange-fire;
+        }
+    }
+
     &__reset-button {
         position: absolute;
         right: 35px;
@@ -21,6 +42,7 @@
         background: transparent;
         border: none;
         fill: @ffe-grey-charcoal;
+        cursor: pointer;
 
         &-icon {
             @size : 11px;

--- a/packages/ffe-account-selector-react/src/components/base-selector/BaseSelector.js
+++ b/packages/ffe-account-selector-react/src/components/base-selector/BaseSelector.js
@@ -74,6 +74,10 @@ class BaseSelector extends Component {
         setTimeout(this.setFocus);
     }
 
+    onExpandOrCollapseClick() {
+        this.showOrHideSuggestions(!this.state.showSuggestions);
+    }
+
     showOrHideSuggestions(show, cb = () => {}) {
         const nextState = show
             ? { showSuggestions: show }
@@ -225,6 +229,7 @@ class BaseSelector extends Component {
                     id={id}
                     name={name}
                     readOnly={readOnly}
+                    onExpandOrCollapseClick={this.onExpandOrCollapseClick}
                 />
                 {showSuggestions && (
                     <SuggestionListContainer

--- a/packages/ffe-account-selector-react/src/components/base-selector/BaseSelector.spec.js
+++ b/packages/ffe-account-selector-react/src/components/base-selector/BaseSelector.spec.js
@@ -207,6 +207,45 @@ describe('<BaseSelector> methods', () => {
         expect(component.state.highlightedSuggestionIndex).toBe(2);
         expect(scollPosSpy).toHaveBeenCalledTimes(1);
     });
+
+    it('should call onInputReset on reset button mousedown', () => {
+        const component = mountBaseSelector({ value: 'notempty' });
+        const onResetSpy = jest.spyOn(component.instance(), 'onInputReset');
+        component.instance().forceUpdate();
+        component.find('.ffe-base-selector__reset-button').simulate('mousedown');
+
+        expect(onResetSpy).toHaveBeenCalled();
+    });
+
+    it('should call onExpandOrCollapseClick on expandOrCollapse button mousedown', () => {
+        const component = mountBaseSelector();
+        const onResetSpy = jest.spyOn(component.instance(), 'onExpandOrCollapseClick');
+        component.instance().forceUpdate();
+        component.find('.ffe-base-selector__expand-button').simulate('mousedown');
+
+        expect(onResetSpy).toHaveBeenCalled();
+    });
+
+    it('should call onInputChange on input change', () => {
+        const component = mountBaseSelector();
+        const onInputChange = jest.spyOn(component.instance(), 'onInputChange');
+        const value = 'value';
+        const event = { target: { value } };
+        component.instance().forceUpdate();
+        component.find('.ffe-base-selector__input-field').simulate('change', event);
+
+        expect(onInputChange).toHaveBeenCalledWith(value);
+    });
+
+    it('should call onBlur on input blur', () => {
+        const component = mountBaseSelector();
+        const onBlur = jest.spyOn(component.instance(), 'onBlur');
+        component.instance().forceUpdate();
+        component.find('.ffe-base-selector__input-field').simulate('blur');
+
+        expect(onBlur).toHaveBeenCalled();
+    })
+
 });
 
 describe('<BaseSelector> keyboard navigation', () => {

--- a/packages/ffe-account-selector-react/src/subcomponents/input-field/InputField.js
+++ b/packages/ffe-account-selector-react/src/subcomponents/input-field/InputField.js
@@ -2,15 +2,15 @@
 /* eslint jsx-a11y/role-has-required-aria-props:0 */
 import React, { Component } from 'react';
 import { func, string, bool, number } from 'prop-types';
+import autoBind from 'react-auto-bind';
 import KryssIkon from '@sb1/ffe-icons-react/lib/kryss-ikon';
+import ChevronIkon from '@sb1/ffe-icons-react/lib/chevron-ikon';
+import classNames from 'classnames';
 
 class Input extends Component {
     constructor(props) {
         super(props);
-        this.onChange = this.onChange.bind(this);
-        this.onFocus = this.onFocus.bind(this);
-        this.onBlur = this.onBlur.bind(this);
-
+        autoBind(this);
         this.state = {
             value: props.value,
             isFocused: false,
@@ -33,6 +33,16 @@ class Input extends Component {
         this.props.onBlur();
     }
 
+    onReset(e) {
+        e.preventDefault();
+        this.props.onReset();
+    }
+
+    onExpandOrCollapse(e) {
+        e.preventDefault();
+        this.props.onExpandOrCollapseClick();
+    }
+
     componentWillReceiveProps(nextProps) {
         if (!this.state.isFocused || this.state.value !== nextProps.value) {
             this.setState({ value: nextProps.value });
@@ -47,7 +57,6 @@ class Input extends Component {
             placeholder,
             isSuggestionsShowing,
             ariaInvalid,
-            onReset,
             onClick,
             inputFieldRef,
             highlightedIndex,
@@ -72,7 +81,7 @@ class Input extends Component {
                 aria-owns={suggestionListId}
             >
                 <input
-                    className="ffe-input-field ffe-dropdown ffe-base-selector__input-field"
+                    className="ffe-input-field ffe-base-selector__input-field"
                     onKeyDown={onKeyDown}
                     autoComplete="off"
                     value={this.state.value}
@@ -89,17 +98,26 @@ class Input extends Component {
                 {showReset && (
                     <button
                         className="ffe-base-selector__reset-button"
-                        onMouseDown={e => {
-                            e.preventDefault();
-                            onReset();
-                        }}
+                        onMouseDown={this.onReset}
                         tabIndex={-1}
                         type="button"
-                        aria-label="Reset"
                     >
-                        <KryssIkon className="ffe-base-selector__reset-button-icon" />
+                        <KryssIkon className="ffe-base-selector__reset-button-icon"/>
                     </button>
                 )}
+                <button
+                    className="ffe-base-selector__expand-button"
+                    onMouseDown={this.onExpandOrCollapse}
+                    tabIndex={-1}
+                    type="button"
+                >
+                    <ChevronIkon
+                        className={classNames(
+                            'ffe-base-selector__expand-button-icon ',
+                            { 'ffe-base-selector__expand-button-icon--invalid': ariaInvalid }
+                        )}
+                    />
+                </button>
             </div>
         );
     }
@@ -108,6 +126,7 @@ class Input extends Component {
 Input.propTypes = {
     onChange: func.isRequired,
     onKeyDown: func.isRequired,
+    onExpandOrCollapseClick: func.isRequired,
     value: string.isRequired,
     onReset: func.isRequired,
     isSuggestionsShowing: bool.isRequired,

--- a/packages/ffe-account-selector-react/src/subcomponents/input-field/InputField.spec.js
+++ b/packages/ffe-account-selector-react/src/subcomponents/input-field/InputField.spec.js
@@ -17,6 +17,7 @@ function renderInputField(
             isSuggestionsShowing={false}
             id="id"
             readOnly={readOnly}
+            onExpandOrCollapseClick={() => {}}
         />
     );
 }


### PR DESCRIPTION

![screenshot from 2018-04-20 11-00-03](https://user-images.githubusercontent.com/1838311/39041967-0ecb1418-448a-11e8-9d3a-22bae29ea688.png)

Expands or collapses the suggestion list when the arrow is pressed.

