### PR TITLE
fix(ffe-message-box-react): move to newest ffe-message-box

### DIFF
--- a/packages/ffe-message-box-react/package.json
+++ b/packages/ffe-message-box-react/package.json
@@ -36,7 +36,7 @@
     "react-dom": "^16.2.0"
   },
   "peerDependencies": {
-    "@sb1/ffe-message-box": "^5.0.0",
+    "@sb1/ffe-message-box": "^6.0.0",
     "react": "^16.2.0"
   },
   "publishConfig": {


### PR DESCRIPTION
This commit moves our peer dependency to the newest version of
ffe-message-box. While this is a major version change for the styling, it
has no impact on this package, as the removed class was never implemented
as a component here.