### PR TITLE
feat(ffe-tabs-react): add props thin and className to TabGroup

### DIFF
--- a/packages/ffe-tabs-react/package.json
+++ b/packages/ffe-tabs-react/package.json
@@ -33,7 +33,7 @@
   },
   "peerDependencies": {
     "@sb1/ffe-core": "^12.0.0",
-    "@sb1/ffe-tabs": "^4.0.0",
+    "@sb1/ffe-tabs": "^4.1.0",
     "react": "^16.2.0"
   },
   "publishConfig": {

--- a/packages/ffe-tabs-react/src/TabGroup.js
+++ b/packages/ffe-tabs-react/src/TabGroup.js
@@ -1,11 +1,26 @@
 import React from 'react';
-import { node } from 'prop-types';
+import { node, string, bool } from 'prop-types';
+import classNames from 'classnames';
 
-export default function TabGroup(props) {
-    return <div className="ffe-tab-button-group" role="group" {...props} />;
+export default function TabGroup({ className, thin, ...rest }) {
+    return (
+        <div
+            className={classNames(
+                'ffe-tab-button-group',
+                { 'ffe-tab-button-group--thin': thin },
+                className,
+            )}
+            role="group"
+            {...rest}
+        />
+    );
 }
 
 TabGroup.propTypes = {
     /** TabGroup contents - a group of Tabs */
     children: node.isRequired,
+    /** Additional css classes */
+    className: string,
+    /** Applies the thin modifier to remove margins */
+    thin: bool,
 };

--- a/packages/ffe-tabs-react/src/TabGroup.md
+++ b/packages/ffe-tabs-react/src/TabGroup.md
@@ -4,11 +4,18 @@ Flere tabs kan grupperes i en `TabGroup`:
 const Tab = require('./Tab').default;
 
 <TabGroup>
-    <Tab>
-        Dette er en tab button
-    </Tab>
-    <Tab>
-        Dette er en annen tab button
-    </Tab>
-</TabGroup>
+    <Tab>Dette er en tab button</Tab>
+    <Tab>Dette er en annen tab button</Tab>
+</TabGroup>;
+```
+
+Det finnes også en tynnere variant ved bruk av `thin`:
+
+```js
+const Tab = require('./Tab').default;
+
+<TabGroup thin={true}>
+    <Tab>Dette er en tab button</Tab>
+    <Tab>Dette er en annen tab button</Tab>
+</TabGroup>;
 ```

--- a/packages/ffe-tabs-react/src/TabGroup.spec.js
+++ b/packages/ffe-tabs-react/src/TabGroup.spec.js
@@ -24,4 +24,22 @@ describe('TabGroup', () => {
         expect(wrapper.contains(<Tab>En tab</Tab>)).toBe(true);
         expect(wrapper.contains(<Tab>En annen tab</Tab>)).toBe(true);
     });
+
+    it('should apply thin modifier class when the thin prop is true', () => {
+        const wrapper = shallow(
+            <TabGroup thin={true}>
+                <Tab>En tab</Tab>
+            </TabGroup>,
+        );
+        expect(wrapper.hasClass('ffe-tab-button-group--thin')).toBe(true);
+    });
+
+    it('should accept custom classes', () => {
+        const wrapper = shallow(
+            <TabGroup className="some-custom-class">
+                <Tab>En tab</Tab>
+            </TabGroup>,
+        );
+        expect(wrapper.hasClass('some-custom-class')).toBe(true);
+    });
 });


### PR DESCRIPTION
This commit adds two new props to the `TabGroup` component.
Bool `thin` adds the `--thin` modifier to remove top and bottom padding.
String `className` adds given css classes to the tab group.

See #203 for screen shots