### PR TITLE
fix(ffe-buttons-react): Restrict isLoading prop

### DIFF
--- a/packages/ffe-buttons-react/src/BaseButton.js
+++ b/packages/ffe-buttons-react/src/BaseButton.js
@@ -21,19 +21,21 @@ const BaseButton = props => {
         ...rest
     } = props;
 
-    const supportsSpinner = ['action', 'primary', 'secondary', 'shortcut'].includes(buttonType);
+    const supportsSpinner = ['action', 'primary', 'secondary'].includes(
+        buttonType,
+    );
     return (
         <Element
-            aria-busy={isLoading}
-            aria-disabled={disabled || isLoading}
+            aria-busy={isLoading && supportsSpinner}
+            aria-disabled={disabled || (isLoading && supportsSpinner)}
             className={classNames(
                 'ffe-button',
                 `ffe-button--${buttonType}`,
                 { 'ffe-button--condensed': condensed },
-                { 'ffe-button--loading': isLoading },
+                { 'ffe-button--loading': isLoading && supportsSpinner },
                 className,
             )}
-            disabled={disabled || isLoading}
+            disabled={disabled || (isLoading && supportsSpinner)}
             ref={innerRef}
             {...rest}
         >
@@ -48,13 +50,13 @@ const BaseButton = props => {
                         className: 'ffe-button__icon ffe-button__icon--right',
                     })}
             </span>
-            {supportsSpinner &&
+            {supportsSpinner && (
                 <div
                     aria-hidden={!isLoading}
                     aria-label={ariaLoadingMessage}
                     className="ffe-button__spinner"
                 />
-            }
+            )}
         </Element>
     );
 };
@@ -66,13 +68,7 @@ BaseButton.propTypes = {
      * Enum of supported prop types. Used internally only.
      * @ignore
      */
-    buttonType: oneOf([
-        'action',
-        'primary',
-        'secondary',
-        'shortcut',
-        'task',
-    ]),
+    buttonType: oneOf(['action', 'primary', 'secondary', 'shortcut', 'task']),
     /** The button label */
     children: node,
     /** Extra class names */
@@ -96,7 +92,6 @@ BaseButton.propTypes = {
 BaseButton.defaultProps = {
     ariaLoadingMessage: 'Vennligst vent',
     element: 'button',
-
 };
 
 export default BaseButton;

--- a/packages/ffe-buttons-react/src/BaseButton.spec.js
+++ b/packages/ffe-buttons-react/src/BaseButton.spec.js
@@ -51,17 +51,36 @@ describe('<BaseButton />', () => {
 
     describe('when loading', () => {
         it('sets the correct class', () => {
-            const wrapper = getWrapper({ isLoading: true });
+            const wrapper = getWrapper({
+                buttonType: 'primary',
+                isLoading: true,
+            });
             expect(wrapper.hasClass('ffe-button--loading')).toBe(true);
         });
         it('sets the correct aria tags', () => {
-            const wrapper = getWrapper({ isLoading: true });
+            const wrapper = getWrapper({
+                buttonType: 'primary',
+                isLoading: true,
+            });
             expect(wrapper.prop('aria-busy')).toBe(true);
         });
         it('disables the button', () => {
-            const wrapper = getWrapper({ isLoading: true });
+            const wrapper = getWrapper({
+                buttonType: 'primary',
+                isLoading: true,
+            });
             expect(wrapper.prop('aria-disabled')).toBe(true);
             expect(wrapper.prop('disabled')).toBe(true);
+        });
+        it('does nothing for unsupported button type', () => {
+            const wrapper = getWrapper({
+                buttonType: 'shortcut',
+                isLoading: true,
+            });
+            expect(wrapper.hasClass('ffe-button--loading')).toBe(false);
+            expect(wrapper.prop('aria-busy')).toBe(false);
+            expect(wrapper.prop('aria-disabled')).toBe(false);
+            expect(wrapper.prop('disabled')).toBe(false);
         });
     });
 });


### PR DESCRIPTION
BREAKING CHANGE: Removed support for `isLoading` from any button
other than ActionButton, PrimaryButton and SecondaryButton.

This commit removes support for the `isLoading` prop for all other
buttons, meaning they will not be disabled or act any differently
if given an `isLoading` prop of true or false.

If you are using `isLoading` with any other kind of button you need
to sit down with design/ux and either start using one of those
three button types or figure out another way to show a loading indicator.

<!-- 
Thanks for opening a pull request! 🎉

If your changes include some kind of UI element, please attach a screenshot of 
how it looks.

Before submitting a pull request, please have a look through the CONTRIBUTING.md
document. TL;DR:

- Follow the conventional commit standard
- Write full, explanatory commit messages
- Follow our code standards
- Write tests where applicable
- Be courteous and respect our code of conduct
-->
