### PR TITLE
fix: Change styleguide page titles to reflect the actual name of the design system

### DIFF
--- a/src/templates/page.hbs
+++ b/src/templates/page.hbs
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>{{ title }} - {{ section.name }}</title>
+  <title>{{ section.name }} — {{ title }}</title>
   <link rel="stylesheet" href="/ffe.css">
   <link rel="stylesheet" href="/styleguidist/styles.css">
   <link rel="shortcut icon" href="/assets/favicon.ico">

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -19,7 +19,7 @@ const PACKAGES_WITH_DEFAULT_EXPORT = [
 ];
 
 module.exports = {
-    title: 'FFE',
+    title: 'SpareBank 1 Designsystem',
     require: [
         'babel-polyfill',
         path.join(__dirname, 'packages/ffe-all.less'),

--- a/styleguide.content.js
+++ b/styleguide.content.js
@@ -12,7 +12,7 @@ module.exports = {
     styleguidistTemplate: 'src/templates/styleguidist.hbs',
     styleguidistDest: 'src/styleguidist.html',
     context: {
-        title: 'FFE',
+        title: 'SpareBank 1 Designsystem',
     },
     sections: [
         {


### PR DESCRIPTION
Fixes #170