### PR TITLE
feat(ffe-radio-button-react): value can be boolean

### DIFF
--- a/packages/ffe-radio-button-react/src/BaseRadioButton.js
+++ b/packages/ffe-radio-button-react/src/BaseRadioButton.js
@@ -1,6 +1,6 @@
 import React, { Component, Fragment } from 'react';
 import classNames from 'classnames';
-import { bool, node, oneOf, shape, string } from 'prop-types';
+import { bool, node, oneOf, oneOfType, shape, string } from 'prop-types';
 import uuid from 'uuid';
 
 import { Tooltip } from '@sb1/ffe-form-react';
@@ -73,13 +73,13 @@ BaseRadioButton.propTypes = {
     /** The name of the radio button */
     name: string.isRequired,
     /** The selected value of the radio button set */
-    selectedValue: string,
+    selectedValue: oneOfType([bool, string]),
     /** Tooltip providing further detail about the choice */
     tooltip: string,
     /** Additional props passed to the Tooltip component */
     tooltipProps: shape({}),
     /** The value of the radio button */
-    value: string.isRequired,
+    value: oneOfType([bool, string]).isRequired,
 };
 
 export default BaseRadioButton;

--- a/packages/ffe-radio-button-react/src/BaseRadioButton.spec.js
+++ b/packages/ffe-radio-button-react/src/BaseRadioButton.spec.js
@@ -36,6 +36,14 @@ describe('<BaseRadioButton />', () => {
         const wrapper = getWrapper({ checked: false, selectedValue: 'nope' });
         expect(wrapper.find('input').props()).toHaveProperty('checked', false);
     });
+    it('accepts boolean values and checks the input if it is selected', () => {
+        const wrapper = getWrapper({ selectedValue: true, value: true });
+        expect(wrapper.find('input').props()).toHaveProperty('checked', true);
+    });
+    it('accepts boolean values and does not check the input if it is not selected', () => {
+        const wrapper = getWrapper({ selectedValue: 'false', value: true });
+        expect(wrapper.find('input').props()).toHaveProperty('checked', false);
+    });
 
     describe('id', () => {
         it('is unique across instances', () => {

--- a/packages/ffe-radio-button-react/src/RadioSwitch.js
+++ b/packages/ffe-radio-button-react/src/RadioSwitch.js
@@ -1,5 +1,5 @@
 import React, { Fragment } from 'react';
-import { string } from 'prop-types';
+import { bool, oneOfType, string } from 'prop-types';
 import classNames from 'classnames';
 
 import BaseRadioButton from './BaseRadioButton';
@@ -40,11 +40,11 @@ RadioSwitch.propTypes = {
     /** The label of the choice to the left */
     leftLabel: string.isRequired,
     /** The value of the choice to the left */
-    leftValue: string.isRequired,
+    leftValue: oneOfType([bool, string]).isRequired,
     /** The label of the choice to the right */
     rightLabel: string.isRequired,
     /** The value of the choice to the right */
-    rightValue: string.isRequired,
+    rightValue: oneOfType([bool, string]).isRequired,
 };
 
 export default RadioSwitch;

--- a/packages/ffe-radio-button-react/src/RadioSwitch.md
+++ b/packages/ffe-radio-button-react/src/RadioSwitch.md
@@ -1,4 +1,4 @@
-Radiobrytere brukes når brukeren skal gjøre et binært valg - typisk i formen 
+Radiobrytere brukes når brukeren skal gjøre et binært valg - typisk i formen
 "ja eller nei", eller "av eller på".
 
 ```js
@@ -6,7 +6,7 @@ const { RadioButtonInputGroup } = require('.');
 
 initialState = { selected: undefined };
 
-<RadioButtonInputGroup 
+<RadioButtonInputGroup
     label="Vil bilen bli kjørt av sjåfører under 23 år?"
     tooltip="Unge sjåfører har en statistisk høyere sjanse for å bulke bilen."
     name="under23"
@@ -14,7 +14,7 @@ initialState = { selected: undefined };
     selectedValue={state.selected}
 >
     {inputProps => (
-        <RadioSwitch 
+        <RadioSwitch
             leftLabel="Ja"
             leftValue="true"
             rightLabel="Nei"

--- a/packages/ffe-radio-button-react/src/RadioSwitch.spec.js
+++ b/packages/ffe-radio-button-react/src/RadioSwitch.spec.js
@@ -5,7 +5,7 @@ import RadioSwitch from './RadioSwitch';
 
 const defaultProps = {
     leftLabel: 'Ja',
-    leftValue: 'ja',
+    leftValue: true,
     name: 'choice',
     rightLabel: 'Nei',
     rightValue: 'nei',


### PR DESCRIPTION
Changed the prop-types of `BaseRadioButton` to accept value and
selectedValue as either boolean or string.

This means, for instance, that when using `RadioSwitch` the consumer
can easier keep state values as booleans. This can help not falling
into the "truthy-trap" when later doing branch logic based on the
value provided to a radio-switch.

<!-- 
Thanks for opening a pull request! 🎉

If your changes include some kind of UI element, please attach a screenshot of 
how it looks.

Before submitting a pull request, please have a look through the CONTRIBUTING.md
document. TL;DR:

- Follow the conventional commit standard
- Write full, explanatory commit messages
- Follow our code standards
- Write tests where applicable
- Be courteous and respect our code of conduct
-->
