### PR TITLE
feat(ffe-buttons-react): add inline prop to ButtonGroup

### DIFF
--- a/packages/ffe-buttons-react/src/ButtonGroup.js
+++ b/packages/ffe-buttons-react/src/ButtonGroup.js
@@ -2,12 +2,13 @@ import React from 'react';
 import { bool, string } from 'prop-types';
 import classNames from 'classnames';
 
-const ButtonGroup = ({ className, thin, ...rest }) =>
+const ButtonGroup = ({ className, thin, inline, ...rest }) =>
     (
         <div
             className={classNames(
                 'ffe-button-group',
                 { 'ffe-button-group--thin': thin },
+                { 'ffe-button-group--inline': inline },
                 className
             )}
             {...rest}
@@ -19,6 +20,8 @@ ButtonGroup.propTypes = {
     className: string,
     /** Applies the thin modifier to remove margins */
     thin: bool,
+    /** Applies the inline modifier to make all child buttons inline */
+    inline: bool,
 };
 
 export default ButtonGroup;

--- a/packages/ffe-buttons-react/src/ButtonGroup.md
+++ b/packages/ffe-buttons-react/src/ButtonGroup.md
@@ -93,3 +93,50 @@ Det finnes også en tynnere variant.
     </ButtonGroup>
 </React.Fragment>
 ```
+
+Det finnes også en inline variant.
+
+```js
+<React.Fragment>
+    <ButtonGroup inline={true}>
+        <ActionButton>
+            Neste
+        </ActionButton>
+        <ActionButton element="a" href="#buttongroup">
+            Lenke
+        </ActionButton>
+        <SecondaryButton>
+            Avbryt
+        </SecondaryButton>
+        <SecondaryButton element="a" href="#buttongroup">
+            Lenke
+        </SecondaryButton>
+        <TertiaryButton>
+            Hopp over
+        </TertiaryButton>
+        <TertiaryButton element="a" href="#buttongroup">
+            Lenke
+        </TertiaryButton>
+    </ButtonGroup>
+    <ButtonGroup thin={true}>
+        <PrimaryButton>
+            Neste
+        </PrimaryButton>
+        <PrimaryButton element="a" href="#buttongroup">
+            Lenke
+        </PrimaryButton>
+        <SecondaryButton>
+            Avbryt
+        </SecondaryButton>
+        <SecondaryButton element="a" href="#buttongroup">
+            Lenke
+        </SecondaryButton>
+        <TertiaryButton>
+            Hopp over
+        </TertiaryButton>
+        <TertiaryButton element="a" href="#buttongroup">
+            Lenke
+        </TertiaryButton>
+    </ButtonGroup>
+</React.Fragment>
+```

--- a/packages/ffe-buttons-react/src/ButtonGroup.spec.js
+++ b/packages/ffe-buttons-react/src/ButtonGroup.spec.js
@@ -29,6 +29,13 @@ describe('<ButtonGroup />', () => {
         expect(wrapper.hasClass('ffe-button-group--thin')).toBe(true);
     });
 
+    it('applies the --inline modifier if inline is true', () => {
+        const wrapper = getWrapper({
+            inline: true,
+        });
+        expect(wrapper.hasClass('ffe-button-group--inline')).toBe(true);
+    });
+
     it('applies the given className prop', () => {
         const wrapper = getWrapper({
             className: 'my-class',


### PR DESCRIPTION
This commit adds prop `inline` to `ButtonGroup`. When set to `true` the
`--inline` modifier will be applied to the `ButtonGroup`.

Fixes #213 