### PR TITLE
fix(ffe-grid-react): remove warning when running tests

### DIFF
--- a/packages/ffe-grid-react/src/GridCol.spec.js
+++ b/packages/ffe-grid-react/src/GridCol.spec.js
@@ -95,13 +95,14 @@ describe('GridCol', () => {
             expect(el.hasClass(`ffe-grid__col--bg-${background}`)).toBe(true);
         });
     });
+
     it('does not set background color class if not valid', () => {
-        const illegalBackgroundColors = ['ice-cream', 'console.log("hack")', '123456'];
+        const illegalBackgroundColors = ['ice-cream', 'log("hack")', '123456'];
         illegalBackgroundColors.forEach(background => {
             const el = renderShallow({ background });
             expect(el.hasClass(`ffe-grid__col--bg-${background}`)).toBe(false);
         });
-    })
+    });
 
     it('sets all the things o/', () => {
         const el = renderShallow({


### PR DESCRIPTION
This commit removes a console warning when running tests.

```
console.warn node_modules/enzyme/build/ShallowWrapper.js:1237
  It looks like you're calling `ShallowWrapper::hasClass()` with a CSS selector. hasClass() expects a class name, not a CSS selector.
```

This warning was caused by the period/dot in the array `illegalBackgroundColors`.