### PR TITLE
feat(ffe-radio-button-react): value can be boolean

### DIFF
--- a/packages/ffe-radio-button-react/src/RadioButtonInputGroup.js
+++ b/packages/ffe-radio-button-react/src/RadioButtonInputGroup.js
@@ -88,7 +88,7 @@ RadioButtonInputGroup.propTypes = {
     /** Change handler, receives value of selected radio button */
     onChange: func,
     /** The currently selected value */
-    selectedValue: string,
+    selectedValue: oneOfType([bool, string]),
     /**
      * String or Tooltip component with further detail about the radio button
      * set


### PR DESCRIPTION
Since support for boolean value was added to `RadioSwitch` it was
now time to also support it in the `RadioButtonInputGroup` we tend
to wrap those in.

<!-- 
Thanks for opening a pull request! 🎉

If your changes include some kind of UI element, please attach a screenshot of 
how it looks.

Before submitting a pull request, please have a look through the CONTRIBUTING.md
document. TL;DR:

- Follow the conventional commit standard
- Write full, explanatory commit messages
- Follow our code standards
- Write tests where applicable
- Be courteous and respect our code of conduct
-->
