### PR TITLE
fix: fix intro paragraph background color

### DIFF
--- a/src/styles/styles.less
+++ b/src/styles/styles.less
@@ -75,9 +75,8 @@
 
     &__heading,
     &__paragraph {
-        background: @ffe-blue-cobalt;
-
         @media screen and (min-width: @breakpoint-lg) {
+            background: @ffe-blue-cobalt;
             color: @ffe-white;
         }
     }
@@ -142,9 +141,8 @@
     }
 
     &__h1 {
-        background: @ffe-blue-cobalt;
-
         @media screen and (min-width: @breakpoint-lg) {
+            background: @ffe-blue-cobalt;
             color: @ffe-white;
         }
     }


### PR DESCRIPTION
Fixes a bug in which the intro paragraph in static pages in the styleguide would have the wrong background color on small screens.

![image](https://user-images.githubusercontent.com/463847/39430536-5fbe7f66-4c8e-11e8-8f48-440fc05b29c8.png)
