### PR TITLE
chore(ffe-core): remove residual static resource property

### DIFF
--- a/packages/ffe-core/package.json
+++ b/packages/ffe-core/package.json
@@ -21,8 +21,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "sb1.StaticResources": [
-    "fonts/**"
-  ]
+  }
 }


### PR DESCRIPTION
This commit removes the residual `package.json` property
`sb1.StaticResources`. This property pointed to the fonts folder, which
was removed in a breaking change of version 12.0.0.

Because the folder is already gone, this property currently has no effect,
and thus removing it should not be a problem.