### PR TITLE
build(ffe-icons): create destination directory if needed

### DIFF
--- a/packages/ffe-icons/bin/build.js
+++ b/packages/ffe-icons/bin/build.js
@@ -4,6 +4,7 @@
 const fs = require('fs');
 const path = require('path');
 const svgstore = require('svgstore');
+const mkdirp = require('mkdirp');
 
 const ICONS_PATH = path.join(__dirname, '..', 'icons');
 
@@ -55,6 +56,8 @@ if (options.projectIcons) {
             sprite.add(iconName, fs.readFileSync(iconPath), 'utf-8');
         });
 }
+
+mkdirp.sync(options.dest);
 
 fs.writeFileSync(
     path.join(options.dest, 'ffe-icons.svg'),

--- a/packages/ffe-icons/package.json
+++ b/packages/ffe-icons/package.json
@@ -20,6 +20,7 @@
     "test": "npm run lint"
   },
   "dependencies": {
+    "mkdirp": "^0.5.1",
     "svgstore": "^2.0.3",
     "yargs": "^6.5.0"
   },


### PR DESCRIPTION
This commit makes `ffe-icons` able to create destination directory when
building icons, if it is missing.