### PR TITLE
fix(ffe-buttons): fix ghost action transitions

### DIFF
--- a/packages/ffe-buttons-react/src/ButtonGroup.md
+++ b/packages/ffe-buttons-react/src/ButtonGroup.md
@@ -118,7 +118,7 @@ Det finnes også en inline variant.
             Lenke
         </TertiaryButton>
     </ButtonGroup>
-    <ButtonGroup thin={true}>
+    <ButtonGroup inline={true}>
         <PrimaryButton>
             Neste
         </PrimaryButton>

--- a/packages/ffe-buttons/less/base-button.less
+++ b/packages/ffe-buttons/less/base-button.less
@@ -204,7 +204,7 @@
 .ffe-button__label {
     align-items: center;
     display: flex;
-    transition: all @ffe-transition-duration @ffe-ease;
+    transition: transform @ffe-transition-duration @ffe-ease;
     .ffe-button--loading & {
         transform: translateY(-32px);
     }


### PR DESCRIPTION
This commit fixes the odd transitions of the ghost action button. As far
    as I can tell, the only transition needed on the button label is the one
    for transforms. Other transitions (background and color) is handled by
    the actual button element.
    
I don't fully understand why this happened. It seems when you have an
    element with `transition: all` and a child element with the same
    transition styling, and you change color and background of the parent
    element, the background of the parent will transition first, and then the
    child element transition will run.
    This is just my theory, so don't consider it the truth of css transitions.

This PR also includes the tiny, insignificant fix:
fix(ffe-buttons-react): fix using wrong property in docs
    
Fixes #223