### PR TITLE
fix(ffe-buttons): margin on left and right inline button icon

### DIFF
--- a/packages/ffe-buttons/less/inline-base-button.less
+++ b/packages/ffe-buttons/less/inline-base-button.less
@@ -98,10 +98,10 @@
     }
 }
 
-.ffe-inline-button--left {
+.ffe-inline-button__icon--left {
     margin-right: 6px;
 }
 
-.ffe-inline-button--right {
+.ffe-inline-button__icon--right {
     margin-left: 6px;
 }


### PR DESCRIPTION
This commit fixes a visual bug that was introduced during an earlier
refactor of ffe-buttons in revision 13a3af5.

Fixes #229 