### PR TITLE
fix(ffe-form): fix placeholder color for input field

### DIFF
--- a/packages/ffe-form/less/input-field.less
+++ b/packages/ffe-form/less/input-field.less
@@ -66,4 +66,8 @@
     &::-ms-clear {
         display: none;
     }
+
+    &::placeholder {
+        color: @ffe-grey-charcoal;
+    }
 }


### PR DESCRIPTION
This commit adds a `::placeholder` modifier to `.ffe-input-field`.
This is necessary for IE, as IE uses the input field color as placeholder
color.