### PR TITLE
Update colors and color docs

### DIFF
--- a/packages/ffe-core/less/colors.less
+++ b/packages/ffe-core/less/colors.less
@@ -2,10 +2,9 @@
 @ffe-blue-royal: #002776; // Titles, lead, overlays
 @ffe-blue-cobalt: #005AA4; // Primary buttons, emphasis on blue areas and product cards
 @ffe-blue-azure: #0071CD; // Secondary buttons
-@ffe-blue-deep-sky: #008ED2; // Anchor, text on ffe-white buttons, active radio buttons
 @ffe-blue-sky: #7FC6E8;
-@ffe-blue-pale: #DFF1F9; // ~20% opacity of ffe-blue-deep-sky. (Info-boxes, etc.)
-@ffe-blue-ice: #EFF8FC; // ~10% opacity of ffe-blue-deep-sky. (Expandable table rows)
+@ffe-blue-pale: #DFF1F9; // Info-boxes, etc.
+@ffe-blue-ice: #EFF8FC; // Expandable table rows
 @ffe-blue-focus: fade(#44C0FF, 50%); // Focus on buttons and controls
 
 // Green
@@ -28,7 +27,6 @@
 
 // Beige
 @ffe-sand: #F8F5EB; // @ffe-sand + @ffe-sand-25
-@ffe-sand-ivory: #FBFAF5;
 
 // White
 @ffe-white: #FFF;
@@ -38,6 +36,11 @@
 @ffe-grey-cloud: #F4F4F4; // Background panels
 @ffe-grey-silver: #CCC; // Lines, borders, inactive tool elements (slider, etc.)
 @ffe-grey-charcoal: #676767;
+@ffe-grey-warm: #F6F6F3;
 
 // Black
 @ffe-black: #262626; // Body text, and some other texts
+
+// Deprecated
+@ffe-blue-deep-sky: #008ED2; // Deprecated 05.2018
+@ffe-sand-ivory: #FBFAF5; // Deprecated 05.2018

--- a/packages/ffe-core/less/colors.less
+++ b/packages/ffe-core/less/colors.less
@@ -42,5 +42,5 @@
 @ffe-black: #262626; // Body text, and some other texts
 
 // Deprecated
-@ffe-blue-deep-sky: #008ED2; // Deprecated 05.2018
-@ffe-sand-ivory: #FBFAF5; // Deprecated 05.2018
+@ffe-blue-deep-sky: #008ED2; // Deprecated 05.2018 - Use @ffe-blue-azure in stead
+@ffe-sand-ivory: #FBFAF5; // Deprecated 05.2018 - Use @ffe-sand or @ffe-grey-warm in stead

--- a/src/assets/sds.js
+++ b/src/assets/sds.js
@@ -19,6 +19,24 @@
     }
 })();
 
+const toggleColorSection = document.querySelectorAll('.sb1ds-color-toggle');
+[].forEach.call(toggleColorSection, function(toggleColor) {
+    toggleColor.addEventListener('click', function(evt) {
+        if (!toggleColor.classList.contains('ffe-tab-button--selected')) {
+            var sectionId = toggleColor.id;
+            var section = document.querySelector('.'+sectionId);
+            var otherSectionBtn = document.querySelector('.sb1ds-color-toggle.ffe-tab-button--selected');
+            var otherSectionId = otherSectionBtn.id;
+            var otherSection = document.querySelector('.'+otherSectionId);
+
+            toggleColor.classList.add('ffe-tab-button--selected');
+            section.classList.add('sb1ds-color-section--active');
+            otherSectionBtn.classList.remove('ffe-tab-button--selected');
+            otherSection.classList.remove('sb1ds-color-section--active');
+        }
+    });
+});
+
 const togglePlay = document.querySelectorAll('.sb1ds-svgcontainer');
 [].forEach.call(togglePlay, function(play) {
     play.addEventListener('click', function(evt) {

--- a/src/styles/examples/color.less
+++ b/src/styles/examples/color.less
@@ -10,121 +10,168 @@
         align-items: center;
         padding: 10px 20px;
         color: @ffe-white;
+    }
+}
 
-        &--ffe-blue-royal {
-            background: @ffe-blue-royal;
+.sb1ds-color-section:not(.sb1ds-color-section--active) {
+    display: none;
+}
+
+.sb1ds-color-usage {
+    &__example {
+        display: inline-block;
+        width: 30px;
+        height: 30px;
+        border-radius: 50%;
+    }
+
+    &__table {
+        tr {
+            border-bottom: 1px solid @ffe-grey-silver;
         }
 
-        &--ffe-blue-cobalt {
-            background: @ffe-blue-cobalt;
+        td {
+            vertical-align: top;
         }
+    }
 
-        &--ffe-blue-azure {
-            background: @ffe-blue-azure;
-        }
+    &__list {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+    }
 
-        &--ffe-blue-deep-sky {
-            background: @ffe-blue-deep-sky;
-        }
+    &__illustration {
+        margin-bottom: 40px;
 
-        &--ffe-blue-sky {
-            background: @ffe-blue-sky;
-            color: @ffe-black;
+        svg {
+            max-width: 600px;
         }
+    }
+}
 
-        &--ffe-blue-focus {
-            background: @ffe-blue-focus;
-            color: @ffe-black;
-        }
+.sb1ds-color-palette__item,
+.sb1ds-color-usage__example {
+    border: 1px solid transparent;
 
-        &--ffe-blue-pale {
-            background: @ffe-blue-pale;
-            color: @ffe-black;
-        }
+    &--ffe-blue-royal {
+        background: @ffe-blue-royal;
+    }
 
-        &--ffe-blue-ice {
-            background: @ffe-blue-ice;
-            color: @ffe-black;
-        }
+    &--ffe-blue-cobalt {
+        background: @ffe-blue-cobalt;
+    }
 
-        &--ffe-green-shamrock {
-            background: @ffe-green-shamrock;
-        }
+    &--ffe-blue-azure {
+        background: @ffe-blue-azure;
+    }
 
-        &--ffe-sand {
-            background: @ffe-sand;
-            color: @ffe-black;
-        }
+    &--ffe-blue-deep-sky {
+        background: @ffe-blue-deep-sky;
+    }
 
-        &--ffe-sand-ivory {
-            background: @ffe-sand-ivory;
-            color: @ffe-black;
-        }
+    &--ffe-blue-sky {
+        background: @ffe-blue-sky;
+        color: @ffe-black;
+    }
 
-        &--ffe-orange-fire {
-            background: @ffe-orange-fire;
-        }
+    &--ffe-blue-focus {
+        background: @ffe-blue-focus;
+        color: @ffe-black;
+    }
 
-        &--ffe-orange {
-            background: @ffe-orange;
-        }
+    &--ffe-blue-pale {
+        background: @ffe-blue-pale;
+        color: @ffe-black;
+    }
 
-        &--ffe-orange-salmon {
-            background: @ffe-orange-salmon;
-            color: @ffe-black;
-        }
+    &--ffe-blue-ice {
+        background: @ffe-blue-ice;
+        color: @ffe-black;
+    }
 
-        &--ffe-black {
-            background: @ffe-black;
-        }
+    &--ffe-green-shamrock {
+        background: @ffe-green-shamrock;
+    }
 
-        &--ffe-grey-charcoal {
-            background: @ffe-grey-charcoal;
-        }
+    &--ffe-sand {
+        background: @ffe-sand;
+        color: @ffe-black;
+    }
 
-        &--ffe-grey {
-            background: @ffe-grey;
-        }
+    &--ffe-sand-ivory {
+        background: @ffe-sand-ivory;
+        color: @ffe-black;
+    }
 
-        &--ffe-grey-silver {
-            background: @ffe-grey-silver;
-            color: @ffe-black;
-        }
+    &--ffe-orange-fire {
+        background: @ffe-orange-fire;
+    }
 
-        &--ffe-grey-cloud {
-            background: @ffe-grey-cloud;
-            color: @ffe-black;
-        }
+    &--ffe-orange {
+        background: @ffe-orange;
+    }
 
-        &--ffe-white {
-            background: @ffe-white;
-            color: @ffe-black;
-            border: 1px solid @ffe-grey-silver;
-        }
+    &--ffe-orange-salmon {
+        background: @ffe-orange-salmon;
+        color: @ffe-black;
+    }
 
-        &--ffe-green {
-            background: @ffe-green;
-        }
+    &--ffe-black {
+        background: @ffe-black;
+    }
 
-        &--ffe-green-emerald {
-            background: @ffe-green-emerald;
-        }
+    &--ffe-grey-charcoal {
+        background: @ffe-grey-charcoal;
+    }
 
-        &--ffe-green-mint {
-            background: @ffe-green-mint;
-            color: @ffe-black;
-        }
+    &--ffe-grey-warm {
+        background: @ffe-grey-warm;
+        color: @ffe-black;
+    }
 
-        &--ffe-purple {
-            background: @ffe-purple;
-        }
+    &--ffe-grey {
+        background: @ffe-grey;
+    }
 
-        &--ffe-purple-magenta {
-            background: @ffe-purple-magenta;
-        }
+    &--ffe-grey-silver {
+        background: @ffe-grey-silver;
+        color: @ffe-black;
+    }
 
-        &--ffe-red {
-            background: @ffe-red;
-        }
+    &--ffe-grey-cloud {
+        background: @ffe-grey-cloud;
+        color: @ffe-black;
+    }
+
+    &--ffe-white {
+        background: @ffe-white;
+        color: @ffe-black;
+        border: 1px solid @ffe-grey-silver;
+    }
+
+    &--ffe-green {
+        background: @ffe-green;
+    }
+
+    &--ffe-green-emerald {
+        background: @ffe-green-emerald;
+    }
+
+    &--ffe-green-mint {
+        background: @ffe-green-mint;
+        color: @ffe-black;
+    }
+
+    &--ffe-purple {
+        background: @ffe-purple;
+    }
+
+    &--ffe-purple-magenta {
+        background: @ffe-purple-magenta;
+    }
+
+    &--ffe-red {
+        background: @ffe-red;
     }
 }

--- a/styleguide-content/visuell-identitet/farger.md
+++ b/styleguide-content/visuell-identitet/farger.md
@@ -1,140 +1,637 @@
-Blå er vår hovedfarge. For å være en tydelig utfordrer i markedet må vi være lette å kjenne igjen.
+<div class="ffe-tab-button-group" role="group">
+    <button class="ffe-tab-button sb1ds-color-toggle ffe-tab-button--selected" id="sb1ds-color-overview">Oversikt</button>
+    <button class="ffe-tab-button sb1ds-color-toggle" id="sb1ds-color-usage">Bruksområder</button>
+</div>
 
-Vi har 2 hovedfarger: **Blue Royal** og **Blue Cobalt**. En blå signatur skal være gjennomgående i vår visuelle profil og er en sterk bærer av SpareBank 1 sin visuelle identitet.  I digitale flater skal disse blå fargene balanseres med et lysere uttrykk for at løsningene skal være intuitive for brukeren.
-
-* Gi en tydelig SpareBank 1 signatur, være bærer av merkevarens verdier
-* Skape oppmerksomhet og fokus
-* Gruppering av informasjon
-* Tilføre varme og vennlighet
-
-
-### Hovedfarger
-
-<ul class="sb1ds-color-palette">
-    <li class="sb1ds-color-palette__item sb1ds-color-palette__item--ffe-blue-royal">
-        <div>Blue Royal</div>
-        <div>#002776<br/>@ffe-blue-royal</div>
-    </li>
-    <li class="sb1ds-color-palette__item sb1ds-color-palette__item--ffe-blue-cobalt">
-        <div>Blue Cobalt</div>
-        <div>#005AA4<br/>@ffe-blue-cobalt</div>
-    </li>
-</ul>
-
-### Støttefarger
-
-<ul class="sb1ds-color-palette">
-    <li class="sb1ds-color-palette__item sb1ds-color-palette__item--ffe-blue-azure">
-        <div>Blue Azure</div>
-        <div>#0071CD<br/>@ffe-blue-azure</div>
-    </li>
-    <li class="sb1ds-color-palette__item sb1ds-color-palette__item--ffe-purple-magenta">
-        <div>Purple Magenta</div>
-        <div>#A20076<br/>@ffe-purple-magenta</div>
-    </li>
-    <li class="sb1ds-color-palette__item sb1ds-color-palette__item--ffe-orange">
-        <div>Orange</div>
-        <div>#FF9100<br/>@ffe-orange</div>
-    </li>
-    <li class="sb1ds-color-palette__item sb1ds-color-palette__item--ffe-green-shamrock">
-        <div>Green Shamrock</div>
-        <div>#008A00<br/>@ffe-green-shamrock</div>
-    </li>
-</ul>
-
-<ul class="sb1ds-color-palette">
-    <li class="sb1ds-color-palette__item sb1ds-color-palette__item--ffe-sand">
-        <div>Sand</div>
-        <div>#F8F5EB<br/>@ffe-sand</div>
-    </li>
-    <li class="sb1ds-color-palette__item sb1ds-color-palette__item--ffe-blue-pale">
-        <div>Blue Pale</div>
-        <div>#DFF1F9<br/>@ffe-blue-pale</div>
-    </li>
-    <li class="sb1ds-color-palette__item sb1ds-color-palette__item--ffe-green-mint">
-        <div>Green Mint</div>
-        <div>#E1F4E3<br/>@ffe-green-mint</div>
-    </li>
-    <li class="sb1ds-color-palette__item sb1ds-color-palette__item--ffe-orange-salmon">
-        <div>Orange Salmon</div>
-        <div>#F3BBAA<br/>@ffe-orange-salmon</div>
-    </li>
-</ul>
-
-### Nøytrale farger
-
-<ul class="sb1ds-color-palette">
-    <li class="sb1ds-color-palette__item sb1ds-color-palette__item--ffe-black">
-        <div>Black</div>
-        <div>#262626<br/>@ffe-black</div>
-    </li>
-    <li class="sb1ds-color-palette__item sb1ds-color-palette__item--ffe-grey-charcoal">
-        <div>Grey Charcoal</div>
-        <div>#676767<br/>@ffe-grey-charcoal</div>
-    </li>
-    <li class="sb1ds-color-palette__item sb1ds-color-palette__item--ffe-grey">
-        <div>Grey</div>
-        <div>#ADADAD<br/>@ffe-grey</div>
-    </li>
-    <li class="sb1ds-color-palette__item sb1ds-color-palette__item--ffe-grey-silver">
-        <div>Grey Silver</div>
-        <div>#CCCCCC<br/>@ffe-grey-silver</div>
-    </li>
-    <li class="sb1ds-color-palette__item sb1ds-color-palette__item--ffe-grey-cloud">
-        <div>Grey Cloud</div>
-        <div>#F4F4F4<br/>@ffe-grey-cloud</div>
-    </li>
-    <li class="sb1ds-color-palette__item sb1ds-color-palette__item--ffe-white">
-        <div>White</div>
-        <div>#FFFFFF<br/>@ffe-white</div>
-    </li>
-</ul>
-
-### Røkla
-
+<div class="sb1ds-color-overview sb1ds-color-section sb1ds-color-section--active">
+    <p class="ffe-lead-paragraph">
+        Det er utviklet en egen fargepalett for det digitale rammeverket. Fargepaletten er basert på SpareBank 1 sin visuelle identitet og skal være med på å bidra til en konsistent opplevelse på tvers av alle digitale flater.
+    </p>
+    <h4 class="ffe-h4">Hovedfarger</h4>
+    <p>
+        En blå signatur skal være gjennomgående i vår visuelle profil og er en sterk bærer av SpareBank 1 sin visuelle identitet. Blåfargene balanseres med et lysere uttrykk for at løsningene skal være intuitive for brukeren.
+    </p>
+    <ul class="sb1ds-color-palette">
+        <li class="sb1ds-color-palette__item sb1ds-color-palette__item--ffe-blue-royal">
+            <div>Royal blå</div>
+            <div>#002776<br/>@ffe-blue-royal</div>
+        </li>
+        <li class="sb1ds-color-palette__item sb1ds-color-palette__item--ffe-blue-cobalt">
+            <div>Hovedblå</div>
+            <div>#005AA4<br/>@ffe-blue-cobalt</div>
+        </li>
+    </ul>
+    <h4 class="ffe-h4">Støttefarger</h4>
+    <p>
+        Sekundærpalettene består av varme komplementærfarger og skal benyttes for å gi varme til et uttrykk, fange noens oppmerksomhet eller motivere. Være forsiktig når du bruker støttefargene, husk at blå alltid spiller hovedrollen!
+    </p>
+    <h5 class="ffe-h5">Støttefarger GUI</h5>
+    <ul class="sb1ds-color-palette">
+        <li class="sb1ds-color-palette__item sb1ds-color-palette__item--ffe-blue-azure">
+            <div>Mellomblå</div>
+            <div>#0071CD<br/>@ffe-blue-azure</div>
+        </li>
+        <li class="sb1ds-color-palette__item sb1ds-color-palette__item--ffe-blue-focus">
+            <div>Fokusblå</div>
+            <div>#44C0FF<br/>@ffe-blue-focus</div>
+        </li>
+        <li class="sb1ds-color-palette__item sb1ds-color-palette__item--ffe-green-shamrock">
+            <div>Grønn WCAG</div>
+            <div>#008A00<br/>@ffe-green-shamrock</div>
+        </li>
+        <li class="sb1ds-color-palette__item sb1ds-color-palette__item--ffe-green-emerald">
+            <div>Grønn Hover</div>
+            <div>#007B00<br/>@ffe-green-emerald</div>
+        </li>
+    </ul>
+    <h4 class="ffe-h5">Støttefarger visuell identitet</h5>
+    <ul class="sb1ds-color-palette">
+        <li class="sb1ds-color-palette__item sb1ds-color-palette__item--ffe-purple">
+            <div>Lilla</div>
+            <div>#C94096<br/>@ffe-purple</div>
+        </li>
+        <li class="sb1ds-color-palette__item sb1ds-color-palette__item--ffe-purple-magenta">
+            <div>Lilla WCAG</div>
+            <div>#A20076<br/>@ffe-purple-magenta</div>
+        </li>
+        <li class="sb1ds-color-palette__item sb1ds-color-palette__item--ffe-orange">
+            <div>Oransje</div>
+            <div>#FF9100<br/>@ffe-orange</div>
+        </li>
+        <li class="sb1ds-color-palette__item sb1ds-color-palette__item--ffe-orange-fire">
+            <div>Oransje WCAG</div>
+            <div>#DA3D00<br/>@ffe-orange-fire</div>
+        </li>
+        <li class="sb1ds-color-palette__item sb1ds-color-palette__item--ffe-green">
+            <div>Grønn</div>
+            <div>#37B441<br/>@ffe-green</div>
+        </li>
+    </ul>
+    <h4 class="ffe-h4">Bakgrunnsfarger</h4>
+    <p>
+        Hovedbakgrunnsfargen i rammeverket til SpareBank 1 er hvit. Den subtile tertiærpaletten benyttes til differensiering og gruppering av innhold. Spekteret imellom kan benyttes for å gi en komplett og fleksibel palett for digitale flater.
+    </p>
+    <h5 class="ffe-h5">Bakgrunnsfarger GUI</h5>
+    <ul class="sb1ds-color-palette">
+        <li class="sb1ds-color-palette__item sb1ds-color-palette__item--ffe-white">
+            <div>Hvit</div>
+            <div>#FFFFFF<br/>@ffe-white</div>
+        </li>
+        <li class="sb1ds-color-palette__item sb1ds-color-palette__item--ffe-grey-warm">
+            <div>Lys varm grå</div>
+            <div>#F6F6F3<br/>@ffe-grey-warm</div>
+        </li>
+        <li class="sb1ds-color-palette__item sb1ds-color-palette__item--ffe-sand">
+            <div>Sand</div>
+            <div>#F8F5EB<br/>@ffe-sand</div>
+        </li>
+        <li class="sb1ds-color-palette__item sb1ds-color-palette__item--ffe-green-mint">
+            <div>Lys grønn</div>
+            <div>#E1F4E3<br/>@ffe-green-mint</div>
+        </li>
+        <li class="sb1ds-color-palette__item sb1ds-color-palette__item--ffe-blue-pale">
+            <div>Lys blå</div>
+            <div>#DFF1F9<br/>@ffe-blue-pale</div>
+        </li>
+        <li class="sb1ds-color-palette__item sb1ds-color-palette__item--ffe-orange-salmon">
+            <div>Lys oransje</div>
+            <div>#F3BBAA<br/>@ffe-orange-salmon</div>
+        </li>
+        <li class="sb1ds-color-palette__item sb1ds-color-palette__item--ffe-red">
+            <div>Rød</div>
+            <div>#E60000<br/>@ffe-red</div>
+        </li>
+    </ul>
+    <h5 class="ffe-h5">Bakgrunnsfarger tabeller</h5>
+    <ul class="sb1ds-color-palette">
+        <li class="sb1ds-color-palette__item sb1ds-color-palette__item--ffe-blue-sky">
+            <div>Himmelblå (Accordion)</div>
+            <div>#7FC6E8<br/>@ffe-blue-sky</div>
+        </li>
+        <li class="sb1ds-color-palette__item sb1ds-color-palette__item--ffe-blue-pale">
+            <div>Lys blå (Hover/markering)</div>
+            <div>#DFF1F9<br/>@ffe-blue-pale</div>
+        </li>
+        <li class="sb1ds-color-palette__item sb1ds-color-palette__item--ffe-blue-ice">
+            <div>Isblå (Hover)</div>
+            <div>#EFF8FC<br/>@ffe-blue-ice</div>
+        </li>
+    </ul>
+    <h4 class="ffe-h4">Nøytrale farger</h4>
+    <ul class="sb1ds-color-palette">
+        <li class="sb1ds-color-palette__item sb1ds-color-palette__item--ffe-black">
+            <div>Sort</div>
+            <div>#262626<br/>@ffe-black</div>
+        </li>
+        <li class="sb1ds-color-palette__item sb1ds-color-palette__item--ffe-grey-charcoal">
+            <div>Koksgrå</div>
+            <div>#676767<br/>@ffe-grey-charcoal</div>
+        </li>
+        <li class="sb1ds-color-palette__item sb1ds-color-palette__item--ffe-grey">
+            <div>Grå</div>
+            <div>#ADADAD<br/>@ffe-grey</div>
+        </li>
+        <li class="sb1ds-color-palette__item sb1ds-color-palette__item--ffe-grey-silver">
+            <div>Sølvgrå</div>
+            <div>#CCCCCC<br/>@ffe-grey-silver</div>
+        </li>
+        <li class="sb1ds-color-palette__item sb1ds-color-palette__item--ffe-grey-cloud">
+            <div>Skygrå</div>
+            <div>#F4F4F4<br/>@ffe-grey-cloud</div>
+        </li>
+        <li class="sb1ds-color-palette__item sb1ds-color-palette__item--ffe-white">
+            <div>Hvit</div>
+            <div>#FFFFFF<br/>@ffe-white</div>
+        </li>
+    </ul>
+<!-- ### Deprecated
 <ul class="sb1ds-color-palette">
     <li class="sb1ds-color-palette__item sb1ds-color-palette__item--ffe-blue-deep-sky">
-        <div>Blue Deep Sky</div>
+        <div>Dyp himmelblå</div>
         <div>#008ED2<br/>@ffe-blue-deep-sky</div>
-    </li>
-    <li class="sb1ds-color-palette__item sb1ds-color-palette__item--ffe-blue-sky">
-        <div>Blue Sky</div>
-        <div>#7FC6E8<br/>@ffe-blue-sky</div>
-    </li>
-    <li class="sb1ds-color-palette__item sb1ds-color-palette__item--ffe-blue-focus">
-        <div>Blue Focus</div>
-        <div>#44C0FF<br/>@ffe-blue-focus</div>
-    </li>
-    <li class="sb1ds-color-palette__item sb1ds-color-palette__item--ffe-blue-pale">
-        <div>Blue Pale</div>
-        <div>#DFF1F9<br/>@ffe-blue-pale</div>
-    </li>
-    <li class="sb1ds-color-palette__item sb1ds-color-palette__item--ffe-blue-ice">
-        <div>Blue Ice</div>
-        <div>#EFF8FC<br/>@ffe-blue-ice</div>
-    </li>
-    <li class="sb1ds-color-palette__item sb1ds-color-palette__item--ffe-green-emerald">
-        <div>Green Emerald</div>
-        <div>#007B00<br/>@ffe-green-emerald</div>
-    </li>
-        <li class="sb1ds-color-palette__item sb1ds-color-palette__item--ffe-green">
-        <div>Green</div>
-        <div>#37B441<br/>@ffe-green</div>
-    </li>
-    <li class="sb1ds-color-palette__item sb1ds-color-palette__item--ffe-red">
-        <div>Red</div>
-        <div>#E60000<br/>@ffe-red</div>
-    </li>
-    <li class="sb1ds-color-palette__item sb1ds-color-palette__item--ffe-orange-fire">
-        <div>Orange Fire</div>
-        <div>#DA3D00<br/>@ffe-orange-fire</div>
-    </li>
-    <li class="sb1ds-color-palette__item sb1ds-color-palette__item--ffe-purple">
-        <div>Purple</div>
-        <div>#C94096<br/>@ffe-purple</div>
     </li>
     <li class="sb1ds-color-palette__item sb1ds-color-palette__item--ffe-sand-ivory">
         <div>Sand Ivory</div>
         <div>#FBFAF5<br/>@ffe-sand-ivory</div>
     </li>
-</ul>
+</ul> -->
+</div>
+
+<div class="sb1ds-color-usage sb1ds-color-section">
+    <h4 class="ffe-h4">Vekting</h4>
+    <div class="sb1ds-color-usage__illustration">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 620 368">
+            <g fill="none" fill-rule="evenodd">
+                <path fill="#005AA4" d="M0 124h248.085368v120H0z"/>
+                <path fill="#F4F2EA" d="M0 248h290v120H0z"/>
+                <path fill="#DFF1F9" d="M0 0h130v120H0z"/>
+                <path fill="#E1F4E3" d="M134 0h55v120h-55z"/>
+                <path fill="#F8D7CC" d="M193 0h55v120h-55z"/>
+                <path fill="#F4F4F4" d="M252 0h55v120h-55z"/>
+                <path fill="#FFF" stroke="#CCC" d="M294.5 248.5h325v119h-325z"/>
+                <path fill="#002776" d="M252 124h120v120H252z"/>
+                <path fill="#0071CD" d="M376 124h84v120h-84z"/>
+                <path fill="#008A00" d="M464 124h34v120h-34z"/>
+                <path fill="#DA3D00" d="M502 124h30v120h-30z"/>
+                <path fill="#FF9100" d="M536 124h30v120h-30z"/>
+                <path fill="#C94096" d="M570 124h30v120h-30z"/>
+                <path fill="#000" d="M604 124h16v120h-16z"/>
+            </g>
+        </svg>
+    </div>
+    <h4 class="ffe-h4">Bruksområder</h4>
+    <table class="ffe-table sb1ds-color-usage__table">
+        <tr class="ffe-table__row">
+            <th class="ffe-table__heading" scope="col">Farge</th>
+            <th class="ffe-table__heading" scope="col">Bruksområde</th>
+            <th class="ffe-table__heading" scope="col" colspan="2">Verdi</th>
+        </tr>
+        <tr class="ffe-table__row">
+            <td class="ffe-table__cell">Royal blå</td>
+            <td class="ffe-table__cell">
+                <ul class="sb1ds-color-usage__list">
+                    <li class="ffe-strong-text">Hovedfarge</li>
+                    <li>Overskrifter</li>
+                    <li>Ikonfarge</li>
+                    <li>Valgte/aktive states</li>
+                </ul>
+            </td>
+            <td class="ffe-table__cell">
+                <ul class="sb1ds-color-usage__list">
+                    <li>#002776</li>
+                    <li>@ffe-blue-royal</li>
+                </ul>
+            </td>
+            <td class="ffe-table__cell">
+                <span class="sb1ds-color-usage__example sb1ds-color-usage__example--ffe-blue-royal"></span>
+            </td>
+        </tr>
+        <tr class="ffe-table__row">
+            <td class="ffe-table__cell">Hovedblå</td>
+            <td class="ffe-table__cell">
+                <ul class="sb1ds-color-usage__list">
+                    <li class="ffe-strong-text">Hovedfarge</li>
+                </ul>
+            </td>
+            <td class="ffe-table__cell">
+                <ul class="sb1ds-color-usage__list">
+                    <li>#005AA4</li>
+                    <li>@ffe-blue-cobalt</li>
+                </ul>
+            </td>
+            <td class="ffe-table__cell">
+                <span class="sb1ds-color-usage__example sb1ds-color-usage__example--ffe-blue-cobalt"></span>
+            </td>
+        </tr>
+        <tr class="ffe-table__row">
+            <td class="ffe-table__cell">Mellomblå</td>
+            <td class="ffe-table__cell">
+                <ul class="sb1ds-color-usage__list">
+                    <li class="ffe-strong-text">Støttefarge</li>
+                    <li>Bakgrunnsfarge</li>
+                    <li>Hover state</li>
+                    <li>Lenkefarge</li>
+                </ul>
+            </td>
+            <td class="ffe-table__cell">
+                <ul class="sb1ds-color-usage__list">
+                    <li>#0071CD</li>
+                    <li>@ffe-blue-azure</li>
+                </ul>
+            </td>
+            <td class="ffe-table__cell">
+                <span class="sb1ds-color-usage__example sb1ds-color-usage__example--ffe-blue-azure"></span>
+            </td>
+        </tr>
+        <tr class="ffe-table__row">
+            <td class="ffe-table__cell">Fokusblå</td>
+            <td class="ffe-table__cell">
+                <ul class="sb1ds-color-usage__list">
+                    <li class="ffe-strong-text">Støttefarge</li>
+                    <li>Fokus state, knapper og skjemafelter</li>
+                </ul>
+            </td>
+            <td class="ffe-table__cell">
+                <ul class="sb1ds-color-usage__list">
+                    <li>#44C0FF</li>
+                    <li>@ffe-blue-focus</li>
+                </ul>
+            </td>
+            <td class="ffe-table__cell">
+                <span class="sb1ds-color-usage__example sb1ds-color-usage__example--ffe-blue-focus"></span>
+            </td>
+        </tr>
+        <tr class="ffe-table__row">
+            <td class="ffe-table__cell">Grønn WCAG</td>
+            <td class="ffe-table__cell">
+                <ul class="sb1ds-color-usage__list">
+                    <li class="ffe-strong-text">Støttefarge</li>
+                    <li>Utførende handlingsfarge (CTA)</li>
+                    <li>Suksessfarge</li>
+                </ul>
+            </td>
+            <td class="ffe-table__cell">
+                <ul class="sb1ds-color-usage__list">
+                    <li>#008A00</li>
+                    <li>@ffe-green-shamrock</li>
+                </ul>
+            </td>
+            <td class="ffe-table__cell">
+                <span class="sb1ds-color-usage__example sb1ds-color-usage__example--ffe-green-shamrock"></span>
+            </td>
+        </tr>
+        <tr class="ffe-table__row">
+            <td class="ffe-table__cell">Grønn Hover</td>
+            <td class="ffe-table__cell">
+                <ul class="sb1ds-color-usage__list">
+                    <li class="ffe-strong-text">Støttefarge</li>
+                    <li>Hover state av utførende handlingsfarge</li>
+                </ul>
+            </td>
+            <td class="ffe-table__cell">
+                <ul class="sb1ds-color-usage__list">
+                    <li>#007B00</li>
+                    <li>@ffe-green-emerald</li>
+                </ul>
+            </td>
+            <td class="ffe-table__cell">
+                <span class="sb1ds-color-usage__example sb1ds-color-usage__example--ffe-green-emerald"></span>
+            </td>
+        </tr>
+        <tr class="ffe-table__row">
+            <td class="ffe-table__cell">Lilla</td>
+            <td class="ffe-table__cell">
+                <ul class="sb1ds-color-usage__list">
+                    <li class="ffe-strong-text">Støttefarge</li>
+                    <li>Illustrasjoner</li>
+                </ul>
+            </td>
+            <td class="ffe-table__cell">
+                <ul class="sb1ds-color-usage__list">
+                    <li>#C94096</li>
+                    <li>@ffe-purple</li>
+                </ul>
+            </td>
+            <td class="ffe-table__cell">
+                <span class="sb1ds-color-usage__example sb1ds-color-usage__example--ffe-purple"></span>
+            </td>
+        </tr>
+        <tr class="ffe-table__row">
+            <td class="ffe-table__cell">Lilla WCAG</td>
+            <td class="ffe-table__cell">
+                <ul class="sb1ds-color-usage__list">
+                    <li class="ffe-strong-text">Støttefarge</li>
+                    <li>Bakgrunnsfarge</li>
+                    <li>Fremheving av designelementer</li>
+                </ul>
+            </td>
+            <td class="ffe-table__cell">
+                <ul class="sb1ds-color-usage__list">
+                    <li>#A20076</li>
+                    <li>@ffe-purple-magenta</li>
+                </ul>
+            </td>
+            <td class="ffe-table__cell">
+                <span class="sb1ds-color-usage__example sb1ds-color-usage__example--ffe-purple-magenta"></span>
+            </td>
+        </tr>
+        <tr class="ffe-table__row">
+            <td class="ffe-table__cell">Oransje</td>
+            <td class="ffe-table__cell">
+                <ul class="sb1ds-color-usage__list">
+                    <li class="ffe-strong-text">Støttefarge</li>
+                    <li>Illustrasjoner</li>
+                </ul>
+            </td>
+            <td class="ffe-table__cell">
+                <ul class="sb1ds-color-usage__list">
+                    <li>#FF9100</li>
+                    <li>@ffe-orange</li>
+                </ul>
+            </td>
+            <td class="ffe-table__cell">
+                <span class="sb1ds-color-usage__example sb1ds-color-usage__example--ffe-orange"></span>
+            </td>
+        </tr>
+        <tr class="ffe-table__row">
+            <td class="ffe-table__cell">Oransje WCAG</td>
+            <td class="ffe-table__cell">
+                <ul class="sb1ds-color-usage__list">
+                    <li class="ffe-strong-text">Støttefarge</li>
+                </ul>
+            </td>
+            <td class="ffe-table__cell">
+                <ul class="sb1ds-color-usage__list">
+                    <li>#DA3D00</li>
+                    <li>@ffe-orange-fire</li>
+                </ul>
+            </td>
+            <td class="ffe-table__cell">
+                <span class="sb1ds-color-usage__example sb1ds-color-usage__example--ffe-orange-fire"></span>
+            </td>
+        </tr>
+        <tr class="ffe-table__row">
+            <td class="ffe-table__cell">Grønn</td>
+            <td class="ffe-table__cell">
+                <ul class="sb1ds-color-usage__list">
+                    <li class="ffe-strong-text">Støttefarge</li>
+                    <li>Illustrasjoner</li>
+                </ul>
+            </td>
+            <td class="ffe-table__cell">
+                <ul class="sb1ds-color-usage__list">
+                    <li>#37B441</li>
+                    <li>@ffe-green</li>
+                </ul>
+            </td>
+            <td class="ffe-table__cell">
+                <span class="sb1ds-color-usage__example sb1ds-color-usage__example--ffe-green"></span>
+            </td>
+        </tr>
+        <tr class="ffe-table__row">
+            <td class="ffe-table__cell">Hvit</td>
+            <td class="ffe-table__cell">
+                <ul class="sb1ds-color-usage__list">
+                    <li class="ffe-strong-text">Tekst/bakgrunn</li>
+                    <li>Hovedbakgrunnsfarge</li>
+                    <li>Produktkort</li>
+                    <li>Klikkbare kort</li>
+                </ul>
+            </td>
+            <td class="ffe-table__cell">
+                <ul class="sb1ds-color-usage__list">
+                    <li>#FFFFFF</li>
+                    <li>@ffe-white</li>
+                </ul>
+            </td>
+            <td class="ffe-table__cell">
+                <span class="sb1ds-color-usage__example sb1ds-color-usage__example--ffe-white"></span>
+            </td>
+        </tr>
+        <tr class="ffe-table__row">
+            <td class="ffe-table__cell">Lys varm grå</td>
+            <td class="ffe-table__cell">
+                <ul class="sb1ds-color-usage__list">
+                    <li class="ffe-strong-text">Bakgrunnsfarge</li>
+                </ul>
+            </td>
+            <td class="ffe-table__cell">
+                <ul class="sb1ds-color-usage__list">
+                    <li>#F6F6F3</li>
+                    <li>@ffe-grey-warm</li>
+                </ul>
+            </td>
+            <td class="ffe-table__cell">
+                <span class="sb1ds-color-usage__example sb1ds-color-usage__example--ffe-grey-warm"></span>
+            </td>
+        </tr>
+        <tr class="ffe-table__row">
+            <td class="ffe-table__cell">Sand</td>
+            <td class="ffe-table__cell">
+                <ul class="sb1ds-color-usage__list">
+                    <li class="ffe-strong-text">Bakgrunnsfarge</li>
+                </ul>
+            </td>
+            <td class="ffe-table__cell">
+                <ul class="sb1ds-color-usage__list">
+                    <li>#F8F5EB</li>
+                    <li>@ffe-sand</li>
+                </ul>
+            </td>
+            <td class="ffe-table__cell">
+                <span class="sb1ds-color-usage__example sb1ds-color-usage__example--ffe-sand"></span>
+            </td>
+        </tr>
+        <tr class="ffe-table__row">
+            <td class="ffe-table__cell">Lys grønn</td>
+            <td class="ffe-table__cell">
+                <ul class="sb1ds-color-usage__list">
+                    <li class="ffe-strong-text">Bakgrunnsfarge</li>
+                </ul>
+            </td>
+            <td class="ffe-table__cell">
+                <ul class="sb1ds-color-usage__list">
+                    <li>#E1F4E3</li>
+                    <li>@ffe-green-mint</li>
+                </ul>
+            </td>
+            <td class="ffe-table__cell">
+                <span class="sb1ds-color-usage__example sb1ds-color-usage__example--ffe-green-mint"></span>
+            </td>
+        </tr>
+        <tr class="ffe-table__row">
+            <td class="ffe-table__cell">Lys blå</td>
+            <td class="ffe-table__cell">
+                <ul class="sb1ds-color-usage__list">
+                    <li class="ffe-strong-text">Bakgrunnsfarge</li>
+                    <li>Tabeller - hover/markering</li>
+                </ul>
+            </td>
+            <td class="ffe-table__cell">
+                <ul class="sb1ds-color-usage__list">
+                    <li>#DFF1F9</li>
+                    <li>@ffe-blue-pale</li>
+                </ul>
+            </td>
+            <td class="ffe-table__cell">
+                <span class="sb1ds-color-usage__example sb1ds-color-usage__example--ffe-blue-pale"></span>
+            </td>
+        </tr>
+        <tr class="ffe-table__row">
+            <td class="ffe-table__cell">Lys oransje</td>
+            <td class="ffe-table__cell">
+                <ul class="sb1ds-color-usage__list">
+                    <li class="ffe-strong-text">Bakgrunnsfarge</li>
+                </ul>
+            </td>
+            <td class="ffe-table__cell">
+                <ul class="sb1ds-color-usage__list">
+                    <li>#F3BBAA</li>
+                    <li>@ffe-orange-salmon</li>
+                </ul>
+            </td>
+            <td class="ffe-table__cell">
+                <span class="sb1ds-color-usage__example sb1ds-color-usage__example--ffe-orange-salmon"></span>
+            </td>
+        </tr>
+        <tr class="ffe-table__row">
+            <td class="ffe-table__cell">Rød</td>
+            <td class="ffe-table__cell">
+                <ul class="sb1ds-color-usage__list">
+                    <li class="ffe-strong-text">Bakgrunnsfarge</li>
+                </ul>
+            </td>
+            <td class="ffe-table__cell">
+                <ul class="sb1ds-color-usage__list">
+                    <li>#E60000</li>
+                    <li>@ffe-red</li>
+                </ul>
+            </td>
+            <td class="ffe-table__cell">
+                <span class="sb1ds-color-usage__example sb1ds-color-usage__example--ffe-red"></span>
+            </td>
+        </tr>
+        <tr class="ffe-table__row">
+            <td class="ffe-table__cell">Himmelblå</td>
+            <td class="ffe-table__cell">
+                <ul class="sb1ds-color-usage__list">
+                    <li class="ffe-strong-text">Bakgrunnsfarge</li>
+                    <li>Tabeller</li>
+                    <li>Accordion</li>
+                </ul>
+            </td>
+            <td class="ffe-table__cell">
+                <ul class="sb1ds-color-usage__list">
+                    <li>#7FC6E8</li>
+                    <li>@ffe-blue-sky</li>
+                </ul>
+            </td>
+            <td class="ffe-table__cell">
+                <span class="sb1ds-color-usage__example sb1ds-color-usage__example--ffe-blue-sky"></span>
+            </td>
+        </tr>
+        <tr class="ffe-table__row">
+            <td class="ffe-table__cell">Isblå</td>
+            <td class="ffe-table__cell">
+                <ul class="sb1ds-color-usage__list">
+                    <li class="ffe-strong-text">Bakgrunnsfarge</li>
+                    <li>Tabeller - Hover</li>
+                </ul>
+            </td>
+            <td class="ffe-table__cell">
+                <ul class="sb1ds-color-usage__list">
+                    <li>#EFF8FC</li>
+                    <li>@ffe-blue-ice</li>
+                </ul>
+            </td>
+            <td class="ffe-table__cell">
+                <span class="sb1ds-color-usage__example sb1ds-color-usage__example--ffe-blue-ice"></span>
+            </td>
+        </tr>
+        <tr class="ffe-table__row">
+            <td class="ffe-table__cell">Sort</td>
+            <td class="ffe-table__cell">
+                <ul class="sb1ds-color-usage__list">
+                    <li class="ffe-strong-text">Tekst</li>
+                </ul>
+            </td>
+            <td class="ffe-table__cell">
+                <ul class="sb1ds-color-usage__list">
+                    <li>#262626</li>
+                    <li>@ffe-black</li>
+                </ul>
+            </td>
+            <td class="ffe-table__cell">
+                <span class="sb1ds-color-usage__example sb1ds-color-usage__example--ffe-black"></span>
+            </td>
+        </tr>
+        <tr class="ffe-table__row">
+            <td class="ffe-table__cell">Koksgrå</td>
+            <td class="ffe-table__cell">
+                <ul class="sb1ds-color-usage__list">
+                    <li class="ffe-strong-text">Tekst</li>
+                </ul>
+            </td>
+            <td class="ffe-table__cell">
+                <ul class="sb1ds-color-usage__list">
+                    <li>#676767</li>
+                    <li>@ffe-grey-charcoal</li>
+                </ul>
+            </td>
+            <td class="ffe-table__cell">
+                <span class="sb1ds-color-usage__example sb1ds-color-usage__example--ffe-grey-charcoal"></span>
+            </td>
+        </tr>
+        <tr class="ffe-table__row">
+            <td class="ffe-table__cell">Grå</td>
+            <td class="ffe-table__cell">
+                <ul class="sb1ds-color-usage__list">
+                    <li class="ffe-strong-text">Tekst</li>
+                </ul>
+            </td>
+            <td class="ffe-table__cell">
+                <ul class="sb1ds-color-usage__list">
+                    <li>#ADADAD</li>
+                    <li>@ffe-grey</li>
+                </ul>
+            </td>
+            <td class="ffe-table__cell">
+                <span class="sb1ds-color-usage__example sb1ds-color-usage__example--ffe-grey"></span>
+            </td>
+        </tr>
+        <tr class="ffe-table__row">
+            <td class="ffe-table__cell">Sølvgrå</td>
+            <td class="ffe-table__cell">
+                <ul class="sb1ds-color-usage__list">
+                    <li class="ffe-strong-text">Tekst</li>
+                </ul>
+            </td>
+            <td class="ffe-table__cell">
+                <ul class="sb1ds-color-usage__list">
+                    <li>#CCCCCC</li>
+                    <li>@ffe-grey-silver</li>
+                </ul>
+            </td>
+            <td class="ffe-table__cell">
+                <span class="sb1ds-color-usage__example sb1ds-color-usage__example--ffe-grey-silver"></span>
+            </td>
+        </tr>
+        <tr class="ffe-table__row">
+            <td class="ffe-table__cell">Skygrå</td>
+            <td class="ffe-table__cell">
+                <ul class="sb1ds-color-usage__list">
+                    <li class="ffe-strong-text">Tekst</li>
+                </ul>
+            </td>
+            <td class="ffe-table__cell">
+                <ul class="sb1ds-color-usage__list">
+                    <li>#F4F4F4</li>
+                    <li>@ffe-grey-cloud</li>
+                </ul>
+            </td>
+            <td class="ffe-table__cell">
+                <span class="sb1ds-color-usage__example sb1ds-color-usage__example--ffe-grey-cloud"></span>
+            </td>
+        </tr>
+    </table>
+</div>


### PR DESCRIPTION
This PR makes adjustments to the color palette as well as updates to the documentation of colors, as described in #80:

* Updated color names with ones used by marketing/design, in addition to Less variable names
* Restructured color categories
* Split color documentation into separate overview and usage sections
* Added visibility toggling of said sections

In `/packages/ffe-core`:
* Added `@ffe-grey-warm`
* Deprecated `@ffe-blue-deep-sky` and `@ffe-sand-ivory`