### PR TITLE
feat(ffe-checkbox-react): allow children as a function

### DIFF
--- a/packages/ffe-checkbox-react/src/Checkbox.js
+++ b/packages/ffe-checkbox-react/src/Checkbox.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { bool, node, string } from 'prop-types';
+import { bool, node, string, func, oneOfType } from 'prop-types';
 import { v4 as hash } from 'uuid';
 import classNames from 'classnames';
 
@@ -7,6 +7,14 @@ export default function CheckBox(props) {
     const { children, inline, invalid, label, noMargins, ...rest } = props;
 
     const id = props.id || `checkbox-${hash()}`;
+    const labelProps = {
+        className: classNames({
+            'ffe-checkbox': true,
+            'ffe-checkbox--inline': inline,
+            'ffe-checkbox--no-margin': noMargins,
+        }),
+        htmlFor: id,
+    };
 
     return (
         <span>
@@ -17,16 +25,16 @@ export default function CheckBox(props) {
                 aria-invalid={String(invalid)}
                 {...rest}
             />
-            <label
-                className={classNames({
-                    'ffe-checkbox': true,
-                    'ffe-checkbox--inline': inline,
-                    'ffe-checkbox--no-margin': noMargins,
-                })}
-                htmlFor={id}
-            >
-                {label || children}
-            </label>
+            {
+                typeof children === 'function'
+                    ? children(labelProps)
+                    : (
+// eslint-disable-next-line jsx-a11y/label-has-for
+                        <label {...labelProps}>
+                            {label || children}
+                        </label>
+                    )
+            }
         </span>
     );
 }
@@ -48,7 +56,7 @@ CheckBox.propTypes = {
      */
     invalid: bool,
     /** The label for the checkbox */
-    children: node,
+    children: oneOfType([node, func]),
 };
 
 CheckBox.defaultProps = {

--- a/packages/ffe-checkbox-react/src/Checkbox.md
+++ b/packages/ffe-checkbox-react/src/Checkbox.md
@@ -50,4 +50,13 @@ seg med `onChange`:
 </CheckBox>
 ```
 
+Du kan sende inn children som en funksjon, for å rendre din egen label. Funksjonen mottar props
+du kan spre på labelen.
+
+```js
+<CheckBox>
+    { labelProps => <label { ...labelProps }>Her benyttes render props</label> }
+</CheckBox>
+```
+
 Komponenten videresender alle udokumenterte props til `<input />`-elementet.

--- a/packages/ffe-checkbox-react/src/Checkbox.spec.js
+++ b/packages/ffe-checkbox-react/src/Checkbox.spec.js
@@ -106,4 +106,17 @@ describe('<Checkbox />', () => {
         );
         expect(wrapper.find('input').prop('tabIndex')).toBe(-1);
     });
+
+    it('should render children if it is a function', () => {
+        const wrapper = shallow(
+            <Checkbox>
+                { labelProps => (
+// eslint-disable-next-line jsx-a11y/label-has-for
+                    <label {...labelProps}>Hello world</label>
+                ) }
+            </Checkbox>
+        );
+
+        expect(wrapper.find('label').prop('children')).toBe('Hello world');
+    });
 });


### PR DESCRIPTION
I haven't quite given up on resolving #158 with changes to the Designsystem.
I'm now taking a more general approach to the problem, with a suggested solution that could potentially be helpful for other issues as well.

This commit allows the children of Checkbox to be a function. This will
allow consumers to further customize their label node. The function is
passed one argument which is an object with props. These props should be
spread on the rendered label.

Resolves #158
Closes #162 