### PR TITLE
fix(ffe-form-react): Make classnames a dependency

### DIFF
--- a/packages/ffe-form-react/package.json
+++ b/packages/ffe-form-react/package.json
@@ -23,11 +23,11 @@
     "setupTestFrameworkScriptFile": "../../test-setup.js"
   },
   "dependencies": {
+    "classnames": "^2.2.5",
     "react-collapse": "^4.0.3",
     "uuid": "^3.1.0"
   },
   "devDependencies": {
-    "classnames": "^2.2.5",
     "enzyme": "^3.3.0",
     "enzyme-adapter-react-16": "^1.1.1",
     "eslint": "^4.13.1",


### PR DESCRIPTION
This commit makes `classnames` a direct dependency, and not a
dev dependency like it was.

Fixes #232 
