### PR TITLE
Hidden label naked checkbox

### DIFF
--- a/packages/ffe-checkbox-react/src/Checkbox.js
+++ b/packages/ffe-checkbox-react/src/Checkbox.js
@@ -1,10 +1,18 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 import { bool, node, string, func, oneOfType } from 'prop-types';
 import { v4 as hash } from 'uuid';
 import classNames from 'classnames';
 
 export default function CheckBox(props) {
-    const { children, inline, invalid, label, noMargins, ...rest } = props;
+    const {
+        children,
+        hiddenLabel,
+        inline,
+        invalid,
+        label,
+        noMargins,
+        ...rest
+    } = props;
 
     const id = props.id || `checkbox-${hash()}`;
     const labelProps = {
@@ -12,12 +20,14 @@ export default function CheckBox(props) {
             'ffe-checkbox': true,
             'ffe-checkbox--inline': inline,
             'ffe-checkbox--no-margin': noMargins,
+            'ffe-checkbox--hidden-label': hiddenLabel,
         }),
         htmlFor: id,
     };
+    const LabelElement = hiddenLabel ? 'span' : 'label';
 
     return (
-        <span>
+        <Fragment>
             <input
                 className="ffe-hidden-checkbox"
                 id={id}
@@ -30,12 +40,12 @@ export default function CheckBox(props) {
                     ? children(labelProps)
                     : (
 // eslint-disable-next-line jsx-a11y/label-has-for
-                        <label {...labelProps}>
-                            {label || children}
-                        </label>
+                        <LabelElement {...labelProps}>
+                            {!hiddenLabel && (label || children)}
+                        </LabelElement>
                     )
             }
-        </span>
+        </Fragment>
     );
 }
 
@@ -47,6 +57,8 @@ CheckBox.propTypes = {
     label: string,
     /** Removes vertical margins from the checkbox */
     noMargins: bool,
+    /** If you plan to render the checkbox without a visible label */
+    hiddenLabel: bool,
     /** Override the automatically generated ID */
     id: string,
     inline: bool,

--- a/packages/ffe-checkbox-react/src/Checkbox.md
+++ b/packages/ffe-checkbox-react/src/Checkbox.md
@@ -30,6 +30,17 @@ Kan komme under hverandre også, ved å sende inn `inline={false}`:
 </fieldset>
 ```
 
+Dersom du skal ha en skjult label, brukes `hiddenLabel={true}` og label sendes inn via en `aria-label` prop og ikke som en child:
+
+```js
+    <CheckBox
+        defaultChecked={true}
+        aria-label="Jeg har en ingen label"
+        hiddenLabel={true}
+        inline={false}
+    />
+```
+
 Du kan merke at et felt er ugyldig ved å sette `aria-invalid="true"`:
 
 ```js

--- a/packages/ffe-checkbox-react/src/Checkbox.spec.js
+++ b/packages/ffe-checkbox-react/src/Checkbox.spec.js
@@ -119,4 +119,16 @@ describe('<Checkbox />', () => {
 
         expect(wrapper.find('label').prop('children')).toBe('Hello world');
     });
+
+    it('should render with a hidden label', () => {
+        const wrapper = getWrapper({ 'aria-label': 'I am label', hiddenLabel: true });
+
+        const label = wrapper.find('.ffe-checkbox--hidden-label');
+        const input = wrapper.find('.ffe-hidden-checkbox');
+
+        expect(label.exists()).toBe(true);
+        expect(label.children()).toHaveLength(0);
+        expect(input.exists()).toBe(true);
+        expect(input.prop('aria-label')).toBe('I am label');
+    });
 });

--- a/packages/ffe-form/less/checkbox.less
+++ b/packages/ffe-form/less/checkbox.less
@@ -52,6 +52,16 @@
         background-color: @ffe-white;
     }
 
+    &--hidden-label {
+        margin: 0;
+        padding-left: 20px;
+        padding-bottom: 20px;
+
+        &::before {
+            margin-right: 0;
+        }
+    }
+
     &::after {
         transform: scaleX(-1) rotate(180deg + -45deg);
         transform-origin: left top;


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request! 🎉

If your changes include some kind of UI element, please attach a screenshot of 
how it looks.

Before submitting a pull request, please have a look through the CONTRIBUTING.md
document. TL;DR:

- Follow the conventional commit standard
- Write full, explanatory commit messages
- Follow our code standards
- Write tests where applicable
- Be courteous and respect our code of conduct
-->

This does not have a corresponding issue for reasons of personal lazyness but mainly, I would like to render (and position) a checkbox without any visible label without having to work around the padding/margin that the label would have had if it was there. Which it isn't. But the padding is. Which I wantn't.