### PR TITLE
feat(ffe-core-react): Expose named exports

### DIFF
--- a/packages/ffe-core-react/src/index.js
+++ b/packages/ffe-core-react/src/index.js
@@ -1,0 +1,8 @@
+export { default as DividerLine } from './typography/DividerLine';
+export { default as EmphasizedText } from './typography/EmphasizedText';
+export * from './typography/Heading';
+export { default as MicroText } from './typography/MicroText';
+export { default as Paragraph } from './typography/Paragraph';
+export { default as PreformattedText } from './typography/PreformattedText';
+export { default as SmallText } from './typography/SmallText';
+export { default as StrongText } from './typography/StrongText';


### PR DESCRIPTION
This PR creates an index file which exposes all components as named
exports from the top level `@sb1/ffe-core-react` import.

Previously, the user would have to dig into the `node_modules` to figure
out that the components were located under `lib/typography/..`. Now, the
consumer can import components like this:

```js
import { Paragraph, Heading2, Heading3 } from '@sb1/ffe-core-react';
```

Fixes #248 