### PR TITLE
Consistent placeholder color

### DIFF
--- a/packages/ffe-form/less/dropdown.less
+++ b/packages/ffe-form/less/dropdown.less
@@ -72,4 +72,9 @@
         display: inline-block;
         width: auto;
     }
+
+    &::placeholder {
+        color: @ffe-grey-charcoal;
+        opacity: 1;
+    }
 }

--- a/packages/ffe-form/less/input-field.less
+++ b/packages/ffe-form/less/input-field.less
@@ -69,5 +69,6 @@
 
     &::placeholder {
         color: @ffe-grey-charcoal;
+        opacity: 1;
     }
 }


### PR DESCRIPTION
Fix/add placeholder color with opacity for both `.ffe-input-field` and `.ffe-dropdown`.

Fixes #240 