### PR TITLE
fix(ffe-grid): Normalize padding and margin

### DIFF
--- a/packages/ffe-grid/less/ffe-grid.less
+++ b/packages/ffe-grid/less/ffe-grid.less
@@ -116,8 +116,9 @@
 .ffe-grid {
     display: flex;
     flex-direction: column;
-    padding-top: @ffe-grid-gutter-sm;
     align-items: center;
+    margin: 0;
+    padding: @ffe-grid-gutter-sm 0 0;
     width: 100%;
 
     &--no-top-padding {


### PR DESCRIPTION
When using the grid with certain elements (like `<ul>`) most
browsers will add a bit of margin and/or padding to the
element itself via user-agent styles. This fixes that by
explicitly setting those so that the `.ffe-grid` class behaves the
same way no matter what element it is put on.

<!-- 
Thanks for opening a pull request! 🎉

If your changes include some kind of UI element, please attach a screenshot of 
how it looks.

Before submitting a pull request, please have a look through the CONTRIBUTING.md
document. TL;DR:

- Follow the conventional commit standard
- Write full, explanatory commit messages
- Follow our code standards
- Write tests where applicable
- Be courteous and respect our code of conduct
-->
