### PR TITLE
fix(ffe-buttons): Stop buttons from breaking

### DIFF
--- a/packages/ffe-buttons/less/base-button.less
+++ b/packages/ffe-buttons/less/base-button.less
@@ -71,6 +71,7 @@
     text-decoration: none;
     transition: all @ffe-transition-duration @ffe-ease;
     user-select: none;
+    white-space: nowrap;
     width: 100%;
     .ffe-fontsize-button;
 


### PR DESCRIPTION
This commit makes sure our buttons stay on one line. Previously, they
were allowed to break on to two lines - which was not according to design.

Fixes #264

Not sure if this should be a breaking change or not. By the API definition, it's not breaking, but I'm sure there's a few places that would have to have an extra look at their buttons if this is merged.