### PR TITLE
feat(ffe-datepicker-react): Add id prop

### DIFF
--- a/packages/ffe-datepicker-react/src/datepicker/Datepicker.js
+++ b/packages/ffe-datepicker-react/src/datepicker/Datepicker.js
@@ -284,6 +284,7 @@ export default class Datepicker extends Component {
         const {
             hideErrors,
             inputProps = {},
+            id,
             label,
             language,
             onChange,
@@ -328,6 +329,7 @@ export default class Datepicker extends Component {
                 >
                     <DateInput
                         aria-invalid={this.ariaInvalid()}
+                        id={id}
                         inputProps={inputProps}
                         onBlur={this.onInputBlur}
                         onChange={evt => onChange(evt.target.value)}
@@ -382,10 +384,10 @@ Datepicker.propTypes = {
     ariaInvalid: oneOfType([bool, string]),
     calendarAbove: bool,
     hideErrors: bool,
+    id: string,
     onValidationComplete: func,
-    inputProps: shape({
+    inputProps: shape({ 
         className: string,
-        id: string,
     }),
     label: string,
     language: string,

--- a/packages/ffe-datepicker-react/src/input/Input.js
+++ b/packages/ffe-datepicker-react/src/input/Input.js
@@ -19,6 +19,7 @@ export default class Input extends Component {
     render() {
         const {
             ariaInvalid,
+            id,
             inputProps = {},
             onBlur,
             onChange,
@@ -33,6 +34,7 @@ export default class Input extends Component {
                     aria-invalid={String(
                         this.props['aria-invalid'] || ariaInvalid,
                     )}
+                    id={id}
                     maxLength="10"
                     onFocus={onFocus}
                     onBlur={onBlur}
@@ -54,6 +56,7 @@ export default class Input extends Component {
 Input.propTypes = {
     'aria-invalid': string,
     ariaInvalid: oneOfType([bool, string]),
+    id: string,
     inputProps: shape({
         className: string,
     }),


### PR DESCRIPTION
This commit passes the id prop to the input field, so that it's easier
to pass the ID to the correct components.

Note: It does NOT auto-generate an ID if one isn't provided. That should be its own discussion imo.

<!-- 
Thanks for opening a pull request! 🎉

If your changes include some kind of UI element, please attach a screenshot of 
how it looks.

Before submitting a pull request, please have a look through the CONTRIBUTING.md
document. TL;DR:

- Follow the conventional commit standard
- Write full, explanatory commit messages
- Follow our code standards
- Write tests where applicable
- Be courteous and respect our code of conduct
-->
