### PR TITLE
chore: Add Prettier as a precommit hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
         "clean": "run-s clean:lib clean:lerna",
         "clean:lib": "rimraf packages/*/lib",
         "clean:lerna": "lerna clean --yes",
-        "prettier": "pretty-quick --staged",
+        "precommit": "pretty-quick --staged",
         "commitmsg": "commitlint -e $GIT_PARAMS",
         "postinstall": "npm run bootstrap",
         "bootstrap": "lerna bootstrap",


### PR DESCRIPTION
We always forget about running prettier on our PRs. This commit re-adds
prettier as a pre-commit hook.

It was removed earlier due to some mis-communications I believe.