### PR TITLE
fix: Add button styling to toolbar buttons

### DIFF
--- a/src/components/toolbarbutton/ToolbarButtonRenderer.js
+++ b/src/components/toolbarbutton/ToolbarButtonRenderer.js
@@ -4,8 +4,10 @@ import PropTypes from 'prop-types';
 export function ToolbarButtonRenderer({ onClick, href, title, children }) {
     if (href !== undefined) {
         return (
-            <a href={href} title={title} className="sb1ds-toolbar-button">
-                {children}
+            <a href={href} title={title} className="sb1ds-toolbar-button ffe-inline-button ffe-inline-button--tertiary">
+                <span class="ffe-inline-button__label sb1ds-toolbar-button__label">
+                    {children}
+                </span>
             </a>
         );
     }
@@ -15,9 +17,11 @@ export function ToolbarButtonRenderer({ onClick, href, title, children }) {
             type="button"
             onClick={onClick}
             title={title}
-            className="sb1ds-toolbar-button"
+            className="sb1ds-toolbar-button ffe-inline-button ffe-inline-button--tertiary"
         >
-            {children}
+            <span class="ffe-inline-button__label sb1ds-toolbar-button__label">
+                {children}
+            </span>
         </button>
     );
 }

--- a/src/styles/components/toolbar-button.less
+++ b/src/styles/components/toolbar-button.less
@@ -1,0 +1,12 @@
+.sb1ds-toolbar-button {
+    z-index: 1;
+
+    &::after {
+        border-bottom: 1px solid transparent;
+    }
+
+    svg {
+        width: 24px;
+        height: 24px;
+    }
+}

--- a/src/styles/styles.less
+++ b/src/styles/styles.less
@@ -2,6 +2,7 @@
 
 @import 'components/components-list';
 @import 'components/sidebar';
+@import 'components/toolbar-button';
 @import 'components/top-menu';
 
 @import 'examples/color';
@@ -158,8 +159,4 @@
         margin-top: -70px;
         background-clip: content-box;
     }
-}
-
-.sb1ds-toolbar-button {
-    z-index: 1;
 }


### PR DESCRIPTION
Fixes a bug in which toolbar buttons in the styleguide would be rendered with default browser styles.

Before:
![image](https://user-images.githubusercontent.com/463847/40972031-b5d962b0-68bf-11e8-9ba9-5f4a3573a3b1.png)

After:
![image](https://user-images.githubusercontent.com/463847/40972038-bbaedc60-68bf-11e8-8c13-11ad50c96225.png)
