### PR TITLE
fix(ffe-buttons): Align buttons in button groups properly

### DIFF
--- a/packages/ffe-buttons/less/button-group.less
+++ b/packages/ffe-buttons/less/button-group.less
@@ -22,6 +22,7 @@
     .ffe-inline-button {
         justify-content: center;
         margin: 0 auto 10px;
+        align-self: center;
     }
 
     &--thin {


### PR DESCRIPTION
Fixes #219, as well as a separate issue in which anchors with `.ffe-inline-button--tertiary` styling were not correctly aligned with other buttons in a `.ffe-button-group`.

Before:
![image](https://user-images.githubusercontent.com/463847/40977040-26593492-68d0-11e8-8a66-4bb2a50b3dc6.png)

After:
![image](https://user-images.githubusercontent.com/463847/40977055-2e3ffc22-68d0-11e8-85f8-ade8ab6cfbc1.png)
