### PR TITLE
fix(ffe-buttons): Remove left margin on small screen for buttons in b…

### DIFF
--- a/packages/ffe-buttons/less/button-group.less
+++ b/packages/ffe-buttons/less/button-group.less
@@ -35,10 +35,6 @@
             display: inline;
             margin: 0 0 10px 10px;
             width: auto;
-
-            &:first-child {
-                margin: 0 0 10px;
-            }
         }
     }
 


### PR DESCRIPTION
Removed left margin on small screen for buttons in button-group. 

Before:
![button-group-with-left-margin](https://user-images.githubusercontent.com/1019313/41028820-86c5f1bc-697a-11e8-8261-d0455cdddce8.png)

After:
![button-group-without-left-margin](https://user-images.githubusercontent.com/1019313/41028821-86f380e6-697a-11e8-8fba-6be3ea4dd2d9.png)
