### PR TITLE
fix(ffe-radio-button-react): Fix ie 11 bug

### DIFF
--- a/packages/ffe-radio-button-react/src/RadioButtonInputGroup.js
+++ b/packages/ffe-radio-button-react/src/RadioButtonInputGroup.js
@@ -45,7 +45,7 @@ const RadioButtonInputGroup = props => {
             {...rest}
         >
             {label && (
-                <legend className="ffe-form-label">
+                <legend className="ffe-form-label ffe-form-label--block">
                     {label}
                     {tooltipContent}
                 </legend>


### PR DESCRIPTION
This commit fixes a bug that made radio buttons directly follow their
label in IE11. It's fixed by adding a block level modifier on the
containing `<legend />` tag.

Fixes #278 