### PR TITLE
fix(ffe-icons-react): Don't set inline size on SVG

### DIFF
--- a/packages/ffe-icons-react/src/build-jsx-components.js
+++ b/packages/ffe-icons-react/src/build-jsx-components.js
@@ -8,10 +8,18 @@ mkdirp.sync('./jsx');
 
 const createSvgMap = () => {
     const map = {};
-    const iconsPath = path.join(__dirname, '..', 'node_modules', '@sb1', 'ffe-icons', 'icons');
-    fs.readdirSync(iconsPath)
+    const iconsPath = path.join(
+        __dirname,
+        '..',
+        'node_modules',
+        '@sb1',
+        'ffe-icons',
+        'icons',
+    );
+    fs
+        .readdirSync(iconsPath)
         .filter(fileName => fileName.match(/\.svg$/))
-        .forEach((fileName) => {
+        .forEach(fileName => {
             const iconPath = path.join(iconsPath, fileName);
             const iconName = fileName.split('.svg')[0];
             map[iconName] = fs.readFileSync(iconPath, 'utf-8');
@@ -28,21 +36,18 @@ const createSvgMap = () => {
  * */
 const toJsx = svgString => {
     const $ = cheerio.load(svgString, {
-        xmlMode: true
+        xmlMode: true,
     });
     const svg = $('svg');
     // React does not support namespace definitions
     svg.attr('xmlns', null);
     svg.attr('xmlns:svg', null);
 
-    svg.attr('height', 150);
-    svg.attr('width', 150);
-
     return $.html()
         .replace(/fill-rule/g, 'fillRule')
         .replace(/stroke-width/g, 'strokeWidth')
         .replace(/stroke-miterlimit/g, 'strokeMiterlimit');
-}
+};
 
 /**
  * Creates a new React component and a corresponding .jsx file for each icon
@@ -85,7 +90,10 @@ export default Icon;
 
 const icons = createSvgMap();
 Object.keys(icons).forEach(iconName =>
-    fs.writeFileSync(`./jsx/${iconName}.js`, createStandaloneJSX(icons, iconName)),
+    fs.writeFileSync(
+        `./jsx/${iconName}.js`,
+        createStandaloneJSX(icons, iconName),
+    ),
 );
 
 /**


### PR DESCRIPTION
No longer adds `width={150} height={150} to the generated SVGs.
This should not affect you, as both inline styling AND CSS will
override those props. The only case where it seems to matter is
if you're embedding an `ffe-icons-react` SVG inside another SVG.

Fixes #285

<!-- 
Thanks for opening a pull request! 🎉

If your changes include some kind of UI element, please attach a screenshot of 
how it looks.

Before submitting a pull request, please have a look through the CONTRIBUTING.md
document. TL;DR:

- Follow the conventional commit standard
- Write full, explanatory commit messages
- Follow our code standards
- Write tests where applicable
- Be courteous and respect our code of conduct
-->
