### PR TITLE
refactor(ffe-grid-react): Normalized padding props

### DIFF
--- a/packages/ffe-grid-react/src/Grid.js
+++ b/packages/ffe-grid-react/src/Grid.js
@@ -18,7 +18,7 @@ export default class Grid extends Component {
             className,
             condensed,
             element,
-            noTopPadding,
+            topPadding,
             ...rest
         } = this.props;
 
@@ -30,7 +30,7 @@ export default class Grid extends Component {
                     className,
                     'ffe-grid',
                     { 'ffe-grid--condensed': condensed },
-                    { 'ffe-grid--no-top-padding': noTopPadding },
+                    { 'ffe-grid--no-top-padding': !topPadding },
                 )}
                 {...rest}
             >
@@ -39,6 +39,10 @@ export default class Grid extends Component {
         );
     }
 }
+
+Grid.defaultProps = {
+    topPadding: true,
+};
 
 Grid.propTypes = {
     /** Any children of a Grid must be a GridRow */
@@ -49,5 +53,6 @@ Grid.propTypes = {
     condensed: bool,
     /** Specify the DOM element being used to create the Grid */
     element: string,
-    noTopPadding: bool,
+    /** Add top padding */
+    topPadding: bool,
 };

--- a/packages/ffe-grid-react/src/Grid.spec.js
+++ b/packages/ffe-grid-react/src/Grid.spec.js
@@ -28,10 +28,14 @@ describe('Grid', () => {
         expect(el.containsMatchingElement(<p>blah</p>)).toBe(true);
     });
 
-    it('sets the noTopPadding modifier', () => {
-        const el = renderShallow({ noTopPadding: true });
+    it('defaults to not setting the "--no-top-padding" modifier', () => {
+        const el = renderShallow();
 
-        expect(el.hasClass('ffe-grid')).toBe(true);
+        expect(el.hasClass('ffe-grid--no-top-padding')).toBe(false);
+    });
+
+    it('sets the "--no-top-padding" modifier if "topPadding" prop is false', () => {
+        const el = renderShallow({ topPadding: false });
         expect(el.hasClass('ffe-grid--no-top-padding')).toBe(true);
     });
 

--- a/packages/ffe-grid-react/src/GridCol.js
+++ b/packages/ffe-grid-react/src/GridCol.js
@@ -1,5 +1,13 @@
 import React, { Component } from 'react';
-import { bool, node, number, oneOf, oneOfType, shape, string } from 'prop-types';
+import {
+    bool,
+    node,
+    number,
+    oneOf,
+    oneOfType,
+    shape,
+    string,
+} from 'prop-types';
 import classNames from 'classnames';
 import backgroundColors from './background-colors';
 
@@ -29,7 +37,6 @@ const MODIFIER_LIST = [
     'end',
     'horizontal',
     'middle',
-    'noBottomPadding',
     'reverse',
     'start',
     'centerText',
@@ -60,8 +67,8 @@ const modifiers = props =>
 
 const backgroundClass = props =>
     props.background && backgroundColors.includes(props.background)
-    ? `ffe-grid__col--bg-${props.background}`
-    : null;
+        ? `ffe-grid__col--bg-${props.background}`
+        : null;
 
 export default class GridCol extends Component {
     componentDidMount() {
@@ -75,6 +82,7 @@ export default class GridCol extends Component {
 
     render() {
         const {
+            bottomPadding,
             children,
             className,
             element: Element,
@@ -97,6 +105,7 @@ export default class GridCol extends Component {
             sizeClasses('sm', !sm && !lg && !md ? 12 : sm),
             modifiers(this.props),
             backgroundClass(this.props),
+            !bottomPadding ? 'ffe-grid__col--no-bottom-padding' : null,
         ]
             .filter(x => x)
             .join(' ');
@@ -110,6 +119,7 @@ export default class GridCol extends Component {
 }
 
 GridCol.defaultProps = {
+    bottomPadding: true,
     element: 'div',
 };
 
@@ -151,8 +161,8 @@ GridCol.propTypes = {
     horizontal: bool,
     /** Center content vertically */
     middle: bool,
-    /** Remove bottom padding */
-    noBottomPadding: bool,
+    /** Add bottom padding */
+    bottomPadding: bool,
     /** Reverse layout direction */
     reverse: bool,
     /** Place content elements to the left of the column */

--- a/packages/ffe-grid-react/src/GridCol.spec.js
+++ b/packages/ffe-grid-react/src/GridCol.spec.js
@@ -171,6 +171,18 @@ describe('GridCol', () => {
         expect(el.hasClass('ffe-grid__col--sm-12')).toBe(true);
     });
 
+    it('defaults to not setting the "--no-bottom-padding" modifier', () => {
+        const el = renderShallow();
+
+        expect(el.hasClass('ffe-grid__col--no-bottom-padding')).toBe(false);
+    });
+
+    it('sets the "--no-bottom-padding" modifier if "bottomPadding" prop is false', () => {
+        const el = renderShallow({ bottomPadding: false });
+
+        expect(el.hasClass('ffe-grid__col--no-bottom-padding')).toBe(true);
+    });
+
     describe('when mounting', () => {
         beforeEach(() => {
             console.error = jest.fn();
@@ -187,10 +199,8 @@ describe('GridCol', () => {
             );
 
             expect(console.error).toHaveBeenCalled();
-            expect(
-                console.error.mock.calls.map(call => call[0]),
-            ).toContain(
-                '`<GridCol vertical={true} />` is the default behavior. You can safely remove this prop.'
+            expect(console.error.mock.calls.map(call => call[0])).toContain(
+                '`<GridCol vertical={true} />` is the default behavior. You can safely remove this prop.',
             );
         });
 
@@ -270,28 +280,36 @@ describe('GridCol', () => {
                 renderWithModifier({ md: { cols: 1, offset: 1 } });
 
                 expect(console.error).toHaveBeenCalledTimes(1);
-                expect(console.error.mock.calls[0][0]).toContain('The grid should have 6 columns for "md" screens');
+                expect(console.error.mock.calls[0][0]).toContain(
+                    'The grid should have 6 columns for "md" screens',
+                );
             });
 
             it('warns about not sticking to 6 columns on "md" screens for numbers', () => {
                 renderWithModifier({ md: 9 });
 
                 expect(console.error).toHaveBeenCalledTimes(1);
-                expect(console.error.mock.calls[0][0]).toContain('The grid should have 6 columns for "md" screens');
+                expect(console.error.mock.calls[0][0]).toContain(
+                    'The grid should have 6 columns for "md" screens',
+                );
             });
 
             it('warns about not sticking to 4 columns on "sm" screens for objects', () => {
                 renderWithModifier({ sm: { cols: 11, offset: 1 } });
 
                 expect(console.error).toHaveBeenCalledTimes(1);
-                expect(console.error.mock.calls[0][0]).toContain('The grid should have 4 columns for "sm" screens');
+                expect(console.error.mock.calls[0][0]).toContain(
+                    'The grid should have 4 columns for "sm" screens',
+                );
             });
 
             it('warns about not sticking to 4 columns on "sm" screens for numbers', () => {
                 renderWithModifier({ sm: 5 });
 
                 expect(console.error).toHaveBeenCalledTimes(1);
-                expect(console.error.mock.calls[0][0]).toContain('The grid should have 4 columns for "sm" screens');
+                expect(console.error.mock.calls[0][0]).toContain(
+                    'The grid should have 4 columns for "sm" screens',
+                );
             });
         });
     });

--- a/packages/ffe-grid-react/src/GridRow.js
+++ b/packages/ffe-grid-react/src/GridRow.js
@@ -51,6 +51,10 @@ export default class GridRow extends Component {
     }
 }
 
+GridRow.defaultProps = {
+    topPadding: false,
+};
+
 GridRow.propTypes = {
     /** Supported background colors */
     background: oneOf([


### PR DESCRIPTION
BREAKING CHANGE: Removed the "no" prefix from the padding props.
For `GridCol`, `noBottomPadding` is now `bottomPadding`.
For `Grid`, `noTopPadding` is now `topPadding`.

The default behaviour has not been changed, so to migrate you need to
* Replace all usage of `noBottomPadding={true}` with `bottomPadding={false}` on GridCols.
* Replace all usage of `noTopPadding={true}` with `topPadding={false}` on Grids.

Fixes #282

<!-- 
Thanks for opening a pull request! 🎉

If your changes include some kind of UI element, please attach a screenshot of 
how it looks.

Before submitting a pull request, please have a look through the CONTRIBUTING.md
document. TL;DR:

- Follow the conventional commit standard
- Write full, explanatory commit messages
- Follow our code standards
- Write tests where applicable
- Be courteous and respect our code of conduct
-->
