### PR TITLE
fix(ffe-searchable-dropdown-react): Disable browsers autoComplete for…

### DIFF
--- a/packages/ffe-searchable-dropdown-react/src/InputField.js
+++ b/packages/ffe-searchable-dropdown-react/src/InputField.js
@@ -30,6 +30,7 @@ class Input extends Component {
             placeholder,
             onReset,
             ariaInvalid,
+            ...rest
         } = this.props;
         return (
             <div>
@@ -46,6 +47,7 @@ class Input extends Component {
                     onKeyDown={onKeyDown}
                     placeholder={placeholder}
                     value={inputValue}
+                    {...rest}
                 />
                 {this.displayReset() && (
                     <button

--- a/packages/ffe-searchable-dropdown-react/src/SearchableDropdown.js
+++ b/packages/ffe-searchable-dropdown-react/src/SearchableDropdown.js
@@ -220,6 +220,7 @@ class SearchableDropdown extends Component {
                         onReset={this.onReset}
                         searchTerm={searchTerm}
                         ariaInvalid={ariaInvalid}
+                        autoComplete="off"
                     />
                     {showListContainer && (
                         <ScrollContainer


### PR DESCRIPTION
… SearchableDropdown

This version fixes an issue where the browsers autoComplete is sometimes triggered for SearchableDropdown, breaking the UI for the component. InputField now pases on rest-props, and SearchableDropdown sets autoComplete="off"
