### PR TITLE
feat(ffe-form-react): Add new `description` prop to `InputGroup`

### DIFF
--- a/packages/ffe-form-react/src/InputGroup.js
+++ b/packages/ffe-form-react/src/InputGroup.js
@@ -17,6 +17,7 @@ class InputGroup extends Component {
         const {
             children,
             className,
+            description,
             label,
             fieldMessage,
             tooltip,
@@ -39,6 +40,12 @@ class InputGroup extends Component {
             throw new Error(
                 'Only use the "onTooltipToggle" prop if you\'re not sending a component of type ' +
                     '<Tooltip /> in the "tooltip" prop. If you are, use "onClick" on that component instead',
+            );
+        }
+
+        if (tooltip && description) {
+            throw new Error(
+                'Don\'t use both "tooltip" and "description" on an <InputGroup />, pick one of them',
             );
         }
 
@@ -67,8 +74,14 @@ class InputGroup extends Component {
                 {typeof tooltip === 'string' && (
                     <Tooltip onClick={onTooltipToggle}>{tooltip}</Tooltip>
                 )}
+
                 {tooltip === true && <Tooltip onClick={onTooltipToggle} />}
+
                 {React.isValidElement(tooltip) && tooltip}
+
+                {description && (
+                    <div className="ffe-small-text">{description}</div>
+                )}
 
                 {modifiedChildren}
 
@@ -89,6 +102,8 @@ InputGroup.propTypes = {
     className: string,
     /** Use the ErrorFieldMessage component if you need more flexibility in how the content is rendered. */
     fieldMessage: oneOfType([string, node]),
+    /** To just render a static, always visible tooltip, use this. */
+    description: string,
     /** Use the Label component if you need more flexibility in how the content is rendered. */
     label: oneOfType([string, instanceOfComponent(Label)]),
     onTooltipToggle: func,

--- a/packages/ffe-form-react/src/InputGroup.md
+++ b/packages/ffe-form-react/src/InputGroup.md
@@ -17,13 +17,28 @@ const { Input } = require('.');
         />
     </InputGroup>
 
-    <InputGroup
-        label="E-postadresse"
-        fieldMessage="Ugyldig e-postadresse"
-    >
+    <InputGroup label="E-postadresse" fieldMessage="Ugyldig e-postadresse">
         <Input />
     </InputGroup>
-</React.Fragment>
+</React.Fragment>;
+```
+
+Dersom man skal vise en hjelpetekst som alltid er synlig brukes `description` i stedet for `tooltip`.
+
+```js
+const { Input } = require('.');
+
+<InputGroup
+    label="Telefonnummer"
+    description="Vi bruker telefonnummer for å sende deg kvittering på SMS"
+>
+    <Input
+        type="tel"
+        name="mobile"
+        onChange={e => console.log('onChange', e.target.value)}
+        onBlur={e => console.log('onBlur', e.target.value)}
+    />
+</InputGroup>;
 ```
 
 Utviklere bør merke seg at man er nødt til å bruke det såkalte _function-as-a-child_-patternet med mindre man bare har

--- a/packages/ffe-form-react/src/InputGroup.spec.js
+++ b/packages/ffe-form-react/src/InputGroup.spec.js
@@ -115,7 +115,7 @@ describe('<InputGroup>', () => {
     it('throws error when receiving a <Tooltip /> and onTooltipToggle is used', () => {
         const wrapper = () =>
             getWrapper({
-                tooltip: (<Tooltip>Message</Tooltip>),
+                tooltip: <Tooltip>Message</Tooltip>,
                 onTooltipToggle: f => f,
             });
 
@@ -148,5 +148,20 @@ describe('<InputGroup>', () => {
         });
         expect(wrapper.find('Input').prop('id')).toHaveLength(42);
         expect(wrapper.find('Input').prop('aria-invalid')).toBe('false');
+    });
+
+    it('renders a static tooltip if description is set', () => {
+        const wrapper = getWrapper({
+            description: 'description',
+        });
+        expect(wrapper.find('.ffe-small-text').text()).toBe('description');
+    });
+
+    it('throws if both tooltip and description is set', () => {
+        expect(() =>
+            getWrapper({ description: 'asda', tooltip: 'asdsad' }),
+        ).toThrow(
+            'Don\'t use both "tooltip" and "description" on an <InputGroup />, pick one of them',
+        );
     });
 });


### PR DESCRIPTION
Setting `helpText` instead of (or in addition to) the existing `tooltip` renders a static helptext instead of the expandable version. It looks the same, but this one will never leave you.

Fixes #291

<!-- 
Thanks for opening a pull request! 🎉

If your changes include some kind of UI element, please attach a screenshot of 
how it looks.

Before submitting a pull request, please have a look through the CONTRIBUTING.md
document. TL;DR:

- Follow the conventional commit standard
- Write full, explanatory commit messages
- Follow our code standards
- Write tests where applicable
- Be courteous and respect our code of conduct
-->
