### PR TITLE
fix(ffe-message-box): Reduce sideflesk on small screens

### DIFF
--- a/packages/ffe-message-box/less/ffe-message-box.less
+++ b/packages/ffe-message-box/less/ffe-message-box.less
@@ -25,8 +25,12 @@
     text-align: center;
 
     &__box {
-        padding: @app-margin*2 @app-margin*2;
+        padding: 40px 30px;
         border-radius: 5px;
+
+        @media only screen and (min-width: @breakpoint-md) {
+            padding: 40px 40px;
+        }
 
         &--tips {
             background-color: @ffe-sand;
@@ -107,8 +111,9 @@
         color: inherit;
         text-decoration: underline;
 
-        &:hover, &:focus {
-            font-family: "MuseoSansRounded-700", arial, sans-serif;
+        &:hover,
+        &:focus {
+            font-family: 'MuseoSansRounded-700', arial, sans-serif;
         }
     }
 }


### PR DESCRIPTION
Left and right padding on small screens reduced from 40px to 30px.

<!-- 
Thanks for opening a pull request! 🎉

If your changes include some kind of UI element, please attach a screenshot of 
how it looks.

Before submitting a pull request, please have a look through the CONTRIBUTING.md
document. TL;DR:

- Follow the conventional commit standard
- Write full, explanatory commit messages
- Follow our code standards
- Write tests where applicable
- Be courteous and respect our code of conduct
-->
