### PR TITLE
fix(ffe-radio-button-react): renamed test text from RadioButtonGroup …

### DIFF
--- a/packages/ffe-radio-button-react/src/RadioButtonInputGroup.spec.js
+++ b/packages/ffe-radio-button-react/src/RadioButtonInputGroup.spec.js
@@ -14,7 +14,7 @@ const defaultProps = {
 const getWrapper = props =>
     mount(<RadioButtonInputGroup {...defaultProps} {...props} />);
 
-describe('<RadioButtonGroup />', () => {
+describe('<RadioButtonInputGroup />', () => {
     it('renders without exploding', () => {
         const wrapper = getWrapper();
         expect(wrapper.exists()).toBe(true);


### PR DESCRIPTION
`RadioButtonGroup` no longer exists so updated the text strings with new `RadioButtonInputGroup` name.
