### PR TITLE
fix(ffe-grid): Give all grid-col descendants max-width 100%

### DIFF
--- a/packages/ffe-grid/less/ffe-grid.less
+++ b/packages/ffe-grid/less/ffe-grid.less
@@ -204,6 +204,10 @@
     max-width: 100%;
 }
 
+[class^='ffe-grid__col'] > * {
+    max-width: 100%;
+}
+
 .ffe-grid__row-wrapper {
     &:extend(.ffe-grid__row);
 


### PR DESCRIPTION
BREAKING CHANGE: All direct descendants of a grid column now
receives `max-width: 100%`. This fixes an issue in IE where
the contents of centered grid columns would ignore the width
of the column. This might break parts of your layout, e.g. if
you have SVGs directly inside full-width centered columns (they
will now use the entire width where they might not have done so
before) and possibly also in other scenarios

<!-- 
Thanks for opening a pull request! 🎉

If your changes include some kind of UI element, please attach a screenshot of 
how it looks.

Before submitting a pull request, please have a look through the CONTRIBUTING.md
document. TL;DR:

- Follow the conventional commit standard
- Write full, explanatory commit messages
- Follow our code standards
- Write tests where applicable
- Be courteous and respect our code of conduct
-->
