### PR TITLE
fix(ffe-form): Increase top margin on ffe-radio-switch

### DIFF
--- a/packages/ffe-form/less/radio-switch.less
+++ b/packages/ffe-form/less/radio-switch.less
@@ -27,6 +27,7 @@
     transition: all @ffe-transition-duration @ffe-ease;
     box-shadow: 0 1px 2px 1px rgba(0, 0, 0, 0.05);
     margin-bottom: 5px;
+    margin-top: 13px;
 
     &::before {
         .ffe-sb1-radioblob();


### PR DESCRIPTION
This commit introduces margin on top of the `ffe-radio-switch`
giving it the same visual distance between the label and the input
control that radio-button-input-group has.

Fixes #349

<!-- 
Thanks for opening a pull request! 🎉

If your changes include some kind of UI element, please attach a screenshot of 
how it looks.

Before submitting a pull request, please have a look through the CONTRIBUTING.md
document. TL;DR:

- Follow the conventional commit standard
- Write full, explanatory commit messages
- Follow our code standards
- Write tests where applicable
- Be courteous and respect our code of conduct
-->
