### PR TITLE
fix(ffe-core): Lock line-height for ffe-link-text

### DIFF
--- a/packages/ffe-core/less/typography.less
+++ b/packages/ffe-core/less/typography.less
@@ -41,7 +41,6 @@
 //
 // Styleguide ffe-core.typography.headings-modifiers
 
-
 // Body paragraph
 //
 // Markup:
@@ -279,6 +278,7 @@
     cursor: pointer;
     text-decoration: none;
     word-wrap: break-word;
+    line-height: 1em;
 
     &:hover {
         border-bottom-color: @ffe-blue-cobalt;

--- a/src/styles/components/components-list.less
+++ b/src/styles/components/components-list.less
@@ -20,6 +20,7 @@
         border-radius: 5px;
         display: block;
         transition: all @ffe-transition-duration @ffe-ease;
+        line-height: inherit;
 
         &:hover {
             color: @ffe-grey-charcoal;


### PR DESCRIPTION
Setting the `line-height` property to `1em` for `ffe-link-text` ensures
the correct distance between the text and the underline, also when the
link element is rendered directly in a flex-container.

Fixes #308

<!-- 
Thanks for opening a pull request! 🎉

If your changes include some kind of UI element, please attach a screenshot of 
how it looks.

Before submitting a pull request, please have a look through the CONTRIBUTING.md
document. TL;DR:

- Follow the conventional commit standard
- Write full, explanatory commit messages
- Follow our code standards
- Write tests where applicable
- Be courteous and respect our code of conduct
-->
