### PR TITLE
Add testURL to jest configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     },
     "jest": {
         "setupTestFrameworkScriptFile": "./test-setup.js",
+        "testURL": "http://localhost",
         "coveragePathIgnorePatterns": [
             "/node_modules/",
             "<rootDir>/packages/.*/lib/"


### PR DESCRIPTION
Adding this configuration option is a workaround for a jsdom/jest issue (see #358) and can be dropped as soon the default configuration value in jest is changed.