### PR TITLE
fix: Update styleguidist root element id

### DIFF
--- a/src/templates/styleguidist.hbs
+++ b/src/templates/styleguidist.hbs
@@ -10,11 +10,11 @@
 	<body>
     	{{> header currentTarget="styleguidist" }}
 		{{!
-			The content of <div id="app"/> will be overwritten by the React implementation.
+			The content of <div id="rsg-root"/> will be overwritten by the React implementation.
 			The idea is to make the jump to and loading of the page less jarring by setting
 			up a basic skeleton while loading.
 		}}
-		<div id="app">
+		<div id="rsg-root">
 			<div class="sb1ds ffe-grid ffe-grid--no-top-padding">
 				<div class="ffe-grid__row">
 					<div class="ffe-grid__col--lg-3 ffe-grid__col--md-4 ffe-grid__col--sm-12 ffe-grid__col--no-bottom-padding">


### PR DESCRIPTION
Changes the id of the styleguidist template container from the deprecated `#app` to the new standard `#rsg-root`, as specified in the following console warning: 

`The use of 'app' element id in the template is deprecated. Please, update your template file to use 'rsg-root' as the container id.`