### PR TITLE
Remove inline JavaScript from less

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
         "build": "run-s build:packages build:css",
         "build:all": "run-s build build:assets build:content styleguidist:build kss:build",
         "build:packages": "lerna run build",
-        "build:css": "lessc --clean-css --js --autoprefix=\"last 3 versions, IE>=9\" packages/ffe-all.less dist/ffe.css",
+        "build:css": "lessc --clean-css --autoprefix=\"last 3 versions, IE>=9\" packages/ffe-all.less dist/ffe.css",
         "build:assets": "mkdir -p dist/assets && cp src/assets/* dist/assets/",
         "build:content": "node bin/build-content.js",
         "lint": "lerna run --parallel lint",

--- a/packages/ffe-form/less/dropdown.less
+++ b/packages/ffe-form/less/dropdown.less
@@ -13,9 +13,9 @@
 // Styleguide ffe-form.dropdown
 
 .ffe-chevron-icon-with-color(@color: @ffe-blue-azure) {
-    @bare-color: replace(~`'@{color}'`, '#', '');
+    @bare-color: escape(@color);
 
-    background-image: url('data:image/svg+xml;charset=utf8,%3Csvg%20xmlns%3Asvg%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20version%3D%221.1%22%20x%3D%220%22%20y%3D%220%22%20viewBox%3D%220%200%201000%201000%22%20width%3D%2218%22%20height%3D%2218%22%20xml%3Aspace%3D%22preserve%22%3E%0A%20%20%20%20%3Cpath%20fill%3D%22%23@{bare-color}%22%20d%3D%22M111.1%20228.6c19.2%200%2038.4%207.3%2053%2022l336.7%20336.7%20334.5-334.5c29.3-29.3%2076.8-29.3%20106.1%200%2029.3%2029.3%2029.3%2076.8%200%20106.1L553.8%20746.3c-29.3%2029.3-76.8%2029.3-106.1%200L58.1%20356.6c-29.3-29.3-29.3-76.8%200-106.1C72.7%20235.9%2091.9%20228.6%20111.1%20228.6z%22%20%2F%3E%0A%3C%2Fsvg%3E%0A');
+    background-image: url('data:image/svg+xml;charset=utf8,%3Csvg%20xmlns%3Asvg%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20version%3D%221.1%22%20x%3D%220%22%20y%3D%220%22%20viewBox%3D%220%200%201000%201000%22%20width%3D%2218%22%20height%3D%2218%22%20xml%3Aspace%3D%22preserve%22%3E%0A%20%20%20%20%3Cpath%20fill%3D%22@{bare-color}%22%20d%3D%22M111.1%20228.6c19.2%200%2038.4%207.3%2053%2022l336.7%20336.7%20334.5-334.5c29.3-29.3%2076.8-29.3%20106.1%200%2029.3%2029.3%2029.3%2076.8%200%20106.1L553.8%20746.3c-29.3%2029.3-76.8%2029.3-106.1%200L58.1%20356.6c-29.3-29.3-29.3-76.8%200-106.1C72.7%20235.9%2091.9%20228.6%20111.1%20228.6z%22%20%2F%3E%0A%3C%2Fsvg%3E%0A');
 }
 
 .ffe-dropdown {

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -117,23 +117,13 @@ module.exports = {
                                   },
                               },
                               'postcss-loader',
-                              {
-                                  loader: 'less-loader',
-                                  options: {
-                                      javascriptEnabled: true,
-                                  },
-                              },
+                              'less-loader',
                           ]
                         : [
                               'style-loader',
                               'css-loader',
                               'postcss-loader',
-                              {
-                                  loader: 'less-loader',
-                                  options: {
-                                      javascriptEnabled: true,
-                                  },
-                              },
+                              'less-loader',
                           ],
                     exclude: /node_modules/,
                 },


### PR DESCRIPTION
This change enables to use less 3 without having to allow inline JavaScript (`lessc --js` and `javascriptEnabled` option).