### PR TITLE
Update eslint peerdep

### DIFF
--- a/linting/eslint-config-ffe-base/package.json
+++ b/linting/eslint-config-ffe-base/package.json
@@ -23,8 +23,8 @@
     "eslint-plugin-import": "^2.0.1"
   },
   "peerDependencies": {
-    "eslint": "^2.0.0 || ^3.0.0 || ^4.0.0",
-    "eslint-plugin-import": "^1.10.1 || ^2.0.1"
+    "eslint": ">=2",
+    "eslint-plugin-import": ">=1.10"
   },
   "publishConfig": {
     "access": "public"

--- a/linting/eslint-config-ffe/package.json
+++ b/linting/eslint-config-ffe/package.json
@@ -26,9 +26,9 @@
     "eslint-plugin-react": "^7.0.0"
   },
   "peerDependencies": {
-    "eslint": "^4.0.0",
+    "eslint": "^5.3.0",
     "eslint-plugin-jsx-a11y": "^6.0.3",
-    "eslint-plugin-react": "^6.0.0 || ^7.0.0"
+    "eslint-plugin-react": ">=6"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Greenkeeper didn't upgrade the peer dependency of the ffe-linting packages to eslint.