### PR TITLE
fix(ffe-context-message-react): Enable class overrides

### DIFF
--- a/packages/ffe-context-message-react/src/ContextMessage.js
+++ b/packages/ffe-context-message-react/src/ContextMessage.js
@@ -50,7 +50,10 @@ export default class ContextMessage extends Component {
         return (
             <div className="ffe-context-message-content__icon">
                 {cloneElement(icon, {
-                    className: 'ffe-context-message-content__icon-svg',
+                    className: classNames(
+                        'ffe-context-message-content__icon-svg',
+                        icon.props.className,
+                    ),
                 })}
             </div>
         );

--- a/packages/ffe-context-message-react/src/ContextMessage.spec.js
+++ b/packages/ffe-context-message-react/src/ContextMessage.spec.js
@@ -77,9 +77,20 @@ describe('<ContextMessage />', () => {
         const wrapper = getMountedWrapper({
             icon: <InfoSirkelIkon />,
         });
-        expect(
-            wrapper.find('svg.ffe-context-message-content__icon-svg'),
-        ).toHaveLength(1);
+        const el = wrapper.find('svg');
+        expect(el).toHaveLength(1);
+        expect(el.hasClass('ffe-context-message-content__icon-svg')).toBe(true);
+    });
+
+    it('lets consumer add extra classes to icon', () => {
+        const wrapper = getMountedWrapper({
+            icon: <InfoSirkelIkon className="extra-extra-read-all-about-it" />,
+        });
+
+        const el = wrapper.find('svg');
+
+        expect(el.hasClass('ffe-context-message-content__icon-svg')).toBe(true);
+        expect(el.hasClass('extra-extra-read-all-about-it')).toBe(true);
     });
 
     it('renders without close button by default', () => {


### PR DESCRIPTION
This fix makes it possible to add extra classes to the icon rendered
via the `icon` prop of context messages

Fixes #377 