### PR TITLE
Link text visited

### DIFF
--- a/packages/ffe-core/less/colors.less
+++ b/packages/ffe-core/less/colors.less
@@ -24,6 +24,7 @@
 // Purple
 @ffe-purple: #C94096;
 @ffe-purple-magenta: #A20076;
+@ffe-purple-violet: #551A8B; // Visited links
 
 // Beige
 @ffe-sand: #F8F5EB; // @ffe-sand + @ffe-sand-25

--- a/packages/ffe-core/less/typography.less
+++ b/packages/ffe-core/less/typography.less
@@ -286,6 +286,12 @@
         text-decoration: none;
     }
 
+    &:visited {
+        border-bottom-color: @ffe-purple-violet;
+        color: @ffe-purple-violet;
+        text-decoration: none;
+    }
+
     &--no-underline {
         border-bottom: none;
     }

--- a/styleguide-content/visuell-identitet/farger.md
+++ b/styleguide-content/visuell-identitet/farger.md
@@ -43,6 +43,10 @@
             <div>Grønn Hover</div>
             <div>#007B00<br/>@ffe-green-emerald</div>
         </li>
+        <li class="sb1ds-color-palette__item sb1ds-color-palette__item--ffe-purple-violet">
+            <div>Fiolett besøkte lenker</div>
+            <div>#551A8B<br/>@ffe-purple-violet</div>
+        </li>
     </ul>
     <h4 class="ffe-h5">Støttefarger visuell identitet</h5>
     <ul class="sb1ds-color-palette">


### PR DESCRIPTION
Lagt til visited tilstand for link-text + visited farge. Farge avklart med @adidick. 
![image](https://user-images.githubusercontent.com/1208362/44448072-79407d80-a5ea-11e8-851e-777c85153029.png)
