### PR TITLE
fix(stylelint-config-ffe): Remove conflicting rule

### DIFF
--- a/linting/stylelint-config-ffe/index.js
+++ b/linting/stylelint-config-ffe/index.js
@@ -9,7 +9,6 @@ module.exports = {
             },
         ],
         'at-rule-no-vendor-prefix': true,
-        'color-hex-case': 'upper',
         indentation: [
             4,
             {


### PR DESCRIPTION
This commit fixes an issue where we create a conflict with Prettier's
way of formatting our LESS.

<!-- 
Thanks for opening a pull request! 🎉

If your changes include some kind of UI element, please attach a screenshot of 
how it looks.

Before submitting a pull request, please have a look through the CONTRIBUTING.md
document. TL;DR:

- Follow the conventional commit standard
- Write full, explanatory commit messages
- Follow our code standards
- Write tests where applicable
- Be courteous and respect our code of conduct
-->
