### PR TITLE
fix: Specify visited state in styleguide navigation links

### DIFF
--- a/src/styles/components/components-list.less
+++ b/src/styles/components/components-list.less
@@ -22,6 +22,10 @@
         transition: all @ffe-transition-duration @ffe-ease;
         line-height: inherit;
 
+        &:visited {
+            color: @ffe-grey-charcoal;
+        }
+
         &:hover {
             color: @ffe-grey-charcoal;
             background: tint(@ffe-grey-silver, 50%);

--- a/src/styles/components/top-menu.less
+++ b/src/styles/components/top-menu.less
@@ -40,6 +40,10 @@
         white-space: nowrap;
         transition: all @ffe-transition-duration @ffe-ease;
 
+        &:visited {
+            color: @ffe-grey-charcoal;
+        }
+
         @media screen and (min-width: @breakpoint-lg) {
             padding: 0 15px;
         }
@@ -59,7 +63,8 @@
                 left: 15px;
                 right: 15px;
                 transform: translateY(-10px);
-                transition: transform @ffe-transition-duration @ffe-ease-in-out-back;
+                transition: transform @ffe-transition-duration
+                    @ffe-ease-in-out-back;
             }
 
             @media screen and (min-width: @breakpoint-xl) {


### PR DESCRIPTION
Overrides visited state in styleguide navigation links.

Before:

![image](https://user-images.githubusercontent.com/463847/44575062-6913d400-a78b-11e8-85be-54728e20bc7e.png)


After:

![image](https://user-images.githubusercontent.com/463847/44575076-6e711e80-a78b-11e8-9d9b-34e692d73259.png)

Related to changes introduced in #379