### PR TITLE
fix: Specify styleguide background color in order to avoid default grey in firefox

### DIFF
--- a/src/styles/styles.less
+++ b/src/styles/styles.less
@@ -11,6 +11,10 @@
 
 @import 'npm-install-builder/npm-install-builder';
 
+body {
+    background-color: @ffe-white;
+}
+
 .sb1ds {
     font-family: 'MuseoSans-500', arial, sans-serif;
     line-height: 1.5;
@@ -27,8 +31,7 @@
     h3,
     h4,
     h5,
-    h6
-     {
+    h6 {
         .ffe-strong-text;
     }
 }
@@ -36,7 +39,7 @@
 .sb1ds-intro {
     &::after {
         @media screen and (min-width: @breakpoint-lg) {
-            content: "";
+            content: '';
             display: block;
             height: 335px;
             position: absolute;
@@ -131,7 +134,6 @@
 
 .sb1ds-section {
     margin: 30px 0;
-
 }
 
 .sb1ds-section-static {


### PR DESCRIPTION
Before:

![fff-1](https://user-images.githubusercontent.com/463847/44665698-dbe4af80-aa16-11e8-9617-354be4701b93.png)

After:

![fff-2](https://user-images.githubusercontent.com/463847/44665709-e141fa00-aa16-11e8-9084-2c84405c1c52.png)
