### PR TITLE
fix(ffe-form): Specify tap highlight color

### DIFF
--- a/packages/ffe-form/less/checkbox.less
+++ b/packages/ffe-form/less/checkbox.less
@@ -26,6 +26,7 @@
     transition: width @ffe-transition-duration @ffe-ease;
     text-align: left;
     padding-left: 35px;
+    -webkit-tap-highlight-color: fade(@ffe-blue-focus, 15%);
 
     &--no-margin {
         margin-top: 0;

--- a/packages/ffe-form/less/radio-button.less
+++ b/packages/ffe-form/less/radio-button.less
@@ -29,6 +29,7 @@
     text-align: left;
     padding-left: 30px;
     padding-top: 1px;
+    -webkit-tap-highlight-color: fade(@ffe-blue-focus, 15%);
 
     &--inline {
         display: inline-block;


### PR DESCRIPTION
`-webkit-tap-highlight-color` provides visual feedback on tap in webkit-based mobile browsers. In some cases the tap highlight has been stuck due to state changes being executed on checking a checkbox. This commit overrides the default color to use our predefined focus state color, and slightly decreases the opacity of the highlight.

Default:
![tap1](https://user-images.githubusercontent.com/463847/44910486-b06a0980-ad23-11e8-975a-8144010a0f02.png)

Override:
![tap2](https://user-images.githubusercontent.com/463847/44910503-b8c24480-ad23-11e8-8f56-0916a3e5c25c.png)
