### PR TITLE
KSS dev server: Add less plugins to build pipeline

### DIFF
--- a/kss-dev-server/app.js
+++ b/kss-dev-server/app.js
@@ -4,6 +4,8 @@ const logger = require('morgan');
 const webpack = require('webpack');
 const webpackDevMiddleware = require('webpack-dev-middleware');
 const webpackHotMiddleware = require('webpack-hot-middleware');
+const LessPluginCleanCSS = require('less-plugin-clean-css');
+const LessPluginAutoPrefix = require('less-plugin-autoprefix');
 
 const apiRouter = require('./apiRoutes');
 
@@ -48,7 +50,12 @@ const webpackCompiler = webpack({
                     {
                         loader: 'less-loader',
                         options: {
-                            presets: ['@babel/preset-env'],
+                            plugins: [
+                                new LessPluginCleanCSS(),
+                                new LessPluginAutoPrefix({
+                                    browsers: 'last 3 versions, IE>=9',
+                                }),
+                            ],
                         },
                     },
                 ],

--- a/kss-dev-server/package.json
+++ b/kss-dev-server/package.json
@@ -16,6 +16,8 @@
     "jsonfile": "^4.0.0",
     "kss": "^3.0.0-beta.23",
     "less-loader": "^4.1.0",
+    "less-plugin-autoprefix": "^2.0.0",
+    "less-plugin-clean-css": "^1.5.1",
     "morgan": "~1.9.0",
     "vue": "^2.5.17",
     "webpack": "^4.17.1",


### PR DESCRIPTION
With this change the dev server will use the same plugins as the common less build.