### PR TITLE
fix(ffe-header): Increase z-index in order to overlap other positioned elements

### DIFF
--- a/packages/ffe-header/less/ffe-header.less
+++ b/packages/ffe-header/less/ffe-header.less
@@ -7,7 +7,7 @@
 
     &__user-nav-list--visible,
     &__site-nav-list--visible {
-        z-index: 1;
+        z-index: 100000;
     }
 
     &__border {


### PR DESCRIPTION
Increases z-index of the header dropdown menu in order to overlap other positioned elements that may or may not be present in different pages.