### PR TITLE
feat(ffe-header): print styles

### DIFF
--- a/packages/ffe-header/less/ffe-header.less
+++ b/packages/ffe-header/less/ffe-header.less
@@ -432,4 +432,21 @@
         }
     }
 }
+
+@media print {
+    .ffe-header {
+        &__logo {
+            text-align: left;
+        }
+
+        &__user-nav,
+        &__user-icon,
+        &__user-chevron,
+        &__site-nav,
+        &__site-nav-toggle,
+        &__notification-bubble {
+            display: none;
+        }
+    }
+}
 // stylelint-enable block-no-empty


### PR DESCRIPTION
Adds a few style overrides in order to hide dropdown menus on print, as well as left align the logo.

Before:

<img width="593" alt="screen shot 2018-09-06 at 16 20 03" src="https://user-images.githubusercontent.com/463847/45163884-9764cb00-b1f1-11e8-9bdd-3473d16068e5.png">

After:

<img width="609" alt="screen shot 2018-09-06 at 16 15 35" src="https://user-images.githubusercontent.com/463847/45163367-98e1c380-b1f0-11e8-80ab-9bfc74193fae.png">
