### PR TITLE
fix(ffe-accordion): Background transition for blue accordion

### DIFF
--- a/packages/ffe-accordion/less/ffe-accordion.less
+++ b/packages/ffe-accordion/less/ffe-accordion.less
@@ -167,6 +167,7 @@
         color: @ffe-blue-royal;
         background-color: @ffe-blue-pale;
         border-radius: 3px;
+        transition: background-color @ffe-transition-duration @ffe-ease;
 
         &:hover,
         &:focus {


### PR DESCRIPTION
This commit adds a transition on background for blue accordion. This is
done to improve the visual quality of the accordion when transitioning
between hover and normal state.

Fixes #398 

![image](https://user-images.githubusercontent.com/435037/45304829-369f0080-b519-11e8-89fc-b6144ee17962.png)