### PR TITLE
fix: Temporarily disable pagePerSection

### DIFF
--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -71,7 +71,7 @@ module.exports = {
             base: ['MuseoSans-500', 'arial', 'sans-serif'],
         },
     },
-    pagePerSection: true,
+    pagePerSection: false,
     assetsDir: './static',
     webpackConfig: {
         module: {


### PR DESCRIPTION
Set `pagePerSection` to `false`, as a temporary workaround for #405.