### PR TITLE
Refactor focus outline

### DIFF
--- a/packages/ffe-buttons/less/base-button.less
+++ b/packages/ffe-buttons/less/base-button.less
@@ -26,7 +26,6 @@
 //
 // Styleguide ffe-buttons.base-button.1
 
-
 // More Buttons
 //
 // Markup:
@@ -38,7 +37,6 @@
 // --task     - Task
 //
 // Styleguide ffe-buttons.base-button.2
-
 
 // Expand Button
 //
@@ -61,7 +59,7 @@
     color: @ffe-white;
     cursor: pointer;
     display: flex;
-    font-family: "MuseoSansRounded-500", arial, sans-serif;
+    font-family: 'MuseoSansRounded-500', arial, sans-serif;
     justify-content: center;
     line-height: 24px;
     overflow: hidden;
@@ -93,7 +91,6 @@
     }
 }
 
-
 .ffe-button--action.ffe-button--ghost {
     &,
     &:focus {
@@ -118,7 +115,7 @@
 
     &:focus {
         background-color: darken(@ffe-green-shamrock, 5%);
-        box-shadow: 0 0 0 2px @ffe-blue-focus;
+        box-shadow: 0 0 0 1px @ffe-white, 0 0 0 4px @ffe-blue-focus;
     }
 
     &:hover {
@@ -135,7 +132,7 @@
 
     &:focus {
         background-color: darken(@ffe-blue-azure, 5%);
-        box-shadow: 0 0 0 2px @ffe-blue-focus;
+        box-shadow: 0 0 0 1px @ffe-white, 0 0 0 4px @ffe-blue-focus;
     }
 
     &:hover {
@@ -161,6 +158,10 @@
         background-color: @ffe-white;
         border-color: @ffe-blue-azure;
     }
+
+    &:focus {
+        box-shadow: 0 0 0 1px @ffe-white, 0 0 0 4px @ffe-blue-focus;
+    }
 }
 
 .ffe-button--expand {
@@ -168,18 +169,18 @@
     height: 45px;
 }
 
-.ffe-button--expanded {
+.ffe-button--expanded  {
     padding: 8px;
     width: 45px;
 }
 
 .ffe-button--task {
-    background-color: @ffe-white;
+    background: transparent;
     border-radius: 0;
     box-shadow: none;
     color: @ffe-blue-azure;
     display: inline-block;
-    padding: 2px;
+    padding: 4px;
     text-align: left;
     transition: all @ffe-transition-duration @ffe-ease;
     width: auto;
@@ -187,8 +188,8 @@
     &:active,
     &:focus,
     &:hover {
-        box-shadow: none;
         color: @ffe-blue-cobalt;
+        box-shadow: none;
     }
 }
 
@@ -200,7 +201,6 @@
 .ffe-button--loading {
     pointer-events: none;
 }
-
 
 .ffe-button__label {
     align-items: center;
@@ -238,11 +238,13 @@
         border: 2px solid @ffe-grey-silver;
         border-radius: 50%;
         box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
+        background-color: @ffe-white;
         fill: @ffe-blue-azure;
         height: 45px;
         padding: 13px;
         margin: 0 5px 0 0;
         width: 45px;
+        transition: all @ffe-transition-duration @ffe-ease;
     }
 
     .ffe-button--task:hover & {
@@ -257,7 +259,7 @@
 
     .ffe-button--task:focus & {
         border-color: @ffe-blue-cobalt;
-        box-shadow: 0 0 0 2px @ffe-blue-focus;
+        box-shadow: 0 0 0 1px @ffe-white, 0 0 0 4px @ffe-blue-focus;
     }
 }
 
@@ -294,8 +296,12 @@
         width: 22px;
 
         @keyframes button-loading-spin {
-            from { transform: none; }
-            to { transform: rotate(360deg); }
+            from {
+                transform: none;
+            }
+            to {
+                transform: rotate(360deg);
+            }
         }
     }
 }

--- a/packages/ffe-buttons/less/inline-base-button.less
+++ b/packages/ffe-buttons/less/inline-base-button.less
@@ -11,7 +11,6 @@
 //
 // Styleguide ffe-buttons.inline-base-button
 
-
 .ffe-inline-button {
     appearance: none;
     background-color: transparent;
@@ -28,14 +27,15 @@
 
     &:active,
     &:focus {
-        box-shadow: 0 0 0 2px @ffe-blue-focus;
+        box-shadow: 0 0 0 3px @ffe-blue-focus;
         color: @ffe-blue-cobalt;
         outline: none;
     }
 }
 
 .ffe-inline-button--back {
-    background: transparent no-repeat url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='0.8em' height='1.5em' viewBox='0 0 200 200'%3E%3Cpath transform = 'rotate(90 100 100)' fill = '%23676767' d='m16.171492,41.999998c-4.143269,0-8.2852797,1.57464-11.4277496,4.706478-6.3249899,6.283609-6.3249899,16.499474,0,22.803034l84.0286676,83.76282c6.30496,6.30356,16.54928,6.30356,22.87426,0l83.60959-83.26412c6.32499-6.28361,6.32499-16.499477,0-22.803038-6.30496-6.30356-16.55553-6.30356-22.88051,0l-72.13806,71.893768-72.613438-72.373767c-3.14247-3.151781-7.29074-4.725174-11.433999-4.725174h-0.0188z'/%3E%3C/svg%3E");
+    background: transparent no-repeat
+        url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='0.8em' height='1.5em' viewBox='0 0 200 200'%3E%3Cpath transform = 'rotate(90 100 100)' fill = '%23676767' d='m16.171492,41.999998c-4.143269,0-8.2852797,1.57464-11.4277496,4.706478-6.3249899,6.283609-6.3249899,16.499474,0,22.803034l84.0286676,83.76282c6.30496,6.30356,16.54928,6.30356,22.87426,0l83.60959-83.26412c6.32499-6.28361,6.32499-16.499477,0-22.803038-6.30496-6.30356-16.55553-6.30356-22.88051,0l-72.13806,71.893768-72.613438-72.373767c-3.14247-3.151781-7.29074-4.725174-11.433999-4.725174h-0.0188z'/%3E%3C/svg%3E");
     color: @ffe-grey-charcoal;
     line-height: 26px;
     padding-left: 1em;

--- a/packages/ffe-core/less/colors.less
+++ b/packages/ffe-core/less/colors.less
@@ -1,47 +1,47 @@
 // Blue
 @ffe-blue-royal: #002776; // Titles, lead, overlays
-@ffe-blue-cobalt: #005AA4; // Primary buttons, emphasis on blue areas and product cards
-@ffe-blue-azure: #0071CD; // Secondary buttons
-@ffe-blue-sky: #7FC6E8;
-@ffe-blue-pale: #DFF1F9; // Info-boxes, etc.
-@ffe-blue-ice: #EFF8FC; // Expandable table rows
-@ffe-blue-focus: rgba(68, 192, 255, 0.5); // Focus on buttons and controls
+@ffe-blue-cobalt: #005aa4; // Primary buttons, emphasis on blue areas and product cards
+@ffe-blue-azure: #0071cd; // Secondary buttons
+@ffe-blue-sky: #7fc6e8;
+@ffe-blue-pale: #dff1f9; // Info-boxes, etc.
+@ffe-blue-ice: #eff8fc; // Expandable table rows
+@ffe-blue-focus: #a1dfff; // Focus on buttons and controls
 
 // Green
-@ffe-green: #37B441; // E.g. slider tool
-@ffe-green-shamrock: #008A00; // Action buttons, slider tool, (should indicate affordance)
-@ffe-green-emerald: #007B00;
-@ffe-green-mint: #E1F4E3; // ~20% opacity of ffe-green-shamrock. (Info-boxes, etc.)
+@ffe-green: #37b441; // E.g. slider tool
+@ffe-green-shamrock: #008a00; // Action buttons, slider tool, (should indicate affordance)
+@ffe-green-emerald: #007b00;
+@ffe-green-mint: #e1f4e3; // ~20% opacity of ffe-green-shamrock. (Info-boxes, etc.)
 
 // Orange
-@ffe-orange: #FF9100; // Campaigns
-@ffe-orange-fire: #DA3D00; // Form validation, Error messages
-@ffe-orange-salmon: #F3BBAA; // ~20% opacity of ffe-orange-fire. (Info-boxes, etc.)
+@ffe-orange: #ff9100; // Campaigns
+@ffe-orange-fire: #da3d00; // Form validation, Error messages
+@ffe-orange-salmon: #f3bbaa; // ~20% opacity of ffe-orange-fire. (Info-boxes, etc.)
 
 // Red
-@ffe-red: #E60000;
+@ffe-red: #e60000;
 
 // Purple
-@ffe-purple: #C94096;
-@ffe-purple-magenta: #A20076;
-@ffe-purple-violet: #551A8B; // Visited links
+@ffe-purple: #c94096;
+@ffe-purple-magenta: #a20076;
+@ffe-purple-violet: #551a8b; // Visited links
 
 // Beige
-@ffe-sand: #F8F5EB; // @ffe-sand + @ffe-sand-25
+@ffe-sand: #f8f5eb; // @ffe-sand + @ffe-sand-25
 
 // White
-@ffe-white: #FFF;
+@ffe-white: #fff;
 
 // Grey
-@ffe-grey: #ADADAD;
-@ffe-grey-cloud: #F4F4F4; // Background panels
-@ffe-grey-silver: #CCC; // Lines, borders, inactive tool elements (slider, etc.)
+@ffe-grey: #adadad;
+@ffe-grey-cloud: #f4f4f4; // Background panels
+@ffe-grey-silver: #ccc; // Lines, borders, inactive tool elements (slider, etc.)
 @ffe-grey-charcoal: #676767;
-@ffe-grey-warm: #F6F6F3;
+@ffe-grey-warm: #f6f6f3;
 
 // Black
 @ffe-black: #262626; // Body text, and some other texts
 
 // Deprecated
-@ffe-blue-deep-sky: #008ED2; // Deprecated 05.2018 - Use @ffe-blue-azure in stead
-@ffe-sand-ivory: #FBFAF5; // Deprecated 05.2018 - Use @ffe-sand or @ffe-grey-warm in stead
+@ffe-blue-deep-sky: #008ed2; // Deprecated 05.2018 - Use @ffe-blue-azure in stead
+@ffe-sand-ivory: #fbfaf5; // Deprecated 05.2018 - Use @ffe-sand or @ffe-grey-warm in stead

--- a/packages/ffe-form/less/checkbox.less
+++ b/packages/ffe-form/less/checkbox.less
@@ -97,7 +97,7 @@
 
     &:active + .ffe-checkbox::before,
     &:focus + .ffe-checkbox::before {
-        box-shadow: 0 0 0 2px @ffe-blue-focus;
+        box-shadow: 0 0 0 1px @ffe-white, 0 0 0 4px @ffe-blue-focus;
     }
 
     &:checked + .ffe-checkbox::before {
@@ -106,7 +106,7 @@
     }
 
     &:focus + .ffe-checkbox::before {
-        box-shadow: 0 0 0 2px @ffe-blue-focus;
+        box-shadow: 0 0 0 1px @ffe-white, 0 0 0 4px @ffe-blue-focus;
     }
 
     &:checked + .ffe-checkbox::after {

--- a/packages/ffe-form/less/file-upload.less
+++ b/packages/ffe-form/less/file-upload.less
@@ -38,6 +38,7 @@
         color: @ffe-blue-azure;
         vertical-align: middle;
         margin-bottom: 10px;
+        transition: all @ffe-transition-duration @ffe-ease;
         .ffe-fontsize-button;
 
         @media all and (max-width: @breakpoint-sm) {
@@ -47,15 +48,12 @@
         &:active,
         &:focus,
         &:hover {
+            background-color: @ffe-white;
             border-color: @ffe-blue-azure;
         }
 
-        &:hover {
-            box-shadow: 0 1px 2px 1px rgba(0, 0, 0, 0.2);
-        }
-
-        &:active {
-            box-shadow: inset 0 1px 1px 0 rgba(0, 0, 0, 0.25);
+        &:focus {
+            box-shadow: 0 0 0 1px @ffe-white, 0 0 0 4px @ffe-blue-focus;
         }
 
         &[aria-invalid='true'] {

--- a/packages/ffe-form/less/input-field.less
+++ b/packages/ffe-form/less/input-field.less
@@ -32,7 +32,7 @@
     &:focus,
     &:active {
         border-color: @ffe-blue-azure;
-        box-shadow: 0 0 0 2px @ffe-blue-focus;
+        box-shadow: 0 0 0 1px @ffe-white, 0 0 0 4px @ffe-blue-focus;
         outline: none;
     }
 

--- a/packages/ffe-form/less/radio-block.less
+++ b/packages/ffe-form/less/radio-block.less
@@ -104,7 +104,7 @@
     }
 
     &:focus + .ffe-radio-block__content {
-        box-shadow: 0 0 0 2px @ffe-blue-focus;
+        box-shadow: 0 0 0 1px @ffe-white, 0 0 0 4px @ffe-blue-focus;
     }
 }
 

--- a/packages/ffe-form/less/radio-button.less
+++ b/packages/ffe-form/less/radio-button.less
@@ -124,7 +124,7 @@
 
     &:active + .ffe-radio-button::after,
     &:focus + .ffe-radio-button::after {
-        box-shadow: 0 0 0 2px @ffe-blue-focus;
+        box-shadow: 0 0 0 1px @ffe-white, 0 0 0 4px @ffe-blue-focus;
     }
 
     &:hover + .ffe-radio-button--invalid::after {

--- a/packages/ffe-form/less/radio-switch.less
+++ b/packages/ffe-form/less/radio-switch.less
@@ -62,7 +62,7 @@
     }
 
     &:focus + .ffe-radio-switch {
-        border-color: @ffe-blue-focus;
+        box-shadow: 0 0 0 1px @ffe-white, 0 0 0 4px @ffe-blue-focus;
     }
 
     /* stylelint-disable-next-line selector-max-specificity */

--- a/packages/ffe-form/less/textarea.less
+++ b/packages/ffe-form/less/textarea.less
@@ -26,7 +26,7 @@
     &:focus,
     &:active {
         border-color: @ffe-blue-azure;
-        box-shadow: 0 0 0 2px @ffe-blue-focus;
+        box-shadow: 0 0 0 1px @ffe-white, 0 0 0 4px @ffe-blue-focus;
         outline: none;
     }
 }

--- a/styleguide-content/visuell-identitet/farger.md
+++ b/styleguide-content/visuell-identitet/farger.md
@@ -33,7 +33,7 @@
         </li>
         <li class="sb1ds-color-palette__item sb1ds-color-palette__item--ffe-blue-focus">
             <div>Fokusblå</div>
-            <div>#44C0FF<br/>@ffe-blue-focus</div>
+            <div>#A1DFFF<br/>@ffe-blue-focus</div>
         </li>
         <li class="sb1ds-color-palette__item sb1ds-color-palette__item--ffe-green-shamrock">
             <div>Grønn WCAG</div>
@@ -257,7 +257,7 @@
             </td>
             <td class="ffe-table__cell">
                 <ul class="sb1ds-color-usage__list">
-                    <li>#44C0FF</li>
+                    <li>#A1DFFF</li>
                     <li>@ffe-blue-focus</li>
                 </ul>
             </td>


### PR DESCRIPTION
This PR adjusts the focus outline on a number of form elements, according to the mockups provided in #11.


#### Screenshot of buttons in focus on different backgrounds (couldn't be bothered to switch text colors for all examples, but you get the gist of it):

![focus-buttons](https://user-images.githubusercontent.com/463847/45683187-138cd600-bb43-11e8-8c41-f19fc41097c1.png)



#### Screenshot of other form elements with the updated focus outline:

![focus-form](https://user-images.githubusercontent.com/463847/45683188-15ef3000-bb43-11e8-8c7f-a789b9dd4502.png)

Fixes #11