### PR TITLE
Added missing border on invalid searchable dropdown

### DIFF
--- a/packages/ffe-searchable-dropdown-react/less/searchable-dropdown.less
+++ b/packages/ffe-searchable-dropdown-react/less/searchable-dropdown.less
@@ -74,4 +74,8 @@
       border-top: none;
     }
   }
+  [aria-invalid='true'] {
+    border-color: @ffe-orange-fire;
+    border-style: solid;
+  }
 }


### PR DESCRIPTION
I was missing this read border when aria-invalid="true". Most of the other components are wrapped in an <InputGroup /> but as this component provide its own label I suppose it should not be used together with <InputGroup />. Documentation did not show usage with <InputGroup /> either