### PR TITLE
fix(ffe-buttons): Specify buttongroup width in order to support full width

### DIFF
--- a/packages/ffe-buttons/less/button-group.less
+++ b/packages/ffe-buttons/less/button-group.less
@@ -17,6 +17,7 @@
     display: flex;
     flex-direction: column;
     padding: 40px 0;
+    width: 100%;
 
     .ffe-button,
     .ffe-inline-button {
@@ -41,6 +42,8 @@
     @media screen and (min-width: @breakpoint-sm) {
         display: inline-flex;
         flex-direction: row;
+        width: auto;
+
         .ffe-button,
         .ffe-inline-button {
             margin: 0 0 10px 10px;


### PR DESCRIPTION
This a fix to an issue in which buttons wrapped in `.ffe-button-group` would not be rendered in full width on mobile screens. This behaviour differs from `.ffe-button`, which is displayed as 100% wide by default on small screens.

#### Before:
![image](https://user-images.githubusercontent.com/463847/45959118-71289300-c019-11e8-9386-71afcfd352a0.png)

#### After:
![image](https://user-images.githubusercontent.com/463847/45959146-7daceb80-c019-11e8-8be6-4c6b37791cab.png)

Fixes #418 