### PR TITLE
feat(ffe-searchable-dropdown-react): Extended noMatch to allow for a …

### DIFF
--- a/packages/ffe-searchable-dropdown-react/src/ListContainer.js
+++ b/packages/ffe-searchable-dropdown-react/src/ListContainer.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { array, string, number, func } from 'prop-types';
+import { array, string, number, func, oneOfType, shape } from 'prop-types';
 import ListItem from './ListItem';
 
 const ListContainer = ({
@@ -13,9 +13,13 @@ const ListContainer = ({
     maxRenderedDropdownElements,
 }) => {
     const itemsToRender =
-        maxRenderedDropdownElements > 0
-            ? dropdownList.slice(0, maxRenderedDropdownElements)
-            : dropdownList;
+        dropdownList.length > 0
+            ? maxRenderedDropdownElements > 0
+                ? dropdownList.slice(0, maxRenderedDropdownElements)
+                : dropdownList
+            : typeof noMatch === 'string'
+                ? []
+                : noMatch.items;
     return (
         <ul
             className="ffe-searchable-dropdown__scroll-container-list"
@@ -26,6 +30,12 @@ const ListContainer = ({
                 highlightedIndex
             }
         >
+            {dropdownList.length === 0 && (
+                <li className="ffe-searchable-dropdown__item">
+                    {typeof noMatch === 'string' ? noMatch : noMatch.text}
+                </li>
+            )}
+
             {itemsToRender.map((item, index) => {
                 return (
                     <ListItem
@@ -44,9 +54,6 @@ const ListContainer = ({
                 dropdownList.length > maxRenderedDropdownElements && (
                     <li className="ffe-searchable-dropdown__item">...</li>
                 )}
-            {dropdownList.length === 0 && (
-                <li className="ffe-searchable-dropdown__item">{noMatch}</li>
-            )}
         </ul>
     );
 };
@@ -56,7 +63,13 @@ ListContainer.propTypes = {
     dropdownList: array.isRequired,
     maxRenderedDropdownElements: number,
     highlightedIndex: number.isRequired,
-    noMatch: string.isRequired,
+    noMatch: oneOfType([
+        string,
+        shape({
+            text: string.isRequired,
+            items: array,
+        }),
+    ]).isRequired,
     onSelect: func.isRequired,
     renderDropdownElement: func,
     refHighlightedListItem: func.isRequired,

--- a/packages/ffe-searchable-dropdown-react/src/ListContainer.spec.js
+++ b/packages/ffe-searchable-dropdown-react/src/ListContainer.spec.js
@@ -127,6 +127,22 @@ describe('<ListContainer>', () => {
         ).toEqual(noMatchText);
     });
 
+    it("renders noMatch's fallback items when input value doesn't match any items in droplist", () => {
+        const props = {
+            ...defaultProps,
+            noMatch: {
+                text: noMatchText,
+                items: yrker.slice(0, 4),
+            },
+            dropdownList: [],
+        };
+        const component = mountDropdownWithProps(props);
+        expect(component.find(ListItem)).toHaveLength(4);
+        expect(
+            component.find('li.ffe-searchable-dropdown__item').text(),
+        ).toEqual(noMatchText);
+    });
+
     it('highlights correct element', () => {
         const highlightedIndex = 4;
         const maxRenderedDropdownElements = 50;

--- a/packages/ffe-searchable-dropdown-react/src/SearchableDropdown.js
+++ b/packages/ffe-searchable-dropdown-react/src/SearchableDropdown.js
@@ -1,5 +1,15 @@
 import React, { Component } from 'react';
-import { string, bool, array, func, arrayOf, object, number } from 'prop-types';
+import {
+    string,
+    bool,
+    array,
+    func,
+    arrayOf,
+    object,
+    number,
+    shape,
+    oneOfType,
+} from 'prop-types';
 import classNames from 'classnames';
 import Input from './InputField';
 import ScrollContainer from './ScrollContainer';
@@ -264,8 +274,15 @@ SearchableDropdown.propTypes = {
     inputId: isRequiredIf(string, props => props.label),
     /** Value of input field */
     inputValue: string,
-    /** value to be displayed in dropdown in case of search with no match */
-    noMatch: string.isRequired,
+    noMatch: oneOfType([
+        /** value to be displayed in dropdown in case of search with no match */
+        string,
+        /** or value to be display along another list of items */
+        shape({
+            text: string.isRequired,
+            items: array,
+        }),
+    ]).isRequired,
     /** Function receives value of inputField and should update inputValue */
     onInputChange: func.isRequired,
     /** Function receives no input expects no return */

--- a/packages/ffe-searchable-dropdown-react/src/SearchableDropdown.md
+++ b/packages/ffe-searchable-dropdown-react/src/SearchableDropdown.md
@@ -93,3 +93,30 @@ const renderItem = unreadLabel => company => (
     searchAttributes={['organizationName', 'organizationNumber']}
 />;
 ```
+
+Du kan også vise ekstra resultater om søket feiler, som under.
+
+```jsx
+const yrker = require('../exampleData').yrker;
+const initialState = { inputValue: '' };
+
+const noMatchExtra = {
+    text: 'Finner ikke yrket. Søk på nytt eller velg en passende kategori:',
+    items: yrker.slice(1, 4),
+};
+
+<SearchableDropdown
+    displayResetWhenInputHasValue={true}
+    dropdownAttributes={['beskrivelse']}
+    dropdownList={yrker}
+    inputId="searchable-dropdown-single-attribute"
+    inputValue={state.inputValue}
+    label="Velg yrke"
+    noMatch={noMatchExtra}
+    onInputChange={value => setState({ inputValue: value })}
+    onReset={() => setState({ inputValue: '' })}
+    onSelect={yrke => setState({ inputValue: yrke.beskrivelse })}
+    placeholder="Velg"
+    searchAttributes={['beskrivelse']}
+/>;
+```


### PR DESCRIPTION
…set of fallback items.

This commit should be backwards compatible while allowing for a new set of items to be displayed for when the search results fail.

The appearance of the dropdown before there is an interaction should remain the same, while the dropdown with this extended noMatch feature will appear like this:
![skjermbilde](https://user-images.githubusercontent.com/193346/46015341-5b2ad900-c0d2-11e8-8f6b-43f10b77daec.PNG)

<!-- 
Thanks for opening a pull request! 🎉

If your changes include some kind of UI element, please attach a screenshot of 
how it looks.

Before submitting a pull request, please have a look through the CONTRIBUTING.md
document. TL;DR:

- Follow the conventional commit standard
- Write full, explanatory commit messages
- Follow our code standards
- Write tests where applicable
- Be courteous and respect our code of conduct
-->
