### PR TITLE
fix(ffe-chart-donut-react): include .less file in lib/ root

### DIFF
--- a/packages/ffe-chart-donut-react/package.json
+++ b/packages/ffe-chart-donut-react/package.json
@@ -18,7 +18,7 @@
     "url": "ssh://git@github.com:SpareBank1/designsystem.git"
   },
   "scripts": {
-    "build": "babel -d lib/. --ignore=*.spec.js src/ && copyfiles src/ffe-chart-donut.less lib/",
+    "build": "babel -d lib/. --ignore=*.spec.js src/ && copyfiles -f src/ffe-chart-donut.less lib/",
     "lint": "eslint src/.",
     "test": "jest",
     "test:watch": "jest --watch"


### PR DESCRIPTION
Flatten the output of `copyfiles` so that the less file is placed
in *lib/* and not *lib/src/*

Fixes #441

<!-- 
Thanks for opening a pull request! 🎉

If your changes include some kind of UI element, please attach a screenshot of 
how it looks.

Before submitting a pull request, please have a look through the CONTRIBUTING.md
document. TL;DR:

- Follow the conventional commit standard
- Write full, explanatory commit messages
- Follow our code standards
- Write tests where applicable
- Be courteous and respect our code of conduct
-->
