### PR TITLE
Use css transiton in ffe-tooltip-react

### DIFF
--- a/packages/ffe-accordion-react/package.json
+++ b/packages/ffe-accordion-react/package.json
@@ -25,7 +25,7 @@
     "@sb1/ffe-icons-react": "^6.0.6",
     "classnames": "^2.2.5",
     "prop-types": "^15.6.0",
-    "react-css-collapse": "^3.5.0",
+    "react-css-collapse": "^3.6.0",
     "uuid": "^3.1.0"
   },
   "devDependencies": {

--- a/packages/ffe-form-react/package.json
+++ b/packages/ffe-form-react/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "classnames": "^2.2.5",
-    "react-collapse": "^4.0.3",
+    "react-css-collapse": "^3.6.0",
     "uuid": "^3.1.0"
   },
   "devDependencies": {

--- a/packages/ffe-form-react/src/Tooltip.js
+++ b/packages/ffe-form-react/src/Tooltip.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { bool, func, node, string, number } from 'prop-types';
 import classNames from 'classnames';
-import { Collapse } from 'react-collapse';
+import Collapse from 'react-css-collapse';
 
 class Tooltip extends React.Component {
     constructor({ isOpen }) {
@@ -31,12 +31,15 @@ class Tooltip extends React.Component {
         const { isOpen } = this.state;
 
         return (
-            <span {...rest}>
+            <span
+                {...rest}
+                className={classNames('ffe-tooltip', {
+                    'ffe-tooltip--open': isOpen,
+                })}
+            >
                 <button
                     aria-label={ariaLabel}
-                    className={classNames('ffe-tooltip__icon', {
-                        'ffe-tooltip__icon--active': isOpen,
-                    })}
+                    className="ffe-tooltip__icon"
                     onClick={this.onToggle}
                     type="button"
                     tabIndex={tabIndex}
@@ -44,7 +47,11 @@ class Tooltip extends React.Component {
                     ?
                 </button>
                 {children && (
-                    <Collapse isOpened={isOpen} aria-expanded={String(isOpen)}>
+                    <Collapse
+                        isOpen={isOpen}
+                        className="ffe-tooltip__text"
+                        aria-expanded={String(isOpen)}
+                    >
                         <div
                             className={classNames('ffe-small-text', className)}
                         >

--- a/packages/ffe-form-react/src/Tooltip.spec.js
+++ b/packages/ffe-form-react/src/Tooltip.spec.js
@@ -35,20 +35,16 @@ describe('<Tooltip>', () => {
     it('toggles collapse if button is clicked', () => {
         const wrapper = getWrapper();
 
-        expect(wrapper.find('Collapse').prop('isOpened')).toBe(false);
+        expect(wrapper.find('Collapse').prop('isOpen')).toBe(false);
         wrapper.find('button').simulate('click');
-        expect(wrapper.find('Collapse').prop('isOpened')).toBe(true);
+        expect(wrapper.find('Collapse').prop('isOpen')).toBe(true);
     });
 
     it('toggles active state if button is clicked', () => {
         const wrapper = getWrapper();
-        expect(
-            wrapper.find('button').hasClass('ffe-tooltip__icon--active'),
-        ).toBe(false);
+        expect(wrapper.hasClass('ffe-tooltip--open')).toBe(false);
         wrapper.find('button').simulate('click');
-        expect(
-            wrapper.find('button').hasClass('ffe-tooltip__icon--active'),
-        ).toBe(true);
+        expect(wrapper.hasClass('ffe-tooltip--open')).toBe(true);
     });
 
     it('does not have a tabIndex unless otherwise specified', () => {

--- a/packages/ffe-form/less/tooltip.less
+++ b/packages/ffe-form/less/tooltip.less
@@ -1,7 +1,14 @@
 // Tooltip
 //
 // Markup:
-// <button class="ffe-tooltip__icon" type="button">?</button>
+// <div class="ffe-tooltip ffe-tooltip{{modifier_class}}">
+//   <button class="ffe-tooltip__icon" type="button">?</button>
+//   <div class="ffe-tooltip__text" aria-expanded="true">
+//     <div class="ffe-small-text">Dette er lurt å tenke på</div>
+//   </div>
+// </div>
+//
+// --open - Tooltip text visible
 //
 // Styleguide ffe-form.tooltip
 
@@ -35,20 +42,24 @@
         }
 
         &:active,
-        &--active {
+        .ffe-tooltip--open & {
             border-color: @ffe-blue-royal;
             color: @ffe-blue-royal;
         }
     }
 
     &__text {
-        margin: 0;
-        max-height: 0;
+        will-change: height;
+        height: 0;
         overflow: hidden;
-        transition: all @ffe-transition-duration @ffe-ease;
+        visibility: hidden;
+        transition: height @ffe-transition-duration @ffe-ease;
+    }
 
-        &--active {
-            margin-bottom: 12px;
-        }
+    &--open &__text {
+        padding-bottom: 12px;
+        height: auto;
+        overflow: visible;
+        visibility: visible;
     }
 }

--- a/packages/ffe-system-message-react/package.json
+++ b/packages/ffe-system-message-react/package.json
@@ -25,7 +25,8 @@
     "@sb1/ffe-grid-react": "^9.0.2",
     "classnames": "^2.2.5",
     "prop-types": "^15.6.0",
-    "react-collapse": "^4.0.3"
+    "react-collapse": "^4.0.3",
+    "react-motion": "^0.5.2"
   },
   "devDependencies": {
     "@sb1/ffe-icons-react": "^6.0.6",


### PR DESCRIPTION
In this pull request:

* `ffe-form/ffe-tooltip`: adds css transition.
* `ffe-form-react/Tooltip`: replaces scripted animation with css.
* `ffe-system-message-react`: adds missing dependency to `react-motion`.