### PR TITLE
Inline grid

### DIFF
--- a/packages/ffe-grid-react/src/Grid.md
+++ b/packages/ffe-grid-react/src/Grid.md
@@ -1,6 +1,6 @@
 Gridet består av tre komponenter - `<Grid />`, `<GridRow />` og `<GridCol />` - grid, rad og kolonne.
 
-Det kan være mange grids per side, men man kan ikke ha grids inni andre grids.
+Det kan være mange grids per side, men man kan ikke ha grids inni andre grids. `Grid`-komponenten brukes til å lage layout på side-nivå.
 
 Det finnes en rekke modifiers på alle tre komponentene som lar deg manipulere hvor innholdet skal plassere seg i en
 kolonne. Ta en titt på prop-types for å finne disse.

--- a/packages/ffe-grid-react/src/InlineGrid.js
+++ b/packages/ffe-grid-react/src/InlineGrid.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import classNames from 'classnames';
+import { node, string } from 'prop-types';
+
+export default function InlineGrid(props) {
+    const { className, element: Element, ...rest } = props;
+
+    return (
+        <Element
+            className={classNames(className, 'ffe-grid', 'ffe-grid--inline')}
+            {...rest}
+        />
+    );
+}
+
+InlineGrid.propTypes = {
+    /** Any children of a InlineGrid must be a GridRow */
+    children: node,
+    /** Any extra classes are attached to the root node, in addition to ffe-grid classes */
+    className: string,
+    /** Specify the DOM element being used to create the Grid */
+    element: string,
+};
+
+InlineGrid.defaultProps = {
+    element: 'div',
+};

--- a/packages/ffe-grid-react/src/InlineGrid.md
+++ b/packages/ffe-grid-react/src/InlineGrid.md
@@ -1,0 +1,34 @@
+`InlineGrid` er et alternativ til `Grid`, men uten noen form for spacing i grid, rader eller kolonner. `<InlineGrid />` er i struktur identisk med `<Grid />` - den tar i mot de samme modifierne, bruker samme props (minus `condensed` og `topPadding`) og bygger rader og kolonner med `<GridRow />` og `<GridCol />`.
+
+`InlineGrid` kan nøstes, i motsetning til `Grid`. Med andre ord kan man ha flere grids inni hverandre. Denne komponenten er ideell til å lage layout på lavere nivå, som i komponenter, skjemaer, widgeter og lignende.
+
+```js
+<InlineGrid>
+    <GridRow>
+        <GridCol sm="6">Litt innhold til venstre</GridCol>
+        <GridCol sm="6">Litt innhold til høyre</GridCol>
+    </GridRow>
+</InlineGrid>
+```
+
+```js
+<InlineGrid>
+    <GridRow>
+        <GridCol sm="12" md="6" background="grey-warm">
+            Litt innhold til venstre
+        </GridCol>
+        <GridCol sm="12" md="6">
+            <InlineGrid>
+                <GridRow>
+                    <GridCol sm="6" background="blue-ice">
+                        Grid inni grid - venstre
+                    </GridCol>
+                    <GridCol sm="6" background="green-mint">
+                        Grid inni grid - høyre
+                    </GridCol>
+                </GridRow>
+            </InlineGrid>
+        </GridCol>
+    </GridRow>
+</InlineGrid>
+```

--- a/packages/ffe-grid-react/src/InlineGrid.spec.js
+++ b/packages/ffe-grid-react/src/InlineGrid.spec.js
@@ -1,0 +1,45 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { InlineGrid } from '.';
+
+const defaultProps = {
+    children: <p>blah</p>,
+};
+
+const renderShallow = (props = {}) =>
+    shallow(<InlineGrid {...defaultProps} {...props} />);
+
+describe('InlineGrid', () => {
+    it('renders with default class and element', () => {
+        const el = renderShallow();
+
+        expect(el.hasClass('ffe-grid--inline')).toBe(true);
+        expect(el.type()).toBe('div');
+    });
+
+    it('renders with custom class', () => {
+        const el = renderShallow({ className: 'custom-class' });
+        expect(el.hasClass('custom-class')).toBe(true);
+    });
+
+    it('renders provided children node', () => {
+        const el = renderShallow();
+
+        expect(el.containsMatchingElement(<p>blah</p>)).toBe(true);
+    });
+
+    it('preserves other attributes that are passed to it', () => {
+        const handler = jest.fn();
+        const el = renderShallow({ onClick: handler });
+
+        el.simulate('click');
+
+        expect(handler).toHaveBeenCalledTimes(1);
+    });
+
+    it('can render a custom root element', () => {
+        const el = renderShallow({ element: 'section' });
+
+        expect(el.type()).toBe('section');
+    });
+});

--- a/packages/ffe-grid-react/src/index.js
+++ b/packages/ffe-grid-react/src/index.js
@@ -1,3 +1,4 @@
 export { default as Grid } from './Grid';
+export { default as InlineGrid } from './InlineGrid';
 export { default as GridRow } from './GridRow';
 export { default as GridCol } from './GridCol';

--- a/packages/ffe-grid/less/ffe-grid.less
+++ b/packages/ffe-grid/less/ffe-grid.less
@@ -18,6 +18,9 @@
 //     </div>
 // </div>
 //
+// --condensed              - Grid with less internal spacing
+// --inline                 - Grid with no internal spacing
+//
 // Styleguide ffe-grid.grid.1
 
 // Grid row
@@ -134,6 +137,10 @@
             padding-top: 0;
         }
     }
+
+    &--inline {
+        padding: 0;
+    }
 }
 
 .ffe-grid__row {
@@ -233,6 +240,10 @@
                 @ffe-condensed-grid-gutter-lg;
         }
     }
+
+    .ffe-grid--inline & {
+        padding: 0;
+    }
 }
 [class*='ffe-grid__col--bg-'] {
     @media only screen and (min-width: @breakpoint-lg) {
@@ -266,6 +277,12 @@
             }
             &::after {
                 right: -(@ffe-condensed-grid-gutter-lg / 2);
+            }
+        }
+        .ffe-grid--inline & {
+            &::before,
+            &::after {
+                display: none;
             }
         }
     }


### PR DESCRIPTION
### Suggested feature

This PR adds `InlineGrid`, a component that renders a `Grid`, but with no spacing. Stripping the spacing allows us to nest grids and create layouts not only for entire pages, but also for separate components, forms, content sections, etc.

#### Why do we need this?

Currently, the design system includes no tools to create layouts other than `ffe-grid(-react)`. While pages can be laid out nicely using the regular grid, it's not suited for other tasks due to internal spacing/gutters. Any lower level layouts are left up to the consumer to deal with, meaning there are many different implementations throughout our apps. Thus, an inline grid has potential to ease the process of writing markup and styling in apps considerably.

Another potential win is a more pragmatic approach to setting element widths. With no tool to use, consumers will typically pick a value specified in pixels or percentages that works on a case by case basis, but patterns established in similar pages/components are less likely to be considered. A grid implementation will limit the options a bit, while ensuring that different elements are generally aligned to one another.

Fixes #388 