### PR TITLE
Add section about peer-dependencies

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -12,4 +12,14 @@ document. TL;DR:
 - Follow our code standards
 - Write tests where applicable
 - Be courteous and respect our code of conduct
+
+*NOTE
+
+If you are making any breaking changes that will lead to a new major release, please
+visit the package's dependents and update their peerDependencies (remember to test
+that they still work)
+
+You can find dependents by visiting https://www.npmjs.com/browse/depended/@sb1/<package>.
+(e.g: https://www.npmjs.com/browse/depended/@sb1/ffe-core)
+
 -->


### PR DESCRIPTION
I was thinking something like this can remedy the issue in #415. The only problem is... The depended URL does not show peerDepedencies and `ffe-form` is showing up because it has an optionalDependency so for this to work we'd need to use both.

Optional means that npm will try to install it but the process won't fail if it can't. I'm not sure what exactly happens if the project already depends on a different version of said package, that's maybe something we should test.

So in short, this can't be merged yet, we need to figure out a way to detect packages that will need updates. I just figured I'd get the ball rolling on this.

<!-- 
Thanks for opening a pull request! 🎉

If your changes include some kind of UI element, please attach a screenshot of 
how it looks.

Before submitting a pull request, please have a look through the CONTRIBUTING.md
document. TL;DR:

- Follow the conventional commit standard
- Write full, explanatory commit messages
- Follow our code standards
- Write tests where applicable
- Be courteous and respect our code of conduct
-->
