### PR TITLE
Visible underline on tertiary button in inline mode

### DIFF
--- a/packages/ffe-buttons/less/inline-base-button.less
+++ b/packages/ffe-buttons/less/inline-base-button.less
@@ -74,6 +74,7 @@
     &::after {
         border-bottom: solid 1px currentColor;
         content: ' ';
+        display: inherit;
         width: 100%;
     }
 


### PR DESCRIPTION
**Bug fix**

This PR fixes a bug where the underline of tertiary button is not visible in inline mode.

This fix makes all tertiary buttons align with the sketch file design of tertiary button:

After fix:

![image](https://user-images.githubusercontent.com/36953762/46478055-683f7a80-c7ec-11e8-8f6d-0f0198bf2c24.png)

Fixes #446.
