### PR TITLE
feat(ffe-accordion-react): Add classname prop for Accordion and Accor…

### DIFF
--- a/packages/ffe-accordion-react/src/Accordion.js
+++ b/packages/ffe-accordion-react/src/Accordion.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { node, bool } from 'prop-types';
+import { node, bool, string } from 'prop-types';
 import uuid from 'uuid';
 import classNames from 'classnames';
 
@@ -11,16 +11,19 @@ class Accordion extends Component {
     }
 
     render() {
-        const { children, isBlue, ...rest } = this.props;
+        const { children, isBlue, className, ...rest } = this.props;
 
         return (
             <ul
                 {...rest}
                 aria-multiselectable="true"
-                className={classNames({
-                    'ffe-accordion': true,
-                    'ffe-accordion--blue': isBlue,
-                })}
+                className={classNames(
+                    {
+                        'ffe-accordion': true,
+                        'ffe-accordion--blue': isBlue,
+                    },
+                    className,
+                )}
                 role="tablist"
             >
                 {React.Children.map(children, ele =>
@@ -39,6 +42,8 @@ Accordion.propTypes = {
      * @ignore
      **/
     isBlue: bool,
+    /** Extra class names */
+    className: string,
 };
 
 Accordion.defaultProps = {

--- a/packages/ffe-accordion-react/src/AccordionItem.js
+++ b/packages/ffe-accordion-react/src/AccordionItem.js
@@ -40,16 +40,26 @@ class AccordionItem extends Component {
     };
 
     render() {
-        const { ariaLabel, children, index, title, uuid } = this.props;
+        const {
+            ariaLabel,
+            className,
+            children,
+            index,
+            title,
+            uuid,
+        } = this.props;
 
         const open = this.getOpen();
 
         return (
             <li
-                className={classNames({
-                    'ffe-accordion-item': true,
-                    'ffe-accordion-item--open': open,
-                })}
+                className={classNames(
+                    {
+                        'ffe-accordion-item': true,
+                        'ffe-accordion-item--open': open,
+                    },
+                    className,
+                )}
             >
                 <div
                     tabIndex={0}
@@ -93,6 +103,8 @@ AccordionItem.propTypes = {
     ariaLabel: string,
     /** The content shown when an accordion item is expanded */
     children: node,
+    /** Extra class names */
+    className: string,
     /** List of node names the toggle click handler will ignore */
     ignoredNodeNames: arrayOf(string),
     /** The index of the accordion item in the current accordion */


### PR DESCRIPTION
…dionItem

This version adds extra className prop to Accordion and AccordionItem to be able to use own classes

<!-- 
Thanks for opening a pull request! 🎉

If your changes include some kind of UI element, please attach a screenshot of 
how it looks.

Before submitting a pull request, please have a look through the CONTRIBUTING.md
document. TL;DR:

- Follow the conventional commit standard
- Write full, explanatory commit messages
- Follow our code standards
- Write tests where applicable
- Be courteous and respect our code of conduct
-->
