### PR TITLE
fix(ffe-buttons): Set a safer display value on tertiary button pseudo element

### DIFF
--- a/packages/ffe-buttons/less/inline-base-button.less
+++ b/packages/ffe-buttons/less/inline-base-button.less
@@ -74,7 +74,7 @@
     &::after {
         border-bottom: solid 1px currentColor;
         content: ' ';
-        display: inherit;
+        display: block;
         width: 100%;
     }
 


### PR DESCRIPTION
Set display value of tertiary button underline to `block` in stead of `inherit`, as discussed in [#449](https://github.com/SpareBank1/designsystem/pull/449#discussion_r222676377).