### PR TITLE
fix(ffe-account-selector-react): Suggestions will now correctly lose …

### DIFF
--- a/packages/ffe-account-selector-react/src/components/base-selector/BaseSelector.js
+++ b/packages/ffe-account-selector-react/src/components/base-selector/BaseSelector.js
@@ -74,10 +74,6 @@ class BaseSelector extends Component {
         setTimeout(this.setFocus);
     }
 
-    onExpandOrCollapseClick() {
-        this.showOrHideSuggestions(!this.state.showSuggestions);
-    }
-
     showOrHideSuggestions(show, cb = () => {}) {
         const nextState = show
             ? { showSuggestions: show }
@@ -202,7 +198,7 @@ class BaseSelector extends Component {
             suggestions,
             onSuggestionSelect,
             readOnly,
-            locale
+            locale,
         } = this.props;
         const {
             showSuggestions,
@@ -230,7 +226,6 @@ class BaseSelector extends Component {
                     id={id}
                     name={name}
                     readOnly={readOnly}
-                    onExpandOrCollapseClick={this.onExpandOrCollapseClick}
                     locale={locale}
                 />
                 {showSuggestions && (
@@ -287,7 +282,7 @@ BaseSelector.defaultProps = {
     ariaInvalid: false,
     placeholder: '',
     value: '',
-    shouldShowSuggestionsOnFocus: true
+    shouldShowSuggestionsOnFocus: true,
 };
 
 export default BaseSelector;

--- a/packages/ffe-account-selector-react/src/components/base-selector/BaseSelector.spec.js
+++ b/packages/ffe-account-selector-react/src/components/base-selector/BaseSelector.spec.js
@@ -213,16 +213,34 @@ describe('<BaseSelector> methods', () => {
         const component = mountBaseSelector({ value: 'notempty' });
         const onResetSpy = jest.spyOn(component.instance(), 'onInputReset');
         component.instance().forceUpdate();
-        component.find('.ffe-base-selector__reset-button').simulate('mousedown');
+        component
+            .find('.ffe-base-selector__reset-button')
+            .simulate('mousedown');
 
         expect(onResetSpy).toHaveBeenCalled();
     });
 
-    it('should call onExpandOrCollapseClick on expandOrCollapse button mousedown', () => {
+    it('should call onFocus on expandOrCollapse button mousedown when suggestions not showing', () => {
         const component = mountBaseSelector();
-        const onResetSpy = jest.spyOn(component.instance(), 'onExpandOrCollapseClick');
+        const onResetSpy = jest.spyOn(component.instance(), 'onFocus');
         component.instance().forceUpdate();
-        component.find('.ffe-base-selector__expand-button').simulate('mousedown');
+        component
+            .find('.ffe-base-selector__expand-button')
+            .simulate('mousedown');
+
+        expect(onResetSpy).toHaveBeenCalled();
+    });
+
+    it('should call onBlur on expandOrCollapse button mousedown when suggestions are showing', () => {
+        const component = mountBaseSelector();
+        component.setState({
+            showSuggestions: true,
+        });
+        const onResetSpy = jest.spyOn(component.instance(), 'onBlur');
+        component.instance().forceUpdate();
+        component
+            .find('.ffe-base-selector__expand-button')
+            .simulate('mousedown');
 
         expect(onResetSpy).toHaveBeenCalled();
     });
@@ -233,7 +251,9 @@ describe('<BaseSelector> methods', () => {
         const value = 'value';
         const event = { target: { value } };
         component.instance().forceUpdate();
-        component.find('.ffe-base-selector__input-field').simulate('change', event);
+        component
+            .find('.ffe-base-selector__input-field')
+            .simulate('change', event);
 
         expect(onInputChange).toHaveBeenCalledWith(value);
     });
@@ -245,8 +265,7 @@ describe('<BaseSelector> methods', () => {
         component.find('.ffe-base-selector__input-field').simulate('blur');
 
         expect(onBlur).toHaveBeenCalled();
-    })
-
+    });
 });
 
 describe('<BaseSelector> keyboard navigation', () => {

--- a/packages/ffe-account-selector-react/src/subcomponents/input-field/InputField.js
+++ b/packages/ffe-account-selector-react/src/subcomponents/input-field/InputField.js
@@ -42,7 +42,14 @@ class Input extends Component {
 
     onExpandOrCollapse(e) {
         e.preventDefault();
-        this.props.onExpandOrCollapseClick();
+
+        const { isSuggestionsShowing } = this.props;
+        if (isSuggestionsShowing) {
+            this.onBlur();
+        } else {
+            e.currentTarget.previousElementSibling.focus();
+            this.onFocus();
+        }
     }
 
     componentWillReceiveProps(nextProps) {
@@ -65,7 +72,7 @@ class Input extends Component {
             suggestionListId,
             name,
             readOnly,
-            locale
+            locale,
         } = this.props;
 
         const showReset = !readOnly && value.length > 0;
@@ -106,7 +113,7 @@ class Input extends Component {
                         type="button"
                         aria-label={txt[locale].RESET_SEARCH}
                     >
-                        <KryssIkon className="ffe-base-selector__reset-button-icon"/>
+                        <KryssIkon className="ffe-base-selector__reset-button-icon" />
                     </button>
                 )}
                 <button
@@ -114,12 +121,18 @@ class Input extends Component {
                     onMouseDown={this.onExpandOrCollapse}
                     tabIndex={-1}
                     type="button"
-                    aria-label={isSuggestionsShowing ? txt[locale].ACCOUNTSLIST_CLOSE : txt[locale].ACCOUNTSLIST_OPEN}
+                    aria-label={
+                        isSuggestionsShowing
+                            ? txt[locale].ACCOUNTSLIST_CLOSE
+                            : txt[locale].ACCOUNTSLIST_OPEN
+                    }
                 >
                     <ChevronIkon
                         className={classNames(
                             'ffe-base-selector__expand-button-icon ',
-                            { 'ffe-base-selector__expand-button-icon--invalid': ariaInvalid }
+                            {
+                                'ffe-base-selector__expand-button-icon--invalid': ariaInvalid,
+                            },
                         )}
                     />
                 </button>
@@ -131,7 +144,6 @@ class Input extends Component {
 Input.propTypes = {
     onChange: func.isRequired,
     onKeyDown: func.isRequired,
-    onExpandOrCollapseClick: func.isRequired,
     value: string.isRequired,
     onReset: func.isRequired,
     isSuggestionsShowing: bool.isRequired,
@@ -146,7 +158,7 @@ Input.propTypes = {
     highlightedIndex: number,
     suggestionListId: string,
     name: string,
-    locale: Locale.isRequired
+    locale: Locale.isRequired,
 };
 
 Input.defaultProps = {

--- a/packages/ffe-account-selector-react/src/subcomponents/input-field/InputField.spec.js
+++ b/packages/ffe-account-selector-react/src/subcomponents/input-field/InputField.spec.js
@@ -1,14 +1,9 @@
 import React from 'react';
 import { mount } from 'enzyme';
 
-
 import InputField from './InputField';
 
-
-function renderInputField(
-    value = 'value',
-    readOnly = false
-) {
+function renderInputField(value = 'value', readOnly = false) {
     return mount(
         <InputField
             onChange={() => {}}
@@ -18,9 +13,8 @@ function renderInputField(
             isSuggestionsShowing={false}
             id="id"
             readOnly={readOnly}
-            onExpandOrCollapseClick={() => {}}
             locale="nb"
-        />
+        />,
     );
 }
 
@@ -28,24 +22,18 @@ describe('<InputField />', () => {
     it('displays a reset button', () => {
         const wrapper = renderInputField();
 
-        expect(
-            wrapper.find('.ffe-base-selector__reset-button').length
-        ).toBe(1);
+        expect(wrapper.find('.ffe-base-selector__reset-button').length).toBe(1);
     });
 
     it('hides reset button when empty', () => {
-       const wrapper = renderInputField('');
+        const wrapper = renderInputField('');
 
-        expect(
-            wrapper.find('.ffe-base-selector__reset-button').length
-        ).toBe(0);
+        expect(wrapper.find('.ffe-base-selector__reset-button').length).toBe(0);
     });
 
     it('hides reset button when readOnly', () => {
         const wrapper = renderInputField('value', true);
 
-        expect(
-            wrapper.find('.ffe-base-selector__reset-button').length
-        ).toBe(0);
+        expect(wrapper.find('.ffe-base-selector__reset-button').length).toBe(0);
     });
 });


### PR DESCRIPTION
…focus

The suggestion list will now close when AccountSelector lose focus after opening it by clicking the chevron

Fixes #435 