### PR TITLE
fix(ffe-form-react): Fix double onTooltipToggle calls

### DIFF
--- a/packages/ffe-form-react/src/Tooltip.js
+++ b/packages/ffe-form-react/src/Tooltip.js
@@ -24,6 +24,8 @@ class Tooltip extends React.Component {
             'aria-label': ariaLabel,
             children,
             className,
+            // eslint-disable-next-line no-unused-vars
+            onClick,
             tabIndex,
             ...rest
         } = this.props;


### PR DESCRIPTION
Make sure InputGroup's onTooltipToggle is not called twice.

This version includes a fix for a bug where the onTooltipToggle callback of InputGroup was called twice.

Fixes #457

<!-- 
Thanks for opening a pull request! 🎉

If your changes include some kind of UI element, please attach a screenshot of 
how it looks.

Before submitting a pull request, please have a look through the CONTRIBUTING.md
document. TL;DR:

- Follow the conventional commit standard
- Write full, explanatory commit messages
- Follow our code standards
- Write tests where applicable
- Be courteous and respect our code of conduct
-->
