### PR TITLE
fix(ffe-grid): Add example with necessary markup for grid rows with background color

### DIFF
--- a/packages/ffe-grid/less/ffe-grid.less
+++ b/packages/ffe-grid/less/ffe-grid.less
@@ -37,6 +37,27 @@
 //     </div>
 // </div>
 //
+// --reverse               - Reverse order
+// --top-padding           - Add top padding
+//
+// Styleguide ffe-grid.grid.2
+
+// Grid row with background color
+//
+// Markup:
+// <div class="ffe-grid">
+//     <div class="ffe-grid__row ffe-grid__row{{modifier_class}}">
+//         <div class="ffe-grid__row-wrapper">
+//             <div class="ffe-grid__col--lg-6 ffe-grid__col--md-6 ffe-grid__col--sm-12">
+//                 6 kolonner bred på store og medium skjermer
+//             </div>
+//             <div class="ffe-grid__col--lg-6 ffe-grid__col--md-6 ffe-grid__col--sm-12">
+//                 12 kolonner bred på små skjermer
+//             </div>
+//         </div>
+//     </div>
+// </div>
+//
 // --bg-blue-ice           - Blue ice background
 // --bg-blue-pale          - Blue pale background
 // --bg-green-mint         - Green mint background
@@ -46,10 +67,8 @@
 // --bg-orange-salmon      - Orange salmon background
 // --bg-red                - Red background
 // --bg-blue-sky           - Blue sky background
-// --reverse               - Reverse order
-// --top-padding           - Add top padding
 //
-// Styleguide ffe-grid.grid.2
+// Styleguide ffe-grid.grid.3
 
 // Grid column
 //
@@ -87,7 +106,7 @@
 // --center-text           - Aligns text to center
 // --no-bottom-padding     - Removes bottom padding
 //
-// Styleguide ffe-grid.grid.3
+// Styleguide ffe-grid.grid.4
 
 // Variables
 @ffe-grid-columns: 12;


### PR DESCRIPTION
Fixes #454 