### PR TITLE
feat(ffe-tables-react): Migrate from deprecated componentWillReceiveP…

### DIFF
--- a/packages/ffe-tables-react/package.json
+++ b/packages/ffe-tables-react/package.json
@@ -25,7 +25,9 @@
     "@sb1/ffe-icons-react": "^6.0.11",
     "classnames": "^2.2.5",
     "deep-equal": "^1.0.1",
+    "memoize-one": "^4.0.3",
     "prop-types": "^15.6.0",
+    "react-lifecycles-compat": "^3.0.4",
     "shallow-equals": "^1.0.0"
   },
   "devDependencies": {

--- a/packages/ffe-tables-react/src/TableParts/TableRowExpandable.js
+++ b/packages/ffe-tables-react/src/TableParts/TableRowExpandable.js
@@ -1,8 +1,9 @@
-import React, { Component } from 'react';
-import PropTypes from 'prop-types';
-import classNames from 'classnames';
-import shallowEqual from 'shallow-equals';
 import ChevronIkon from '@sb1/ffe-icons-react/lib/chevron-ikon';
+import classNames from 'classnames';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { polyfill } from 'react-lifecycles-compat';
+import shallowEqual from 'shallow-equals';
 import TableRow from './TableRow';
 
 class TableRowExpandable extends Component {
@@ -12,7 +13,22 @@ class TableRowExpandable extends Component {
         this.toggleExpand = this.toggleExpand.bind(this);
         this.state = {
             expanded: false,
+            sort: props.sort,
         };
+    }
+
+    static getDerivedStateFromProps(nextProps, prevState) {
+        if (
+            (!nextProps.children && prevState.expanded) ||
+            !shallowEqual(nextProps.sort, prevState.sort)
+        ) {
+            return {
+                expanded: false,
+                sort: nextProps.sort,
+            };
+        }
+
+        return null;
     }
 
     toggleExpand() {
@@ -26,15 +42,6 @@ class TableRowExpandable extends Component {
         ) {
             this.setState(prevState => ({ expanded: !prevState.expanded }));
             event.preventDefault();
-        }
-    }
-
-    componentWillReceiveProps(newProps) {
-        if (
-            (!newProps.children && this.state.expanded) ||
-            !shallowEqual(newProps.sort, this.props.sort)
-        ) {
-            this.setState({ expanded: false });
         }
     }
 
@@ -111,5 +118,7 @@ TableRowExpandable.propTypes = {
     footerRender: PropTypes.func,
     rowIndex: PropTypes.number,
 };
+
+polyfill(TableRowExpandable);
 
 export default TableRowExpandable;


### PR DESCRIPTION
This is a suggested solution for #372 for ffe-tables-react. I am not sure if this is the best way to solve it, especially  for the SortableTable, see: https://reactjs.org/blog/2018/06/07/you-probably-dont-need-derived-state.html. “If you’re updating derived state unconditionally or updating it whenever props and state don’t match, your component likely resets its state too frequently”.

I am open for suggestions for how to improve this solution. 

