### PR TITLE
fix(ffe-grid-react): remove nested grid warnings and tests

### DIFF
--- a/packages/ffe-grid-react/src/Grid.js
+++ b/packages/ffe-grid-react/src/Grid.js
@@ -1,43 +1,32 @@
-import React, { Component } from 'react';
+import React from 'react';
 import classNames from 'classnames';
 import { bool, node, string } from 'prop-types';
 
-import { checkForNestedComponent } from './utils';
+export default function Grid(props) {
+    const {
+        children,
+        className,
+        condensed,
+        element,
+        topPadding,
+        ...rest
+    } = props;
 
-export default class Grid extends Component {
-    componentDidMount() {
-        /* istanbul ignore else: there is no else  */
-        if (process.env.NODE_ENV !== 'production') {
-            checkForNestedComponent(this.props.children, Grid);
-        }
-    }
+    const Element = element || 'div';
 
-    render() {
-        const {
-            children,
-            className,
-            condensed,
-            element,
-            topPadding,
-            ...rest
-        } = this.props;
-
-        const Element = element || 'div';
-
-        return (
-            <Element
-                className={classNames(
-                    className,
-                    'ffe-grid',
-                    { 'ffe-grid--condensed': condensed },
-                    { 'ffe-grid--no-top-padding': !topPadding },
-                )}
-                {...rest}
-            >
-                {children}
-            </Element>
-        );
-    }
+    return (
+        <Element
+            className={classNames(
+                className,
+                'ffe-grid',
+                { 'ffe-grid--condensed': condensed },
+                { 'ffe-grid--no-top-padding': !topPadding },
+            )}
+            {...rest}
+        >
+            {children}
+        </Element>
+    );
 }
 
 Grid.defaultProps = {

--- a/packages/ffe-grid-react/src/Grid.spec.js
+++ b/packages/ffe-grid-react/src/Grid.spec.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import { mount, shallow } from 'enzyme';
-import { Grid, GridRow, GridCol } from '.';
+import { shallow } from 'enzyme';
+import { Grid } from '.';
 
 const defaultProps = {
     children: <p>blah</p>,
@@ -59,42 +59,5 @@ describe('Grid', () => {
         const el = renderShallow({ element: 'section' });
 
         expect(el.type()).toBe('section');
-    });
-
-    describe('when mounting', () => {
-        console.error = jest.fn();
-
-        it('warns about nested <Grid> tag', () => {
-            mount(
-                <Grid>
-                    <GridRow>
-                        <GridCol>
-                            <div>
-                                <div>
-                                    <div>
-                                        <Grid />
-                                    </div>
-                                </div>
-                            </div>
-                        </GridCol>
-                    </GridRow>
-                </Grid>,
-            );
-
-            expect(console.error).toHaveBeenCalled();
-            expect(console.error.mock.calls[0][0]).toContain('<Grid />');
-        });
-
-        it('does not blow up if a null-child is received', () => {
-            // The below inline check on "false" will result in the outer <Grid>
-            // receiving children as an array-like of [<Grid />, null] which it needs
-            // to handle when checking for nesten grids.
-            mount(
-                <Grid>
-                    <Grid />
-                    {false && <Grid />}
-                </Grid>,
-            );
-        });
     });
 });

--- a/packages/ffe-grid-react/src/GridCol.js
+++ b/packages/ffe-grid-react/src/GridCol.js
@@ -11,11 +11,7 @@ import {
 import classNames from 'classnames';
 import backgroundColors, { removedColors } from './background-colors';
 
-import {
-    checkForDeprecatedModifiers,
-    checkForNestedComponent,
-    checkValidColumnCount,
-} from './utils';
+import { checkForDeprecatedModifiers, checkValidColumnCount } from './utils';
 
 function camelCaseToDashCase(str) {
     return str
@@ -86,7 +82,6 @@ export default class GridCol extends Component {
         /* istanbul ignore else: there is no else  */
         if (process.env.NODE_ENV !== 'production') {
             checkForDeprecatedModifiers(this.props);
-            checkForNestedComponent(this.props.children, GridCol);
             checkValidColumnCount(this.props);
         }
     }

--- a/packages/ffe-grid-react/src/GridCol.spec.js
+++ b/packages/ffe-grid-react/src/GridCol.spec.js
@@ -210,41 +210,6 @@ describe('GridCol', () => {
             );
         });
 
-        it('warns about nested <GridCol> tag', () => {
-            mount(
-                <Grid>
-                    <GridRow>
-                        <GridCol>
-                            <div>
-                                <div>
-                                    <div>
-                                        <GridCol>
-                                            <div>hadoken</div>
-                                        </GridCol>
-                                    </div>
-                                </div>
-                            </div>
-                        </GridCol>
-                    </GridRow>
-                </Grid>,
-            );
-
-            expect(console.error).toHaveBeenCalledTimes(1);
-            expect(console.error.mock.calls[0][0]).toContain('<GridCol />');
-        });
-
-        it('does not blow up if a null-child is received', () => {
-            // The below inline check on "false" will result in the outer <GridCol>
-            // receiving children as an array-like of [<GridCol />, null] which it needs
-            // to handle when checking for nesten grid columns.
-            mount(
-                <GridCol>
-                    <GridCol />
-                    {false && <GridCol />}
-                </GridCol>,
-            );
-        });
-
         describe('checks cols and offset validity', () => {
             console.error = jest.fn();
             const renderWithModifier = modifier =>

--- a/packages/ffe-grid-react/src/GridRow.js
+++ b/packages/ffe-grid-react/src/GridRow.js
@@ -1,61 +1,51 @@
-import React, { Component } from 'react';
+import React from 'react';
 import { bool, node, oneOf, string } from 'prop-types';
 import classNames from 'classnames';
 
 import backgroundColors, { removedColors } from './background-colors';
-import { checkForNestedComponent } from './utils';
 
-export default class GridRow extends Component {
-    componentDidMount() {
-        /* istanbul ignore else: there is no else */
-        if (process.env.NODE_ENV !== 'production') {
-            checkForNestedComponent(this.props.children, GridRow);
-        }
+export default function GridRow(props) {
+    const {
+        background,
+        className,
+        children,
+        element,
+        reverse,
+        topPadding,
+        ...rest
+    } = props;
+
+    let content = children;
+
+    const hasBackgroundColor = backgroundColors.includes(background);
+    const hasRemovedColor = removedColors.includes(background);
+
+    if (hasBackgroundColor) {
+        content = <div className="ffe-grid__row-wrapper">{children}</div>;
     }
 
-    render() {
-        const {
-            background,
-            className,
-            children,
-            element,
-            reverse,
-            topPadding,
-            ...rest
-        } = this.props;
-
-        let content = children;
-
-        const hasBackgroundColor = backgroundColors.includes(background);
-        const hasRemovedColor = removedColors.includes(background);
-
-        if (hasBackgroundColor) {
-            content = <div className="ffe-grid__row-wrapper">{children}</div>;
-        }
-
-        if (hasRemovedColor) {
-            throw new Error(
-                `Support for the ${background} background on <GridRow> has been removed, please see the CHANGELOG`,
-            );
-        }
-
-        const Element = element || 'div';
-
-        return (
-            <Element
-                className={classNames(
-                    className,
-                    'ffe-grid__row',
-                    { [`ffe-grid__row--bg-${background}`]: hasBackgroundColor },
-                    { 'ffe-grid__row--reverse': reverse },
-                    { 'ffe-grid__row--top-padding': topPadding },
-                )}
-                {...rest}
-            >
-                {content}
-            </Element>
+    if (hasRemovedColor) {
+        throw new Error(
+            `Support for the ${background} background on <GridRow> has been removed, please see the CHANGELOG`,
         );
     }
+
+    const Element = element || 'div';
+
+    return (
+        <Element
+            className={classNames(
+                className,
+                'ffe-grid__row',
+                { [`ffe-grid__row--bg-${background}`]: hasBackgroundColor },
+                { 'ffe-grid__row--reverse': reverse },
+                { 'ffe-grid__row--top-padding': topPadding },
+            )}
+            {...rest}
+        >
+            {content}
+        </Element>
+    );
 }
 
 GridRow.defaultProps = {

--- a/packages/ffe-grid-react/src/GridRow.spec.js
+++ b/packages/ffe-grid-react/src/GridRow.spec.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { mount, shallow } from 'enzyme';
+import { shallow } from 'enzyme';
 
 import { GridRow, GridCol } from '.';
 import backgroundColors from './background-colors';
@@ -101,36 +101,5 @@ describe('GridRow', () => {
             global.console.error = jest.fn();
         });
         afterEach(() => global.console.error.mockRestore());
-
-        it('warns about nested <GridRow> tag', () => {
-            mount(
-                <GridRow>
-                    <GridCol>
-                        <div>
-                            <div>
-                                <div>
-                                    <GridRow />
-                                </div>
-                            </div>
-                        </div>
-                    </GridCol>
-                </GridRow>,
-            );
-
-            expect(console.error).toHaveBeenCalledTimes(1);
-            expect(console.error.mock.calls[0][0]).toContain('<GridRow />');
-        });
-
-        it('does not blow up if a null-child is received', () => {
-            // The below inline check on "false" will result in the outer <GridRow>
-            // receiving children as an array-like of [<GridRow />, null] which it needs
-            // to handle when checking for nesten grid rows.
-            mount(
-                <GridRow>
-                    <GridRow />
-                    {false && <GridRow />}
-                </GridRow>,
-            );
-        });
     });
 });

--- a/packages/ffe-grid-react/src/utils.dev.js
+++ b/packages/ffe-grid-react/src/utils.dev.js
@@ -1,21 +1,3 @@
-import React from 'react';
-
-const checkForNestedComponent = (children, Component) =>
-    React.Children.forEach(children, child => {
-        if (!child) {
-            return;
-        } else if (child.type === Component) {
-            console.error(`
-                Detected a <${Component.name} /> child within another ${
-                Component.name
-            }.
-                Do not nest these, the result will be unpredictable.
-            `);
-        } else if (child.props && child.props.children) {
-            return checkForNestedComponent(child.props.children, Component);
-        }
-    });
-
 const DEPRECATED_MODIFIERS = {
     vertical:
         '`<GridCol vertical={true} />` is the default behavior. You can safely remove this prop.',
@@ -81,8 +63,4 @@ const checkValidColumnCount = ({ sm, md }) => {
     }
 };
 
-export {
-    checkForDeprecatedModifiers,
-    checkForNestedComponent,
-    checkValidColumnCount,
-};
+export { checkForDeprecatedModifiers, checkValidColumnCount };

--- a/packages/ffe-grid-react/src/utils.js
+++ b/packages/ffe-grid-react/src/utils.js
@@ -3,7 +3,6 @@ if (process.env.NODE_ENV === 'production') {
     const emptyFn = () => {};
     module.exports = {
         checkForDeprecatedModifiers: emptyFn,
-        checkForNestedComponent: emptyFn,
         checkValidColumnCount: emptyFn,
     };
 } else {


### PR DESCRIPTION
Since `InlineGrid` was implemented in #445, nesting of grids is now accepted. This PR removes related warnings and tests that have thus become obsolete.