### PR TITLE
ffe-form-react: Require peer dependency version

### DIFF
--- a/packages/ffe-form-react/package.json
+++ b/packages/ffe-form-react/package.json
@@ -40,8 +40,8 @@
     "sinon": "^6.1.4"
   },
   "peerDependencies": {
-    "@sb1/ffe-core": "^12.0.0 || ^13.0.0",
-    "@sb1/ffe-form": "^9.0.0",
+    "@sb1/ffe-core": ">=14.0.1",
+    "@sb1/ffe-form": ">=10.0.0",
     "react": "^16.3.0"
   },
   "publishConfig": {


### PR DESCRIPTION
Tooltip does not work with releases of ffe-form before version 10.0.0, so now the right version of ffe-form is required as peer dependency.