### PR TITLE
feat(ffe-lists): Add new modifier ffe-check-list__item--cross

### DIFF
--- a/packages/ffe-lists-react/src/BulletList.md
+++ b/packages/ffe-lists-react/src/BulletList.md
@@ -2,9 +2,9 @@
 <div>
     <h3 className="ffe-h4">Våre forsikringer</h3>
     <BulletList>
-        <li>Bilforsikring</li>
-        <li>Reiseforsikring</li>
-        <li>Innboforsikring</li>
+        <BulletListItem>Bilforsikring</BulletListItem>
+        <BulletListItem>Reiseforsikring</BulletListItem>
+        <BulletListItem>Innboforsikring</BulletListItem>
     </BulletList>
 </div>
 ```

--- a/packages/ffe-lists-react/src/BulletList.spec.js
+++ b/packages/ffe-lists-react/src/BulletList.spec.js
@@ -1,12 +1,13 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import BulletList from './BulletList';
+import BulletListItem from './BulletListItem';
 
 const getWrapper = props =>
     shallow(
         <BulletList {...props}>
-            <li>Firstly</li>
-            <li>Secondly</li>
+            <BulletListItem>Firstly</BulletListItem>
+            <BulletListItem>Secondly</BulletListItem>
         </BulletList>,
     );
 
@@ -24,6 +25,6 @@ describe('<BulletList>', () => {
     it('passes props', () => {
         const wrapper = getWrapper({ id: 'that-id' });
         expect(wrapper.prop('id')).toBe('that-id');
-        expect(wrapper.text()).toContain('Firstly');
+        expect(wrapper.html()).toContain('Firstly');
     });
 });

--- a/packages/ffe-lists-react/src/BulletListItem.js
+++ b/packages/ffe-lists-react/src/BulletListItem.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import { node } from 'prop-types';
+import classNames from 'classnames';
+
+const BulletListItem = props => {
+    const { className, ...rest } = props;
+    return (
+        <li
+            className={classNames('ffe-bullet-list__item', className)}
+            {...rest}
+        />
+    );
+};
+
+BulletListItem.propTypes = {
+    children: node,
+};
+
+export default BulletListItem;

--- a/packages/ffe-lists-react/src/CheckList.md
+++ b/packages/ffe-lists-react/src/CheckList.md
@@ -2,9 +2,10 @@
 <div>
     <h3 className="ffe-h4">Ved å bruke FFE får du</h3>
     <CheckList>
-        <li>Massevis av ferdige, testede komponenter</li>
-        <li>Likt design som resten av SpareBank 1</li>
-        <li>Høyere utviklingshastighet</li>
+        <CheckListItem>Massevis av ferdige, testede komponenter</CheckListItem>
+        <CheckListItem>Likt design som resten av SpareBank 1</CheckListItem>
+        <CheckListItem>Høyere utviklingshastighet</CheckListItem>
+        <CheckListItem isCross={true}>Flere bugs</CheckListItem>
     </CheckList>
 </div>
 ```

--- a/packages/ffe-lists-react/src/CheckList.spec.js
+++ b/packages/ffe-lists-react/src/CheckList.spec.js
@@ -1,12 +1,13 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import CheckList from './CheckList';
+import CheckListItem from './CheckListItem';
 
 const getWrapper = props =>
     shallow(
         <CheckList {...props}>
-            <li>Firstly</li>
-            <li>Secondly</li>
+            <CheckListItem>Firstly</CheckListItem>
+            <CheckListItem>Secondly</CheckListItem>
         </CheckList>,
     );
 
@@ -24,6 +25,18 @@ describe('<CheckList>', () => {
     it('passes props', () => {
         const wrapper = getWrapper({ id: 'that-id' });
         expect(wrapper.prop('id')).toBe('that-id');
-        expect(wrapper.text()).toContain('Firstly');
+        expect(wrapper.html()).toContain('Firstly');
+    });
+});
+
+describe('<CheckListItem />', () => {
+    it('sets correct class for isCross flag', () => {
+        const wrapper = shallow(<CheckListItem>An item</CheckListItem>);
+
+        expect(wrapper.hasClass('ffe-check-list__item--cross')).toBe(false);
+
+        wrapper.setProps({ isCross: true });
+
+        expect(wrapper.hasClass('ffe-check-list__item--cross')).toBe(true);
     });
 });

--- a/packages/ffe-lists-react/src/CheckListItem.js
+++ b/packages/ffe-lists-react/src/CheckListItem.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import { bool, node } from 'prop-types';
+import classNames from 'classnames';
+
+const CheckListItem = props => {
+    const { className, isCross, ...rest } = props;
+    return (
+        <li
+            className={classNames(
+                'ffe-check-list__item',
+                { 'ffe-check-list__item--cross': isCross },
+                className,
+            )}
+            {...rest}
+        />
+    );
+};
+
+CheckListItem.propTypes = {
+    children: node,
+    /** If true, render a red cross instead of a green checkmark */
+    isCross: bool,
+};
+
+CheckListItem.defaultProps = {
+    isCross: false,
+};
+
+export default CheckListItem;

--- a/packages/ffe-lists-react/src/DescriptionList.md
+++ b/packages/ffe-lists-react/src/DescriptionList.md
@@ -2,12 +2,12 @@
 <div>
     <h3 className="ffe-h4">Personalia</h3>
     <DescriptionList>
-        <dt>Navn</dt>
-        <dd>Navn Navnesen</dd>
-        <dt>Adresse</dt>
-        <dd>Husgata 14</dd>
-        <dt>Postnummer og sted</dt>
-        <dd>1337 Sandvika</dd>
+        <DescriptionListTerm>Navn</DescriptionListTerm>
+        <DescriptionListDescription>Navn Navnesen</DescriptionListDescription>
+        <DescriptionListTerm>Adresse</DescriptionListTerm>
+        <DescriptionListDescription>Husgata 14</DescriptionListDescription>
+        <DescriptionListTerm>Postnummer og sted</DescriptionListTerm>
+        <DescriptionListDescription>1337 Sandvika</DescriptionListDescription>
     </DescriptionList>
 </div>
 ```

--- a/packages/ffe-lists-react/src/DescriptionList.spec.js
+++ b/packages/ffe-lists-react/src/DescriptionList.spec.js
@@ -1,14 +1,20 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import DescriptionList from './DescriptionList';
+import DescriptionListTerm from './DescriptionListTerm';
+import DescriptionListDescription from './DescriptionListDescription';
 
 const getWrapper = props =>
     shallow(
         <DescriptionList {...props}>
-            <dt>Porsche</dt>
-            <dd>German car maker</dd>
-            <dt>Toyota</dt>
-            <dd>Japanese toy maker</dd>
+            <DescriptionListTerm>Porsche</DescriptionListTerm>
+            <DescriptionListDescription>
+                German car maker
+            </DescriptionListDescription>
+            <DescriptionListTerm>Toyota</DescriptionListTerm>
+            <DescriptionListDescription>
+                Japanese toy maker
+            </DescriptionListDescription>
         </DescriptionList>,
     );
 
@@ -39,6 +45,6 @@ describe('<DescriptionList>', () => {
     it('passes props', () => {
         const wrapper = getWrapper({ id: 'that-id' });
         expect(wrapper.prop('id')).toBe('that-id');
-        expect(wrapper.text()).toContain('Porsche');
+        expect(wrapper.html()).toContain('Porsche');
     });
 });

--- a/packages/ffe-lists-react/src/DescriptionListDescription.js
+++ b/packages/ffe-lists-react/src/DescriptionListDescription.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import { node } from 'prop-types';
+import classNames from 'classnames';
+
+const DescriptionListDescription = props => {
+    const { className, ...rest } = props;
+    return (
+        <dd
+            className={classNames(
+                'ffe-description-list__description',
+                className,
+            )}
+            {...rest}
+        />
+    );
+};
+
+DescriptionListDescription.propTypes = {
+    children: node,
+};
+
+export default DescriptionListDescription;

--- a/packages/ffe-lists-react/src/DescriptionListMultiCol.md
+++ b/packages/ffe-lists-react/src/DescriptionListMultiCol.md
@@ -2,14 +2,14 @@
 <div>
     <h3 className="ffe-h4">Personalia</h3>
     <DescriptionListMultiCol>
-        <dt>Navn</dt>
-        <dd>Navn Navnesen</dd>
-        <dt>Adresse</dt>
-        <dd>Husgata 14</dd>
-        <dt>Postnummer</dt>
-        <dd>0362</dd>
-        <dt>Adresse</dt>
-        <dd>Oslo</dd>
+        <DescriptionListTerm>Navn</DescriptionListTerm>
+        <DescriptionListDescription>Navn Navnesen</DescriptionListDescription>
+        <DescriptionListTerm>Adresse</DescriptionListTerm>
+        <DescriptionListDescription>Husgata 14</DescriptionListDescription>
+        <DescriptionListTerm>Postnummer</DescriptionListTerm>
+        <DescriptionListDescription>0362</DescriptionListDescription>
+        <DescriptionListTerm>Adresse</DescriptionListTerm>
+        <DescriptionListDescription>Oslo</DescriptionListDescription>
     </DescriptionListMultiCol>
 </div>
 ```

--- a/packages/ffe-lists-react/src/DescriptionListMultiCol.spec.js
+++ b/packages/ffe-lists-react/src/DescriptionListMultiCol.spec.js
@@ -1,14 +1,20 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import DescriptionListMultiCol from './DescriptionListMultiCol';
+import DescriptionListTerm from './DescriptionListTerm';
+import DescriptionListDescription from './DescriptionListDescription';
 
 const getWrapper = props =>
     shallow(
         <DescriptionListMultiCol {...props}>
-            <dt>Porsche</dt>
-            <dd>German car maker</dd>
-            <dt>Toyota</dt>
-            <dd>Japanese toy maker</dd>
+            <DescriptionListTerm>Porsche</DescriptionListTerm>
+            <DescriptionListDescription>
+                German car maker
+            </DescriptionListDescription>
+            <DescriptionListTerm>Toyota</DescriptionListTerm>
+            <DescriptionListDescription>
+                Japanese toy maker
+            </DescriptionListDescription>
         </DescriptionListMultiCol>,
     );
 
@@ -26,11 +32,15 @@ describe('<DescriptionListMultiCol>', () => {
     it('passes props', () => {
         const wrapper = getWrapper({ id: 'that-id' });
         expect(wrapper.prop('id')).toBe('that-id');
-        expect(wrapper.text()).toContain('Porsche');
+        expect(wrapper.html()).toContain('Porsche');
     });
     it('wraps pairs in `dl`', () => {
         const wrapper = getWrapper();
-        expect(wrapper.find('.ffe-description-list-multicol__avoid-break').every('dl')).toBe(true);
+        expect(
+            wrapper
+                .find('.ffe-description-list-multicol__avoid-break')
+                .every('dl'),
+        ).toBe(true);
     });
     it('supports several columns', () => {
         const wrapper = getWrapper();

--- a/packages/ffe-lists-react/src/DescriptionListTerm.js
+++ b/packages/ffe-lists-react/src/DescriptionListTerm.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import { node } from 'prop-types';
+import classNames from 'classnames';
+
+const DescriptionListTerm = props => {
+    const { className, ...rest } = props;
+    return (
+        <dt
+            className={classNames('ffe-description-list__term', className)}
+            {...rest}
+        />
+    );
+};
+
+DescriptionListTerm.propTypes = {
+    children: node,
+};
+
+export default DescriptionListTerm;

--- a/packages/ffe-lists-react/src/NumberedList.md
+++ b/packages/ffe-lists-react/src/NumberedList.md
@@ -2,9 +2,11 @@
 <div>
     <h3 className="ffe-h4">Å bruke FFE er enkelt!</h3>
     <NumberedList>
-        <li>Installer pakken du vil bruke via NPM</li>
-        <li>Importer pakken i koden din</li>
-        <li>Profit!</li>
+        <NumberedListItem>
+            Installer pakken du vil bruke via NPM
+        </NumberedListItem>
+        <NumberedListItem>Importer pakken i koden din</NumberedListItem>
+        <NumberedListItem>Profit!</NumberedListItem>
     </NumberedList>
 </div>
 ```

--- a/packages/ffe-lists-react/src/NumberedList.spec.js
+++ b/packages/ffe-lists-react/src/NumberedList.spec.js
@@ -1,12 +1,13 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import NumberedList from './NumberedList';
+import NumberedListItem from './NumberedListItem';
 
 const getWrapper = props =>
     shallow(
         <NumberedList {...props}>
-            <li>Firstly</li>
-            <li>Secondly</li>
+            <NumberedListItem>Firstly</NumberedListItem>
+            <NumberedListItem>Secondly</NumberedListItem>
         </NumberedList>,
     );
 
@@ -24,6 +25,6 @@ describe('<NumberedList>', () => {
     it('passes props', () => {
         const wrapper = getWrapper({ id: 'that-id' });
         expect(wrapper.prop('id')).toBe('that-id');
-        expect(wrapper.text()).toContain('Firstly');
+        expect(wrapper.html()).toContain('Firstly');
     });
 });

--- a/packages/ffe-lists-react/src/NumberedListItem.js
+++ b/packages/ffe-lists-react/src/NumberedListItem.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import { node } from 'prop-types';
+import classNames from 'classnames';
+
+const NumberedListItem = props => {
+    const { className, ...rest } = props;
+    return (
+        <li
+            className={classNames('ffe-numbered-list__item', className)}
+            {...rest}
+        />
+    );
+};
+
+NumberedListItem.propTypes = {
+    children: node,
+};
+
+export default NumberedListItem;

--- a/packages/ffe-lists-react/src/StylizedNumberedList.md
+++ b/packages/ffe-lists-react/src/StylizedNumberedList.md
@@ -2,9 +2,13 @@
 <div>
     <h3 className="ffe-h4">Å bruke FFE er enkelt!</h3>
     <StylizedNumberedList>
-        <li>Installer pakken du vil bruke via NPM</li>
-        <li>Importer pakken i koden din</li>
-        <li>Profit!</li>
+        <StylizedNumberedListItem>
+            Installer pakken du vil bruke via NPM
+        </StylizedNumberedListItem>
+        <StylizedNumberedListItem>
+            Importer pakken i koden din
+        </StylizedNumberedListItem>
+        <StylizedNumberedListItem>Profit!</StylizedNumberedListItem>
     </StylizedNumberedList>
 </div>
 ```

--- a/packages/ffe-lists-react/src/StylizedNumberedList.spec.js
+++ b/packages/ffe-lists-react/src/StylizedNumberedList.spec.js
@@ -1,12 +1,13 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import StylizedNumberedList from './StylizedNumberedList';
+import StylizedNumberedListItem from './StylizedNumberedListItem';
 
 const getWrapper = props =>
     shallow(
         <StylizedNumberedList {...props}>
-            <li>Firstly</li>
-            <li>Secondly</li>
+            <StylizedNumberedListItem>Firstly</StylizedNumberedListItem>
+            <StylizedNumberedListItem>Secondly</StylizedNumberedListItem>
         </StylizedNumberedList>,
     );
 
@@ -24,6 +25,6 @@ describe('<StylizedNumberedList>', () => {
     it('passes props', () => {
         const wrapper = getWrapper({ id: 'that-id' });
         expect(wrapper.prop('id')).toBe('that-id');
-        expect(wrapper.text()).toContain('Firstly');
+        expect(wrapper.html()).toContain('Firstly');
     });
 });

--- a/packages/ffe-lists-react/src/StylizedNumberedListItem.js
+++ b/packages/ffe-lists-react/src/StylizedNumberedListItem.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import { node } from 'prop-types';
+import classNames from 'classnames';
+
+const StylizedNumberedListItem = props => {
+    const { className, ...rest } = props;
+    return (
+        <li
+            className={classNames(
+                'ffe-stylized-numbered-list__item',
+                className,
+            )}
+            {...rest}
+        />
+    );
+};
+
+StylizedNumberedListItem.propTypes = {
+    children: node,
+};
+
+export default StylizedNumberedListItem;

--- a/packages/ffe-lists-react/src/index.js
+++ b/packages/ffe-lists-react/src/index.js
@@ -1,17 +1,29 @@
 import BulletList from './BulletList';
+import BulletListItem from './BulletListItem';
 import CheckList from './CheckList';
+import CheckListItem from './CheckListItem';
 import NumberedList from './NumberedList';
+import NumberedListItem from './NumberedListItem';
 import StylizedNumberedList from './StylizedNumberedList';
+import StylizedNumberedListItem from './StylizedNumberedListItem';
 import DescriptionList from './DescriptionList';
 import DescriptionListMultiCol from './DescriptionListMultiCol';
+import DescriptionListTerm from './DescriptionListTerm';
+import DescriptionListDescription from './DescriptionListDescription';
 
 export {
     BulletList,
+    BulletListItem,
     CheckList,
+    CheckListItem,
     NumberedList,
+    NumberedListItem,
     StylizedNumberedList,
+    StylizedNumberedListItem,
     DescriptionList,
     DescriptionListMultiCol,
+    DescriptionListTerm,
+    DescriptionListDescription,
 };
 
 export default BulletList;

--- a/packages/ffe-lists/less/description-list.less
+++ b/packages/ffe-lists/less/description-list.less
@@ -2,12 +2,12 @@
 //
 // Markup:
 // <dl class="ffe-description-list ffe-description-list{{modifier_class}}">
-//     <dt>Navn</dt>
-//     <dd>Navn Navnesen</dd>
-//     <dt>Adresse</dt>
-//     <dd>Husgata 14</dd>
-//     <dt>Postnummer og sted</dt>
-//     <dd>1337 Sandvika</dd>
+//     <dt class="ffe-description-list__title">Navn</dt>
+//     <dd class="ffe-description-list__description">Navn Navnesen</dd>
+//     <dt class="ffe-description-list__title">Adresse</dt>
+//     <dd class="ffe-description-list__description">Husgata 14</dd>
+//     <dt class="ffe-description-list__title">Postnummer og sted</dt>
+//     <dd class="ffe-description-list__description">1337 Sandvika</dd>
 // </dl>
 //
 // --md     - Medium column size
@@ -20,20 +20,20 @@
 // Markup:
 // <div class="ffe-description-list-multicol ffe-description-list-multicol{{modifier_class}}">
 //     <dl class="ffe-description-list-multicol__avoid-break">
-//         <dt>Navn</dt>
-//         <dd>Navn Navnesen</dd>
+//         <dt class="ffe-description-list__title">Navn</dt>
+//         <dd class="ffe-description-list__description">Navn Navnesen</dd>
 //     </dl>
 //     <dl class="ffe-description-list-multicol__avoid-break">
-//         <dt>Adresse</dt>
-//         <dd>Husgata 14</dd>
+//         <dt class="ffe-description-list__title">Adresse</dt>
+//         <dd class="ffe-description-list__description">Husgata 14</dd>
 //     </dl>
 //     <dl class="ffe-description-list-multicol__avoid-break">
-//         <dt>Postnummer</dt>
-//         <dd>0362</dd>
+//         <dt class="ffe-description-list__title">Postnummer</dt>
+//         <dd class="ffe-description-list__description">0362</dd>
 //     </dl>
 //     <dl class="ffe-description-list-multicol__avoid-break">
-//         <dt>Adresse</dt>
-//         <dd>Oslo</dd>
+//         <dt class="ffe-description-list__title">Adresse</dt>
+//         <dd class="ffe-description-list__description">Oslo</dd>
 //     </dl>
 // </div>
 //
@@ -45,14 +45,14 @@
 
 .ffe-description-list,
 .ffe-description-list-multicol {
-    dt {
+    .ffe-description-list__term {
         color: @ffe-blue-royal;
         &:extend(.ffe-strong-text);
         .ffe-fontsize-h6;
     }
 
     /* Use padding rather than margin in bottom to avoid extra spacing overflowing to the top of the next column */
-    dd {
+    .ffe-description-list__description {
         padding-bottom: @description-list-vertical-seperation;
         margin-left: 0;
         &:extend(.ffe-body-text);
@@ -65,62 +65,65 @@
     align-items: flex-start;
     width: 100%;
 
-    dt {
+    .ffe-description-list__term {
         flex: 0 0 35%;
         overflow: hidden;
     }
 
-    dd {
+    .ffe-description-list__description {
         flex: 65% 0 0;
         padding-left: 20px;
         max-width: 65%; /* Fix for IE issue in which box-sizing is not taken into account when using flex */
     }
 
-    dd + dd {
+    .ffe-description-list__description + .ffe-description-list__description {
         margin-left: 35%; /* Keep left margin when using multiple dd's */
     }
 
     @media (min-width: @breakpoint-sm) {
-        dt {
+        .ffe-description-list__term {
             flex: 0 0 20%;
         }
 
-        dd {
+        .ffe-description-list__description {
             flex: 80% 0 0;
             max-width: 80%;
         }
 
-        dd + dd {
+        .ffe-description-list__description
+            + .ffe-description-list__description {
             margin-left: 20%;
         }
     }
 
     &--md {
-        dt {
+        .ffe-description-list__term {
             flex: 0 0 40%;
         }
 
-        dd {
+        .ffe-description-list__description {
             flex: 60% 0 0;
             max-width: 60%;
         }
 
-        dd + dd {
+        .ffe-description-list__description
+            + .ffe-description-list__description {
             margin-left: 40%;
         }
     }
 
     &--lg {
-        dt {
+        .ffe-description-list__term {
             flex: 0 0 50%;
         }
 
-        dd {
+        .ffe-description-list__description {
             flex: 50% 0 0;
             max-width: 50%;
         }
 
-        dd + dd {
+        .ffe-description-list__description
+            + .ffe-description-list__description {
             margin-left: 50%;
         }
     }

--- a/packages/ffe-lists/less/regular-lists.less
+++ b/packages/ffe-lists/less/regular-lists.less
@@ -2,9 +2,9 @@
 //
 // Markup:
 // <ul class="ffe-bullet-list ffe-bullet-list{{modifier_class}}">
-//     <li>Bilforsikring</li>
-//     <li>Reiseforsikring</li>
-//     <li>Innboforsikring</li>
+//     <li class="ffe-bullet-list__item">Bilforsikring</li>
+//     <li class="ffe-bullet-list__item">Reiseforsikring</li>
+//     <li class="ffe-bullet-list__item">Innboforsikring</li>
 // </ul>
 //
 // --condensed  - Condensed
@@ -15,9 +15,10 @@
 //
 // Markup:
 // <ul class="ffe-check-list ffe-check-list{{modifier_class}}">
-//     <li>Massevis av ferdige, testede komponenter</li>
-//     <li>Likt design som resten av SpareBank 1</li>
-//     <li>Høyere utviklingshastighet</li>
+//     <li class="ffe-check-list__item">Massevis av ferdige, testede komponenter</li>
+//     <li class="ffe-check-list__item">Likt design som resten av SpareBank 1</li>
+//     <li class="ffe-check-list__item">Høyere utviklingshastighet</li>
+//     <li class="ffe-check-list__item ffe-check-list__item--cross">Null bugs</li>
 // </ul>
 //
 // --bg-sand    - Sand background
@@ -28,9 +29,9 @@
 //
 // Markup:
 // <ol class="ffe-numbered-list ffe-numbered-list{{modifier_class}}">
-//     <li>Installer pakken du vil bruke via NPM</li>
-//     <li>Importer pakken i koden din</li>
-//     <li>Profit!</li>
+//     <li class="ffe-numbered-list__item">Installer pakken du vil bruke via NPM</li>
+//     <li class="ffe-numbered-list__item">Importer pakken i koden din</li>
+//     <li class="ffe-numbered-list__item">Profit!</li>
 // </ol>
 //
 // --condensed  - Condensed
@@ -41,9 +42,9 @@
 //
 // Markup:
 // <ol class="ffe-stylized-numbered-list">
-//     <li>Installer pakken du vil bruke via NPM</li>
-//     <li>Importer pakken i koden din</li>
-//     <li>Profit!</li>
+//     <li class="ffe-stylized-numbered-list__item">Installer pakken du vil bruke via NPM</li>
+//     <li class="ffe-stylized-numbered-list__item">Importer pakken i koden din</li>
+//     <li class="ffe-stylized-numbered-list__item">Profit!</li>
 // </ol>
 //
 // Styleguide ffe-lists.regular-lists.4
@@ -54,7 +55,8 @@
     text-align: left;
     margin: 0 0 20px;
 
-    > li {
+    > .ffe-numbered-list__item,
+    > .ffe-bullet-list__item {
         margin-top: 10px;
         margin-left: 15px;
     }
@@ -70,7 +72,7 @@
     &--condensed {
         margin-left: 0;
 
-        > li {
+        > .ffe-bullet-list__item {
             margin-top: 0;
         }
     }
@@ -90,8 +92,8 @@
 
 /* Desktop */
 @media screen and (min-width: @breakpoint-md) {
-    .ffe-numbered-list > li,
-    .ffe-bullet-list > li {
+    .ffe-numbered-list > .ffe-numbered-list__item,
+    .ffe-bullet-list > .ffe-bullet-list__item {
         margin-left: 30px;
 
         &--condensed {
@@ -107,7 +109,8 @@
     margin: 0 0 20px;
     list-style: none;
 
-    > li {
+    > .ffe-check-list__item,
+    > .ffe-stylized-numbered-list__item {
         margin-top: 1.75em;
         margin-left: 2.5em;
         position: relative;
@@ -117,11 +120,13 @@
 
 @ffe-green-shamrock-escape: escape('@{ffe-green-shamrock}');
 @ffe-blue-royal-escape: escape('@{ffe-blue-royal}');
+@ffe-red-escape: escape('@{ffe-red}');
 @ffe-green-shamrock-fill: @ffe-green-shamrock-escape;
 @ffe-blue-royal-fill: @ffe-blue-royal-escape;
+@ffe-red-fill: @ffe-red-escape;
 
 .ffe-check-list {
-    > li {
+    > .ffe-check-list__item {
         &::before {
             content: '\2022';
             display: block;
@@ -138,8 +143,16 @@
         }
     }
 
+    > .ffe-check-list__item--cross {
+        &::before {
+            background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 200 200'%3E%3Cpath fill='@{ffe-red-fill}' d='M18.77,0c-3.562,0-7.125,1.347-9.834,4.044l-4.429,4.439c-5.381,5.394-5.381,14.25,0,19.68l71.19,71.83-71.66,71.83c-5.381,5.394-5.381,14.25,0,19.68l4.429,4.439c5.381,5.394,14.22,5.394,19.64,0l71.66-71.83,71.65,71.83c5.381,5.394,14.23,5.394,19.65,0l4.429-4.439c5.381-5.394,5.381-14.25,0-19.68l-71.19-71.83,71.66-71.83c5.381-4.914,5.381-13.78,0-19.21l-4.429-4.423c-5.381-5.394-14.22-5.394-19.64,0l-72.13,71.34-71.17-71.83c-2.691-2.697-6.257-4.044-9.819-4.044z'/%3E%3C/svg%3E");
+            color: @ffe-red;
+            content: '\2717';
+        }
+    }
+
     &--bg-sand {
-        > li {
+        > .ffe-check-list__item {
             color: @ffe-blue-royal;
             background-color: @ffe-sand;
             padding: 0.85em 1em 0.85em 3em;
@@ -155,11 +168,19 @@
                 background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 200 200' width='200' height='200'%3E%3Cpath fill='@{ffe-blue-royal-fill}' d='M176.56-8.325E-7c-4.403,0-8.307,2.46595-10.288,5.89248l-90.5448,156.336-42.6109-59.77c-2.46172-2.94562-5.88534-4.89058-9.78806-4.89058h-7.3426c-4.40307,0-8.30704,2.46094-10.2884,6.36839-1.94136,3.94753-1.46102,8.8406,1.0007,12.2671l54.8007,75.963c3.4224,4.89,9.3077,7.834,15.1918,7.834,6.84477,0,12.7076-3.42654,16.13-9.31777l100.827-173.487c2.46172-3.4666,2.46547-7.83618,0.0438-11.3028-1.942-3.94755-5.886-5.8925-10.289-5.8925h-6.84226z'/%3E%3C/svg%3E");
             }
         }
+
+        > .ffe-check-list__item--cross {
+            &::before {
+                background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 200 200'%3E%3Cpath fill='@{ffe-blue-royal-fill}' d='M18.77,0c-3.562,0-7.125,1.347-9.834,4.044l-4.429,4.439c-5.381,5.394-5.381,14.25,0,19.68l71.19,71.83-71.66,71.83c-5.381,5.394-5.381,14.25,0,19.68l4.429,4.439c5.381,5.394,14.22,5.394,19.64,0l71.66-71.83,71.65,71.83c5.381,5.394,14.23,5.394,19.65,0l4.429-4.439c5.381-5.394,5.381-14.25,0-19.68l-71.19-71.83,71.66-71.83c5.381-4.914,5.381-13.78,0-19.21l-4.429-4.423c-5.381-5.394-14.22-5.394-19.64,0l-72.13,71.34-71.17-71.83c-2.691-2.697-6.257-4.044-9.819-4.044z'/%3E%3C/svg%3E");
+                color: @ffe-red;
+                content: '\2717';
+            }
+        }
     }
 }
 
 .ffe-stylized-numbered-list {
-    > li {
+    > .ffe-stylized-numbered-list__item {
         counter-increment: list-elements;
 
         &::before {


### PR DESCRIPTION
This commit adds a new modifier for ffe-check-list list items to show that the item is not included in
whatever the list is about.

Resolves #471 

Not sure about the class name, nor how this should be implemented for the React component. We don't have any `ListItem` components I could add a flag to - should we perhaps add that?
