### PR TITLE
Two column lists

### DIFF
--- a/packages/ffe-lists-react/src/CheckList.js
+++ b/packages/ffe-lists-react/src/CheckList.js
@@ -1,9 +1,16 @@
 import React from 'react';
 import classNames from 'classnames';
-import { node, string } from 'prop-types';
+import { node, oneOf, string } from 'prop-types';
 
-const CheckList = ({ className, ...rest }) => (
-    <ul className={classNames('ffe-check-list', className)} {...rest} />
+const CheckList = ({ className, columns, ...rest }) => (
+    <ul
+        className={classNames(
+            'ffe-check-list',
+            { 'ffe-check-list--two-columns': Number(columns) === 2 },
+            className,
+        )}
+        {...rest}
+    />
 );
 
 CheckList.propTypes = {
@@ -11,6 +18,11 @@ CheckList.propTypes = {
     children: node.isRequired,
     /** Any extra classes */
     className: string,
+    columns: oneOf([1, 2, '1', '2']),
+};
+
+CheckList.defaultProps = {
+    columns: 1,
 };
 
 export default CheckList;

--- a/packages/ffe-lists-react/src/CheckList.md
+++ b/packages/ffe-lists-react/src/CheckList.md
@@ -9,3 +9,18 @@
     </CheckList>
 </div>
 ```
+
+Det er også mulig å spre innholdet ut over 2 kolonner der det er plass til det:
+
+```js
+<div>
+    <h3 className="ffe-h4">Ved å bruke FFE får du</h3>
+    <CheckList columns={2}>
+        <CheckListItem>Massevis av ferdige, testede komponenter</CheckListItem>
+        <CheckListItem>Likt design som resten av SpareBank 1</CheckListItem>
+        <CheckListItem>Høyere utviklingshastighet</CheckListItem>
+        <CheckListItem isCross={true}>Flere bugs</CheckListItem>
+        <CheckListItem isCross={true}>Mindre tid</CheckListItem>
+    </CheckList>
+</div>
+```

--- a/packages/ffe-lists-react/src/CheckList.spec.js
+++ b/packages/ffe-lists-react/src/CheckList.spec.js
@@ -27,6 +27,18 @@ describe('<CheckList>', () => {
         expect(wrapper.prop('id')).toBe('that-id');
         expect(wrapper.html()).toContain('Firstly');
     });
+    it('sets the correct class when columns prop is 2', () => {
+        const wrapper = getWrapper({ columns: 2 });
+        expect(wrapper.hasClass('ffe-check-list--two-columns')).toBe(true);
+        wrapper.setProps({ columns: '2' });
+        expect(wrapper.hasClass('ffe-check-list--two-columns')).toBe(true);
+    });
+    it('only supports 1 and 2 columns', () => {
+        const wrapper = getWrapper({ columns: 3 });
+        expect(wrapper.hasClass('ffe-check-list--two-columns')).toBe(false);
+        wrapper.setProps({ columns: 1 });
+        expect(wrapper.hasClass('ffe-check-list--two-columns')).toBe(false);
+    });
 });
 
 describe('<CheckListItem />', () => {

--- a/packages/ffe-lists/less/regular-lists.less
+++ b/packages/ffe-lists/less/regular-lists.less
@@ -21,7 +21,8 @@
 //     <li class="ffe-check-list__item ffe-check-list__item--cross">Null bugs</li>
 // </ul>
 //
-// --bg-sand    - Sand background
+// --bg-sand        - Sand background
+// --two-columns    - Two columns
 //
 // Styleguide ffe-lists.regular-lists.2
 
@@ -174,6 +175,20 @@
                 background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 200 200'%3E%3Cpath fill='@{ffe-blue-royal-fill}' d='M18.77,0c-3.562,0-7.125,1.347-9.834,4.044l-4.429,4.439c-5.381,5.394-5.381,14.25,0,19.68l71.19,71.83-71.66,71.83c-5.381,5.394-5.381,14.25,0,19.68l4.429,4.439c5.381,5.394,14.22,5.394,19.64,0l71.66-71.83,71.65,71.83c5.381,5.394,14.23,5.394,19.65,0l4.429-4.439c5.381-5.394,5.381-14.25,0-19.68l-71.19-71.83,71.66-71.83c5.381-4.914,5.381-13.78,0-19.21l-4.429-4.423c-5.381-5.394-14.22-5.394-19.64,0l-72.13,71.34-71.17-71.83c-2.691-2.697-6.257-4.044-9.819-4.044z'/%3E%3C/svg%3E");
                 color: @ffe-red;
                 content: '\2717';
+            }
+        }
+    }
+
+    &--two-columns {
+        @media all and (min-width: @breakpoint-md) {
+            display: flex;
+            flex-wrap: wrap;
+            justify-content: space-between;
+
+            .ffe-check-list__item {
+                flex: 1 0 auto;
+                display: block;
+                width: 40%;
             }
         }
     }


### PR DESCRIPTION
This pull request adds support for two-column check lists.

End result looks like this: 

![image](https://user-images.githubusercontent.com/1307267/47771456-9f1d8900-dce3-11e8-8b2e-59452548e4f0.png)

For the React component, I went for adding a `columns="2"` prop instead of a `twoColumns={true}` flag, just in case we'll want to add support for three columns later. 

Note that you can write `columns={2}` and `columns="2"` - that I added as a convenience for developers.

I first tried implementing the two-column layout by using [CSS Columns](https://developer.mozilla.org/en-US/docs/Web/CSS/columns), but that behaved a bit weirdly with wrapping margins and what not. Here's how that looked like:

![image](https://user-images.githubusercontent.com/1307267/47771647-6fbb4c00-dce4-11e8-9a24-d973e4875a83.png)

Thus, I ended up with wrapping flexbox items and setting an explicit width of 40 %.

---

This branch will be merged into develop eventually, but since #471 is still open, I decided to branch out from that branch (since there was a lot of changes to the ffe-lists package there). I will change the base of this PR once that is merged.

Fixes #472 