### PR TITLE
fix(ffe-system-message): Ensure close button icon doesn't get cropped…

### DIFF
--- a/packages/ffe-system-message/less/ffe-system-message.less
+++ b/packages/ffe-system-message/less/ffe-system-message.less
@@ -107,14 +107,14 @@
         color: inherit;
         cursor: pointer;
         display: inline-block;
-        height: 14px;
+        height: 16px;
         margin: 0;
         padding: 0;
         position: absolute;
         right: 20px;
         top: 15px;
         vertical-align: middle;
-        width: 14px;
+        width: 16px;
 
         > svg {
             fill: @ffe-black;


### PR DESCRIPTION
… on Safari

This version fixes issue with the close button icon being cropped on Safari.

<!-- 
Thanks for opening a pull request! 🎉

If your changes include some kind of UI element, please attach a screenshot of 
how it looks.

Before submitting a pull request, please have a look through the CONTRIBUTING.md
document. TL;DR:

- Follow the conventional commit standard
- Write full, explanatory commit messages
- Follow our code standards
- Write tests where applicable
- Be courteous and respect our code of conduct
-->

Before:
<img width="898" alt="before" src="https://user-images.githubusercontent.com/8436510/47785218-562bfb80-dd08-11e8-8d5c-33ea9fe8ba98.png">

After:
<img width="896" alt="after" src="https://user-images.githubusercontent.com/8436510/47785234-6217bd80-dd08-11e8-94b4-6b8310b4287c.png">
