### PR TITLE
Add missing 'ffe-' prefix to example in ffe-icons

### DIFF
--- a/packages/ffe-icons/README.md
+++ b/packages/ffe-icons/README.md
@@ -79,7 +79,7 @@ royal blue as the primary color, add the following to your global icon class:
 ```
 .icon {
     fill: "#002776"; // Or, even better:
-    fill: @blue-royal; // assuming use and import of ffe-core variables
+    fill: @ffe-blue-royal; // assuming use and import of ffe-core variables
 
     // To add alternatives, replace the fill attribute with whatever color you need
     &--white {


### PR DESCRIPTION
Minor fix in the documentation, add missing `ffe-` prefix to the example so copy & paste works when getting started with ffe :smile: 