### PR TITLE
fix(ffe-buttons): Increased margin between buttons to give them som air

### DIFF
--- a/packages/ffe-buttons/less/button-group.less
+++ b/packages/ffe-buttons/less/button-group.less
@@ -46,7 +46,7 @@
 
         .ffe-button,
         .ffe-inline-button {
-            margin: 0 0 10px 10px;
+            margin: 0 0 10px 20px;
             width: auto;
 
             &:first-child {


### PR DESCRIPTION
This PR solves #515 

New distance between buttons in a button group:

![image](https://user-images.githubusercontent.com/36953762/48888070-c32b4080-ee31-11e8-80e3-9dcc7e7d583b.png)

Implemented according to sketch from @adidick 
