### PR TITLE
Fix: Implement focus and active states for tertiary buttons according to sketches

### DIFF
--- a/packages/ffe-buttons/less/inline-base-button.less
+++ b/packages/ffe-buttons/less/inline-base-button.less
@@ -109,6 +109,7 @@
             border-bottom: 2px solid @ffe-blue-focus;
         }
 
+        &:active,
         &:hover {
             color: @ffe-blue-onahau--dark;
 
@@ -118,7 +119,13 @@
         }
 
         &:focus {
-            border-color: @ffe-blue-focus;
+            border: 2px solid @ffe-blue-focus;
+            padding: 8px 18px 7px;
+        }
+
+        &:active {
+            border: none;
+            padding: 10px 20px 9px;
         }
     }
 }

--- a/packages/ffe-buttons/less/inline-base-button.less
+++ b/packages/ffe-buttons/less/inline-base-button.less
@@ -70,6 +70,7 @@
     align-content: center;
     color: @ffe-blue-azure;
     flex-wrap: wrap;
+    padding: 10px 20px 9px;
 
     &::after {
         border-bottom: solid 1px currentColor;
@@ -80,6 +81,24 @@
 
     &:hover {
         color: @ffe-blue-cobalt;
+    }
+
+    &:active,
+    &:focus {
+        border-radius: 4px;
+        box-shadow: none;
+    }
+
+    &:focus {
+        border: 3px solid @ffe-blue-focus;
+        color: @ffe-blue-cobalt;
+        padding: 7px 17px 6px;
+    }
+
+    &:active {
+        border: 2px solid @ffe-blue-azure;
+        color: @ffe-blue-azure;
+        padding: 8px 18px 7px;
     }
 
     &.ffe-inline-button--dark {
@@ -99,7 +118,7 @@
         }
 
         &:focus {
-            box-shadow: 0 0 0 2px @ffe-blue-focus;
+            border-color: @ffe-blue-focus;
         }
     }
 }


### PR DESCRIPTION
This pull request solves issue #516.

Ny focus state for vanlig:
![image](https://user-images.githubusercontent.com/36953762/48935220-33f05c80-ef07-11e8-87c1-b4cbd0ccd32b.png)

Ny focus state for dark mode:

![image](https://user-images.githubusercontent.com/36953762/48935177-00adcd80-ef07-11e8-8764-f748345a8468.png)

Implemented according to sketches from Adi and Line H.