### PR TITLE
fix(ffe-radio-button-react): show error message correctly for RadioSw…

### DIFF
--- a/packages/ffe-form/less/radio-switch.less
+++ b/packages/ffe-form/less/radio-switch.less
@@ -68,7 +68,9 @@
 
 .ffe-radio-input {
     &:checked + .ffe-radio-switch {
-        border-color: @ffe-blue-royal;
+        &:not(.ffe-radio-button--invalid) {
+            border-color: @ffe-blue-royal;
+        }
         background-color: @ffe-blue-royal;
         color: @ffe-white;
     }
@@ -88,7 +90,6 @@
     }
 
     &--dark {
-
         &:hover + .ffe-radio-switch {
             border-color: @ffe-blue-focus;
         }

--- a/packages/ffe-form/less/radio-switch.less
+++ b/packages/ffe-form/less/radio-switch.less
@@ -68,9 +68,11 @@
 
 .ffe-radio-input {
     &:checked + .ffe-radio-switch {
+        /* stylelint-disable-next-line selector-max-specificity */
         &:not(.ffe-radio-button--invalid) {
             border-color: @ffe-blue-royal;
         }
+
         background-color: @ffe-blue-royal;
         color: @ffe-white;
     }

--- a/packages/ffe-radio-button-react/src/RadioSwitch.js
+++ b/packages/ffe-radio-button-react/src/RadioSwitch.js
@@ -1,5 +1,5 @@
 import React, { Fragment } from 'react';
-import { bool, oneOfType, string } from 'prop-types';
+import { bool, oneOf, oneOfType, string } from 'prop-types';
 import classNames from 'classnames';
 
 import BaseRadioButton from './BaseRadioButton';
@@ -13,8 +13,11 @@ const RadioSwitch = props => {
         rightValue,
         condensed,
         dark,
+        'aria-invalid': ariaInvalid,
         ...rest
     } = props;
+
+    const noneSelected = props.selectedValue === undefined;
 
     return (
         <Fragment>
@@ -25,6 +28,10 @@ const RadioSwitch = props => {
                 })}
                 value={leftValue}
                 dark={dark}
+                aria-invalid={String(
+                    ariaInvalid === 'true' &&
+                        (props.selectedValue === leftValue || noneSelected),
+                )}
                 {...rest}
             >
                 {leftLabel}
@@ -36,6 +43,10 @@ const RadioSwitch = props => {
                 })}
                 value={rightValue}
                 dark={dark}
+                aria-invalid={String(
+                    ariaInvalid === 'true' &&
+                        (props.selectedValue === rightValue || noneSelected),
+                )}
                 {...rest}
             >
                 {rightLabel}
@@ -59,6 +70,11 @@ RadioSwitch.propTypes = {
     condensed: bool,
     /** Dark variant */
     dark: bool,
+    /**
+     * Indicates whether the radio buttons inside this radio button group is
+     * invalid or not. Propagated to all children.
+     * */
+    'aria-invalid': oneOf(['true', 'false']),
 };
 
 RadioSwitch.defaultProps = {

--- a/packages/ffe-radio-button-react/src/RadioSwitch.js
+++ b/packages/ffe-radio-button-react/src/RadioSwitch.js
@@ -17,7 +17,7 @@ const RadioSwitch = props => {
         ...rest
     } = props;
 
-    const noneSelected = props.selectedValue === undefined;
+    const noneSelected = [null, undefined, ''].includes(props.selectedValue);
 
     return (
         <Fragment>

--- a/packages/ffe-radio-button-react/src/RadioSwitch.md
+++ b/packages/ffe-radio-button-react/src/RadioSwitch.md
@@ -1,6 +1,8 @@
 Radiobrytere brukes når brukeren skal gjøre et binært valg - typisk i formen
 "ja eller nei", eller "av eller på".
 
+Radiobryter uten defaultvalg.
+
 ```js
 const { RadioButtonInputGroup } = require('.');
 
@@ -10,7 +12,7 @@ initialState = { selected: undefined };
     label="Vil bilen bli kjørt av sjåfører under 23 år?"
     tooltip="Unge sjåfører har en statistisk høyere sjanse for å bulke bilen."
     name="under23"
-    onChange={(e) => setState({ selected: e.target.value })}
+    onChange={e => setState({ selected: e.target.value })}
     selectedValue={state.selected}
 >
     {inputProps => (
@@ -22,7 +24,90 @@ initialState = { selected: undefined };
             {...inputProps}
         />
     )}
-</RadioButtonInputGroup>
+</RadioButtonInputGroup>;
+```
+
+Radiobrytere med defaultvalg.
+
+```js
+const { RadioButtonInputGroup } = require('.');
+
+initialState = { selected: 'false' };
+
+<RadioButtonInputGroup
+    label="Vil bilen bli kjørt av sjåfører under 23 år?"
+    tooltip="Unge sjåfører har en statistisk høyere sjanse for å bulke bilen."
+    name="under23"
+    onChange={e => setState({ selected: e.target.value })}
+    selectedValue={state.selected}
+>
+    {inputProps => (
+        <RadioSwitch
+            leftLabel="Ja"
+            leftValue="true"
+            rightLabel="Nei"
+            rightValue="false"
+            {...inputProps}
+        />
+    )}
+</RadioButtonInputGroup>;
+```
+
+Radiobrytere med feilmelding på brukerens valg
+
+```js
+const { RadioButtonInputGroup } = require('.');
+
+initialState = {
+    selectedLeasing: 'true',
+    selectedPant: 'true',
+    fieldMessageLeasing:
+        'Bilen kan ikke være leaset hvis du har billån med pant i bilen.',
+};
+<RadioButtonInputGroup
+    label="Er bilen leaset?"
+    name="hasLeasing"
+    onChange={e => setState({ selectedLeasing: e.target.value })}
+    selectedValue={state.selectedLeasing}
+    fieldMessage={state.fieldMessageLeasing}
+>
+    {inputProps => (
+        <RadioSwitch
+            leftLabel="Ja"
+            leftValue="true"
+            rightLabel="Nei"
+            rightValue="false"
+            {...inputProps}
+        />
+    )}
+</RadioButtonInputGroup>;
+```
+
+Radiobrytere med feilmelding der brukeren ikke har gjort et valg.
+
+```js
+const { RadioButtonInputGroup } = require('.');
+
+initialState = { selected: undefined, fieldMessage: 'Du må gjøre et valg' };
+
+<RadioButtonInputGroup
+    label="Vil bilen bli kjørt av sjåfører under 23 år?"
+    tooltip="Unge sjåfører har en statistisk høyere sjanse for å bulke bilen."
+    name="under23"
+    onChange={e => setState({ selected: e.target.value })}
+    selectedValue={state.selected}
+    fieldMessage={state.fieldMessage}
+>
+    {inputProps => (
+        <RadioSwitch
+            leftLabel="Ja"
+            leftValue="true"
+            rightLabel="Nei"
+            rightValue="false"
+            {...inputProps}
+        />
+    )}
+</RadioButtonInputGroup>;
 ```
 
 Variant _dark_ for interne løsninger med mørk bakgrunn.
@@ -35,8 +120,8 @@ initialState = { selected: undefined };
 <RadioButtonInputGroup
     label="Røykfri siste 2 år?"
     tooltip="Røyk er ikke bra for deg!"
-    name="non-smoker"                    
-    onChange={(e) => setState({ selected: e.target.value })}
+    name="non-smoker"
+    onChange={e => setState({ selected: e.target.value })}
     selectedValue={state.selected}
     dark={true}
 >
@@ -50,6 +135,5 @@ initialState = { selected: undefined };
             {...inputProps}
         />
     )}
-</RadioButtonInputGroup>
+</RadioButtonInputGroup>;
 ```
-

--- a/packages/ffe-radio-button-react/src/RadioSwitch.spec.js
+++ b/packages/ffe-radio-button-react/src/RadioSwitch.spec.js
@@ -20,6 +20,70 @@ describe('<RadioSwitch />', () => {
         expect(wrapper.exists()).toBe(true);
     });
 
+    it('sets aria-invalid correctly', () => {
+        const wrapper = getWrapper({
+            'aria-invalid': 'true',
+            selectedValue: true,
+        });
+        expect(wrapper.find('BaseRadioButton')).toHaveLength(2);
+
+        const leftOne = wrapper.find('BaseRadioButton').first();
+        const rightOne = wrapper.find('BaseRadioButton').last();
+
+        expect(leftOne.prop('aria-invalid')).toBe('true');
+        expect(rightOne.prop('aria-invalid')).toBe('false');
+    });
+
+    it('sets aria-invalid on button with selected value, type of selected value is bool', () => {
+        const wrapper = getWrapper({
+            'aria-invalid': 'true',
+            selectedValue: defaultProps.leftValue,
+        });
+        expect(wrapper.find('BaseRadioButton')).toHaveLength(2);
+
+        const leftOne = wrapper.find('BaseRadioButton').first();
+        const rightOne = wrapper.find('BaseRadioButton').last();
+
+        expect(leftOne.prop('aria-invalid')).toBe('true');
+        expect(rightOne.prop('aria-invalid')).toBe('false');
+    });
+
+    it('sets aria-invalid on button with selected value, type of selected value is string', () => {
+        const wrapper = getWrapper({
+            'aria-invalid': 'true',
+            selectedValue: defaultProps.rightValue,
+        });
+        expect(wrapper.find('BaseRadioButton')).toHaveLength(2);
+
+        const leftOne = wrapper.find('BaseRadioButton').first();
+        const rightOne = wrapper.find('BaseRadioButton').last();
+
+        expect(leftOne.prop('aria-invalid')).toBe('false');
+        expect(rightOne.prop('aria-invalid')).toBe('true');
+    });
+
+    it('sets aria-invalid on both buttons for undefined selected value ', () => {
+        const wrapper = getWrapper({ 'aria-invalid': 'true' });
+        expect(wrapper.find('BaseRadioButton')).toHaveLength(2);
+
+        const leftOne = wrapper.find('BaseRadioButton').first();
+        const rightOne = wrapper.find('BaseRadioButton').last();
+
+        expect(leftOne.prop('aria-invalid')).toBe('true');
+        expect(rightOne.prop('aria-invalid')).toBe('true');
+    });
+
+    it('sets aria-invalid on both buttons for undefined selected value ', () => {
+        const wrapper = getWrapper({ 'aria-invalid': 'false' });
+        expect(wrapper.find('BaseRadioButton')).toHaveLength(2);
+
+        const leftOne = wrapper.find('BaseRadioButton').first();
+        const rightOne = wrapper.find('BaseRadioButton').last();
+
+        expect(leftOne.prop('aria-invalid')).toBe('false');
+        expect(rightOne.prop('aria-invalid')).toBe('false');
+    });
+
     it('passes the correct props to each radio button', () => {
         const wrapper = getWrapper();
         expect(wrapper.find('BaseRadioButton')).toHaveLength(2);

--- a/packages/ffe-radio-button-react/src/RadioSwitch.spec.js
+++ b/packages/ffe-radio-button-react/src/RadioSwitch.spec.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
+import each from 'jest-each';
 
 import RadioSwitch from './RadioSwitch';
 
@@ -99,4 +100,33 @@ describe('<RadioSwitch />', () => {
         expect(rightOne.prop('value')).toBe(defaultProps.rightValue);
         expect(rightOne.prop('name')).toBe(defaultProps.name);
     });
+
+    each([
+        [undefined, undefined],
+        [null, null],
+        ['', ''],
+        [defaultProps.leftValue, defaultProps.leftValue],
+        [defaultProps.rightValue, defaultProps.rightValue],
+    ]).test(
+        'returns the correct value of selectedValue when input selected value is %s',
+        (selectedValue, expectedSelectedValue) => {
+            const wrapper = getWrapper({
+                selectedValue: selectedValue,
+            });
+            expect(wrapper.find('BaseRadioButton')).toHaveLength(2);
+
+            const leftOne = wrapper.find('BaseRadioButton').first();
+            const rightOne = wrapper.find('BaseRadioButton').last();
+
+            expect(leftOne.prop('children')).toBe(defaultProps.leftLabel);
+            expect(leftOne.prop('value')).toBe(defaultProps.leftValue);
+            expect(leftOne.prop('name')).toBe(defaultProps.name);
+            expect(leftOne.prop('selectedValue')).toBe(expectedSelectedValue);
+
+            expect(rightOne.prop('children')).toBe(defaultProps.rightLabel);
+            expect(rightOne.prop('value')).toBe(defaultProps.rightValue);
+            expect(rightOne.prop('name')).toBe(defaultProps.name);
+            expect(rightOne.prop('selectedValue')).toBe(expectedSelectedValue);
+        },
+    );
 });


### PR DESCRIPTION
…itch.

If selectedValue is not undefined, the red circle for validation error should only be around the button that is selected. If selectedValue is undefined, the red circle is around both buttons. The error text below the buttons is shown the same way as before.

<!-- 
Thanks for opening a pull request! 🎉

If your changes include some kind of UI element, please attach a screenshot of 
how it looks.

Before submitting a pull request, please have a look through the CONTRIBUTING.md
document. TL;DR:

- Follow the conventional commit standard
- Write full, explanatory commit messages
- Follow our code standards
- Write tests where applicable
- Be courteous and respect our code of conduct
-->
