### PR TITLE
Add toggle switch component

### DIFF
--- a/packages/ffe-form-react/src/ToggleSwitch.js
+++ b/packages/ffe-form-react/src/ToggleSwitch.js
@@ -1,0 +1,55 @@
+import React from 'react';
+import { bool, node, string } from 'prop-types';
+import uuid from 'uuid';
+import classNames from 'classnames';
+
+class ToggleSwitch extends React.Component {
+    id = `toggle-${uuid.v4()}`;
+
+    render() {
+        const { children, className, alignRight, id, ...rest } = this.props;
+
+        return (
+            <div
+                className={classNames(
+                    'ffe-toggle-switch',
+                    { 'ffe-toggle-switch--align-right': alignRight },
+                    className,
+                )}
+            >
+                <input
+                    className="ffe-toggle-switch__input"
+                    type="checkbox"
+                    id={id || this.id}
+                    {...rest}
+                />
+                <label
+                    className="ffe-toggle-switch__label"
+                    htmlFor={id || this.id}
+                >
+                    {children}
+                </label>
+            </div>
+        );
+    }
+}
+
+ToggleSwitch.propTypes = {
+    /** The label text */
+    children: node.isRequired,
+    /** Any extra classes */
+    className: string,
+    /** Overrides the generated id with a custom one */
+    id: string,
+    /** Overrides the value attribute of the input with a custom one */
+    value: string,
+    /** Aligns the switch to the right */
+    alignRight: bool,
+};
+
+ToggleSwitch.defaultProps = {
+    alignRight: false,
+    value: 'on',
+};
+
+export default ToggleSwitch;

--- a/packages/ffe-form-react/src/ToggleSwitch.md
+++ b/packages/ffe-form-react/src/ToggleSwitch.md
@@ -1,0 +1,23 @@
+Toggle-switcher er av/på-switcher. De tilbyr brukerne valget mellom to avhengige valg og de har alltid en default verdi. De skal brukes i kontekster hvor systemet gir umiddelbare resultater. De skal ikke brukes dersom du har behov for en lagre-knapp i tillegg. I tillegg skal navnet være kort og konsist.
+
+Toggle-switcher kan erstatte to radioknapper eller én enkelt checkbox når en bruker skal velge mellom to avhengige states.
+
+```js
+<ToggleSwitch>Jeg vil gjerne ha reklame</ToggleSwitch>
+```
+
+Switchen kan skrus på som utgangspunkt med `defaultChecked`:
+
+```js
+<ToggleSwitch defaultChecked={true}>
+    Send meg interessant informasjon
+</ToggleSwitch>
+```
+
+Switch alignet til høyre for labelteksten:
+
+```js
+<ToggleSwitch alignRight={true}>
+    Abonner på ulidelig spennende oppdateringer
+</ToggleSwitch>
+```

--- a/packages/ffe-form-react/src/ToggleSwitch.spec.js
+++ b/packages/ffe-form-react/src/ToggleSwitch.spec.js
@@ -1,0 +1,79 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import ToggleSwitch from './ToggleSwitch';
+
+const getWrapper = props =>
+    shallow(<ToggleSwitch {...props}>Hello world</ToggleSwitch>);
+
+describe('<ToggleSwitch />', () => {
+    it('should render a checkbox', () => {
+        const wrapper = getWrapper();
+        expect(wrapper.find('input[type="checkbox"]').exists()).toBe(true);
+    });
+
+    it('should render a default value if passed', () => {
+        let wrapper = getWrapper();
+
+        expect(wrapper.find('input').prop('checked')).toBe(undefined);
+
+        wrapper = getWrapper({ checked: true });
+
+        expect(wrapper.find('input').prop('checked')).toBe(true);
+    });
+
+    it('should apply the same id to <label> and <input>', () => {
+        const wrapper = getWrapper({ name: 'Some text goes here' });
+
+        expect(wrapper.find('label').prop('htmlFor')).toBe(
+            wrapper.find('input').prop('id'),
+        );
+    });
+
+    it('should apply an unique id for each instance', () => {
+        const wrapper1 = getWrapper({ name: 'Some text goes here' });
+        const wrapper2 = getWrapper({ name: 'Some other text goes here' });
+
+        expect(wrapper1.find('input').prop('id')).not.toBe(
+            wrapper2.find('input').prop('id'),
+        );
+    });
+
+    it('should not change id when re-rendering an instance', () => {
+        const wrapper = getWrapper({ name: 'Some text goes here' });
+        const id = wrapper.find('input').prop('id');
+
+        // ShallowWrapper.update() alone does not force a re-render, it seems.
+        wrapper.instance().forceUpdate();
+        wrapper.update();
+        wrapper.setProps({});
+
+        expect(wrapper.find('input').prop('id')).toBe(id);
+    });
+
+    it('should allow to override the id', () => {
+        const id = 'this-is-not-a-generated-id';
+        const wrapper = getWrapper({ id, name: 'Some text goes here' });
+
+        expect(wrapper.find('label').prop('htmlFor')).toBe(id);
+        expect(wrapper.find('input').prop('id')).toBe(id);
+    });
+
+    it('should set arbitrary props (rest) on input', () => {
+        const wrapper = getWrapper({
+            name: 'toggle',
+            randomProp: 'false',
+            tabIndex: -1,
+        });
+
+        expect(wrapper.find('input').prop('name')).toBe('toggle');
+        expect(wrapper.find('input').prop('randomProp')).toBe('false');
+        expect(wrapper.find('input').prop('tabIndex')).toBe(-1);
+    });
+
+    it('should render children', () => {
+        const wrapper = getWrapper();
+
+        expect(wrapper.find('label').prop('children')).toBe('Hello world');
+    });
+});

--- a/packages/ffe-form/less/form.less
+++ b/packages/ffe-form/less/form.less
@@ -12,6 +12,7 @@
 @import 'radio-block';
 @import 'file-upload';
 @import 'phone-number';
+@import 'toggle-switch';
 
 /* Form Layout */
 @import 'input-group';

--- a/packages/ffe-form/less/toggle-switch.less
+++ b/packages/ffe-form/less/toggle-switch.less
@@ -1,0 +1,91 @@
+// Toggle switch
+//
+// Markup:
+// <div class="ffe-toggle-switch ffe-toggle-switch{{modifier_class}}">
+//     <input type="checkbox" class="ffe-toggle-switch__input" id="toggle{{modifier_class}}" name="toggle{{modifier_class}}" value="on">
+//     <label class="ffe-toggle-switch__label" for="toggle{{modifier_class}}">
+//         Send meg spam
+//     </label>
+// </div>
+//
+// --align-right - Aligns the switch to the right
+//
+// Styleguide ffe-form.toggle-switch
+
+.ffe-toggle-switch {
+    &__input {
+        position: absolute;
+        opacity: 0;
+        cursor: pointer;
+    }
+
+    &__label {
+        position: relative;
+        cursor: pointer;
+        padding: 0 0 0 65px;
+        line-height: 32px;
+        height: 32px;
+        display: block;
+
+        &::before {
+            display: inline-block;
+            content: '';
+            width: 50px;
+            height: 30px;
+            background: @ffe-grey-silver;
+            border-radius: 15px;
+            position: absolute;
+            z-index: 1;
+            left: 0;
+            transition: background 0.4s @ffe-ease,
+                box-shadow @ffe-transition-duration @ffe-ease;
+        }
+
+        &::after {
+            display: inline-block;
+            content: '';
+            width: 26px;
+            height: 26px;
+            background: @ffe-white;
+            border-radius: 13px;
+            position: absolute;
+            z-index: 2;
+            left: 2px;
+            top: 2px;
+            box-shadow: 0 1px 1px rgba(0, 0, 0, 0.2);
+            transition: transform @ffe-transition-duration @ffe-ease-in-out-back;
+        }
+
+        &:hover::before {
+            box-shadow: 0 0 0 1px @ffe-white, 0 0 0 4px @ffe-blue-focus;
+        }
+    }
+
+    &__input:checked + .ffe-toggle-switch__label::after {
+        transform: translateX(20px);
+    }
+
+    &__input:checked + .ffe-toggle-switch__label::before {
+        background: @ffe-green-shamrock;
+    }
+
+    &__input:focus + .ffe-toggle-switch__label::before {
+        box-shadow: 0 0 0 1px @ffe-white, 0 0 0 4px @ffe-blue-focus;
+    }
+
+    &--align-right {
+        .ffe-toggle-switch__label {
+            padding: 0 65px 0 0;
+
+            &::before {
+                left: auto;
+                right: 0;
+            }
+
+            &::after {
+                left: auto;
+                right: 22px;
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a new toggle switch component. It looks like this:

Default:
![image](https://user-images.githubusercontent.com/463847/49089997-1865b880-f25d-11e8-9832-4c7b97e9acc9.png)

Checked/selected:
![image](https://user-images.githubusercontent.com/463847/49090042-2d424c00-f25d-11e8-8c9d-c07775930ddb.png)

**It's not yet decided whether or not this will be merged.** Some questions have arisen along the way and need to be answered first:

- Does the toggle switch pattern make sense in a desktop UI? This component renders a switch on any screen size. Should the switch in stead be replaced by a different pattern on large screens, and if so, which one?

- Guidelines are not yet written, but should be if this is to be merged. When to use a toggle switch vs radio buttons/checkboxes should be very clear. According to [NN Group guidelines](https://www.nngroup.com/articles/toggle-switch-guidelines/) the toggle switch pattern demands immediate results, i.e. they should not be used in forms that require users to click a button for changes to take effect. Any input on this? Anything else?

- How to handle the focus state? This implementation includes the regular focus outline (same one used in form elements), but it feels a bit off given that switches generally don't have an outline in a native mobile context. Do we:

1. Keep it as is?
2. Show the outline only on large screens?
3. Remove the outline altogether? (If so, what consequenses does it have for accessibility?)

- How about the hover state? I've added the focus style on hover for now.

Hover/focus state:
![image](https://user-images.githubusercontent.com/463847/49090300-b2c5fc00-f25d-11e8-860f-f3b1d8e3e493.png)
![image](https://user-images.githubusercontent.com/463847/49090315-b78ab000-f25d-11e8-8fef-ebd01486dd87.png)

Any input is welcome!

Fixes #519 