### PR TITLE
feat(ffe-lists-react): add condensed modifier to bullet and number list

### DIFF
--- a/packages/ffe-lists-react/src/BulletList.js
+++ b/packages/ffe-lists-react/src/BulletList.js
@@ -1,9 +1,16 @@
 import React from 'react';
-import { node, string } from 'prop-types';
+import { node, string, bool } from 'prop-types';
 import classNames from 'classnames';
 
-const BulletList = ({ className, ...rest }) => (
-    <ul className={classNames('ffe-bullet-list', className)} {...rest} />
+const BulletList = ({ className, condensed, ...rest }) => (
+    <ul
+        className={classNames(
+            'ffe-bullet-list',
+            { 'ffe-bullet-list--condensed': condensed },
+            className,
+        )}
+        {...rest}
+    />
 );
 
 BulletList.propTypes = {
@@ -11,6 +18,8 @@ BulletList.propTypes = {
     children: node.isRequired,
     /** Any extra classes */
     className: string,
+    /** Condensed modifier. Use in condensed designs */
+    condensed: bool,
 };
 
 export default BulletList;

--- a/packages/ffe-lists-react/src/BulletList.spec.js
+++ b/packages/ffe-lists-react/src/BulletList.spec.js
@@ -27,4 +27,11 @@ describe('<BulletList>', () => {
         expect(wrapper.prop('id')).toBe('that-id');
         expect(wrapper.html()).toContain('Firstly');
     });
+    it('renders condensed modifier', () => {
+        const modifierClass = 'ffe-bullet-list--condensed';
+        expect(getWrapper().hasClass(modifierClass)).toBe(false);
+        expect(getWrapper({ condensed: true }).hasClass(modifierClass)).toBe(
+            true,
+        );
+    });
 });

--- a/packages/ffe-lists-react/src/NumberedList.js
+++ b/packages/ffe-lists-react/src/NumberedList.js
@@ -1,9 +1,16 @@
 import React from 'react';
-import { string, node } from 'prop-types';
+import { string, node, bool } from 'prop-types';
 import classNames from 'classnames';
 
-const NumberedList = ({ className, ...rest }) => (
-    <ol className={classNames('ffe-numbered-list', className)} {...rest} />
+const NumberedList = ({ className, condensed, ...rest }) => (
+    <ol
+        className={classNames(
+            'ffe-numbered-list',
+            { 'ffe-numbered-list--condensed': condensed },
+            className,
+        )}
+        {...rest}
+    />
 );
 
 NumberedList.propTypes = {
@@ -11,6 +18,8 @@ NumberedList.propTypes = {
     children: node.isRequired,
     /** Any extra classes */
     className: string,
+    /** Condensed modifier. Use in condensed designs */
+    condensed: bool,
 };
 
 export default NumberedList;

--- a/packages/ffe-lists-react/src/NumberedList.spec.js
+++ b/packages/ffe-lists-react/src/NumberedList.spec.js
@@ -27,4 +27,11 @@ describe('<NumberedList>', () => {
         expect(wrapper.prop('id')).toBe('that-id');
         expect(wrapper.html()).toContain('Firstly');
     });
+    it('renders condensed modifier', () => {
+        const modifierClass = 'ffe-numbered-list--condensed';
+        expect(getWrapper().hasClass(modifierClass)).toBe(false);
+        expect(getWrapper({ condensed: true }).hasClass(modifierClass)).toBe(
+            true,
+        );
+    });
 });


### PR DESCRIPTION
Add a prop for turning the `--condensed` modifer on for react
components BulletList and NumberedList. Resolves #525.