### PR TITLE
feat(ffe-form-react): Allow node as label

### DIFF
--- a/packages/ffe-form-react/src/RadioButtonInputGroup.js
+++ b/packages/ffe-form-react/src/RadioButtonInputGroup.js
@@ -90,7 +90,7 @@ RadioButtonInputGroup.propTypes = {
      * prop but provide your own label you should make sure your solution passes
      * acessibility validation using a tool such as aXe DevTools.
      */
-    label: string,
+    label: oneOfType([node, string]),
     /** The name of the radio button */
     name: string,
     /** Change handler, receives value of selected radio button */


### PR DESCRIPTION
Allow using either a node or a string for the label of a
`RadioButtonInputGroup`.

Closes #522

<!-- 
Thanks for opening a pull request! 🎉

If your changes include some kind of UI element, please attach a screenshot of 
how it looks.

Before submitting a pull request, please have a look through the CONTRIBUTING.md
document. TL;DR:

- Follow the conventional commit standard
- Write full, explanatory commit messages
- Follow our code standards
- Write tests where applicable
- Be courteous and respect our code of conduct
-->
