### PR TITLE
chore: fix all hoisting warnings

### DIFF
--- a/linting/eslint-config-ffe-base/package.json
+++ b/linting/eslint-config-ffe-base/package.json
@@ -18,7 +18,7 @@
     "unused": "eslint-find-rules -u"
   },
   "devDependencies": {
-    "eslint": "^5.3.0",
+    "eslint": "^5.9.0",
     "eslint-find-rules": "^3.1.1",
     "eslint-plugin-import": "^2.0.1"
   },

--- a/linting/eslint-config-ffe/package.json
+++ b/linting/eslint-config-ffe/package.json
@@ -20,13 +20,13 @@
     "@sb1/eslint-config-ffe-base": "^3.0.2"
   },
   "devDependencies": {
-    "eslint": "^5.3.0",
+    "eslint": "^5.9.0",
     "eslint-plugin-import": "^2.0.1",
     "eslint-plugin-jsx-a11y": "^6.0.3",
     "eslint-plugin-react": "^7.0.0"
   },
   "peerDependencies": {
-    "eslint": "^5.3.0",
+    "eslint": "^5.9.0",
     "eslint-plugin-jsx-a11y": "^6.0.3",
     "eslint-plugin-react": ">=6"
   },

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
         "babel-eslint": "^9.0.0",
         "babel-jest": "^23.6.0",
         "babel-loader": "^8.0.0",
-        "case": "^1.5.4",
+        "case": "^1.5.5",
         "copyfiles": "^2.1.0",
         "coveralls": "^3.0.2",
         "cross-env": "^5.2.0",

--- a/packages/ffe-account-selector-react/package.json
+++ b/packages/ffe-account-selector-react/package.json
@@ -40,7 +40,7 @@
   "devDependencies": {
     "enzyme": "^3.7.0",
     "enzyme-adapter-react-16": "^1.7.0",
-    "eslint": "^5.3.0",
+    "eslint": "^5.9.0",
     "jest": "^23.4.2",
     "react": "^16.6.3",
     "react-dom": "^16.6.3"

--- a/packages/ffe-buttons-react/package.json
+++ b/packages/ffe-buttons-react/package.json
@@ -33,7 +33,7 @@
   "devDependencies": {
     "enzyme": "^3.7.0",
     "enzyme-adapter-react-16": "^1.7.0",
-    "eslint": "^5.3.0",
+    "eslint": "^5.9.0",
     "jest": "^23.4.2",
     "react": "^16.6.3",
     "react-dom": "^16.6.3"

--- a/packages/ffe-core-react/package.json
+++ b/packages/ffe-core-react/package.json
@@ -31,7 +31,7 @@
   "devDependencies": {
     "enzyme": "^3.7.0",
     "enzyme-adapter-react-16": "^1.7.0",
-    "eslint": "^5.3.0",
+    "eslint": "^5.9.0",
     "jest": "^23.4.2",
     "prop-types": "^15.6.0",
     "react": "^16.6.3",

--- a/packages/ffe-datepicker-react/package.json
+++ b/packages/ffe-datepicker-react/package.json
@@ -30,7 +30,7 @@
   "devDependencies": {
     "enzyme": "^3.7.0",
     "enzyme-adapter-react-16": "^1.7.0",
-    "eslint": "^5.3.0",
+    "eslint": "^5.9.0",
     "jest": "^23.4.2",
     "react": "^16.6.3",
     "react-dom": "^16.6.3"

--- a/packages/ffe-decorators-react/package.json
+++ b/packages/ffe-decorators-react/package.json
@@ -28,7 +28,7 @@
   "devDependencies": {
     "enzyme": "^3.7.0",
     "enzyme-adapter-react-16": "^1.7.0",
-    "eslint": "^5.3.0",
+    "eslint": "^5.9.0",
     "jest": "^23.4.2",
     "mock-raf": "^1.0.0",
     "react": "^16.6.3",

--- a/packages/ffe-dropdown-react/package.json
+++ b/packages/ffe-dropdown-react/package.json
@@ -26,7 +26,7 @@
   "devDependencies": {
     "enzyme": "^3.7.0",
     "enzyme-adapter-react-16": "^1.7.0",
-    "eslint": "^5.3.0",
+    "eslint": "^5.9.0",
     "jest": "^23.4.2",
     "react": "^16.6.3",
     "react-addons-test-utils": "^15.6.2",

--- a/packages/ffe-form-react/package.json
+++ b/packages/ffe-form-react/package.json
@@ -30,7 +30,7 @@
   "devDependencies": {
     "enzyme": "^3.7.0",
     "enzyme-adapter-react-16": "^1.7.0",
-    "eslint": "^5.3.0",
+    "eslint": "^5.9.0",
     "jest": "^23.4.2",
     "prop-types": "^15.6.0",
     "react": "^16.6.3",

--- a/packages/ffe-formatters/package.json
+++ b/packages/ffe-formatters/package.json
@@ -25,7 +25,7 @@
     "underscore.string": "^3.3.4"
   },
   "devDependencies": {
-    "eslint": "^5.3.0",
+    "eslint": "^5.9.0",
     "jest": "^23.4.2",
     "moment": "^2.18.1"
   },

--- a/packages/ffe-icons-react/package.json
+++ b/packages/ffe-icons-react/package.json
@@ -30,7 +30,7 @@
     "@sb1/ffe-icons": "^12.4.0",
     "cheerio": "^1.0.0-rc.2",
     "cross-env": "^5.2.0",
-    "eslint": "^5.3.0",
+    "eslint": "^5.9.0",
     "eslint-loader": "^2.1.0",
     "json-loader": "^0.5.7",
     "mkdirp": "^0.5.1",

--- a/packages/ffe-icons/package.json
+++ b/packages/ffe-icons/package.json
@@ -25,7 +25,7 @@
     "yargs": "^12.0.1"
   },
   "devDependencies": {
-    "eslint": "^5.3.0",
+    "eslint": "^5.9.0",
     "mkdirp": "^0.5.1",
     "npm-run-all": "^4.1.2",
     "run-p": "0.0.0",

--- a/packages/ffe-message-box-react/package.json
+++ b/packages/ffe-message-box-react/package.json
@@ -28,7 +28,7 @@
   "devDependencies": {
     "enzyme": "^3.7.0",
     "enzyme-adapter-react-16": "^1.7.0",
-    "eslint": "^5.3.0",
+    "eslint": "^5.9.0",
     "jest": "^23.4.2",
     "prop-types": "^15.6.0",
     "react": "^16.6.3",

--- a/packages/ffe-sb1-logos/package.json
+++ b/packages/ffe-sb1-logos/package.json
@@ -19,6 +19,6 @@
     "access": "public"
   },
   "devDependencies": {
-    "handlebars": "^4.0.11"
+    "handlebars": "^4.0.12"
   }
 }

--- a/packages/ffe-searchable-dropdown-react/package.json
+++ b/packages/ffe-searchable-dropdown-react/package.json
@@ -34,7 +34,7 @@
   "devDependencies": {
     "enzyme": "^3.7.0",
     "enzyme-adapter-react-16": "^1.7.0",
-    "eslint": "^5.3.0",
+    "eslint": "^5.9.0",
     "jest": "^23.4.2",
     "less": "^3.8.1",
     "react": "^16.6.3",


### PR DESCRIPTION
Bumping a few minors and patches to the newest already in use in the repository to fix hoisting warnings.