### PR TITLE
Condensed condensed task button

### DIFF
--- a/packages/ffe-buttons-react/src/TaskButton.md
+++ b/packages/ffe-buttons-react/src/TaskButton.md
@@ -4,5 +4,8 @@ const { PlussIkon } = require('../../ffe-icons-react');
 
 <ButtonGroup thin={true}>
     <TaskButton icon={<PlussIkon />}>Legg til bruker</TaskButton>
+    <TaskButton icon={<PlussIkon />} condensed={true}>
+        Legg til bruker
+    </TaskButton>
 </ButtonGroup>;
 ```

--- a/packages/ffe-buttons/less/base-button.less
+++ b/packages/ffe-buttons/less/base-button.less
@@ -272,6 +272,12 @@
         transition: all @ffe-transition-duration @ffe-ease;
     }
 
+    .ffe-button--task.ffe-button--condensed & {
+        height: 25px;
+        width: 25px;
+        padding: 5px;
+    }
+
     .ffe-button--task:hover & {
         border-color: @ffe-blue-cobalt;
         box-shadow: 0 1px 2px 1px rgba(0, 0, 0, 0.2);


### PR DESCRIPTION
This commit condenses the circle and icon in the condensed version of the
task button. While this modifier already reduced font size of the button,
it did nothing to the circle and icon. This means the button did not get
condensed at all.

TaskButton and condensed TaskButton pre changes
![image](https://user-images.githubusercontent.com/435037/49447594-3ab88280-f7d7-11e8-9ceb-65f530b620a7.png)

TaskButton and condensed TaskButton post changes
![image](https://user-images.githubusercontent.com/435037/49447604-41df9080-f7d7-11e8-870a-84bf4eb535f4.png)
