### PR TITLE
fix(ffe-formatters): Make sure formatters are transpiled!

### DIFF
--- a/packages/ffe-formatters/package.json
+++ b/packages/ffe-formatters/package.json
@@ -16,7 +16,7 @@
     "url": "ssh://git@github.com:SpareBank1/designsystem.git"
   },
   "scripts": {
-    "build": "babel -d lib/. --ignore=*.spec.js src/.",
+    "build": "babel -d lib/. --root-mode=upward --ignore=*.spec.js src/.",
     "lint": "eslint src/.",
     "test": "jest",
     "test:watch": "jest --watch"


### PR DESCRIPTION
This fixes the issue with ffe-formatters, which couldn't find its `babel.config.js` file, and therefore didn't transpile anything at all! 