### PR TITLE
fix: Build tree shakeable packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ dist/
 lib/
 src/styleguidist.html
 tmp/
+es/
 
 # Editors
 .idea/

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     },
     "scripts": {
         "clean": "run-s clean:lib clean:lerna",
-        "clean:lib": "rimraf packages/*/lib",
+        "clean:lib": "rimraf packages/*/lib packages/*/es",
         "clean:lerna": "lerna clean --yes",
         "postinstall": "npm run bootstrap",
         "bootstrap": "lerna bootstrap --no-ci",

--- a/packages/ffe-accordion-react/package.json
+++ b/packages/ffe-accordion-react/package.json
@@ -5,15 +5,19 @@
   "author": "SpareBank 1",
   "files": [
     "lib",
-    "*.js"
+    "es"
   ],
   "main": "lib/index.js",
+  "module": "es/index.js",
+  "sideEffects": false,
   "repository": {
     "type": "git",
     "url": "ssh://git@github.com:SpareBank1/designsystem.git"
   },
   "scripts": {
-    "build": "babel -d lib/. --root-mode=upward --ignore=*.spec.js src/.",
+    "build": "npm run build:cjs && npm run build:es",
+    "build:cjs": "babel -d lib/. --root-mode=upward  --env-name=cjs --ignore=*.spec.js src/.",
+    "build:es": "babel -d es/. --root-mode=upward --env-name=es --ignore=*.spec.js src/.",
     "lint": "eslint src/.",
     "test": "jest",
     "test:watch": "jest --watch"

--- a/packages/ffe-account-selector-react/package.json
+++ b/packages/ffe-account-selector-react/package.json
@@ -8,18 +8,21 @@
   "license": "MIT",
   "author": "SpareBank 1",
   "files": [
-    "less",
     "lib",
-    "src",
-    "*.js"
+    "es",
+    "less"
   ],
   "main": "lib/index.js",
+  "module": "es/index.js",
+  "sideEffects": false,
   "repository": {
     "type": "git",
     "url": "ssh://git@github.com:SpareBank1/designsystem.git"
   },
   "scripts": {
-    "build": "babel -d lib/. --root-mode=upward --ignore=*.spec.js src/.",
+    "build": "npm run build:cjs && npm run build:es",
+    "build:cjs": "babel -d lib/. --root-mode=upward  --env-name=cjs --ignore=*.spec.js src/.",
+    "build:es": "babel -d es/. --root-mode=upward --env-name=es --ignore=*.spec.js src/.",
     "lint": "eslint src/.",
     "test": "jest",
     "test:watch": "jest --watch"

--- a/packages/ffe-buttons-react/package.json
+++ b/packages/ffe-buttons-react/package.json
@@ -9,15 +9,19 @@
   "author": "SpareBank 1",
   "files": [
     "lib",
-    "*.js"
+    "es"
   ],
   "main": "lib/index.js",
+  "module": "es/index.js",
+  "sideEffects": false,
   "repository": {
     "type": "git",
     "url": "ssh://git@github.com:SpareBank1/designsystem.git"
   },
   "scripts": {
-    "build": "babel -d lib/. --root-mode=upward --ignore=*.spec.js src/.",
+    "build": "npm run build:cjs && npm run build:es",
+    "build:cjs": "babel -d lib/. --root-mode=upward  --env-name=cjs --ignore=*.spec.js src/.",
+    "build:es": "babel -d es/. --root-mode=upward --env-name=es --ignore=*.spec.js src/.",
     "lint": "eslint src/.",
     "test": "jest",
     "test:watch": "jest --watch"

--- a/packages/ffe-cards-react/package.json
+++ b/packages/ffe-cards-react/package.json
@@ -4,13 +4,21 @@
   "description": "React implementation of ffe-react",
   "license": "MIT",
   "author": "SpareBank 1",
+  "files": [
+    "lib",
+    "es"
+  ],
   "main": "lib/index.js",
+  "module": "es/index.js",
+  "sideEffects": false,
   "repository": {
     "type": "git",
     "url": "ssh://git@github.com:SpareBank1/designsystem.git"
   },
   "scripts": {
-    "build": "babel -d lib/. --root-mode=upward --ignore=*.spec.js src/.",
+    "build": "npm run build:cjs && npm run build:es",
+    "build:cjs": "babel -d lib/. --root-mode=upward  --env-name=cjs --ignore=*.spec.js src/.",
+    "build:es": "babel -d es/. --root-mode=upward --env-name=es --ignore=*.spec.js src/.",
     "lint": "eslint src/.",
     "test": "jest",
     "test:watch": "jest --watch"

--- a/packages/ffe-chart-donut-react/package.json
+++ b/packages/ffe-chart-donut-react/package.json
@@ -9,16 +9,21 @@
   "author": "SpareBank 1",
   "files": [
     "lib",
-    "*.js",
-    "*.less"
+    "es",
+    "less"
   ],
   "main": "lib/index.js",
+  "module": "es/index.js",
+  "sideEffects": false,
   "repository": {
     "type": "git",
     "url": "ssh://git@github.com:SpareBank1/designsystem.git"
   },
   "scripts": {
-    "build": "babel -d lib/. --root-mode=upward --ignore=*.spec.js src/ && copyfiles -f src/ffe-chart-donut.less lib/",
+    "build": "npm run build:cjs && npm run build:es && npm run build:less",
+    "build:cjs": "babel -d lib/. --root-mode=upward  --env-name=cjs --ignore=*.spec.js src/.",
+    "build:es": "babel -d es/. --root-mode=upward --env-name=es --ignore=*.spec.js src/.",
+    "build:less": "copyfiles -f src/ffe-chart-donut.less lib/",
     "lint": "eslint src/.",
     "test": "jest",
     "test:watch": "jest --watch"

--- a/packages/ffe-context-message-react/package.json
+++ b/packages/ffe-context-message-react/package.json
@@ -7,13 +7,21 @@
   ],
   "license": "MIT",
   "author": "SpareBank 1",
+  "files": [
+    "lib",
+    "es"
+  ],
   "main": "lib/index.js",
+  "module": "es/index.js",
+  "sideEffects": false,
   "repository": {
     "type": "git",
     "url": "ssh://git@github.com:SpareBank1/designsystem.git"
   },
   "scripts": {
-    "build": "babel -d lib/. --root-mode=upward --ignore=*.spec.js src/.",
+    "build": "npm run build:cjs && npm run build:es",
+    "build:cjs": "babel -d lib/. --root-mode=upward  --env-name=cjs --ignore=*.spec.js src/.",
+    "build:es": "babel -d es/. --root-mode=upward --env-name=es --ignore=*.spec.js src/.",
     "lint": "eslint src/.",
     "test": "jest",
     "test:watch": "jest --watch"

--- a/packages/ffe-core-react/package.json
+++ b/packages/ffe-core-react/package.json
@@ -9,15 +9,19 @@
   "author": "SpareBank 1",
   "files": [
     "lib",
-    "*.js"
+    "es"
   ],
   "main": "lib/index.js",
+  "module": "es/index.js",
+  "sideEffects": false,
   "repository": {
     "type": "git",
     "url": "ssh://git@github.com:SpareBank1/designsystem.git"
   },
   "scripts": {
-    "build": "babel -d lib/. --root-mode=upward --ignore=*.spec.js src/.",
+    "build": "npm run build:cjs && npm run build:es",
+    "build:cjs": "babel -d lib/. --root-mode=upward  --env-name=cjs --ignore=*.spec.js src/.",
+    "build:es": "babel -d es/. --root-mode=upward --env-name=es --ignore=*.spec.js src/.",
     "lint": "eslint src/.",
     "test": "jest",
     "test:watch": "jest --watch"
@@ -36,8 +40,7 @@
     "prop-types": "^15.6.0",
     "react": "^16.6.3",
     "react-dom": "^16.6.3",
-    "react-test-renderer": "^16.2.0",
-    "rimraf": "^2.6.2"
+    "react-test-renderer": "^16.2.0"
   },
   "peerDependencies": {
     "@sb1/ffe-core": "^14.0.2",

--- a/packages/ffe-core/package.json
+++ b/packages/ffe-core/package.json
@@ -3,12 +3,13 @@
   "version": "14.0.3",
   "description": "Rammeverk for Felles Front End",
   "license": "MIT",
-  "main": "lib/index.js",
   "author": "SpareBank 1",
   "files": [
     "lib",
+    "es",
     "less"
   ],
+  "main": "lib/index.js",
   "repository": {
     "type": "git",
     "url": "ssh://git@github.com:SpareBank1/designsystem.git"
@@ -16,13 +17,11 @@
   "scripts": {
     "lint": "stylelint less/*.less",
     "test": "npm run lint",
-    "prebuild": "rimraf lib",
-    "build": "node ./bin/build.js && babel --out-dir lib --root-mode=upward lib"
+    "build": "node ./bin/build.js"
   },
   "devDependencies": {
     "case": "^1.5.5",
     "mkdirp": "^0.5.1",
-    "rimraf": "^2.6.2",
     "stylelint": "^9.4.0"
   },
   "publishConfig": {

--- a/packages/ffe-datepicker-react/package.json
+++ b/packages/ffe-datepicker-react/package.json
@@ -4,15 +4,19 @@
   "license": "MIT",
   "files": [
     "lib",
-    "*.js"
+    "es"
   ],
-  "main": "lib/ffe-datepicker-react.js",
+  "main": "lib/index.js",
+  "module": "es/index.js",
+  "sideEffects": false,
   "repository": {
     "type": "git",
     "url": "ssh://git@github.com:SpareBank1/designsystem.git"
   },
   "scripts": {
-    "build": "babel -d lib/. --root-mode=upward --ignore=*.spec.js src/.",
+    "build": "npm run build:cjs && npm run build:es",
+    "build:cjs": "babel -d lib/. --root-mode=upward  --env-name=cjs --ignore=*.spec.js src/.",
+    "build:es": "babel -d es/. --root-mode=upward --env-name=es --ignore=*.spec.js src/.",
     "lint": "eslint src/.",
     "test": "jest",
     "test:watch": "jest --watch"

--- a/packages/ffe-decorators-react/package.json
+++ b/packages/ffe-decorators-react/package.json
@@ -9,15 +9,19 @@
   "author": "SpareBank 1",
   "files": [
     "lib",
-    "*.js"
+    "es"
   ],
   "main": "lib/index.js",
+  "module": "es/index.js",
+  "sideEffects": false,
   "repository": {
     "type": "git",
     "url": "ssh://git@github.com:SpareBank1/designsystem.git"
   },
   "scripts": {
-    "build": "babel -d lib/. --root-mode=upward --ignore=*.spec.js src/.",
+    "build": "npm run build:cjs && npm run build:es",
+    "build:cjs": "babel -d lib/. --root-mode=upward  --env-name=cjs --ignore=*.spec.js src/.",
+    "build:es": "babel -d es/. --root-mode=upward --env-name=es --ignore=*.spec.js src/.",
     "lint": "eslint src/.",
     "test": "jest",
     "test:watch": "jest --watch"

--- a/packages/ffe-details-list-react/package.json
+++ b/packages/ffe-details-list-react/package.json
@@ -4,17 +4,21 @@
   "license": "MIT",
   "author": "SpareBank 1",
   "files": [
-    "less",
     "lib",
-    "*.js"
+    "es",
+    "less"
   ],
   "main": "lib/index.js",
+  "module": "es/index.js",
+  "sideEffects": false,
   "repository": {
     "type": "git",
     "url": "ssh://git@github.com:SpareBank1/designsystem.git"
   },
   "scripts": {
-    "build": "babel -d lib/. --ignore=*.spec.js --root-mode=upward src/.",
+    "build": "npm run build:cjs && npm run build:es",
+    "build:cjs": "babel -d lib/. --root-mode=upward  --env-name=cjs --ignore=*.spec.js src/.",
+    "build:es": "babel -d es/. --root-mode=upward --env-name=es --ignore=*.spec.js src/.",
     "lint": "eslint src/.",
     "test": "jest",
     "test:watch": "jest --watch"

--- a/packages/ffe-dropdown-react/package.json
+++ b/packages/ffe-dropdown-react/package.json
@@ -4,15 +4,19 @@
   "license": "MIT",
   "files": [
     "lib",
-    "*.js"
+    "es"
   ],
-  "main": "lib/Dropdown.js",
+  "main": "lib/index.js",
+  "module": "es/index.js",
+  "sideEffects": false,
   "repository": {
     "type": "git",
     "url": "ssh://git@github.com:SpareBank1/designsystem.git"
   },
   "scripts": {
-    "build": "babel -d lib/. --root-mode=upward --ignore=*.spec.js src/.",
+    "build": "npm run build:cjs && npm run build:es",
+    "build:cjs": "babel -d lib/. --root-mode=upward  --env-name=cjs --ignore=*.spec.js src/.",
+    "build:es": "babel -d es/. --root-mode=upward --env-name=es --ignore=*.spec.js src/.",
     "lint": "eslint src/.",
     "test": "jest",
     "test:watch": "jest --watch"

--- a/packages/ffe-dropdown-react/src/index.js
+++ b/packages/ffe-dropdown-react/src/index.js
@@ -1,0 +1,3 @@
+import Dropdown from './Dropdown';
+
+export default Dropdown;

--- a/packages/ffe-file-upload-react/package.json
+++ b/packages/ffe-file-upload-react/package.json
@@ -7,13 +7,21 @@
   ],
   "license": "MIT",
   "author": "SpareBank 1",
+  "files": [
+    "lib",
+    "es"
+  ],
   "main": "lib/index.js",
+  "module": "es/index.js",
+  "sideEffects": false,
   "repository": {
     "type": "git",
     "url": "ssh://git@github.com:SpareBank1/designsystem.git"
   },
   "scripts": {
-    "build": "babel -d lib/. --root-mode=upward --ignore=*.spec.js src/.",
+    "build": "npm run build:cjs && npm run build:es",
+    "build:cjs": "babel -d lib/. --root-mode=upward  --env-name=cjs --ignore=*.spec.js src/.",
+    "build:es": "babel -d es/. --root-mode=upward --env-name=es --ignore=*.spec.js src/.",
     "lint": "eslint src/.",
     "test": "jest",
     "test:watch": "jest --watch"

--- a/packages/ffe-form-react/package.json
+++ b/packages/ffe-form-react/package.json
@@ -6,15 +6,19 @@
   "author": "SpareBank 1",
   "files": [
     "lib",
-    "*.js"
+    "es"
   ],
   "main": "lib/index.js",
+  "module": "es/index.js",
+  "sideEffects": false,
   "repository": {
     "type": "git",
     "url": "ssh://git@github.com:SpareBank1/designsystem.git"
   },
   "scripts": {
-    "build": "babel -d lib/. --root-mode=upward --ignore=*.spec.js src/.",
+    "build": "npm run build:cjs && npm run build:es",
+    "build:cjs": "babel -d lib/. --root-mode=upward  --env-name=cjs --ignore=*.spec.js src/.",
+    "build:es": "babel -d es/. --root-mode=upward --env-name=es --ignore=*.spec.js src/.",
     "lint": "eslint src/.",
     "test": "jest",
     "test:watch": "jest --watch"

--- a/packages/ffe-formatters/package.json
+++ b/packages/ffe-formatters/package.json
@@ -8,15 +8,20 @@
   "license": "MIT",
   "author": "SpareBank 1",
   "files": [
-    "lib"
+    "lib",
+    "es"
   ],
   "main": "lib/index.js",
+  "module": "es/index.js",
+  "sideEffects": false,
   "repository": {
     "type": "git",
     "url": "ssh://git@github.com:SpareBank1/designsystem.git"
   },
   "scripts": {
-    "build": "babel -d lib/. --root-mode=upward --ignore=*.spec.js src/.",
+    "build": "npm run build:cjs && npm run build:es",
+    "build:cjs": "babel -d lib/. --root-mode=upward  --env-name=cjs --ignore=*.spec.js src/.",
+    "build:es": "babel -d es/. --root-mode=upward --env-name=es --ignore=*.spec.js src/.",
     "lint": "eslint src/.",
     "test": "jest",
     "test:watch": "jest --watch"

--- a/packages/ffe-grid-react/package.json
+++ b/packages/ffe-grid-react/package.json
@@ -5,15 +5,19 @@
   "author": "SpareBank1",
   "files": [
     "lib",
-    "*.js"
+    "es"
   ],
   "main": "lib/index.js",
+  "module": "es/index.js",
+  "sideEffects": false,
   "repository": {
     "type": "git",
     "url": "ssh://git@github.com:SpareBank1/designsystem.git"
   },
   "scripts": {
-    "build": "babel -d lib/. --root-mode=upward --ignore=*.spec.js src/.",
+    "build": "npm run build:cjs && npm run build:es",
+    "build:cjs": "babel -d lib/. --root-mode=upward  --env-name=cjs --ignore=*.spec.js src/.",
+    "build:es": "babel -d es/. --root-mode=upward --env-name=es --ignore=*.spec.js src/.",
     "lint": "eslint src/.",
     "test": "jest",
     "test:watch": "jest --watch"

--- a/packages/ffe-icons-react/package.json
+++ b/packages/ffe-icons-react/package.json
@@ -15,9 +15,9 @@
     "url": "ssh://git@github.com:SpareBank1/designsystem.git"
   },
   "scripts": {
-    "build": "npm run build:jsx-components && npm run build:babel && npm run build:es",
-    "build:babel": "babel -d lib --root-mode=upward jsx",
-    "build:es": "cross-env BABEL_ENV=es babel jsx --root-mode=upward -d es",
+    "build": "npm run build:jsx-components && npm run build:cjs && npm run build:es",
+    "build:cjs": "babel -d lib --env-name=cjs --root-mode=upward jsx",
+    "build:es": "babel -d es --env-name=es --root-mode=upward jsx",
     "build:jsx-components": "node ./src/build-jsx-components.js",
     "clean": "rimraf tmp jsx lib es",
     "lint": "eslint src/.",

--- a/packages/ffe-lists-react/package.json
+++ b/packages/ffe-lists-react/package.json
@@ -6,15 +6,19 @@
   "author": "SpareBank 1",
   "files": [
     "lib",
-    "*.js"
+    "es"
   ],
   "main": "lib/index.js",
+  "module": "es/index.js",
+  "sideEffects": false,
   "repository": {
     "type": "git",
     "url": "ssh://git@github.com:SpareBank1/designsystem.git"
   },
   "scripts": {
-    "build": "babel -d lib/. --root-mode=upward --ignore=*.spec.js src/.",
+    "build": "npm run build:cjs && npm run build:es",
+    "build:cjs": "babel -d lib/. --root-mode=upward  --env-name=cjs --ignore=*.spec.js src/.",
+    "build:es": "babel -d es/. --root-mode=upward --env-name=es --ignore=*.spec.js src/.",
     "lint": "eslint src/.",
     "test": "jest",
     "test:watch": "jest --watch"

--- a/packages/ffe-message-box-react/package.json
+++ b/packages/ffe-message-box-react/package.json
@@ -5,15 +5,19 @@
   "author": "SpareBank 1",
   "files": [
     "lib",
-    "*.js"
+    "es"
   ],
   "main": "lib/index.js",
+  "module": "es/index.js",
+  "sideEffects": false,
   "repository": {
     "type": "git",
     "url": "ssh://git@github.com:SpareBank1/designsystem.git"
   },
   "scripts": {
-    "build": "babel -d lib/. --root-mode=upward --ignore=*.spec.js src/.",
+    "build": "npm run build:cjs && npm run build:es",
+    "build:cjs": "babel -d lib/. --root-mode=upward  --env-name=cjs --ignore=*.spec.js src/.",
+    "build:es": "babel -d es/. --root-mode=upward --env-name=es --ignore=*.spec.js src/.",
     "lint": "eslint src/.",
     "test": "jest",
     "test:watch": "jest --watch"

--- a/packages/ffe-searchable-dropdown-react/package.json
+++ b/packages/ffe-searchable-dropdown-react/package.json
@@ -5,17 +5,21 @@
   "license": "MIT",
   "author": "SpareBank 1",
   "files": [
-    "less/searchable-dropdown.less",
     "lib",
-    "*.js"
+    "es",
+    "less"
   ],
-  "main": "lib/SearchableDropdown.js",
+  "main": "lib/index.js",
+  "module": "es/index.js",
+  "sideEffects": false,
   "repository": {
     "type": "git",
     "url": "ssh://git@github.com:SpareBank1/designsystem.git"
   },
   "scripts": {
-    "build": "babel -d lib/. --root-mode=upward --ignore=*.spec.js src/.",
+    "build": "npm run build:cjs && npm run build:es",
+    "build:cjs": "babel -d lib/. --root-mode=upward  --env-name=cjs --ignore=*.spec.js src/.",
+    "build:es": "babel -d es/. --root-mode=upward --env-name=es --ignore=*.spec.js src/.",
     "lint": "eslint src/.",
     "test": "jest",
     "test:watch": "jest --watch"

--- a/packages/ffe-searchable-dropdown-react/src/index.js
+++ b/packages/ffe-searchable-dropdown-react/src/index.js
@@ -1,0 +1,3 @@
+import SearchableDropdown from './SearchableDropdown';
+
+export default SearchableDropdown;

--- a/packages/ffe-spinner-react/package.json
+++ b/packages/ffe-spinner-react/package.json
@@ -5,15 +5,19 @@
   "author": "SpareBank 1",
   "files": [
     "lib",
-    "*.js"
+    "es"
   ],
   "main": "lib/index.js",
+  "module": "es/index.js",
+  "sideEffects": false,
   "repository": {
     "type": "git",
     "url": "ssh://git@github.com:SpareBank1/designsystem.git"
   },
   "scripts": {
-    "build": "babel -d lib/. --root-mode=upward --ignore=*.spec.js src/.",
+    "build": "npm run build:cjs && npm run build:es",
+    "build:cjs": "babel -d lib/. --root-mode=upward  --env-name=cjs --ignore=*.spec.js src/.",
+    "build:es": "babel -d es/. --root-mode=upward --env-name=es --ignore=*.spec.js src/.",
     "lint": "eslint src/.",
     "test": "jest",
     "test:watch": "jest --watch"

--- a/packages/ffe-system-message-react/package.json
+++ b/packages/ffe-system-message-react/package.json
@@ -13,7 +13,9 @@
     "url": "ssh://git@github.com:SpareBank1/designsystem.git"
   },
   "scripts": {
-    "build": "babel -d lib/. --root-mode=upward --ignore=*.spec.js src/.",
+    "build": "npm run build:cjs && npm run build:es",
+    "build:cjs": "babel -d lib/. --root-mode=upward  --env-name=cjs --ignore=*.spec.js src/.",
+    "build:es": "babel -d es/. --root-mode=upward --env-name=es --ignore=*.spec.js src/.",
     "lint": "eslint src/.",
     "test": "jest",
     "test:watch": "jest --watch"

--- a/packages/ffe-tables-react/package.json
+++ b/packages/ffe-tables-react/package.json
@@ -5,15 +5,19 @@
   "license": "MIT",
   "files": [
     "lib",
-    "*.js"
+    "es"
   ],
   "main": "lib/index.js",
+  "module": "es/index.js",
+  "sideEffects": false,
   "repository": {
     "type": "git",
     "url": "ssh://git@github.com:SpareBank1/designsystem.git"
   },
   "scripts": {
-    "build": "babel -d lib/. --root-mode=upward --ignore=*.spec.js src/.",
+    "build": "npm run build:cjs && npm run build:es",
+    "build:cjs": "babel -d lib/. --root-mode=upward  --env-name=cjs --ignore=*.spec.js src/.",
+    "build:es": "babel -d es/. --root-mode=upward --env-name=es --ignore=*.spec.js src/.",
     "lint": "eslint src/.",
     "test": "jest",
     "test:watch": "jest --watch"

--- a/packages/ffe-tabs-react/package.json
+++ b/packages/ffe-tabs-react/package.json
@@ -4,15 +4,20 @@
   "license": "MIT",
   "author": "SpareBank 1",
   "files": [
-    "lib"
+    "lib",
+    "es"
   ],
   "main": "lib/index.js",
+  "module": "es/index.js",
+  "sideEffects": false,
   "repository": {
     "type": "git",
     "url": "ssh://git@github.com:SpareBank1/designsystem.git"
   },
   "scripts": {
-    "build": "babel -d lib/. --root-mode=upward --ignore=*.spec.js src/.",
+    "build": "npm run build:cjs && npm run build:es",
+    "build:cjs": "babel -d lib/. --root-mode=upward  --env-name=cjs --ignore=*.spec.js src/.",
+    "build:es": "babel -d es/. --root-mode=upward --env-name=es --ignore=*.spec.js src/.",
     "lint": "eslint src/.",
     "test": "jest",
     "test:watch": "jest --watch"


### PR DESCRIPTION
This commit introduces a second build step, where files now are built
without transpiled imports and exports. This, in addition to the
"sideEffects: false" flag and "module: es/index.js" additions to the
respective `package.json` files, should be enough to satisfy Webpack's
requirements for tree shaking and dead code elimination - leading to
smaller bundles!
