### PR TITLE
fix(ffe-form): remove clickable ghost checkboxes

### DIFF
--- a/packages/ffe-form/less/checkbox.less
+++ b/packages/ffe-form/less/checkbox.less
@@ -91,6 +91,8 @@
     position: absolute;
     opacity: 0;
     cursor: pointer;
+    width: 0;
+    height: 0;
 
     &:checked + .ffe-checkbox::before,
     &:hover + .ffe-checkbox::before,


### PR DESCRIPTION
The ghost checkboxes (inputs with `.ffe-hidden-checkbox`) are clickable, which can create some confusing UI. Let's fix that.

Please let me know if you think there are better ways to fix this.