### PR TITLE
chore(ffe-form-react): fix typo, Checkbox should have lower case b

### DIFF
--- a/packages/ffe-form-react/src/Checkbox.js
+++ b/packages/ffe-form-react/src/Checkbox.js
@@ -3,7 +3,7 @@ import { bool, node, string, func, oneOfType } from 'prop-types';
 import { v4 as hash } from 'uuid';
 import classNames from 'classnames';
 
-export default function CheckBox(props) {
+export default function Checkbox(props) {
     const {
         children,
         hiddenLabel,
@@ -50,7 +50,7 @@ export default function CheckBox(props) {
     );
 }
 
-CheckBox.propTypes = {
+Checkbox.propTypes = {
     /**
      * @deprecated
      * Use `children` instead
@@ -74,7 +74,7 @@ CheckBox.propTypes = {
     dark: bool,
 };
 
-CheckBox.defaultProps = {
+Checkbox.defaultProps = {
     inline: true,
     invalid: false,
     dark: false,

--- a/packages/ffe-form-react/src/Checkbox.md
+++ b/packages/ffe-form-react/src/Checkbox.md
@@ -3,15 +3,15 @@
     <legend className="ffe-form-label ffe-form-label--block">
         Hvilke aviser leser du?
     </legend>
-    <CheckBox name="newspapers" value="vg">
+    <Checkbox name="newspapers" value="vg">
         VG
-    </CheckBox>
-    <CheckBox name="newspapers" value="dagbladet">
+    </Checkbox>
+    <Checkbox name="newspapers" value="dagbladet">
         Dagbladet
-    </CheckBox>
-    <CheckBox name="newspapers" value="aftenposten">
+    </Checkbox>
+    <Checkbox name="newspapers" value="aftenposten">
         Aftenposten
-    </CheckBox>
+    </Checkbox>
 </fieldset>
 ```
 
@@ -20,22 +20,22 @@ Kan komme under hverandre også, ved å sende inn `inline={false}`:
 ```js
 <fieldset className="ffe-fieldset">
     <legend className="ffe-form-label">Hva er du interessert i?</legend>
-    <CheckBox name="interests" value="sport" inline={false}>
+    <Checkbox name="interests" value="sport" inline={false}>
         Sport
-    </CheckBox>
-    <CheckBox name="interests" value="food" inline={false}>
+    </Checkbox>
+    <Checkbox name="interests" value="food" inline={false}>
         Matlaging
-    </CheckBox>
-    <CheckBox name="interests" value="moon" inline={false}>
+    </Checkbox>
+    <Checkbox name="interests" value="moon" inline={false}>
         Månen
-    </CheckBox>
+    </Checkbox>
 </fieldset>
 ```
 
 Dersom du skal ha en skjult label, brukes `hiddenLabel={true}` og label sendes inn via en `aria-label` prop og ikke som en child:
 
 ```js
-<CheckBox
+<Checkbox
     defaultChecked={true}
     aria-label="Jeg har en ingen label"
     hiddenLabel={true}
@@ -46,30 +46,30 @@ Dersom du skal ha en skjult label, brukes `hiddenLabel={true}` og label sendes i
 Du kan merke at et felt er ugyldig ved å sette `aria-invalid="true"`:
 
 ```js
-<CheckBox name="loves-ads" aria-invalid="true" checked={true} onChange={f => f}>
+<Checkbox name="loves-ads" aria-invalid="true" checked={true} onChange={f => f}>
     Ja, jeg vil gjerne motta reklame!
-</CheckBox>
+</Checkbox>
 ```
 
 Du kan kan sende inn en callback-funksjon som blir kalt hver gang verdien i checkboxen endrer
 seg med `onChange`:
 
 ```js
-<CheckBox
+<Checkbox
     name="clicked"
     onChange={e => alert(`Nå er jeg ${e.target.checked ? 'på' : 'av'}!`)}
 >
     Trykk for å lære litt om meg
-</CheckBox>
+</Checkbox>
 ```
 
 Du kan sende inn children som en funksjon, for å rendre din egen label. Funksjonen mottar props
 du kan spre på labelen.
 
 ```js
-<CheckBox>
+<Checkbox>
     {labelProps => <label {...labelProps}>Her benyttes render props</label>}
-</CheckBox>
+</Checkbox>
 ```
 
 Variant _dark_ for interne løsninger med mørk bakgrunn.
@@ -79,15 +79,15 @@ Variant _dark_ for interne løsninger med mørk bakgrunn.
     <legend className="ffe-form-label ffe-form-label--block ffe-form-label--dark">
         Hvilke TV kanal ser du på?
     </legend>
-    <CheckBox name="newspapers" value="nrk" dark={true}>
+    <Checkbox name="newspapers" value="nrk" dark={true}>
         NRK
-    </CheckBox>
-    <CheckBox name="newspapers" value="tv2" dark={true}>
+    </Checkbox>
+    <Checkbox name="newspapers" value="tv2" dark={true}>
         TV2
-    </CheckBox>
-    <CheckBox name="newspapers" value="tvnorge" dark={true}>
+    </Checkbox>
+    <Checkbox name="newspapers" value="tvnorge" dark={true}>
         TVNorge
-    </CheckBox>
+    </Checkbox>
 </fieldset>
 ```
 

--- a/styleguide-content/komponenter/knapper.md
+++ b/styleguide-content/komponenter/knapper.md
@@ -124,11 +124,11 @@ Generelt for alle knapper gjelder:
 ### Når skal knapper ikke brukes?
 
 -   Generelt brukes ikke primær eller sekundærknapper for å navigere til sider utenfor løsningen. Bruk heller [lenke](#!/LinkText).
--   Knapper brukes vanligvis til å gjøre handlinger, ikke for å ta valg. For å ta valg, bruk [checkbox](#!/CheckBox) eller [radioknapp](#!/RadioButton) isteden og forplikt med en knapp.
+-   Knapper brukes vanligvis til å gjøre handlinger, ikke for å ta valg. For å ta valg, bruk [checkbox](#!/Checkbox) eller [radioknapp](#!/RadioButton) isteden og forplikt med en knapp.
 
 ### Relaterte komponenter
 
--   [Checkbox](#!/CheckBox)
+-   [Checkbox](#!/Checkbox)
 -   [Radioknapp](#!/RadioButton)
 -   [Lenke](#!/LinkText)
 


### PR DESCRIPTION
Changes does not affect anything for the consumer. The typo was just in some documentation and internally in the js-file. The export is a default export, and the exported name from index.js is correct with lower case b.