### PR TITLE
fix(ffe-buttons-react): stop spreading icon prop to Button

### DIFF
--- a/packages/ffe-buttons-react/src/TaskButton.js
+++ b/packages/ffe-buttons-react/src/TaskButton.js
@@ -2,12 +2,8 @@ import React from 'react';
 import { bool, func, node, string, oneOfType } from 'prop-types';
 import Button from './BaseButton';
 
-const TaskButton = props => (
-    <Button
-        buttonType="task"
-        leftIcon={props.icon}
-        {...props}
-    />
+const TaskButton = ({ icon, ...rest }) => (
+    <Button buttonType="task" leftIcon={icon} {...rest} />
 );
 
 TaskButton.propTypes = {


### PR DESCRIPTION
This commit fixes the spreading of `props.icon` from `TaskButton` to
`Button`. Prior to this fix you would see the prop `icon` on the HTML
element with the value `[object Object]`.