### PR TITLE
feat(ffe-cards): optional overflow ellipsis on title and left-align on text-card

### DIFF
--- a/packages/ffe-cards/less/components.less
+++ b/packages/ffe-cards/less/components.less
@@ -8,16 +8,20 @@
     }
 
     &--subtext {
+        &:extend(.ffe-small-text);
+
         margin: 5px 0 0 0;
-        color: @ffe-grey-charcoal;
     }
 
     &--title {
         &:extend(.ffe-h5);
 
         margin: 0;
-        text-overflow: ellipsis;
-        white-space: nowrap;
-        overflow: hidden;
+
+        &--overflow-ellipsis {
+            text-overflow: ellipsis;
+            white-space: nowrap;
+            overflow: hidden;
+        }
     }
 }

--- a/packages/ffe-cards/less/icon-card.less
+++ b/packages/ffe-cards/less/icon-card.less
@@ -44,7 +44,7 @@
         min-width: 30px;
         width: 30px;
         height: 30px;
-        margin: 0 25px 0 10px;
+        margin: 0 15px 0 0;
     }
 
     .ffe-icon-component--card-name {

--- a/packages/ffe-cards/less/image-card.less
+++ b/packages/ffe-cards/less/image-card.less
@@ -15,7 +15,7 @@
     }
 
     &__image {
-        max-height: 140px;
+        max-height: 160px;
         position: relative;
         overflow: hidden;
         border-top-left-radius: 5px;
@@ -45,7 +45,7 @@
         border-top: 0;
         border-bottom-left-radius: 5px;
         border-bottom-right-radius: 5px;
-        min-height: 220px;
+        min-height: 200px;
     }
 
     @media screen and (min-width: @breakpoint-md) {

--- a/packages/ffe-cards/less/text-card.less
+++ b/packages/ffe-cards/less/text-card.less
@@ -1,7 +1,16 @@
 .ffe-text-card {
-    padding: 20px;
+    padding: 20px 30px;
     display: flex;
     flex-flow: column nowrap;
     text-align: center;
     overflow: hidden;
+    min-height: auto;
+
+    @media screen and (min-width: @breakpoint-md) {
+        min-height: 100px;
+    }
+}
+
+.ffe-text-card--left-align {
+    text-align: left;
 }


### PR DESCRIPTION
This commit adds two modifiers to classes in ffe-cards:
1. ffe-text-card now has a modifier --left-align which will align content
to the left in the card. This will make the card work nicely together with
condensed icon cards.
2. ffe-card-component--title now requires the modifier --overflow-ellipsis
to limit the title to one line, and cut it off with ellipsis if it is too
long.
This commit also adds a few fixes:
* ffe-card-component--subtext now extends .ffe-small-text. The subtext was
too big, as it was always supposed to match the small text, and thus
extending it makes sense.
* ffe-icon-card__icon within a condensed icon card now has reduced
margins. The condensed version of icon card seemed to have too much air,
and this fix addresses that issue.
* ffe-image-card got its image max-height increased to 160px and its body
min-height reduced to 200px. Both adjustments are by 20px, so the overall
size of the card remains the same (unless your body exceeds 200px height).
* ffe-text-card got left and right padding increased from 20px to 30px.
This makes for a nicer look, especially when using the left-align modifier.
* ffe-text-card now has a min-height of 100px on screen sizes above
breakpoint medium. This is the same as the condensed icon card, and makes
sure they look uniform when used together.

BREAKING CHANGE: ffe-card-component--title now requires the modifier
--overflow-ellipsis to limit the title to one line, and cut it off with
ellipsis.