### PR TITLE
feat(ffe-cards-react): left align text card and toggle title wrapping

### DIFF
--- a/packages/ffe-cards-react/package.json
+++ b/packages/ffe-cards-react/package.json
@@ -36,7 +36,7 @@
     "react-dom": "^16.6.3"
   },
   "peerDependencies": {
-    "@sb1/ffe-cards": "^6.0.0",
+    "@sb1/ffe-cards": "^7.0.0",
     "react": "^16.6.3"
   },
   "publishConfig": {

--- a/packages/ffe-cards-react/src/CardBase.js
+++ b/packages/ffe-cards-react/src/CardBase.js
@@ -19,7 +19,7 @@ CardBase.defaultProps = {
 CardBase.propTypes = {
     className: string,
     children: node,
-    /** The element to render the card as. */
+    /** The element to render the card as */
     element: oneOfType([func, string]),
 };
 

--- a/packages/ffe-cards-react/src/IconCard/IconCard.js
+++ b/packages/ffe-cards-react/src/IconCard/IconCard.js
@@ -48,6 +48,8 @@ IconCard.propTypes = {
     condensed: bool,
     /** Icon and text will all be ffe-grey-charcoal */
     greyCharcoal: bool,
+    /** The element to render the card as */
+    element: oneOfType([func, string]),
     /** Function that's passed available sub-components as arguments, or regular children */
     children: oneOfType([func, node]),
 };

--- a/packages/ffe-cards-react/src/ImageCard/ImageCard.js
+++ b/packages/ffe-cards-react/src/ImageCard/ImageCard.js
@@ -27,6 +27,8 @@ ImageCard.propTypes = {
     className: string,
     /** A rendered image */
     image: node.isRequired,
+    /** The element to render the card as */
+    element: oneOfType([func, string]),
     /** Function that's passed available sub-components as arguments, or regular children */
     children: oneOfType([func, node]),
 };

--- a/packages/ffe-cards-react/src/TextCard/TextCard.js
+++ b/packages/ffe-cards-react/src/TextCard/TextCard.js
@@ -1,15 +1,22 @@
 import React from 'react';
 import classNames from 'classnames';
-import { string, func, node, oneOfType } from 'prop-types';
+import { string, func, node, oneOfType, bool } from 'prop-types';
 
 import CardBase from '../CardBase';
 import * as components from '../components';
 
 const TextCard = props => {
-    const { className, children, ...rest } = props;
+    const { className, leftAlign, children, ...rest } = props;
 
     return (
-        <CardBase className={classNames('ffe-text-card', className)} {...rest}>
+        <CardBase
+            className={classNames(
+                'ffe-text-card',
+                { 'ffe-text-card--left-align': leftAlign },
+                className,
+            )}
+            {...rest}
+        >
             {typeof children === 'function' ? children(components) : children}
         </CardBase>
     );
@@ -17,6 +24,10 @@ const TextCard = props => {
 
 TextCard.propTypes = {
     className: string,
+    /** Left-aligned text on the card */
+    leftAlign: bool,
+    /** The element to render the card as */
+    element: oneOfType([func, string]),
     /** Function that's passed available sub-components as arguments, or regular children */
     children: oneOfType([func, node]),
 };

--- a/packages/ffe-cards-react/src/components/Title.js
+++ b/packages/ffe-cards-react/src/components/Title.js
@@ -1,16 +1,28 @@
 import React from 'react';
 import classNames from 'classnames';
-import { string } from 'prop-types';
+import { string, bool } from 'prop-types';
 
 import ComponentBase from './ComponentBase';
 
-const Title = ({ className, ...rest }) => (
+const Title = ({ className, overflowEllipsis, ...rest }) => (
     <ComponentBase
-        className={classNames('ffe-card-component--title', className)}
+        className={classNames(
+            'ffe-card-component--title',
+            {
+                'ffe-card-component--title--overflow-ellipsis': overflowEllipsis,
+            },
+            className,
+        )}
         {...rest}
     />
 );
 
-Title.propTypes = { className: string };
+Title.defaultProps = { overflowEllipsis: true };
+
+Title.propTypes = {
+    className: string,
+    /** Disable wrapping and hide overflow with ellipsis */
+    overflowEllipsis: bool,
+};
 
 export default Title;


### PR DESCRIPTION
This commit adds two modifier properties to components in ffe-cards-react:
1. TextCard now has a bool property leftAlign which will align all text
content to the left in the card.
2. Render-prop component Title now has a bool prop overflowEllipsis which
will disable wrapping and hide overflow with ellipsis. This is true by
default, and thus this change is not breaking.

Other improvements to this package:
* TextCard, ImageCard and IconCard now has element in their prop types.
This is actually a property on CardBase, but we can help IDEs by informing
that these components accepts this property.
