### PR TITLE
fix(ffe-grid-react): Allow nesting inline grids

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ es/
 .idea/
 .vscode/
 *.iml
+*.code-workspace
 
 # OS
 .DS_Store

--- a/packages/ffe-grid-react/src/Grid.spec.js
+++ b/packages/ffe-grid-react/src/Grid.spec.js
@@ -62,7 +62,11 @@ describe('Grid', () => {
     });
 
     describe('when mounting', () => {
-        console.error = jest.fn();
+        beforeEach(() => {
+            global.console.error = jest.fn();
+        });
+
+        afterEach(() => global.console.error.mockRestore());
 
         it('warns about nested <Grid> tag', () => {
             mount(

--- a/packages/ffe-grid-react/src/GridCol.js
+++ b/packages/ffe-grid-react/src/GridCol.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { Component, createRef } from 'react';
 import {
     bool,
     node,
@@ -20,11 +20,10 @@ import {
 function camelCaseToDashCase(str) {
     return str
         .split('')
-        .reduce(
-            (previous, current) =>
-                /[A-Z]/.test(current)
-                    ? `${previous}-${current.toLowerCase()}`
-                    : `${previous}${current}`,
+        .reduce((previous, current) =>
+            /[A-Z]/.test(current)
+                ? `${previous}-${current.toLowerCase()}`
+                : `${previous}${current}`,
         );
 }
 
@@ -82,12 +81,18 @@ const backgroundClass = ({ background }) => {
 };
 
 export default class GridCol extends Component {
+    constructor() {
+        super();
+
+        this.ref = createRef();
+    }
+
     componentDidMount() {
         /* istanbul ignore else: there is no else  */
         if (process.env.NODE_ENV !== 'production') {
             checkForDeprecatedModifiers(this.props);
             checkForNestedComponent(this.props.children, GridCol);
-            checkValidColumnCount(this.props);
+            checkValidColumnCount(this.props, this.ref.current);
         }
     }
 
@@ -122,7 +127,7 @@ export default class GridCol extends Component {
             .join(' ');
 
         return (
-            <Element className={classes} {...rest}>
+            <Element className={classes} ref={this.ref} {...rest}>
                 {children}
             </Element>
         );

--- a/packages/ffe-grid-react/src/GridCol.spec.js
+++ b/packages/ffe-grid-react/src/GridCol.spec.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { mount, shallow } from 'enzyme';
-import { Grid, GridRow, GridCol } from '.';
+import { Grid, GridRow, GridCol, InlineGrid } from '.';
 import backgroundColors from './background-colors';
 
 const defaultProps = {
@@ -233,6 +233,20 @@ describe('GridCol', () => {
             expect(console.error.mock.calls[0][0]).toContain('<GridCol />');
         });
 
+        it('does not warn about nested <GridCol> tags inside an <InlineGrid> tag', () => {
+            mount(
+                <GridCol>
+                    <InlineGrid>
+                        <GridRow>
+                            <GridCol />
+                        </GridRow>
+                    </InlineGrid>
+                </GridCol>,
+            );
+
+            expect(console.error).not.toHaveBeenCalled();
+        });
+
         it('does not blow up if a null-child is received', () => {
             // The below inline check on "false" will result in the outer <GridCol>
             // receiving children as an array-like of [<GridCol />, null] which it needs
@@ -247,13 +261,13 @@ describe('GridCol', () => {
 
         describe('checks cols and offset validity', () => {
             console.error = jest.fn();
-            const renderWithModifier = modifier =>
+            const renderWithModifier = (modifier, Component = Grid) =>
                 mount(
-                    <Grid>
+                    <Component>
                         <GridRow>
                             <GridCol {...modifier} />
                         </GridRow>
-                    </Grid>,
+                    </Component>,
                 );
 
             it('does not warn about valid columns and offsets for "lg" screens', () => {
@@ -316,6 +330,14 @@ describe('GridCol', () => {
                 expect(console.error.mock.calls[0][0]).toContain(
                     'The grid should have 4 columns for "sm" screens',
                 );
+            });
+
+            describe('when nested inside an inline grid', () => {
+                it('does not warn about usage of cols and offsets', () => {
+                    renderWithModifier({ sm: 5 }, InlineGrid);
+
+                    expect(console.error).not.toHaveBeenCalled();
+                });
             });
         });
     });

--- a/packages/ffe-grid-react/src/GridRow.spec.js
+++ b/packages/ffe-grid-react/src/GridRow.spec.js
@@ -3,6 +3,7 @@ import { mount, shallow } from 'enzyme';
 
 import { GridRow, GridCol } from '.';
 import backgroundColors from './background-colors';
+import InlineGrid from './InlineGrid';
 
 const defaultProps = {
     children: <p>blah</p>,
@@ -100,6 +101,7 @@ describe('GridRow', () => {
         beforeEach(() => {
             global.console.error = jest.fn();
         });
+
         afterEach(() => global.console.error.mockRestore());
 
         it('warns about nested <GridRow> tag', () => {
@@ -119,6 +121,20 @@ describe('GridRow', () => {
 
             expect(console.error).toHaveBeenCalledTimes(1);
             expect(console.error.mock.calls[0][0]).toContain('<GridRow />');
+        });
+
+        it('does not warn about nested <GridRow> tags inside an <InlineGrid> tag', () => {
+            mount(
+                <GridRow>
+                    <GridCol>
+                        <InlineGrid>
+                            <GridRow />
+                        </InlineGrid>
+                    </GridCol>
+                </GridRow>,
+            );
+
+            expect(console.error).not.toHaveBeenCalled();
         });
 
         it('does not blow up if a null-child is received', () => {

--- a/packages/ffe-grid-react/src/InlineGrid.js
+++ b/packages/ffe-grid-react/src/InlineGrid.js
@@ -1,16 +1,32 @@
-import React from 'react';
+import React, { Component } from 'react';
 import classNames from 'classnames';
 import { node, string } from 'prop-types';
 
-export default function InlineGrid(props) {
-    const { className, element: Element, ...rest } = props;
+import { checkForNestedComponent } from './utils';
+import { Grid } from '.';
 
-    return (
-        <Element
-            className={classNames(className, 'ffe-grid', 'ffe-grid--inline')}
-            {...rest}
-        />
-    );
+export default class InlineGrid extends Component {
+    componentDidMount() {
+        /* istanbul ignore else: there is no else  */
+        if (process.env.NODE_ENV !== 'production') {
+            checkForNestedComponent(this.props.children, Grid, 'InlineGrid');
+        }
+    }
+
+    render() {
+        const { className, element: Element, ...rest } = this.props;
+
+        return (
+            <Element
+                className={classNames(
+                    className,
+                    'ffe-grid',
+                    'ffe-grid--inline',
+                )}
+                {...rest}
+            />
+        );
+    }
 }
 
 InlineGrid.propTypes = {

--- a/packages/ffe-grid-react/src/InlineGrid.spec.js
+++ b/packages/ffe-grid-react/src/InlineGrid.spec.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import { shallow } from 'enzyme';
-import { InlineGrid } from '.';
+import { mount, shallow } from 'enzyme';
+import { Grid, GridRow, GridCol, InlineGrid } from '.';
 
 const defaultProps = {
     children: <p>blah</p>,
@@ -41,5 +41,42 @@ describe('InlineGrid', () => {
         const el = renderShallow({ element: 'section' });
 
         expect(el.type()).toBe('section');
+    });
+
+    describe('when mounting', () => {
+        beforeEach(() => {
+            global.console.error = jest.fn();
+        });
+
+        afterEach(() => global.console.error.mockRestore());
+
+        it('warns about a <Grid> inside an <InlineGrid>', () => {
+            mount(
+                <InlineGrid>
+                    <GridRow>
+                        <GridCol>
+                            <Grid />
+                        </GridCol>
+                    </GridRow>
+                </InlineGrid>,
+            );
+
+            expect(console.error).toHaveBeenCalled();
+            expect(console.error.mock.calls[0][0]).toContain('InlineGrid');
+        });
+
+        it('allows an <InlineGrid> inside another <InlineGrid>', () => {
+            mount(
+                <InlineGrid>
+                    <GridRow>
+                        <GridCol>
+                            <InlineGrid />
+                        </GridCol>
+                    </GridRow>
+                </InlineGrid>,
+            );
+
+            expect(console.error).not.toHaveBeenCalled();
+        });
     });
 });

--- a/packages/ffe-grid-react/src/utils.dev.js
+++ b/packages/ffe-grid-react/src/utils.dev.js
@@ -1,18 +1,24 @@
 import React from 'react';
 
-const checkForNestedComponent = (children, Component) =>
+import { InlineGrid } from '.';
+
+const checkForNestedComponent = (children, Component, componentName) =>
     React.Children.forEach(children, child => {
-        if (!child) {
+        if (!child || child.type === InlineGrid) {
             return;
         } else if (child.type === Component) {
             console.error(`
-                Detected a <${Component.name} /> child within another ${
-                Component.name
-            }.
+                Detected a <${
+                    Component.name
+                } /> child within an ${componentName || Component.name}.
                 Do not nest these, the result will be unpredictable.
             `);
         } else if (child.props && child.props.children) {
-            return checkForNestedComponent(child.props.children, Component);
+            return checkForNestedComponent(
+                child.props.children,
+                Component,
+                componentName,
+            );
         }
     });
 
@@ -72,7 +78,17 @@ const checkValidSmColumns = modifier => {
     }
 };
 
-const checkValidColumnCount = ({ sm, md }) => {
+const checkValidColumnCount = ({ sm, md }, domNode) => {
+    if (domNode) {
+        let parent = domNode.parentElement;
+        while (parent) {
+            if (parent.className.indexOf('--inline') !== -1) {
+                return;
+            }
+            parent = parent.parentElement;
+        }
+    }
+
     if (md) {
         checkValidMdColumns(md);
     }


### PR DESCRIPTION
`ffe-grid-react` should no longer spam warnings about nesting
the new `<InlineGrid>` component.

<!-- 
Thanks for opening a pull request! 🎉

If your changes include some kind of UI element, please attach a screenshot of 
how it looks.

Before submitting a pull request, please have a look through the CONTRIBUTING.md
document. TL;DR:

- Follow the conventional commit standard
- Write full, explanatory commit messages
- Follow our code standards
- Write tests where applicable
- Be courteous and respect our code of conduct
-->
