### PR TITLE
fix: Misc bugfixes in styleguide layout

### DIFF
--- a/src/components/style-guide/StyleGuide.js
+++ b/src/components/style-guide/StyleGuide.js
@@ -2,7 +2,7 @@ import React, { Component, Fragment } from 'react';
 import { bool, node, shape, string } from 'prop-types';
 
 import Sidebar from '../sidebar';
-import { Grid, GridRow, GridCol } from '../../../packages/ffe-grid-react';
+import { InlineGrid, GridRow, GridCol } from '../../../packages/ffe-grid-react';
 
 class StyleGuide extends Component {
     componentDidUpdate(prevProps) {
@@ -18,13 +18,13 @@ class StyleGuide extends Component {
 
         return (
             <Fragment>
-                <Grid topPadding={false} className="sb1ds">
+                <InlineGrid topPadding={false} className="sb1ds">
                     <GridRow>
                         <GridCol lg={3} md={4} sm={12} bottomPadding={false}>
                             <Sidebar toc={toc} title={title} />
                         </GridCol>
                         <GridCol lg={9} md={8} sm={12} bottomPadding={false}>
-                            <main className="sb1ds-main">
+                            <main className="sb1ds-main sb1ds-main--hero">
                                 <h1 className="ffe-h1 sb1ds-intro__heading">
                                     Komponenter
                                 </h1>
@@ -39,7 +39,7 @@ class StyleGuide extends Component {
                             </main>
                         </GridCol>
                     </GridRow>
-                </Grid>
+                </InlineGrid>
             </Fragment>
         );
     }

--- a/src/styles/components/sidebar.less
+++ b/src/styles/components/sidebar.less
@@ -10,6 +10,8 @@
 
     @media screen and (min-width: @breakpoint-xl) {
         overflow: auto;
+        position: fixed;
+        min-width: 280px;
     }
 
     &__menu {
@@ -18,13 +20,13 @@
         margin-bottom: 20px;
 
         @media screen and (min-width: @breakpoint-md) {
-            padding: 0 20px 20px 20px;
             border-bottom: none;
-            margin-bottom: 0;
         }
 
         @media screen and (min-width: @breakpoint-lg) {
             margin-top: 60px;
+            margin-bottom: 0;
+            padding: 0 20px 20px 20px;
         }
 
         @media screen and (min-width: @breakpoint-xl) {
@@ -51,11 +53,10 @@
     }
 
     &__wrapper {
-        margin: 0 -10px;
-
         @media screen and (min-width: @breakpoint-md) {
             height: 100%;
             margin: 0;
+            padding-right: 20px;
         }
     }
 

--- a/src/styles/components/top-menu.less
+++ b/src/styles/components/top-menu.less
@@ -10,10 +10,6 @@
         margin: 10px 0;
         vertical-align: middle;
 
-        @media screen and (min-width: @breakpoint-md) {
-            margin: 10px 20px;
-        }
-
         @media screen and (min-width: @breakpoint-xl) {
             height: 40px;
             width: 182px;
@@ -34,7 +30,7 @@
     &__link {
         display: inline-block;
         height: 100%;
-        padding: 5px 10px;
+        padding: 10px;
         color: @ffe-grey-charcoal;
         position: relative;
         white-space: nowrap;
@@ -117,8 +113,8 @@
 
     &__toggle-button {
         position: absolute;
-        top: 12px;
-        right: 10px;
+        top: 3px;
+        right: 0;
 
         &::after {
             border: none;

--- a/src/styles/styles.less
+++ b/src/styles/styles.less
@@ -124,11 +124,7 @@ body {
 }
 
 .sb1ds-main {
-    margin-top: 20px;
-
-    @media screen and (min-width: @breakpoint-lg) {
-        margin-top: 90px;
-    }
+    margin: 20px 10px 10px;
 
     img {
         max-width: 100%;
@@ -137,6 +133,12 @@ body {
     pre {
         overflow: auto;
         max-width: 100%;
+    }
+
+    &--hero {
+        @media screen and (min-width: @breakpoint-lg) {
+            margin-top: 90px;
+        }
     }
 }
 

--- a/src/templates/frontpage.hbs
+++ b/src/templates/frontpage.hbs
@@ -15,7 +15,7 @@
   <main class="sb1ds ffe-grid ffe-grid--condensed ffe-grid--no-top-padding">
     <div class="ffe-grid__row">
       <div class="ffe-grid__col ffe-grid__col--sm12 ffe-grid__col--md-offset-2 ffe-grid__col--md-8 ffe-grid__col--center">
-        <div class="sb1ds-main">
+        <div class="sb1ds-main sb1ds-main--hero">
           <div class="sb1ds-intro sb1ds-intro--frontpage">
             <h1 class="ffe-h1 sb1ds-intro__heading">SpareBank 1 Designsystem</h1>
             <div class="sb1ds-intro__illustration sb1ds-intro__illustration--frontpage" role="presentation">
@@ -44,33 +44,33 @@
     </div>
     <div class="ffe-grid__row sb1ds-frontpage-excerpt">
       <div class="ffe-grid__col ffe-grid__col--md-4 ffe-grid__col--md-offset-2 ffe-grid__col--sm-12 ffe-grid__col--center ffe-grid__col--no-bottom-padding">
-        <a href="stil-og-tone.html" class="ffe-product-card">
-          <h2 class="ffe-h5">Stil og tone</h2>
-          <p class="ffe-body-text">Lær om hvordan vi bruker språk til å snakke direkte med kundene våre.</p>
+        <a href="stil-og-tone.html" class="ffe-card-base ffe-text-card">
+          <h2 class="ffe-card-component ffe-card-component--title ffe-card-component--title--overflow-ellipsis">Stil og tone</h2>
+          <p class="ffe-card-component ffe-card-component--text">Lær om hvordan vi bruker språk til å snakke direkte med kundene våre.</p>
         </a>
       </div>
       <div class="ffe-grid__col ffe-grid__col--md-4 ffe-grid__col--sm-12 ffe-grid__col--center ffe-grid__col--no-bottom-padding">
-        <a href="visuell-identitet.html" class="ffe-product-card">
-          <h2 class="ffe-h5">Visuell identitet</h2>
-          <p class="ffe-body-text">Hvordan vi tilnærmer oss utformingen av våre digitale produkter.</p>
+        <a href="visuell-identitet.html" class="ffe-card-base ffe-text-card">
+          <h2 class="ffe-card-component ffe-card-component--title ffe-card-component--title--overflow-ellipsis">Visuell identitet</h2>
+          <p class="ffe-card-component ffe-card-component--text">Hvordan vi tilnærmer oss utformingen av våre digitale produkter.</p>
         </a>
       </div>
       <div class="ffe-grid__col ffe-grid__col--md-4 ffe-grid__col--md-offset-2 ffe-grid__col--sm-12 ffe-grid__col--center ffe-grid__col--no-bottom-padding">
-        <a href="universell-utforming.html" class="ffe-product-card">
-          <h2 class="ffe-h5">Universell utforming</h2>
-          <p class="ffe-body-text">Retningslinjer for design og utvikling av tilgjengelige løsninger.</p>
+        <a href="universell-utforming.html" class="ffe-card-base ffe-text-card">
+          <h2 class="ffe-card-component ffe-card-component--title ffe-card-component--title--overflow-ellipsis">Universell utforming</h2>
+          <p class="ffe-card-component ffe-card-component--text">Retningslinjer for design og utvikling av tilgjengelige løsninger.</p>
         </a>
       </div>
       <div class="ffe-grid__col ffe-grid__col--md-4 ffe-grid__col--sm-12 ffe-grid__col--center ffe-grid__col--no-bottom-padding">
-        <a href="styleguidist/index.html" class="ffe-product-card">
-          <h2 class="ffe-h5">Komponenter</h2>
-          <p class="ffe-body-text">Vårt komponentbibliotek, implementert i Less og React.</p>
+        <a href="styleguidist/index.html" class="ffe-card-base ffe-text-card">
+          <h2 class="ffe-card-component ffe-card-component--title ffe-card-component--title--overflow-ellipsis">Komponenter</h2>
+          <p class="ffe-card-component ffe-card-component--text">Vårt komponentbibliotek, implementert i Less og React.</p>
         </a>
       </div>
     </div>
     <div class="ffe-grid__row ffe-grid__row--top-padding">
       <div class="ffe-grid__col--md-8 ffe-grid__col--md-offset-2">
-        <div>
+        <div class="sb1ds-main">
           <h2 class="ffe-h3">Hjelp</h2>
           <p class="ffe-body-text">
             Spørsmål om designsystemet, forslag til forbedringer eller annet du trenger å kontakte oss om? Vi kan nås på en av følgende måter:

--- a/src/templates/header.hbs
+++ b/src/templates/header.hbs
@@ -10,7 +10,7 @@
 		<div class="sb1ds-header-grid__row ffe-grid__row">
 			<div class="
 				ffe-grid__col
-				ffe-grid__col--md-4
+				ffe-grid__col--lg-4
 				ffe-grid__col--sm-12
 				ffe-grid__col--start
 				ffe-grid__col--middle
@@ -48,7 +48,7 @@
 			<div class="
 				sb1ds-top-menu__wrapper
 				ffe-grid__col
-				ffe-grid__col--md-8
+				ffe-grid__col--lg-8
 				ffe-grid__col--sm-12
 				ffe-grid__col--middle
 				ffe-grid__col--no-bottom-padding

--- a/src/templates/page.hbs
+++ b/src/templates/page.hbs
@@ -12,7 +12,7 @@
 <body>
   {{> header currentTarget=section.target }}
 
-  <div class="sb1ds ffe-grid ffe-grid--no-top-padding">
+  <div class="sb1ds ffe-grid ffe-grid--inline">
     <div class="ffe-grid__row">
       <div class="ffe-grid__col--lg-3 ffe-grid__col--md-4 ffe-grid__col--sm-12 ffe-grid__col--no-bottom-padding">
         <div class="sb1ds-sidebar__wrapper">
@@ -29,7 +29,7 @@
         </div>
       </div>
       <div class="ffe-grid__col--lg-9 ffe-grid__col--md-8 ffe-grid__col--sm-12 ffe-grid__col--no-bottom-padding">
-        <main class="sb1ds-main">
+        <main class="sb1ds-main sb1ds-main--hero">
           {{> section depth=1}}
         </main>
       </div>

--- a/src/templates/styleguidist.hbs
+++ b/src/templates/styleguidist.hbs
@@ -15,7 +15,7 @@
 			up a basic skeleton while loading.
 		}}
 		<div id="rsg-root">
-			<div class="sb1ds ffe-grid ffe-grid--no-top-padding">
+			<div class="sb1ds ffe-grid ffe-grid--inline">
 				<div class="ffe-grid__row">
 					<div class="ffe-grid__col--lg-3 ffe-grid__col--md-4 ffe-grid__col--sm-12 ffe-grid__col--no-bottom-padding">
 					</div>


### PR DESCRIPTION
A few minor tweaks in the styleguide layout:

* Use `InlineGrid` rather than `Grid` for layout, in order to avoid padding bugs in layout elements that span 100% width (i.e. hero background, sidebar on small screens)
* Rewrite frontpage cards from deprecated card styling to new version
* Minor breakpoint adjustments to make sure different elements break at the same width
* Minor positioning tweaks in header elements