### PR TITLE
fix(ffe-account-selector-react): Optimize performance of suggestion list

### DIFF
--- a/packages/ffe-account-selector-react/less/base-selector.less
+++ b/packages/ffe-account-selector-react/less/base-selector.less
@@ -12,7 +12,7 @@
 
     &__expand-button {
         position: absolute;
-        padding : 6px;
+        padding: 6px;
         top: 50%;
         transform: translateY(-50%);
         right: 10px;
@@ -59,15 +59,5 @@
         border: @border;
         border-radius: 2px;
         background: @ffe-white;
-        &-list {
-            left: 0;
-            width: 100%;
-            top: 45px;
-            box-sizing: border-box;
-            z-index: 100;
-            margin: 0;
-            padding: 0;
-            list-style: none;
-        }
     }
 }

--- a/packages/ffe-account-selector-react/package.json
+++ b/packages/ffe-account-selector-react/package.json
@@ -38,7 +38,8 @@
     "classnames": "^2.2.5",
     "prop-types": "^15.6.0",
     "react-auto-bind": "^0.4.2",
-    "react-custom-scrollbars": "^4.2.1"
+    "react-custom-scrollbars": "^4.2.1",
+    "react-window": "^1.5.1"
   },
   "devDependencies": {
     "enzyme": "^3.7.0",

--- a/packages/ffe-account-selector-react/src/subcomponents/suggestion/SuggestionItem.js
+++ b/packages/ffe-account-selector-react/src/subcomponents/suggestion/SuggestionItem.js
@@ -1,6 +1,6 @@
-import React, { Component } from 'react';
-import { object, bool, func, string } from 'prop-types';
 import classNames from 'classnames';
+import { bool, func, object, string } from 'prop-types';
+import React, { Component } from 'react';
 
 class SuggestionItem extends Component {
     render() {
@@ -11,9 +11,10 @@ class SuggestionItem extends Component {
             render,
             onSelect,
             refHighlightedSuggestion,
+            style,
         } = this.props;
         return (
-            <li
+            <div
                 ref={itemRef => {
                     if (itemRef && isHighlighted) {
                         refHighlightedSuggestion(itemRef);
@@ -30,9 +31,10 @@ class SuggestionItem extends Component {
                     'ffe-account-suggestion--highlighted': isHighlighted,
                 })}
                 tabIndex={-1}
+                style={style}
             >
                 {render(item)}
-            </li>
+            </div>
         );
     }
 }
@@ -44,6 +46,7 @@ SuggestionItem.propTypes = {
     render: func.isRequired,
     onSelect: func.isRequired,
     refHighlightedSuggestion: func.isRequired,
+    style: object,
 };
 
 export default SuggestionItem;

--- a/packages/ffe-account-selector-react/src/subcomponents/suggestion/SuggestionItem.spec.js
+++ b/packages/ffe-account-selector-react/src/subcomponents/suggestion/SuggestionItem.spec.js
@@ -27,10 +27,10 @@ function renderSuggestionItem(
 describe('<SuggestionItem />', () => {
     it('item is rendered', () => {
         const wrapper = renderSuggestionItem();
-        const li = wrapper.find('li');
+        const div = wrapper.find('div');
 
-        expect(li.prop('id') === 'suggestion-option-0').toBe(true);
-        expect(li.childAt(0).html()).toBe('<h1>header</h1>');
+        expect(div.prop('id') === 'suggestion-option-0').toBe(true);
+        expect(div.childAt(0).html()).toBe('<h1>header</h1>');
     });
 
     it('isHighlighted', () => {

--- a/packages/ffe-account-selector-react/src/subcomponents/suggestion/SuggestionList.js
+++ b/packages/ffe-account-selector-react/src/subcomponents/suggestion/SuggestionList.js
@@ -1,8 +1,28 @@
-import React from 'react';
-import { func, arrayOf, number, string, object, bool } from 'prop-types';
 import Spinner from '@sb1/ffe-spinner-react';
+import { arrayOf, bool, func, number, object, string } from 'prop-types';
+import React, { forwardRef } from 'react';
+import { FixedSizeList as List } from 'react-window';
 
 import SuggestionItem from './SuggestionItem';
+
+const Row = props => {
+    const {
+        style,
+        index,
+        data: { forwardProps, suggestions, renderSuggestion, highlightedIndex },
+    } = props;
+
+    return (
+        <SuggestionItem
+            {...forwardProps}
+            item={suggestions[index]}
+            id={`suggestion-item-${index}`}
+            isHighlighted={index === highlightedIndex}
+            render={renderSuggestion}
+            style={style}
+        />
+    );
+};
 
 export default function SuggestionList(props) {
     const {
@@ -12,30 +32,33 @@ export default function SuggestionList(props) {
         renderNoMatches,
         id,
         isLoading,
+        height,
+        itemSize,
     } = props;
+
     return isLoading ? (
         <Spinner center={true} large={true} />
-    ) : (
-        <ul
-            className="ffe-base-selector__suggestion-container-list"
-            role="listbox"
-            id={id}
+    ) : suggestions.length > 0 ? (
+        <List
+            height={height}
+            innerElementType={forwardRef((forwardProps, ref) => (
+                <div ref={ref} id={id} role="listbox" {...forwardProps} />
+            ))}
+            itemCount={suggestions.length}
+            itemSize={itemSize}
+            itemData={{
+                forwardProps: props,
+                renderSuggestion,
+                highlightedIndex,
+                suggestions,
+            }}
+            ref={props.refList}
+            style={{ overflow: false }}
         >
-            {suggestions.length > 0 ? (
-                suggestions.map((item, index) => (
-                    <SuggestionItem
-                        {...props}
-                        key={index}
-                        item={item}
-                        id={`suggestion-item-${index}`}
-                        isHighlighted={index === highlightedIndex}
-                        render={renderSuggestion}
-                    />
-                ))
-            ) : (
-                <li>{renderNoMatches()}</li>
-            )}
-        </ul>
+            {Row}
+        </List>
+    ) : (
+        <li>{renderNoMatches()}</li>
     );
 }
 
@@ -46,9 +69,14 @@ SuggestionList.propTypes = {
     renderNoMatches: func,
     id: string.isRequired,
     isLoading: bool,
+    refList: object,
+    height: number,
+    itemSize: number,
 };
 
 SuggestionList.defaultProps = {
     renderNoMatches: () => {},
     isLoading: false,
+    height: 300,
+    itemSize: 55,
 };

--- a/packages/ffe-account-selector-react/src/subcomponents/suggestion/SuggestionList.spec.js
+++ b/packages/ffe-account-selector-react/src/subcomponents/suggestion/SuggestionList.spec.js
@@ -39,6 +39,10 @@ function propsSuggestionListContainer() {
     };
 }
 
+function mountSuggestionList(props) {
+    return mount(<SuggestionList {...propsSuggestionList()} {...props} />);
+}
+
 function shallowSuggestionList(props) {
     return shallow(<SuggestionList {...propsSuggestionList()} {...props} />);
 }
@@ -49,26 +53,30 @@ function mountSuggestionListContainer(props = propsSuggestionListContainer()) {
 
 describe('<SuggestionList />', () => {
     it('highlighted <Suggestion> set to highlightedIndex', () => {
-        const wrapper = shallowSuggestionList();
-        const ul = wrapper.find('ul');
+        const wrapper = mountSuggestionList();
+        const suggestionList = wrapper.find('[role="listbox"]');
+        const firstRow = suggestionList.childAt(0);
+        const secondRow = suggestionList.childAt(1);
 
-        expect(ul.children().length).toBe(2);
-        expect(ul.childAt(0).props().isHighlighted).toBe(false);
-        expect(ul.childAt(1).props().isHighlighted).toBe(true);
+        expect(suggestionList.children().length).toBe(2);
+        expect(firstRow.children().length).toBe(1);
+        expect(secondRow.children().length).toBe(1);
+        expect(firstRow.childAt(0).props().isHighlighted).toBe(false);
+        expect(secondRow.childAt(0).props().isHighlighted).toBe(true);
         expect(wrapper.find(Spinner).length === 0).toBe(true);
     });
 
     it('should renderNoSuggestions when suggestions is empty', () => {
         const renderNoMatchesSpy = jest.fn();
-        const wrapper = shallowSuggestionList({
+        const suggestionList = mountSuggestionList({
             ...propsSuggestionList(),
             suggestions: [],
             renderNoMatches: renderNoMatchesSpy,
         });
-        const ul = wrapper.find('ul');
-        expect(ul.children().length).toBe(1);
+
+        expect(suggestionList.children().length).toBe(1);
         expect(renderNoMatchesSpy).toHaveBeenCalled();
-        expect(wrapper.find(Spinner).length === 0).toBe(true);
+        expect(suggestionList.find(Spinner).length === 0).toBe(true);
     });
 
     it('should render spinner', () => {

--- a/packages/ffe-account-selector-react/src/subcomponents/suggestion/SuggestionListContainer.js
+++ b/packages/ffe-account-selector-react/src/subcomponents/suggestion/SuggestionListContainer.js
@@ -7,6 +7,8 @@ import { Scrollbars } from 'react-custom-scrollbars';
 import SuggestionList from './SuggestionList';
 
 class SuggestionListContainer extends React.Component {
+    listRef = React.createRef();
+
     constructor(props) {
         super(props);
         this.refHighlightedSuggestion = this.refHighlightedSuggestion.bind(
@@ -43,6 +45,12 @@ class SuggestionListContainer extends React.Component {
         );
     }
 
+    handleScroll = ({ target }) => {
+        const { scrollTop } = target;
+
+        this.listRef.current.scrollTo(scrollTop);
+    };
+
     render() {
         const { heightMax, autoHeight } = this.props;
         return (
@@ -58,8 +66,11 @@ class SuggestionListContainer extends React.Component {
                             this.scrollbars = scrollbars;
                         }
                     }}
+                    onScroll={this.handleScroll}
                 >
                     <SuggestionList
+                        height={heightMax}
+                        refList={this.listRef}
                         refHighlightedSuggestion={this.refHighlightedSuggestion}
                         {...this.props}
                     />


### PR DESCRIPTION
Not sure if you still want this, but fixes #367. It might be better to rewrite for #501 first?

The list will require a height, as `react-window` does not automatically shrink if needed bvaughn/react-window#121.

Doesn't look great with the default height when items doesn't max out the height.
![image](https://user-images.githubusercontent.com/6494049/52526010-c4427000-2cb2-11e9-8d03-e56a2e65672f.png)
