### PR TITLE
372 deprecated lifecycle callbacks

### DIFF
--- a/packages/ffe-datepicker-react/src/calendar/Calendar.js
+++ b/packages/ffe-datepicker-react/src/calendar/Calendar.js
@@ -38,14 +38,15 @@ export default class Calendar extends Component {
         this.renderDay = this.renderDay.bind(this);
     }
 
-    componentWillReceiveProps(nextProps) {
-        if (nextProps.selectedDate !== this.props.selectedDate) {
+    /* eslint-disable react/no-did-update-set-state */
+    componentDidUpdate(prevProps) {
+        if (prevProps.selectedDate !== this.props.selectedDate) {
             this.setState({
                 calendar: simpleCalendar(
-                    simpleDate.fromString(nextProps.selectedDate),
-                    nextProps.minDate,
-                    nextProps.maxDate,
-                    nextProps.language,
+                    simpleDate.fromString(this.props.selectedDate),
+                    this.props.minDate,
+                    this.props.maxDate,
+                    this.props.language,
                 ),
             });
         }
@@ -137,13 +138,13 @@ export default class Calendar extends Component {
     }
 
     focusHandler(evt) {
-        if(this._wrapper && this._wrapper.contains(evt.target)){
+        if (this._wrapper && this._wrapper.contains(evt.target)) {
             this.forceDateFocus = true;
         }
     }
 
-    wrapperBlurHandler(){
-            this.forceDateFocus = false;
+    wrapperBlurHandler() {
+        this.forceDateFocus = false;
     }
 
     nextMonth(evt) {
@@ -241,7 +242,7 @@ export default class Calendar extends Component {
 }
 
 Calendar.defaultProps = {
-    focusOnOpen: false
+    focusOnOpen: false,
 };
 
 Calendar.propTypes = {

--- a/packages/ffe-datepicker-react/src/datepicker/Datepicker.js
+++ b/packages/ffe-datepicker-react/src/datepicker/Datepicker.js
@@ -47,13 +47,14 @@ export default class Datepicker extends Component {
         this.removeGlobalEventListeners();
     }
 
-    componentWillReceiveProps(nextProps) {
+    /* eslint-disable react/no-did-update-set-state */
+    componentDidUpdate() {
         if (
-            (nextProps.minDate && nextProps.minDate !== this.state.minDate) ||
-            (nextProps.maxDate && nextProps.maxDate !== this.state.maxDate)
+            (this.props.minDate && this.props.minDate !== this.state.minDate) ||
+            (this.props.maxDate && this.props.maxDate !== this.state.maxDate)
         ) {
             this.setState(
-                { minDate: nextProps.minDate, maxDate: nextProps.maxDate },
+                { minDate: this.props.minDate, maxDate: this.props.maxDate },
                 this.validateDateIntervals,
             );
         }
@@ -369,16 +370,15 @@ export default class Datepicker extends Component {
                     )}
                 </div>
 
-                {this.state.ariaInvalid &&
-                    !hideErrors && (
-                        <div
-                            id={`date-input-validation-${this.datepickerId}`}
-                            className="ffe-body-text ffe-field-error-message"
-                            role="alert"
-                        >
-                            {this.state.errorMessage}
-                        </div>
-                    )}
+                {this.state.ariaInvalid && !hideErrors && (
+                    <div
+                        id={`date-input-validation-${this.datepickerId}`}
+                        className="ffe-body-text ffe-field-error-message"
+                        role="alert"
+                    >
+                        {this.state.errorMessage}
+                    </div>
+                )}
             </div>
         );
     }


### PR DESCRIPTION
It's possible that the datepicker could have been changed to not cause an extra render with `componentDidUpdate` but it was the easiest and shortest way to remove the deprecated callbacks without touching too much of the other code.