### PR TITLE
feat(ffe-tables-react): Expandable table rows may be expanded as default

### DIFF
--- a/packages/ffe-tables-react/src/Table.md
+++ b/packages/ffe-tables-react/src/Table.md
@@ -129,6 +129,65 @@ const onSort = ({ sortBy, descending, tableData }) => {};
 />;
 ```
 
+Dersom tabellen har rader som kan ekspanderes kan data-arrayet også inneholder verdier som sier hvorvidt en rad skal være ekspandert som default.
+
+```js
+const Button = ({ children }) => (
+    // stopPropagation hindrer at raden ekspanderer/kollapser når vi trykker på knappen
+    <TertiaryButton onClick={e => e.stopPropagation()}>
+        {children}
+    </TertiaryButton>
+);
+
+const data = [
+    {
+        id: 0,
+        name: 'Ola Normann',
+        email: 'ola@normann.no',
+        info: 'mer spennende info',
+    },
+    {
+        id: 1,
+        name: 'Sivert Svenska',
+        email: 'sivert@svenska.se',
+        info: 'mer spennende info',
+        defaultExpanded: true,
+    },
+    {
+        id: 2,
+        name: 'Daniel Dansk',
+        email: 'daniel@dansk.dk',
+        info: 'mer spennende info',
+    },
+    {
+        id: 3,
+        name: 'Lille Ole',
+        email: 'lilleole@gmail.com',
+        info: 'mer spennende info',
+    },
+];
+
+const columns = [
+    { key: 'name', header: 'Navn', footer: 'Gjennomsnitt' },
+    { key: 'email', header: 'E-post', hideOnTablet: true, hideOnMobile: true },
+];
+
+// Rader uten address vil ikke kunne ekspanderes fordi funksjonen returnerer falsy
+const expandedContentMapper = row => row.info && <span>Info: {row.info}</span>;
+
+<Table
+    columns={columns}
+    data={data}
+    expandedContentMapper={expandedContentMapper}
+    descending={true}
+    condensed={true}
+    smallHeader={true}
+    columnLayoutMobile={true}
+    breakpoint={'none'}
+    caption="Masse spennende data, med en rad som er ekspandert"
+/>;
+```
+
 Bruk av render funksjoner for columns: cellRender, columnHeaderRender, columnFooterRender.
 
 For hele tabellen: rowRender, headerRender, footerRender.
@@ -208,9 +267,11 @@ data.map(e => {
     e.syntetic = e.age > 18 && formatNumber(e.networth) > 10000;
 });
 
-const ageSum = data.map(e => e.age).reduce((total, num) => {
-    return total + num;
-});
+const ageSum = data
+    .map(e => e.age)
+    .reduce((total, num) => {
+        return total + num;
+    });
 
 const networthSum = data
     .map(e => formatNumber(e.networth))
@@ -405,3 +466,6 @@ const onSort = ({ sortBy, descending, tableData }) => {};
     }}
 />;
 ```
+
+Det er også mulig å si at en rad skal scrolles til når tabell-komponentet mountes.
+Dette gjøres ved å sette scrollToOnMount = true i for det rad-elementet i data-arrayt som det skal scrolles til.

--- a/packages/ffe-tables-react/src/Table/Table.js
+++ b/packages/ffe-tables-react/src/Table/Table.js
@@ -87,6 +87,8 @@ class Table extends Component {
                     sort,
                     rowRender,
                     rowIndex: index,
+                    defaultExpanded: row.defaultExpanded,
+                    scrollToOnMount: row.scrollToOnMount,
                 };
                 return expandedContent ? (
                     <TableRowExpandable key={key} {...rowProps}>

--- a/packages/ffe-tables-react/src/TableParts/TableRowExpandable.js
+++ b/packages/ffe-tables-react/src/TableParts/TableRowExpandable.js
@@ -12,9 +12,16 @@ class TableRowExpandable extends Component {
         this.handleKeyPress = this.handleKeyPress.bind(this);
         this.toggleExpand = this.toggleExpand.bind(this);
         this.state = {
-            expanded: false,
+            expanded: !!props.defaultExpanded,
             sort: props.sort,
         };
+        this.rowRef = React.createRef();
+    }
+
+    componentDidMount() {
+        if (this.props.scrollToOnMount && this.rowRef.current) {
+            this.rowRef.current.scrollIntoView();
+        }
     }
 
     static getDerivedStateFromProps(nextProps, prevState) {
@@ -50,7 +57,7 @@ class TableRowExpandable extends Component {
         const unexpandable = !children;
 
         return (
-            <tbody>
+            <tbody ref={this.rowRef}>
                 <TableRow
                     cells={{
                         ...cells,
@@ -117,6 +124,8 @@ TableRowExpandable.propTypes = {
     headerRender: PropTypes.func,
     footerRender: PropTypes.func,
     rowIndex: PropTypes.number,
+    defaultExpanded: PropTypes.bool,
+    scrollToOnMount: PropTypes.bool,
 };
 
 polyfill(TableRowExpandable);

--- a/packages/ffe-tables-react/src/TableParts/TableRowExpandable.spec.js
+++ b/packages/ffe-tables-react/src/TableParts/TableRowExpandable.spec.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { shallow, render } from 'enzyme';
+import { shallow, render, mount } from 'enzyme';
 import TableRowExpandable from './TableRowExpandable';
 
 const props = {
@@ -32,6 +32,12 @@ const unexpandableWrapper = shallow(
     </TableRowExpandable>,
 );
 
+const defaultExpandedWrapper = shallow(
+    <TableRowExpandable {...props} defaultExpanded={true}>
+        <p>The cake is a lie</p>
+    </TableRowExpandable>,
+);
+
 describe('<TableRowExpandable>', () => {
     it('should be collapsed by default', () => {
         expect(wrapper.state().expanded).toBe(false);
@@ -48,6 +54,36 @@ describe('<TableRowExpandable>', () => {
                 .find('.ffe-table__row-expandable-content')
                 .hasClass('ffe-table__row--collapsed'),
         ).toBe(true);
+    });
+
+    it('should be expanded if provided true defaultExpanded', () => {
+        expect(defaultExpandedWrapper.state().expanded).toBe(true);
+        expect(
+            defaultExpandedWrapper.find('.ffe-table__row--collapsed'),
+        ).toHaveLength(0);
+        expect(
+            defaultExpandedWrapper
+                .find('.ffe-table__row-expandable-content')
+                .prop('aria-hidden'),
+        ).toBe('false');
+        expect(
+            defaultExpandedWrapper
+                .find('.ffe-table__row-expandable-content')
+                .hasClass('ffe-table__row-expandable-content--expanded'),
+        ).toBe(true);
+    });
+
+    it('should scroll into view on mount if true scrollToOnMount is provided', () => {
+        const scrollIntoViewMock = jest.fn();
+        window.HTMLElement.prototype.scrollIntoView = scrollIntoViewMock;
+
+        mount(
+            <TableRowExpandable {...props} scrollToOnMount={true}>
+                <p>The cake is a lie</p>
+            </TableRowExpandable>,
+        );
+
+        expect(scrollIntoViewMock).toHaveBeenCalledTimes(1);
     });
 
     it('should render expanded content', () => {


### PR DESCRIPTION
This version adds support for expanding a table row by default. The cells prop in TableRowExpandable may have a value defaultExpanded, that row is then expanded as default and scrolled to on mount.

This functionality is needed eg. when the expanded content is containing a link to another page, and that page has a back button. We then want to keep the position in the table, and have the option still expanded, when pressing the back button.

Fixes: #595 
