### PR TITLE
fix(ffe-datepicker-react): Do not overwrite aria-describedby if given…

### DIFF
--- a/packages/ffe-datepicker-react/src/datepicker/Datepicker.js
+++ b/packages/ffe-datepicker-react/src/datepicker/Datepicker.js
@@ -301,7 +301,7 @@ export default class Datepicker extends Component {
         } = this.state;
         const latestValue = validateDate(value) ? value : lastValidDate;
 
-        if (this.state.ariaInvalid) {
+        if (this.state.ariaInvalid && !inputProps['aria-describedby']) {
             inputProps['aria-describedby'] = `date-input-validation-${
                 this.datepickerId
             }`;

--- a/packages/ffe-datepicker-react/src/datepicker/Datepicker.spec.js
+++ b/packages/ffe-datepicker-react/src/datepicker/Datepicker.spec.js
@@ -66,7 +66,7 @@ describe('<Datepicker />', () => {
             ).toBeUndefined();
         });
 
-        it('renders aria-describeby if a label is given', () => {
+        it('renders aria-describedby if a label is given', () => {
             const wrapper = getShallowWrapper({
                 label: 'Velg startdato',
             });
@@ -160,6 +160,19 @@ describe('<Datepicker />', () => {
             it('has correct aria-invalid value if given prop', () => {
                 const wrapper = getMountedWrapper({ ariaInvalid: true });
                 expect(wrapper.find('input').prop('aria-invalid')).toBe('true');
+            });
+
+            it('has correct aria-describedby if aria-describedby given as input prop', () => {
+                const inputProps = {
+                    'aria-describedby': 'test',
+                };
+                const wrapper = getMountedWrapper({
+                    ariaInvalid: true,
+                    inputProps,
+                });
+                expect(wrapper.find('input').prop('aria-describedby')).toBe(
+                    'test',
+                );
             });
         });
 


### PR DESCRIPTION
I have a use-case where it would be helpful to be able to set the `aria-describedby` on the input field wrapped by Datepicker, but the current implementation overwrites this field without checking the `inputProps`. This commit adds a check, making sure the Datepicker won't overwrite  `aria-describedby` if it was passed down as a prop. 
