### PR TITLE
fix(ffe-context-message-react): Do not set aria-labelledby when referenced header is not rendered

### DIFF
--- a/packages/ffe-context-message-react/src/ContextMessage.js
+++ b/packages/ffe-context-message-react/src/ContextMessage.js
@@ -82,7 +82,7 @@ export default class ContextMessage extends Component {
         return (
             <div
                 aria-describedby={contentElementId}
-                aria-labelledby={headerElementId}
+                aria-labelledby={header && headerElementId}
                 className={classNames(
                     'ffe-context-message',
                     `ffe-context-message--${messageType}`,

--- a/packages/ffe-context-message-react/src/ContextMessage.spec.js
+++ b/packages/ffe-context-message-react/src/ContextMessage.spec.js
@@ -126,6 +126,15 @@ describe('<ContextMessage />', () => {
             done();
         }, 20);
     });
+
+    it('does not have aria-labelledby when header was not specified', () => {
+        const wrapper = getMountedWrapper({
+            headerElementId: 'header-element-id',
+        });
+
+        const message = wrapper.find('.ffe-context-message');
+        expect(message.prop('aria-labelledby')).toBe(undefined);
+    });
 });
 
 describe('<ContextInfoMessage />', () => {


### PR DESCRIPTION
With the current implementation, the aria-labelledby attribute on the `<div/>` wrapping the message is set when no header was passed as a prop. This will lead to a broken aria reference. This commit changes the implementation to only set the `aria-labelledby` when a header prop exists. 
