### PR TITLE
feat(ffe-decorators-react): Add `alwaysEaseFrom` option to `easePrope…

### DIFF
--- a/packages/ffe-decorators-react/src/ease-properties/easeProperties.js
+++ b/packages/ffe-decorators-react/src/ease-properties/easeProperties.js
@@ -19,7 +19,8 @@ export default (properties = {}) => TargetComponent =>
     // {
     //      somePropertyToEase: {
     //          duration: 0.5, // duration of easing in seconds
-    //          initialValue: 0 // the initial value to start the easing from when the component mounts
+    //          initialValue: 0, // the initial value to start the easing from when the component mounts
+    //          alwaysEaseFrom: 0, // Optional. All easings will start from this value rather than the previous
     //      },
     //  }
     // , with a property for each property to ease. The duration defaults to 1 second, and there is no default
@@ -133,7 +134,11 @@ export default (properties = {}) => TargetComponent =>
                             [propName]: {
                                 ...prevState[propName],
                                 currentIteration: 0,
-                                fromValue: prevState[propName].currentValue,
+                                fromValue:
+                                    properties[propName].alwaysEaseFrom !==
+                                    undefined
+                                        ? properties[propName].alwaysEaseFrom
+                                        : prevState[propName].currentValue,
                                 rafId: window.requestAnimationFrame(
                                     this.nextFrame.bind(this, propName),
                                 ),


### PR DESCRIPTION
…rties`

Adds a configuration option, `alwaysEaseFrom`, that if set will cause all
updates on the wrapped component to start easing from that value instead
of the previous value.

Closes #605

<!-- 
Thanks for opening a pull request! 🎉

If your changes include some kind of UI element, please attach a screenshot of 
how it looks.

Before submitting a pull request, please have a look through the CONTRIBUTING.md
document. TL;DR:

- Follow the conventional commit standard
- Write full, explanatory commit messages
- Follow our code standards
- Write tests where applicable
- Be courteous and respect our code of conduct
-->
