### PR TITLE
feat(ffe-form-react): Add showChildren prop to RadioBlock

### DIFF
--- a/packages/ffe-form-react/src/RadioBlock.js
+++ b/packages/ffe-form-react/src/RadioBlock.js
@@ -14,6 +14,7 @@ class RadioBlock extends Component {
             label,
             name,
             selectedValue,
+            showChildren,
             value,
             ...inputProps
         } = this.props;
@@ -38,7 +39,7 @@ class RadioBlock extends Component {
                     >
                         {label}
                     </label>
-                    {isSelected && (
+                    {(isSelected || showChildren) && (
                         <div
                             className={classNames('ffe-radio-block__wrapper', {
                                 'ffe-radio-block__wrapper--empty': !children,
@@ -66,6 +67,8 @@ RadioBlock.propTypes = {
     name: string.isRequired,
     /** The selected value of the radio button set */
     selectedValue: string,
+    /** Whether or not children are always visible */
+    showChildren: bool,
     /** The value of the radio block */
     value: string.isRequired,
 };

--- a/packages/ffe-form-react/src/RadioBlock.md
+++ b/packages/ffe-form-react/src/RadioBlock.md
@@ -17,6 +17,7 @@ initialState = { selected: 'you' };
             <RadioBlock
                 {...inputProps}
                 label="Ektefelle, samboer eller registrert partner"
+                showChildren={true}
                 value="partner"
             >
                 Da må ektefelle, samboer eller registrert partner skrive inn

--- a/packages/ffe-form-react/src/RadioBlock.spec.js
+++ b/packages/ffe-form-react/src/RadioBlock.spec.js
@@ -65,5 +65,12 @@ describe('<RadioBlock />', () => {
             });
             expect(wrapper.text()).toContain('sample children');
         });
+        it('is rendered if showChildren is true', () => {
+            const wrapper = getWrapper({
+                children: 'sample children',
+                showChildren: true,
+            });
+            expect(wrapper.text()).toContain('sample children');
+        });
     });
 });


### PR DESCRIPTION
This version adds the possibility to make children of the RadioBlock component visible permanently.

To use this new feature you need to set the showChildren prop.