### PR TITLE
More ts definition files

### DIFF
--- a/packages/ffe-buttons-react/README.md
+++ b/packages/ffe-buttons-react/README.md
@@ -10,3 +10,8 @@ npm install --save @sb1/ffe-buttons-react
 
 Run Styleguidist from the repository root to see live examples and documentation,
 or see the markdown files next to the component code in `src/`.
+
+## TypeScript definition files
+
+This component supports TypeScript - please update `index.d.ts` if you change any
+of the external methods or properties in this component.

--- a/packages/ffe-buttons-react/package.json
+++ b/packages/ffe-buttons-react/package.json
@@ -9,19 +9,22 @@
   "author": "SpareBank 1",
   "files": [
     "lib",
-    "es"
+    "es",
+    "types"
   ],
   "main": "lib/index.js",
   "module": "es/index.js",
+  "types": "types/index.d.ts",
   "sideEffects": false,
   "repository": {
     "type": "git",
     "url": "ssh://git@github.com:SpareBank1/designsystem.git"
   },
   "scripts": {
-    "build": "npm run build:cjs && npm run build:es",
+    "build": "npm run build:cjs && npm run build:es && npm run build:types",
     "build:cjs": "babel -d lib/. --root-mode=upward  --env-name=cjs --ignore=*.spec.js src/.",
     "build:es": "babel -d es/. --root-mode=upward --env-name=es --ignore=*.spec.js src/.",
+    "build:types": "copyfiles -f src/index.d.ts types/",
     "lint": "eslint src/.",
     "test": "jest",
     "test:watch": "jest --watch"

--- a/packages/ffe-buttons-react/src/index.d.ts
+++ b/packages/ffe-buttons-react/src/index.d.ts
@@ -1,0 +1,97 @@
+import * as React from 'react';
+
+export interface MinimalBaseButtonProps extends React.HTMLProps<HTMLElement> {
+    className?: string;
+    element?: HTMLElement | string;
+    innerRef?: React.RefObject<HTMLElement>;
+}
+
+export interface BaseButtonProps extends MinimalBaseButtonProps {
+    children?: React.ReactNode;
+    ariaLoadingMessage?: string;
+    condensed?: boolean;
+    disabled?: boolean;
+    isLoading?: boolean;
+    leftIcon?: React.ReactNode;
+    rightIcon?: React.ReactNode;
+    dark?: boolean;
+}
+
+export interface ActionButtonProps extends BaseButtonProps {
+    ghost?: boolean;
+}
+
+export interface BackButtonProps extends MinimalBaseButtonProps {
+    children?: React.ReactNode;
+    dark?: boolean;
+}
+
+export interface ButtonGroupProps {
+    className?: string;
+    thin?: boolean;
+    inline?: boolean;
+}
+
+export interface ExpandButtonProps extends MinimalBaseButtonProps {
+    children: React.ReactNode;
+    closeLabel?: string;
+    leftIcon?: React.ReactNode;
+    rightIcon?: React.ReactNode;
+    isExpanded: boolean;
+    onClick: (e: React.MouseEvent | undefined) => void;
+}
+
+export interface InlineExpandButtonProps {
+    children?: React.ReactNode;
+    innerRef?: React.RefObject<HTMLElement>;
+    isExpanded: boolean;
+    onClick: (e: React.MouseEvent | undefined) => void;
+}
+
+export interface PrimaryButtonProps extends BaseButtonProps {}
+
+export interface SecondaryButtonProps extends BaseButtonProps {}
+
+export interface ShortcutButtonProps extends MinimalBaseButtonProps {
+    children?: React.ReactNode;
+    condensed?: boolean;
+    disabled?: boolean;
+    leftIcon?: React.ReactNode;
+}
+
+export interface TaskButtonProps extends MinimalBaseButtonProps {
+    children?: React.ReactNode;
+    condensed?: boolean;
+    disabled?: boolean;
+    icon: React.ReactNode;
+}
+
+export interface TertiaryButtonProps extends MinimalBaseButtonProps {
+    children?: React.ReactNode;
+    leftIcon?: React.ReactNode;
+    rightIcon?: React.ReactNode;
+    dark?: boolean;
+}
+
+declare class ActionButton extends React.Component<ActionButtonProps, any> {}
+declare class BackButton extends React.Component<BackButtonProps, any> {}
+declare class ButtonGroup extends React.Component<ButtonGroupProps, any> {}
+declare class ExpandButton extends React.Component<ExpandButtonProps, any> {}
+declare class InlineExpandButton extends React.Component<
+    InlineExpandButtonProps,
+    any
+> {}
+declare class PrimaryButton extends React.Component<PrimaryButtonProps, any> {}
+declare class SecondaryButton extends React.Component<
+    SecondaryButtonProps,
+    any
+> {}
+declare class ShortcutButton extends React.Component<
+    ShortcutButtonProps,
+    any
+> {}
+declare class TaskButton extends React.Component<TaskButtonProps, any> {}
+declare class TertiaryButton extends React.Component<
+    TertiaryButtonProps,
+    any
+> {}

--- a/packages/ffe-context-message-react/README.md
+++ b/packages/ffe-context-message-react/README.md
@@ -10,3 +10,8 @@ npm install --save @sb1/ffe-context-message-react
 
 Run Styleguidist from the repository root to see live examples and documentation,
 or see the markdown files next to the component code in `src/`.
+
+## TypeScript definition files
+
+This component supports TypeScript - please update `index.d.ts` if you change any
+of the external methods or properties in this component.

--- a/packages/ffe-context-message-react/package.json
+++ b/packages/ffe-context-message-react/package.json
@@ -9,19 +9,22 @@
   "author": "SpareBank 1",
   "files": [
     "lib",
-    "es"
+    "es",
+    "types"
   ],
   "main": "lib/index.js",
   "module": "es/index.js",
+  "types": "types/index.d.ts",
   "sideEffects": false,
   "repository": {
     "type": "git",
     "url": "ssh://git@github.com:SpareBank1/designsystem.git"
   },
   "scripts": {
-    "build": "npm run build:cjs && npm run build:es",
+    "build": "npm run build:cjs && npm run build:es && npm run build:types",
     "build:cjs": "babel -d lib/. --root-mode=upward  --env-name=cjs --ignore=*.spec.js src/.",
     "build:es": "babel -d es/. --root-mode=upward --env-name=es --ignore=*.spec.js src/.",
+    "build:types": "copyfiles -f src/index.d.ts types/",
     "lint": "eslint src/.",
     "test": "jest",
     "test:watch": "jest --watch"

--- a/packages/ffe-context-message-react/src/index.d.ts
+++ b/packages/ffe-context-message-react/src/index.d.ts
@@ -1,0 +1,33 @@
+import * as React from 'react';
+
+export interface ContextMessageProps {
+    animationLengthMs?: number;
+    children: React.ReactNode;
+    className?: string;
+    compact?: boolean;
+    contentElementId?: string;
+    header?: string;
+    headerElementId?: string;
+    icon?: React.ReactNode;
+    locale?: 'nb' | 'nn' | 'en';
+    onClose?: (event: React.MouseEvent) => void;
+    showCloseButton?: boolean;
+    style?: React.CSSProperties;
+}
+
+declare class ContextInfoMessage extends React.Component<
+    ContextMessageProps,
+    any
+> {}
+declare class ContextTipMessage extends React.Component<
+    ContextMessageProps,
+    any
+> {}
+declare class ContextSuccessMessage extends React.Component<
+    ContextMessageProps,
+    any
+> {}
+declare class ContextErrorMessage extends React.Component<
+    ContextMessageProps,
+    any
+> {}

--- a/packages/ffe-core-react/README.md
+++ b/packages/ffe-core-react/README.md
@@ -12,3 +12,8 @@ npm install --save @sb1/ffe-core-react
 
 Run Styleguidist from the repository root to see live examples and documentation,
 or see the markdown files next to the component code in `src/`.
+
+## TypeScript definition files
+
+This component supports TypeScript - please update `index.d.ts` if you change any
+of the external methods or properties in this component.

--- a/packages/ffe-core-react/package.json
+++ b/packages/ffe-core-react/package.json
@@ -9,19 +9,22 @@
   "author": "SpareBank 1",
   "files": [
     "lib",
-    "es"
+    "es",
+    "types"
   ],
   "main": "lib/index.js",
   "module": "es/index.js",
+  "types": "types/index.d.ts",
   "sideEffects": false,
   "repository": {
     "type": "git",
     "url": "ssh://git@github.com:SpareBank1/designsystem.git"
   },
   "scripts": {
-    "build": "npm run build:cjs && npm run build:es",
+    "build": "npm run build:cjs && npm run build:es && npm run build:types",
     "build:cjs": "babel -d lib/. --root-mode=upward  --env-name=cjs --ignore=*.spec.js src/.",
     "build:es": "babel -d es/. --root-mode=upward --env-name=es --ignore=*.spec.js src/.",
+    "build:types": "copyfiles -f src/index.d.ts types/",
     "lint": "eslint src/.",
     "test": "jest",
     "test:watch": "jest --watch"

--- a/packages/ffe-core-react/src/index.d.ts
+++ b/packages/ffe-core-react/src/index.d.ts
@@ -1,0 +1,72 @@
+import * as React from 'react';
+
+export interface DividerLineProps extends React.HTMLAttributes<HTMLHRElement> {
+    className?: string;
+}
+
+export interface EmphasizedTextProps extends React.HTMLAttributes<HTMLElement> {
+    children: React.ReactNode;
+    className?: string;
+}
+
+export interface HeadingProps extends React.HTMLAttributes<HTMLHeadingElement> {
+    children: React.ReactNode;
+    className?: string;
+    error?: boolean;
+    inline?: boolean;
+    lookLike?: 1 | 2 | 3 | 4 | 5 | 6;
+    noMargin?: boolean;
+    withBorder?: boolean;
+}
+
+export interface LinkTextProps extends React.AnchorHTMLAttributes<HTMLElement> {
+    children: React.ReactNode;
+    className?: string;
+    element?: HTMLElement | string;
+    underline?: boolean;
+}
+
+export interface SimpleElementProps {
+    children: React.ReactNode;
+    className?: string;
+}
+
+export interface ParagraphProps
+    extends React.HTMLAttributes<HTMLParagraphElement> {
+    children: React.ReactNode;
+    className?: string;
+    lead?: boolean;
+    subLead?: boolean;
+    textCenter?: boolean;
+    textLeft?: boolean;
+}
+
+declare class DividerLine extends React.Component<DividerLineProps, any> {}
+declare class EmphasizedText extends React.Component<
+    EmphasizedTextProps,
+    any
+> {}
+declare class Heading1 extends React.Component<HeadingProps, any> {}
+declare class Heading2 extends React.Component<HeadingProps, any> {}
+declare class Heading3 extends React.Component<HeadingProps, any> {}
+declare class Heading4 extends React.Component<HeadingProps, any> {}
+declare class Heading5 extends React.Component<HeadingProps, any> {}
+declare class Heading6 extends React.Component<HeadingProps, any> {}
+declare class LinkText extends React.Component<LinkTextProps, any> {}
+declare class MicroText extends React.Component<
+    SimpleElementProps & React.HTMLAttributes<HTMLSpanElement>,
+    any
+> {}
+declare class Paragraph extends React.Component<ParagraphProps, any> {}
+declare class PreformattedText extends React.Component<
+    SimpleElementProps & React.HTMLAttributes<HTMLPreElement>,
+    any
+> {}
+declare class SmallText extends React.Component<
+    SimpleElementProps & React.HTMLAttributes<HTMLSpanElement>,
+    any
+> {}
+declare class StrongText extends React.Component<
+    SimpleElementProps & React.HTMLAttributes<HTMLElement>,
+    any
+> {}

--- a/packages/ffe-dropdown-react/README.md
+++ b/packages/ffe-dropdown-react/README.md
@@ -12,3 +12,8 @@ npm install --save @sb1/ffe-dropdown-react
 
 Run Styleguidist from the repository root to see live examples and documentation,
 or see the markdown files next to the component code in `src/`.
+
+## TypeScript definition files
+
+This component supports TypeScript - please update `index.d.ts` if you change any
+of the external methods or properties in this component.

--- a/packages/ffe-dropdown-react/package.json
+++ b/packages/ffe-dropdown-react/package.json
@@ -4,19 +4,22 @@
   "license": "MIT",
   "files": [
     "lib",
-    "es"
+    "es",
+    "types"
   ],
   "main": "lib/index.js",
   "module": "es/index.js",
+  "types": "types/index.d.ts",
   "sideEffects": false,
   "repository": {
     "type": "git",
     "url": "ssh://git@github.com:SpareBank1/designsystem.git"
   },
   "scripts": {
-    "build": "npm run build:cjs && npm run build:es",
+    "build": "npm run build:cjs && npm run build:es && npm run build:types",
     "build:cjs": "babel -d lib/. --root-mode=upward  --env-name=cjs --ignore=*.spec.js src/.",
     "build:es": "babel -d es/. --root-mode=upward --env-name=es --ignore=*.spec.js src/.",
+    "build:types": "copyfiles -f src/index.d.ts types/",
     "lint": "eslint src/.",
     "test": "jest",
     "test:watch": "jest --watch"

--- a/packages/ffe-dropdown-react/src/index.d.ts
+++ b/packages/ffe-dropdown-react/src/index.d.ts
@@ -1,0 +1,13 @@
+import * as React from 'react';
+
+export interface DropdownProps
+    extends React.SelectHTMLAttributes<HTMLSelectElement> {
+    children?: React.ReactNode;
+    className?: string;
+    inline?: boolean;
+    dark?: boolean;
+}
+
+declare class Dropdown extends React.Component<DropdownProps, any> {}
+
+export default Dropdown;

--- a/packages/ffe-form-react/README.md
+++ b/packages/ffe-form-react/README.md
@@ -12,3 +12,8 @@ npm install --save @sb1/ffe-form-react
 
 Run Styleguidist from the repository root to see live examples and documentation,
 or see the markdown files next to the component code in `src/`.
+
+## TypeScript definition files
+
+This component supports TypeScript - please update `index.d.ts` if you change any
+of the external methods or properties in this component.

--- a/packages/ffe-form-react/package.json
+++ b/packages/ffe-form-react/package.json
@@ -6,19 +6,22 @@
   "author": "SpareBank 1",
   "files": [
     "lib",
-    "es"
+    "es",
+    "types"
   ],
   "main": "lib/index.js",
   "module": "es/index.js",
+  "types": "types/index.d.ts",
   "sideEffects": false,
   "repository": {
     "type": "git",
     "url": "ssh://git@github.com:SpareBank1/designsystem.git"
   },
   "scripts": {
-    "build": "npm run build:cjs && npm run build:es",
+    "build": "npm run build:cjs && npm run build:es && npm run build:types",
     "build:cjs": "babel -d lib/. --root-mode=upward  --env-name=cjs --ignore=*.spec.js src/.",
     "build:es": "babel -d es/. --root-mode=upward --env-name=es --ignore=*.spec.js src/.",
+    "build:types": "copyfiles -f src/index.d.ts types/",
     "lint": "eslint src/.",
     "test": "jest",
     "test:watch": "jest --watch"

--- a/packages/ffe-form-react/src/index.d.ts
+++ b/packages/ffe-form-react/src/index.d.ts
@@ -1,0 +1,177 @@
+import * as React from 'react';
+import { isRequiredIf } from 'react-proptype-conditional-require';
+
+export interface CheckboxProps
+    extends React.InputHTMLAttributes<HTMLInputElement> {
+    /**
+     * @deprecated
+     * Use `children` instead
+     */
+    label?: string;
+    noMargins?: boolean;
+    hiddenLabel?: boolean;
+    id?: string;
+    inline?: boolean;
+    /**
+     * @deprecated
+     * Use `aria-invalid` directly instead
+     */
+    invalid?: boolean;
+    children?: React.ReactNode;
+    dark?: boolean;
+}
+
+export interface BaseFieldMessageProps
+    extends React.HTMLAttributes<HTMLDivElement> {
+    children: React.ReactNode;
+    className?: string;
+}
+
+export interface InputProps
+    extends React.InputHTMLAttributes<HTMLInputElement> {
+    className?: string;
+    inline?: boolean;
+    textLike?: boolean;
+    dark?: boolean;
+}
+
+export interface PhoneNumberProps {
+    number?: string;
+    countryCode?: string;
+    onCountryCodeChange?: React.FormEventHandler<HTMLInputElement>;
+    onNumberChange?: React.FormEventHandler<HTMLInputElement>;
+    onCountryCodeBlur?: React.FocusEventHandler<HTMLInputElement>;
+    onNumberBlur?: React.FocusEventHandler<HTMLInputElement>;
+    locale?: string;
+    disabled?: boolean;
+    countryCodeInvalid?: boolean;
+    numberInvalid?: boolean;
+    className?: string;
+    dark?: boolean;
+}
+
+export interface LabelProps
+    extends React.LabelHTMLAttributes<HTMLLabelElement> {
+    block?: boolean;
+    children: React.ReactNode;
+    className?: string;
+    htmlFor?: string;
+    dark?: boolean;
+}
+
+export interface InputGroupProps extends React.HTMLAttributes<HTMLDivElement> {
+    /** Unless you only have one element in your `InputGroup` you will have to use the function-as-a-child pattern. */
+    children: JSX.Element;
+    className?: string;
+    fieldMessage?: string | React.ReactNode;
+    description?: string;
+    label?: string | Label;
+    onTooltipToggle?: (e: React.MouseEvent | undefined) => void;
+    tooltip?: boolean | string | Tooltip;
+}
+
+export interface TooltipProps extends React.HTMLAttributes<HTMLSpanElement> {
+    children?: React.ReactNode;
+    className?: string;
+    isOpen?: boolean;
+    onClick: (e: React.MouseEvent | undefined) => void;
+    tabIndex?: number;
+    dark?: boolean;
+}
+
+export interface RadioBlockProps
+    extends React.InputHTMLAttributes<HTMLInputElement> {
+    checked?: boolean;
+    children?: React.ReactNode;
+    className?: string;
+    label: string | React.ReactNode;
+    name: string;
+    selectedValue?: string;
+    showChildren?: boolean;
+    value: string;
+}
+
+// As value has a different type than InputHTMLAttributes<T> we have to weaken it
+interface WeakInputAttributes
+    extends React.InputHTMLAttributes<HTMLInputElement> {
+    value: any;
+}
+
+export interface RadioButtonProps extends WeakInputAttributes {
+    checked?: boolean;
+    children: React.ReactNode;
+    className?: string;
+    labelProps?: object;
+    inline?: boolean;
+    name: string;
+    selectedValue?: boolean | string;
+    tooltip?: string;
+    tooltipProps?: TooltipProps;
+    value: boolean | string;
+    dark?: boolean;
+}
+
+export interface RadioButtonInputGroupProps
+    extends React.FieldsetHTMLAttributes<HTMLFieldSetElement> {
+    children: React.ReactNode;
+    className?: string;
+    fieldMessage?: string | React.ReactNode;
+    inline?: boolean;
+    label?: string | React.ReactNode;
+    name?: string;
+    onChange?: React.FormEventHandler<HTMLElement>;
+    selectedValue?: string | boolean;
+    tooltip?: string | React.ReactNode;
+    dark?: boolean;
+}
+
+export interface RadioSwitchProps
+    extends React.InputHTMLAttributes<HTMLInputElement> {
+    checked?: boolean;
+    children: React.ReactNode;
+    className?: string;
+    labelProps?: object;
+    leftLabel: string;
+    leftValue: boolean | string;
+    rightLabel: string;
+    rightValue: boolean | string;
+    name: string;
+    selectedValue?: boolean | string;
+    tooltip?: string;
+    tooltipProps?: TooltipProps;
+    condensed?: boolean;
+    dark?: boolean;
+}
+
+export interface TextAreaProps
+    extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {
+    className?: string;
+    dark?: boolean;
+}
+
+declare class Checkbox extends React.Component<CheckboxProps, any> {}
+declare class ErrorFieldMessage extends React.Component<
+    BaseFieldMessageProps,
+    any
+> {}
+declare class InfoFieldMessage extends React.Component<
+    BaseFieldMessageProps,
+    any
+> {}
+declare class SuccessFieldMessage extends React.Component<
+    BaseFieldMessageProps,
+    any
+> {}
+declare class Input extends React.Component<InputProps, any> {}
+declare class PhoneNumber extends React.Component<PhoneNumberProps, any> {}
+declare class Label extends React.Component<LabelProps, any> {}
+declare class InputGroup extends React.Component<InputGroupProps, any> {}
+declare class Tooltip extends React.Component<TooltipProps, any> {}
+declare class RadioBlock extends React.Component<RadioBlockProps, any> {}
+declare class RadioButton extends React.Component<RadioButtonProps, any> {}
+declare class RadioButtonInputGroup extends React.Component<
+    RadioButtonInputGroupProps,
+    any
+> {}
+declare class RadioSwitch extends React.Component<RadioSwitchProps, any> {}
+declare class TextArea extends React.Component<TextAreaProps, any> {}

--- a/packages/ffe-lists-react/README.md
+++ b/packages/ffe-lists-react/README.md
@@ -10,3 +10,8 @@ npm install --save @sb1/ffe-lists-react
 
 Run Styleguidist from the repository root to see live examples and documentation,
 or see the markdown files next to the component code in `src/`.
+
+## TypeScript definition files
+
+This component supports TypeScript - please update `index.d.ts` if you change any
+of the external methods or properties in this component.

--- a/packages/ffe-lists-react/package.json
+++ b/packages/ffe-lists-react/package.json
@@ -6,19 +6,22 @@
   "author": "SpareBank 1",
   "files": [
     "lib",
-    "es"
+    "es",
+    "types"
   ],
   "main": "lib/index.js",
   "module": "es/index.js",
+  "types": "types/index.d.ts",
   "sideEffects": false,
   "repository": {
     "type": "git",
     "url": "ssh://git@github.com:SpareBank1/designsystem.git"
   },
   "scripts": {
-    "build": "npm run build:cjs && npm run build:es",
+    "build": "npm run build:cjs && npm run build:es && npm run build:types",
     "build:cjs": "babel -d lib/. --root-mode=upward  --env-name=cjs --ignore=*.spec.js src/.",
     "build:es": "babel -d es/. --root-mode=upward --env-name=es --ignore=*.spec.js src/.",
+    "build:types": "copyfiles -f src/index.d.ts types/",
     "lint": "eslint src/.",
     "test": "jest",
     "test:watch": "jest --watch"

--- a/packages/ffe-lists-react/src/index.d.ts
+++ b/packages/ffe-lists-react/src/index.d.ts
@@ -1,0 +1,81 @@
+import * as React from 'react';
+
+export interface BaseListItemProps {
+    children?: React.ReactNode;
+    className?: string;
+}
+
+export interface BaseListProps {
+    children: React.ReactNode;
+    className?: string;
+}
+
+export interface BulletListProps extends BaseListProps {
+    condensed?: boolean;
+}
+
+export interface CheckListItemProps extends BaseListItemProps {
+    isCross?: boolean;
+}
+
+export interface CheckListProps extends BaseListProps {
+    columns?: 1 | 2 | '1' | '2';
+}
+
+export interface NumberedListProps extends BaseListProps {
+    condensed?: boolean;
+}
+
+export interface DescriptionListProps extends BaseListProps {
+    medium?: boolean;
+    large?: boolean;
+}
+
+declare class BulletList extends React.Component<
+    BulletListProps & React.HTMLAttributes<HTMLUListElement>,
+    any
+> {}
+declare class BulletListItem extends React.Component<
+    BaseListItemProps & React.LiHTMLAttributes<HTMLLIElement>,
+    any
+> {}
+declare class CheckList extends React.Component<
+    CheckListProps & React.HTMLAttributes<HTMLUListElement>,
+    any
+> {}
+declare class CheckListItem extends React.Component<
+    CheckListItemProps & React.LiHTMLAttributes<HTMLLIElement>,
+    any
+> {}
+declare class NumberedList extends React.Component<
+    NumberedListProps & React.OlHTMLAttributes<HTMLOListElement>,
+    any
+> {}
+declare class NumberedListItem extends React.Component<
+    BaseListItemProps & React.LiHTMLAttributes<HTMLLIElement>,
+    any
+> {}
+declare class StylizedNumberedList extends React.Component<
+    BaseListProps & React.OlHTMLAttributes<HTMLOListElement>,
+    any
+> {}
+declare class StylizedNumberedListItem extends React.Component<
+    BaseListItemProps & React.LiHTMLAttributes<HTMLLIElement>,
+    any
+> {}
+declare class DescriptionList extends React.Component<
+    DescriptionListProps & React.HTMLAttributes<HTMLDListElement>,
+    any
+> {}
+declare class DescriptionListMultiCol extends React.Component<
+    BaseListProps & React.HTMLAttributes<HTMLDivElement>,
+    any
+> {}
+declare class DescriptionListTerm extends React.Component<
+    BaseListItemProps & React.HTMLAttributes<HTMLElement>,
+    any
+> {}
+declare class DescriptionListDescription extends React.Component<
+    BaseListItemProps & React.HTMLAttributes<HTMLElement>,
+    any
+> {}

--- a/packages/ffe-message-box-react/README.md
+++ b/packages/ffe-message-box-react/README.md
@@ -10,3 +10,8 @@ npm install --save @sb1/ffe-message-box-react
 
 Run Styleguidist from the repository root to see live examples and documentation,
 or see the markdown files next to the component code in `src/`.
+
+## TypeScript definition files
+
+This component supports TypeScript - please update `index.d.ts` if you change any
+of the external methods or properties in this component.

--- a/packages/ffe-message-box-react/package.json
+++ b/packages/ffe-message-box-react/package.json
@@ -5,19 +5,22 @@
   "author": "SpareBank 1",
   "files": [
     "lib",
-    "es"
+    "es",
+    "types"
   ],
   "main": "lib/index.js",
   "module": "es/index.js",
+  "types": "types/index.d.ts",
   "sideEffects": false,
   "repository": {
     "type": "git",
     "url": "ssh://git@github.com:SpareBank1/designsystem.git"
   },
   "scripts": {
-    "build": "npm run build:cjs && npm run build:es",
+    "build": "npm run build:cjs && npm run build:es && npm run build:types",
     "build:cjs": "babel -d lib/. --root-mode=upward  --env-name=cjs --ignore=*.spec.js src/.",
     "build:es": "babel -d es/. --root-mode=upward --env-name=es --ignore=*.spec.js src/.",
+    "build:types": "copyfiles -f src/index.d.ts types/",
     "lint": "eslint src/.",
     "test": "jest",
     "test:watch": "jest --watch"

--- a/packages/ffe-message-box-react/src/index.d.ts
+++ b/packages/ffe-message-box-react/src/index.d.ts
@@ -1,0 +1,35 @@
+import * as React from 'react';
+
+export interface MessageBoxProps {
+    children?: React.ReactNode;
+    className?: string;
+    /**
+     * Deprecated. Use `children` instead.
+     * @deprecated
+     */
+    content?: React.ReactNode;
+    icon?: React.ReactNode;
+    title?: React.ReactNode;
+}
+
+export interface InfoMessageListItemProps {
+    children: string;
+    href?: string;
+}
+
+export interface InfoMessageListProps {
+    children: React.ReactNode;
+}
+
+declare class SuccessMessage extends React.Component<MessageBoxProps, any> {}
+declare class ErrorMessage extends React.Component<MessageBoxProps, any> {}
+declare class InfoMessage extends React.Component<MessageBoxProps, any> {}
+declare class TipsMessage extends React.Component<MessageBoxProps, any> {}
+declare class InfoMessageList extends React.Component<
+    InfoMessageListProps,
+    any
+> {}
+declare class InfoMessageListItem extends React.Component<
+    InfoMessageListItemProps,
+    any
+> {}

--- a/packages/ffe-system-message-react/src/index.d.ts
+++ b/packages/ffe-system-message-react/src/index.d.ts
@@ -5,7 +5,7 @@ export interface SystemMessageProps {
     className?: string;
     icon?: React.ReactNode;
     locale?: 'en' | 'nb' | 'nn';
-    onClose?: () => void;
+    onClose?: (e: React.MouseEvent | undefined) => void;
 }
 
 declare class SystemErrorMessage extends React.Component<

--- a/packages/ffe-tables-react/README.md
+++ b/packages/ffe-tables-react/README.md
@@ -12,3 +12,8 @@ npm install --save @sb1/ffe-tables-react
 
 Run Styleguidist from the repository root to see live examples and documentation,
 or see the markdown files next to the component code in `src/`.
+
+## TypeScript definition files
+
+This component supports TypeScript - please update `index.d.ts` if you change any
+of the external methods or properties in this component.

--- a/packages/ffe-tables-react/package.json
+++ b/packages/ffe-tables-react/package.json
@@ -5,19 +5,22 @@
   "license": "MIT",
   "files": [
     "lib",
-    "es"
+    "es",
+    "types"
   ],
   "main": "lib/index.js",
   "module": "es/index.js",
+  "types": "types/index.d.ts",
   "sideEffects": false,
   "repository": {
     "type": "git",
     "url": "ssh://git@github.com:SpareBank1/designsystem.git"
   },
   "scripts": {
-    "build": "npm run build:cjs && npm run build:es",
+    "build": "npm run build:cjs && npm run build:es && npm run build:types",
     "build:cjs": "babel -d lib/. --root-mode=upward  --env-name=cjs --ignore=*.spec.js src/.",
     "build:es": "babel -d es/. --root-mode=upward --env-name=es --ignore=*.spec.js src/.",
+    "build:types": "copyfiles -f src/index.d.ts types/",
     "lint": "eslint src/.",
     "test": "jest",
     "test:watch": "jest --watch"

--- a/packages/ffe-tables-react/src/index.d.ts
+++ b/packages/ffe-tables-react/src/index.d.ts
@@ -1,0 +1,127 @@
+import * as React from 'react';
+
+export interface RowRenderTrProps
+    extends React.HTMLAttributes<HTMLTableRowElement> {}
+
+export interface TableRowProps {
+    cells: Data;
+    columns: Column[];
+    expandable?: boolean;
+    expanded?: boolean;
+    onClick?: (e: React.MouseEvent | undefined) => void;
+    rowRender?: (
+        trprops: RowRenderTrProps,
+        props: TableRowProps,
+        rowIndex: number,
+    ) => JSX.Element;
+    headerRender?: (
+        trprops: HeaderRenderTrProps,
+        columns: Column[],
+    ) => JSX.Element;
+    footerRender?: (
+        trprops: HeaderRenderTrProps,
+        columns: Column[],
+    ) => JSX.Element;
+    onKeyDown?: (e: React.KeyboardEvent | undefined) => void;
+    trClasses?: string;
+    rowIndex?: number;
+}
+
+export interface SpanProps {
+    className?: string;
+}
+
+export interface ThProps {
+    className: string;
+    key: number;
+    'aria-sort': 'none' | 'ascending' | 'descending' | 'other';
+    scope: string;
+}
+
+export interface TdProps {
+    classNames: string;
+    'data-th': string;
+    key: number;
+}
+
+export interface Column {
+    header: React.ReactNode | '';
+    key: string;
+    footer?: React.ReactNode;
+    alignRight?: boolean;
+    alignTop?: boolean;
+    hideOnDesktop?: boolean;
+    hideOnTablet?: boolean;
+    hideOnSmallTablet?: boolean;
+    hideOnMobile?: boolean;
+    compare?: (a: any, b: any) => number;
+    notSortable?: boolean;
+    cellRender?: (
+        value: any,
+        col: Column,
+        props: TableRowProps,
+        index: number,
+    ) => JSX.Element;
+    columnHeaderRender?: (
+        value: React.ReactNode | '',
+        dataWindow: Data[],
+        spanProps: SpanProps,
+        thProps: ThProps,
+        columns: Column[],
+        index: number,
+    ) => JSX.Element;
+    columnFooterRender?: (
+        value: any,
+        dataWindow: Data[],
+        tdProps: TdProps,
+        spanProps: SpanProps,
+        columns: Column[],
+        index: number,
+    ) => JSX.Element;
+}
+
+export interface Data {
+    id?: string | number;
+    [propName: string]: any;
+}
+
+export interface HeaderRenderTrProps {
+    className: string;
+    children: any;
+}
+
+export interface TableProps {
+    caption?: React.ReactNode;
+    srOnlyCaption?: boolean;
+    expandedContentMapper?: (data: Data) => JSX.Element | false;
+    sortable?: boolean;
+    sortBy?: string;
+    descending?: boolean;
+    offset?: number;
+    limit?: number;
+    condensed?: boolean;
+    smallHeader?: boolean;
+    alignLeft?: boolean;
+    columnLayoutMobile?: boolean;
+    breakpoint?: 'sm' | 'none';
+    rowRender?: (
+        trprops: RowRenderTrProps,
+        props: TableRowProps,
+        rowIndex: number,
+    ) => JSX.Element;
+    headerRender?: (
+        trprops: HeaderRenderTrProps,
+        columns: Column[],
+    ) => JSX.Element;
+    footerRender?: (
+        trprops: HeaderRenderTrProps,
+        columns: Column[],
+    ) => JSX.Element;
+    data?: Data[];
+    columns?: Column[];
+    className?: string;
+}
+
+declare class Table extends React.Component<TableProps, any> {}
+
+export default Table;

--- a/packages/ffe-tabs-react/README.md
+++ b/packages/ffe-tabs-react/README.md
@@ -8,3 +8,8 @@ npm install --save @sb1/ffe-tabs-react
 
 Run Styleguidist from the repository root to see live examples and documentation,
 or see the markdown files next to the component code in `src/`.
+
+## TypeScript definition files
+
+This component supports TypeScript - please update `index.d.ts` if you change any
+of the external methods or properties in this component.

--- a/packages/ffe-tabs-react/package.json
+++ b/packages/ffe-tabs-react/package.json
@@ -5,19 +5,22 @@
   "author": "SpareBank 1",
   "files": [
     "lib",
-    "es"
+    "es",
+    "types"
   ],
   "main": "lib/index.js",
   "module": "es/index.js",
+  "types": "types/index.d.ts",
   "sideEffects": false,
   "repository": {
     "type": "git",
     "url": "ssh://git@github.com:SpareBank1/designsystem.git"
   },
   "scripts": {
-    "build": "npm run build:cjs && npm run build:es",
+    "build": "npm run build:cjs && npm run build:es && npm run build:types",
     "build:cjs": "babel -d lib/. --root-mode=upward  --env-name=cjs --ignore=*.spec.js src/.",
     "build:es": "babel -d es/. --root-mode=upward --env-name=es --ignore=*.spec.js src/.",
+    "build:types": "copyfiles -f src/index.d.ts types/",
     "lint": "eslint src/.",
     "test": "jest",
     "test:watch": "jest --watch"

--- a/packages/ffe-tabs-react/src/index.d.ts
+++ b/packages/ffe-tabs-react/src/index.d.ts
@@ -1,0 +1,28 @@
+import * as React from 'react';
+
+export interface TabProps
+    extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+    selected?: boolean;
+    condensed?: boolean;
+    className?: string;
+}
+
+export interface TabButtonProps
+    extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+    selected?: boolean;
+    ghost?: boolean;
+    condensed?: boolean;
+    className?: string;
+    dark?: boolean;
+}
+
+export interface TabGroupProps extends React.HTMLAttributes<HTMLDivElement> {
+    children: React.ReactNode;
+    className?: string;
+    thin?: boolean;
+}
+
+declare class Tab extends React.Component<TabProps, any> {}
+declare class TabButton extends React.Component<TabButtonProps, any> {}
+declare class TabGroup extends React.Component<TabGroupProps, any> {}
+declare class TabButtonGroup extends React.Component<TabGroupProps, any> {}


### PR DESCRIPTION
This PR adds typescript definition files, according to issue #598, for the following ffe-packages:
* ffe-message-box-react
* ffe-context-message-react
* ffe-lists-react
* ffe-buttons-react
* ffe-core-react
* ffe-dropdown-react
* ffe-form-react
* ffe-tables-react
* ffe-tabs-react

It also adds a fix to ffe-system-message-react ts definitions.

Please note that there is a breaking change in  ffe-form-react, where a few value-parameters have changed propType-definitions as well, according to HTML input value being a DOMString-attribute (https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/radio).