### PR TITLE
fix(ffe-form-react): propagate `dark` prop

### DIFF
--- a/packages/ffe-form-react/src/RadioButtonInputGroup.js
+++ b/packages/ffe-form-react/src/RadioButtonInputGroup.js
@@ -58,7 +58,7 @@ const RadioButtonInputGroup = props => {
                     {tooltipContent}
                 </legend>
             )}
-            {children(buttonProps)}
+            {children({ ...buttonProps, dark })}
             {fieldMessageContent}
         </fieldset>
     );

--- a/packages/ffe-form-react/src/RadioButtonInputGroup.md
+++ b/packages/ffe-form-react/src/RadioButtonInputGroup.md
@@ -36,3 +36,41 @@ initialState = { selected: 'red' };
     )}
 </RadioButtonInputGroup>;
 ```
+
+Variant _dark_ for interne løsninger med mørk bakgrunn.
+
+```js { "props": { "className": "sb1ds-example-dark" } }
+const { RadioButton } = require('.');
+const { Tooltip } = require('../../ffe-form-react');
+
+initialState = { selected: 'red' };
+
+<RadioButtonInputGroup
+    dark={true}
+    label="Hva er din favorittfarge?"
+    inline={true}
+    name="color"
+    fieldMessage={
+        state.selected === 'yellow' ? 'Gult er ikke kult.' : undefined
+    }
+    tooltip={
+        <Tooltip>Din favorittfarge er viktig for oss. Vår er blå!</Tooltip>
+    }
+    selectedValue={state.selected}
+    onChange={e => setState({ selected: e.target.value })}
+>
+    {inputProps => (
+        <React.Fragment>
+            <RadioButton {...inputProps} value="red">
+                Rød
+            </RadioButton>
+            <RadioButton {...inputProps} value="blue">
+                Blå
+            </RadioButton>
+            <RadioButton {...inputProps} value="yellow">
+                Gul
+            </RadioButton>
+        </React.Fragment>
+    )}
+</RadioButtonInputGroup>;
+```

--- a/packages/ffe-form-react/src/RadioButtonInputGroup.spec.js
+++ b/packages/ffe-form-react/src/RadioButtonInputGroup.spec.js
@@ -79,6 +79,26 @@ describe('<RadioButtonInputGroup />', () => {
                 }),
             );
         });
+        it('passes down "dark" property if set', () => {
+            const childrenSpy = jest.fn();
+            const wrapper = getWrapper({
+                dark: true,
+                children: childrenSpy,
+            });
+
+            expect(childrenSpy).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    dark: true,
+                }),
+            );
+
+            wrapper.setProps({ dark: false });
+            expect(childrenSpy).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    dark: false,
+                }),
+            );
+        });
         it(`passes down a default noop function to silence intermittent propType
             warnings about the radio buttons being controlled components without
             an onChange listener (which is a lie - the onChange is in RadioButtonInputGroup)`, () => {


### PR DESCRIPTION
`RadioButtonInputGroup` was not passing the `dark` prop to its
children function, meaning consumers. It now does, removing the
need for the consumer to manually apply it to all children in the
group.

Fixes #613

<!-- 
Thanks for opening a pull request! 🎉

If your changes include some kind of UI element, please attach a screenshot of 
how it looks.

Before submitting a pull request, please have a look through the CONTRIBUTING.md
document. TL;DR:

- Follow the conventional commit standard
- Write full, explanatory commit messages
- Follow our code standards
- Write tests where applicable
- Be courteous and respect our code of conduct
-->
