### PR TITLE
fix(ffe-form): Fix field-message text alignment

### DIFF
--- a/packages/ffe-form/less/field-info-message.less
+++ b/packages/ffe-form/less/field-info-message.less
@@ -20,7 +20,6 @@
         color: @ffe-white;
         background-color: @ffe-blue-royal;
         border-radius: 50%;
-        vertical-align: middle;
         padding: 2px;
         width: 18px;
         height: 18px;


### PR DESCRIPTION
Make the text centered vertically in relation to the icon
on all three types of field-message (info, error, success).

Fixes #609

<!-- 
Thanks for opening a pull request! 🎉

If your changes include some kind of UI element, please attach a screenshot of 
how it looks.

Before submitting a pull request, please have a look through the CONTRIBUTING.md
document. TL;DR:

- Follow the conventional commit standard
- Write full, explanatory commit messages
- Follow our code standards
- Write tests where applicable
- Be courteous and respect our code of conduct
-->
