### PR TITLE
fix(ffe-form-react): ARIA improvements to Tooltip

### DIFF
--- a/packages/ffe-form-react/src/Tooltip.js
+++ b/packages/ffe-form-react/src/Tooltip.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { bool, func, node, string, number } from 'prop-types';
 import classNames from 'classnames';
 import Collapse from 'react-css-collapse';
+import uuid from 'uuid';
 
 class Tooltip extends React.Component {
     constructor({ isOpen }) {
@@ -10,6 +11,7 @@ class Tooltip extends React.Component {
             isOpen: !!isOpen,
         };
         this.onToggle = this.onToggle.bind(this);
+        this.tooltipId = uuid.v4();
     }
 
     onToggle(evt) {
@@ -41,6 +43,8 @@ class Tooltip extends React.Component {
                 })}
             >
                 <button
+                    aria-expanded={isOpen}
+                    aria-controls={this.tooltipId}
                     aria-label={ariaLabel}
                     className={classNames('ffe-tooltip__icon', {
                         'ffe-tooltip--dark__icon': dark,
@@ -49,13 +53,13 @@ class Tooltip extends React.Component {
                     type="button"
                     tabIndex={tabIndex}
                 >
-                    ?
+                    <span aria-hidden={true}>?</span>
                 </button>
                 {children && (
                     <Collapse
-                        isOpen={isOpen}
                         className="ffe-tooltip__text"
-                        aria-expanded={String(isOpen)}
+                        id={this.tooltipId}
+                        isOpen={isOpen}
                     >
                         <div
                             className={classNames(
@@ -74,6 +78,7 @@ class Tooltip extends React.Component {
 }
 
 Tooltip.propTypes = {
+    /** Descriptive text for the Tooltip expand icon */
     'aria-label': string,
     /** The children are rendered in the expanded tooltip. */
     children: node,
@@ -89,6 +94,7 @@ Tooltip.propTypes = {
 };
 
 Tooltip.defaultProps = {
+    'aria-label': 'Vis hjelpetekst',
     dark: false,
 };
 

--- a/packages/ffe-form-react/src/Tooltip.spec.js
+++ b/packages/ffe-form-react/src/Tooltip.spec.js
@@ -36,8 +36,10 @@ describe('<Tooltip>', () => {
         const wrapper = getWrapper();
 
         expect(wrapper.find('Collapse').prop('isOpen')).toBe(false);
+        expect(wrapper.find('button').prop('aria-expanded')).toBe(false);
         wrapper.find('button').simulate('click');
         expect(wrapper.find('Collapse').prop('isOpen')).toBe(true);
+        expect(wrapper.find('button').prop('aria-expanded')).toBe(true);
     });
 
     it('toggles active state if button is clicked', () => {
@@ -55,5 +57,11 @@ describe('<Tooltip>', () => {
     it('haves a tabIndex if specified', () => {
         const wrapper = getWrapper({ tabIndex: -1 });
         expect(wrapper.find('button').prop('tabIndex')).toBe(-1);
+    });
+
+    it('connects the toggle button to the correct element', () => {
+        const wrapper = getWrapper();
+        const tipId = wrapper.find('Collapse').prop('id');
+        expect(wrapper.find('button').prop('aria-controls')).toBe(tipId);
     });
 });


### PR DESCRIPTION
* `aria-expanded` is now applied to the correct element (the button)
* Added `aria-controls` to the button
* Added a default value `aria-label` ("Vis hjelpetekst") for the button. This can be overridden if e.g. your application has i18n.

Fixes #504

<!-- 
Thanks for opening a pull request! 🎉

If your changes include some kind of UI element, please attach a screenshot of 
how it looks.

Before submitting a pull request, please have a look through the CONTRIBUTING.md
document. TL;DR:

- Follow the conventional commit standard
- Write full, explanatory commit messages
- Follow our code standards
- Write tests where applicable
- Be courteous and respect our code of conduct
-->
