### PR TITLE
fix(ffe-buttons-react): a11y improvements to `ExpandButton`

### DIFF
--- a/packages/ffe-buttons-react/src/ExpandButton.js
+++ b/packages/ffe-buttons-react/src/ExpandButton.js
@@ -3,10 +3,11 @@ import { bool, func, oneOfType, string, node } from 'prop-types';
 import classNames from 'classnames';
 import KryssIkon from '@sb1/ffe-icons-react/lib/kryss-ikon';
 
-const ExpandButton = (props) => {
+const ExpandButton = props => {
     const {
         children,
         className,
+        closeLabel,
         element: Element,
         innerRef,
         isExpanded,
@@ -17,6 +18,7 @@ const ExpandButton = (props) => {
     return (
         <Element
             aria-expanded={isExpanded}
+            aria-label={isExpanded ? closeLabel : undefined}
             className={classNames(
                 'ffe-button',
                 'ffe-button--expand',
@@ -27,28 +29,34 @@ const ExpandButton = (props) => {
             {...rest}
         >
             {isExpanded && <KryssIkon className="ffe-button__icon" />}
-            {!isExpanded &&
+            {!isExpanded && (
                 <Fragment>
                     {leftIcon &&
-                        React.cloneElement(leftIcon, { className: 'ffe-button__icon ffe-button__icon--left' })
-                    }
+                        React.cloneElement(leftIcon, {
+                            className:
+                                'ffe-button__icon ffe-button__icon--left',
+                        })}
                     {children}
                     {rightIcon &&
-                        React.cloneElement(rightIcon, { className: 'ffe-button__icon ffe-button__icon--right' })
-                    }
+                        React.cloneElement(rightIcon, {
+                            className:
+                                'ffe-button__icon ffe-button__icon--right',
+                        })}
                 </Fragment>
-            }
+            )}
         </Element>
     );
 };
 
 ExpandButton.propTypes = {
     /** The button label */
-    children: node,
+    children: node.isRequired,
     /** Extra class names */
     className: string,
     /** The rendered element, like an `<a />` or `<Link />` */
     element: oneOfType([func, string]),
+    /** An accessible label for the close-button, only shown in the "isExpanded" state  */
+    closeLabel: string,
     /** Icon shown to the left of the label */
     leftIcon: node,
     /** Icon shown to the right of the label */
@@ -62,7 +70,8 @@ ExpandButton.propTypes = {
 };
 
 ExpandButton.defaultProps = {
+    closeLabel: 'Lukk',
     element: 'button',
-}
+};
 
 export default ExpandButton;

--- a/packages/ffe-buttons-react/src/ExpandButton.spec.js
+++ b/packages/ffe-buttons-react/src/ExpandButton.spec.js
@@ -27,11 +27,15 @@ describe('<ExpandButton />', () => {
     });
     it('renders leftIcon and rightIcon', () => {
         const wrapper = getWrapper({
-            leftIcon: (<BestikkIkon />),
-            rightIcon: (<BamseIkon />),
+            leftIcon: <BestikkIkon />,
+            rightIcon: <BamseIkon />,
         });
         expect(wrapper.find(BestikkIkon).exists()).toBe(true);
         expect(wrapper.find(BamseIkon).exists()).toBe(true);
+    });
+    it('does not use an aria-label since the button itself has a children acting as label', () => {
+        const wrapper = getWrapper();
+        expect(wrapper.prop('aria-label')).toBe(undefined);
     });
     describe('when expanded', () => {
         it('does not render children', () => {
@@ -40,9 +44,9 @@ describe('<ExpandButton />', () => {
         });
         it('does not render leftIcon and rightIcon', () => {
             const wrapper = getWrapper({
-                leftIcon: (<BestikkIkon />),
+                leftIcon: <BestikkIkon />,
                 isExpanded: true,
-                rightIcon: (<BamseIkon />),
+                rightIcon: <BamseIkon />,
             });
             expect(wrapper.find(BestikkIkon).exists()).toBe(false);
             expect(wrapper.find(BamseIkon).exists()).toBe(false);
@@ -58,7 +62,15 @@ describe('<ExpandButton />', () => {
         it('renders a KryssIkon', () => {
             const wrapper = getWrapper({ isExpanded: true });
             expect(wrapper.find(KryssIkon).exists()).toBe(true);
-            expect(wrapper.find(KryssIkon).hasClass('ffe-button__icon')).toBe(true);
+            expect(wrapper.find(KryssIkon).hasClass('ffe-button__icon')).toBe(
+                true,
+            );
+        });
+        it('uses the default aria-label property on the button', () => {
+            const wrapper = getWrapper({ isExpanded: true });
+            expect(wrapper.prop('aria-label')).toBe(
+                ExpandButton.defaultProps.closeLabel,
+            );
         });
     });
 });


### PR DESCRIPTION
* The `children` prop is now required, since it provides the button label in the closed state
* A new prop `closeLabel` is introduced for showing an accessible label in the expanded state, where no visible label is rendered. It defaults to "Lukk" but can be overriden

Fixes #619

<!-- 
Thanks for opening a pull request! 🎉

If your changes include some kind of UI element, please attach a screenshot of 
how it looks.

Before submitting a pull request, please have a look through the CONTRIBUTING.md
document. TL;DR:

- Follow the conventional commit standard
- Write full, explanatory commit messages
- Follow our code standards
- Write tests where applicable
- Be courteous and respect our code of conduct
-->
