### PR TITLE
Add required ariaControls to Tab and TabButton

### DIFF
--- a/packages/ffe-tabs-react/src/Tab.js
+++ b/packages/ffe-tabs-react/src/Tab.js
@@ -26,4 +26,6 @@ Tab.propTypes = {
     condensed: bool,
     /** Additional css classes */
     className: string,
+    /** Id of the element it controls */
+    'aria-controls': string.isRequired,
 };

--- a/packages/ffe-tabs-react/src/Tab.spec.js
+++ b/packages/ffe-tabs-react/src/Tab.spec.js
@@ -29,6 +29,12 @@ describe('Tab', () => {
         expect(wrapper.prop('aria-selected')).toBe(false);
     });
 
+    it('should have aria-controls attribute when passed to it', () => {
+        const controlId = 'controlId';
+        const wrapper = shallow(<Tab aria-controls={controlId}>En tab</Tab>);
+        expect(wrapper.prop('aria-controls')).toBe(controlId);
+    });
+
     it('passes any prop on to a tab', () => {
         const tab = shallow(<Tab data-analytics-track="logMe">En tab</Tab>);
         expect(tab.prop('data-analytics-track')).toBe('logMe');

--- a/packages/ffe-tabs-react/src/TabButton.js
+++ b/packages/ffe-tabs-react/src/TabButton.js
@@ -32,6 +32,8 @@ TabButton.propTypes = {
     className: string,
     /** Dark variant */
     dark: bool,
+    /** Id of the element it controls */
+    'aria-controls': string.isRequired,
 };
 
 TabButton.defaultProps = {

--- a/packages/ffe-tabs-react/src/TabButton.spec.js
+++ b/packages/ffe-tabs-react/src/TabButton.spec.js
@@ -34,6 +34,14 @@ describe('TabButton', () => {
         expect(wrapper.prop('aria-selected')).toBe(false);
     });
 
+    it('should have aria-controls attribute when passed to it', () => {
+        const controldId = 'controlId';
+        const wrapper = shallow(
+            <TabButton aria-controls={controldId}>En tab</TabButton>,
+        );
+        expect(wrapper.prop('aria-controls')).toBe(controldId);
+    });
+
     it('passes any prop on to a tab button', () => {
         const tab = shallow(
             <TabButton data-analytics-track="logMe">En tab</TabButton>,

--- a/packages/ffe-tabs-react/src/TabButtonGroup.md
+++ b/packages/ffe-tabs-react/src/TabButtonGroup.md
@@ -19,3 +19,66 @@ const TabButton = require('./TabButton').default;
     <TabButton>Dette er en annen tab button</TabButton>
 </TabButtonGroup>;
 ```
+
+Eksempel med innhold knyttet til hver tab:
+
+```js
+const { HusIkon, BilIkon } = require('../../ffe-icons-react');
+
+const displayNone = {
+    display: 'none',
+};
+
+const loan = { house: 'house', car: 'car' };
+initialState = { activeTabId: loan.house };
+
+<React.Fragment>
+    <TabButtonGroup>
+        <TabButton
+            selected={state.activeTabId === loan.house}
+            onClick={() => {
+                setState({ activeTabId: loan.house });
+            }}
+            aria-controls={loan.house}
+        >
+            Huslån
+        </TabButton>
+
+        <TabButton
+            selected={state.activeTabId === loan.car}
+            onClick={() => {
+                setState({ activeTabId: loan.car });
+            }}
+            aria-controls={loan.car}
+        >
+            Billån
+        </TabButton>
+    </TabButtonGroup>
+
+    <IconCard
+        icon={<HusIkon />}
+        id={loan.house}
+        style={state.activeTabId === loan.house ? null : displayNone}
+    >
+        {({ Title, Subtext }) => (
+            <React.Fragment>
+                <Title>Huslån</Title>
+                <Subtext>Ta opp huslån</Subtext>
+            </React.Fragment>
+        )}
+    </IconCard>
+
+    <IconCard
+        icon={<BilIkon />}
+        id={loan.car}
+        style={state.activeTabId === loan.car ? null : displayNone}
+    >
+        {({ Title, Subtext }) => (
+            <React.Fragment>
+                <Title>Billån</Title>
+                <Subtext>Ta opp billån</Subtext>
+            </React.Fragment>
+        )}
+    </IconCard>
+</React.Fragment>;
+```

--- a/packages/ffe-tabs-react/src/TabGroup.md
+++ b/packages/ffe-tabs-react/src/TabGroup.md
@@ -21,3 +21,68 @@ const Tab = require('./Tab').default;
     <Tab>Dette er en annen tab</Tab>
 </TabGroup>;
 ```
+
+Eksempel med innhold knyttet til hver tab:
+
+```js
+const { HusIkon, BilIkon } = require('../../ffe-icons-react');
+
+const displayNone = {
+    display: 'none',
+};
+
+const loan = { house: 'house', car: 'car' };
+initialState = { activeTabId: loan.house };
+
+<React.Fragment>
+    <TabGroup>
+        <Tab
+            selected={state.activeTabId === loan.house}
+            onClick={() => {
+                setState({ activeTabId: loan.house });
+            }}
+            aria-controls={loan.house}
+        >
+            Huslån
+        </Tab>
+
+        <Tab
+            selected={state.activeTabId === loan.car}
+            onClick={() => {
+                setState({ activeTabId: loan.car });
+            }}
+            aria-controls={loan.car}
+        >
+            Billån
+        </Tab>
+    </TabGroup>
+
+    <IconCard
+        role="tabpanel"
+        icon={<HusIkon />}
+        id={loan.house}
+        style={state.activeTabId === loan.house ? null : displayNone}
+    >
+        {({ Title, Subtext }) => (
+            <React.Fragment>
+                <Title>Huslån</Title>
+                <Subtext>Ta opp huslån</Subtext>
+            </React.Fragment>
+        )}
+    </IconCard>
+
+    <IconCard
+        role="tabpanel"
+        icon={<BilIkon />}
+        id={loan.car}
+        style={state.activeTabId === loan.car ? null : displayNone}
+    >
+        {({ Title, Subtext }) => (
+            <React.Fragment>
+                <Title>Billån</Title>
+                <Subtext>Ta opp billån</Subtext>
+            </React.Fragment>
+        )}
+    </IconCard>
+</React.Fragment>;
+```


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request! 🎉

If your changes include some kind of UI element, please attach a screenshot of 
how it looks.

Before submitting a pull request, please have a look through the CONTRIBUTING.md
document. TL;DR:

- Follow the conventional commit standard
- Write full, explanatory commit messages
- Follow our code standards
- Write tests where applicable
- Be courteous and respect our code of conduct
-->

Adds a required property called ariaControls which is set as `aria-controls` for the element.

This pull request also introduces examples of how to use the tab and tab button with content related to the tabs.

Tab example:

![Tab example](https://user-images.githubusercontent.com/7822644/57468892-ac649300-7285-11e9-893d-944278740193.gif)

TabButton example:

![TabButton example](https://user-images.githubusercontent.com/7822644/57468912-b71f2800-7285-11e9-8cef-d5524dc80059.gif)


Fixes #626 
