### PR TITLE
Save space for error messages in order to avoid page jumps on validation

### DIFF
--- a/packages/ffe-form-react/package.json
+++ b/packages/ffe-form-react/package.json
@@ -48,7 +48,7 @@
   },
   "peerDependencies": {
     "@sb1/ffe-core": "^14.0.2",
-    "@sb1/ffe-form": "^10.1.1",
+    "@sb1/ffe-form": "^10.1.1 || 11.x",
     "react": "^16.3.0"
   },
   "publishConfig": {

--- a/packages/ffe-form-react/src/BaseFieldMessage.js
+++ b/packages/ffe-form-react/src/BaseFieldMessage.js
@@ -6,20 +6,27 @@ import classNames from 'classnames';
  * Internal factory component
  * @ignore
  */
-const BaseFieldMessage = ({ children, className, type, ...rest }) => {
+const BaseFieldMessage = props => {
+    const { children, className, element: Element, type, ...rest } = props;
+
     return (
-        <div
+        <Element
             className={classNames(`ffe-field-${type}-message`, className)}
             {...rest}
         >
             {children}
-        </div>
+        </Element>
     );
+};
+
+BaseFieldMessage.defaultProps = {
+    element: 'div',
 };
 
 BaseFieldMessage.propTypes = {
     children: node.isRequired,
     className: string,
+    element: string,
     type: oneOf(['success', 'info', 'error']).isRequired,
 };
 

--- a/packages/ffe-form-react/src/InputGroup.js
+++ b/packages/ffe-form-react/src/InputGroup.js
@@ -17,6 +17,7 @@ class InputGroup extends Component {
         const {
             children,
             className,
+            extraMargin,
             description,
             label,
             fieldMessage,
@@ -64,7 +65,14 @@ class InputGroup extends Component {
                 : React.cloneElement(children, extraProps);
 
         return (
-            <div className={classNames('ffe-input-group', className)} {...rest}>
+            <div
+                className={classNames(
+                    'ffe-input-group',
+                    { 'ffe-input-group--no-extra-margin': !extraMargin },
+                    className,
+                )}
+                {...rest}
+            >
                 {typeof label === 'string' && (
                     <Label htmlFor={this.id}>{label}</Label>
                 )}
@@ -86,7 +94,9 @@ class InputGroup extends Component {
                 {modifiedChildren}
 
                 {typeof fieldMessage === 'string' && (
-                    <ErrorFieldMessage>{fieldMessage}</ErrorFieldMessage>
+                    <ErrorFieldMessage element="p">
+                        {fieldMessage}
+                    </ErrorFieldMessage>
                 )}
                 {React.isValidElement(fieldMessage) && fieldMessage}
             </div>
@@ -100,6 +110,11 @@ InputGroup.propTypes = {
     /** Unless you only have one element in your `InputGroup` you will have to use the function-as-a-child pattern. */
     children: oneOfType([func, node]).isRequired,
     className: string,
+    /** Reserve space for showing `fieldMessage`s so content below don't move
+     *  vertically if an errormessage shows up. Note that this will only reserve
+     *  space for one line of content, so keep messages short.
+     */
+    extraMargin: bool,
     /** Use the ErrorFieldMessage component if you need more flexibility in how the content is rendered. */
     fieldMessage: oneOfType([string, node]),
     /** To just render a static, always visible tooltip, use this. */
@@ -109,6 +124,10 @@ InputGroup.propTypes = {
     onTooltipToggle: func,
     /** Use the Tooltip component if you need more flexibility in how the content is rendered. */
     tooltip: oneOfType([bool, string, instanceOfComponent(Tooltip)]),
+};
+
+InputGroup.defaultProps = {
+    extraMargin: true,
 };
 
 export default InputGroup;

--- a/packages/ffe-form-react/src/InputGroup.md
+++ b/packages/ffe-form-react/src/InputGroup.md
@@ -2,12 +2,29 @@ En _input group_ er en standarisert omverden for enkelt-inputs i et skjema. En g
 tooltip, skjemaelementet, og en feilmelding for valideringsfeil som vil bli vist om det er feil i skjemaet.
 
 ```js
-const { Input } = require('.');
+const { DatePicker } = require('../../ffe-datepicker-react');
+const { DropDown } = require('../../ffe-dropdown-react');
+const { Checkbox, Input, TextArea } = require('.');
+const { SecondaryButton } = require('../../ffe-buttons-react');
+
+initialState = { showErrors: false };
 
 <React.Fragment>
+    <div className="ffe-button-group">
+        <SecondaryButton
+            onClick={() =>
+                setState(prevState => ({
+                    showErrors: !prevState.showErrors,
+                }))
+            }
+        >
+            Skru feilmeldinger av/på
+        </SecondaryButton>
+    </div>
     <InputGroup
         label="Telefonnummer"
         tooltip="Vi bruker telefonnummer for å sende deg kvittering på SMS"
+        fieldMessage={state.showErrors ? 'Ugyldig telefonnummer' : null}
     >
         <Input
             type="tel"
@@ -17,8 +34,138 @@ const { Input } = require('.');
         />
     </InputGroup>
 
-    <InputGroup label="E-postadresse" fieldMessage="Ugyldig e-postadresse">
+    <InputGroup
+        label="E-postadresse"
+        fieldMessage={state.showErrors ? 'Ugyldig e-postadresse' : null}
+    >
         <Input />
+    </InputGroup>
+
+    <InputGroup
+        label="Måned"
+        fieldMessage={state.showErrors ? 'Du må velge måned' : null}
+    >
+        <Dropdown defaultValue="placeholder">
+            <option value="placeholder" disabled>
+                Velg måned
+            </option>
+            <option value="jan">Januar</option>
+            <option value="feb">Februar</option>
+            <option value="mar">Mars</option>
+        </Dropdown>
+    </InputGroup>
+
+    <InputGroup
+        label="Fritekst"
+        fieldMessage={state.showErrors ? 'Du må skrive noe lurt' : null}
+    >
+        <TextArea rows={4} />
+    </InputGroup>
+
+    <InputGroup
+        label="Dato"
+        fieldMessage={state.showErrors ? 'Feil dato' : null}
+    >
+        <Datepicker
+            language="nb"
+            maxDate="31.12.2016"
+            minDate="01.01.2016"
+            onChange={f => f}
+            value={'01.01.2016'}
+        />
+    </InputGroup>
+
+    <InputGroup fieldMessage={state.showErrors ? 'Ooops' : null}>
+        <Checkbox name="check">Kryssboks</Checkbox>
+    </InputGroup>
+</React.Fragment>;
+```
+
+Default oppførsel er at det holdes av plass under inputfeltene for å vise en feilmelding uten at innholdet lengre ned endres. Dersom man ikke ønsker dette kan det skrus
+av med å sette `extraMargin` prop til `false`.
+
+```js
+const { SecondaryButton } = require('../../ffe-buttons-react');
+const { Input } = require('.');
+
+initialState = { showErrors: false };
+
+<React.Fragment>
+    <div className="ffe-button-group">
+        <SecondaryButton
+            onClick={() =>
+                setState(prevState => ({
+                    showErrors: !prevState.showErrors,
+                }))
+            }
+        >
+            Skru feilmeldinger av/på
+        </SecondaryButton>
+    </div>
+    <InputGroup
+        extraMargin={false}
+        label="Telefonnummer"
+        tooltip="Vi bruker telefonnummer for å sende deg kvittering på SMS"
+        fieldMessage={state.showErrors ? 'Ugyldig telefonnummer' : null}
+    >
+        <Input
+            type="tel"
+            name="mobile"
+            onChange={e => console.log('onChange', e.target.value)}
+            onBlur={e => console.log('onBlur', e.target.value)}
+        />
+    </InputGroup>
+
+    <InputGroup
+        extraMargin={false}
+        label="E-postadresse"
+        fieldMessage={state.showErrors ? 'Ugyldig e-postadresse' : null}
+    >
+        <Input />
+    </InputGroup>
+
+    <InputGroup
+        extraMargin={false}
+        label="Måned"
+        fieldMessage={state.showErrors ? 'Du må velge måned' : null}
+    >
+        <Dropdown defaultValue="placeholder">
+            <option value="placeholder" disabled>
+                Velg måned
+            </option>
+            <option value="jan">Januar</option>
+            <option value="feb">Februar</option>
+            <option value="mar">Mars</option>
+        </Dropdown>
+    </InputGroup>
+
+    <InputGroup
+        extraMargin={false}
+        label="Fritekst"
+        fieldMessage={state.showErrors ? 'Du må skrive noe lurt' : null}
+    >
+        <TextArea rows={4} />
+    </InputGroup>
+
+    <InputGroup
+        extraMargin={false}
+        label="Dato"
+        fieldMessage={state.showErrors ? 'Feil dato' : null}
+    >
+        <Datepicker
+            language="nb"
+            maxDate="31.12.2016"
+            minDate="01.01.2016"
+            onChange={f => f}
+            value={'01.01.2016'}
+        />
+    </InputGroup>
+
+    <InputGroup
+        extraMargin={false}
+        fieldMessage={state.showErrors ? 'Ooops' : null}
+    >
+        <Checkbox name="check">Kryssboks</Checkbox>
     </InputGroup>
 </React.Fragment>;
 ```

--- a/packages/ffe-form-react/src/RadioBlock.js
+++ b/packages/ffe-form-react/src/RadioBlock.js
@@ -11,6 +11,12 @@ class RadioBlock extends Component {
             checked,
             children,
             className,
+            /* Support for the dark theme has not been added for this component
+             * but since we're passing props onwards to DOM nodes we need to make
+             * sure we don't pass this as part of "inputProps" since it's not being
+             * used but can still be passed down from a parent `RadioButtonInputGroup`.
+             */
+            dark, //eslint-disable-line
             label,
             name,
             selectedValue,

--- a/packages/ffe-form-react/src/RadioButtonInputGroup.js
+++ b/packages/ffe-form-react/src/RadioButtonInputGroup.js
@@ -12,13 +12,13 @@ const ensureComponent = Comp => (input, dark) => {
 };
 
 const ensureTooltip = ensureComponent(Tooltip);
-const ensureFieldMessage = ensureComponent(ErrorFieldMessage);
 
 const RadioButtonInputGroup = props => {
     const {
         'aria-invalid': ariaInvalid,
         children,
         className,
+        extraMargin,
         fieldMessage,
         inline,
         label,
@@ -38,12 +38,15 @@ const RadioButtonInputGroup = props => {
     };
 
     const tooltipContent = tooltip && ensureTooltip(tooltip, dark);
-    const fieldMessageContent =
-        fieldMessage && ensureFieldMessage(fieldMessage);
 
     return (
         <fieldset
-            className={classNames('ffe-fieldset', 'ffe-input-group', className)}
+            className={classNames(
+                'ffe-fieldset',
+                'ffe-input-group',
+                { 'ffe-fieldset--no-extra-margin': !extraMargin },
+                className,
+            )}
             {...rest}
         >
             {label && (
@@ -59,7 +62,13 @@ const RadioButtonInputGroup = props => {
                 </legend>
             )}
             {children({ ...buttonProps, dark })}
-            {fieldMessageContent}
+
+            {typeof fieldMessage === 'string' && (
+                <ErrorFieldMessage element="p">
+                    {fieldMessage}
+                </ErrorFieldMessage>
+            )}
+            {React.isValidElement(fieldMessage) && fieldMessage}
         </fieldset>
     );
 };
@@ -78,6 +87,11 @@ RadioButtonInputGroup.propTypes = {
     children: func.isRequired,
     /** Additional class names applied to the fieldset */
     className: string,
+    /** Reserve space for showing `fieldMessage`s so content below don't move
+     *  vertically if an errormessage shows up. Note that this will only reserve
+     *  space for one line of content, so keep messages short.
+     */
+    extraMargin: bool,
     /** String or ErrorFieldMessage component with message */
     fieldMessage: oneOfType([node, string]),
     /**
@@ -107,6 +121,7 @@ RadioButtonInputGroup.propTypes = {
 };
 
 RadioButtonInputGroup.defaultProps = {
+    extraMargin: true,
     dark: false,
 };
 

--- a/packages/ffe-form-react/src/RadioButtonInputGroup.md
+++ b/packages/ffe-form-react/src/RadioButtonInputGroup.md
@@ -4,37 +4,227 @@ være et spørsmål:
 
 ```js
 const { RadioButton } = require('.');
-const { Tooltip } = require('../../ffe-form-react');
+const { RadioBlock, RadioSwitch, Tooltip } = require('../../ffe-form-react');
 
-initialState = { selected: 'red' };
+initialState = {
+    selected: 'red',
+    showErrors: false,
+};
 
-<RadioButtonInputGroup
-    label="Hva er din favorittfarge?"
-    inline={true}
-    name="color"
-    fieldMessage={
-        state.selected === 'yellow' ? 'Gult er ikke kult.' : undefined
-    }
-    tooltip={
-        <Tooltip>Din favorittfarge er viktig for oss. Vår er blå!</Tooltip>
-    }
-    selectedValue={state.selected}
-    onChange={e => setState({ selected: e.target.value })}
->
-    {inputProps => (
-        <React.Fragment>
-            <RadioButton {...inputProps} value="red">
-                Rød
-            </RadioButton>
-            <RadioButton {...inputProps} value="blue">
-                Blå
-            </RadioButton>
-            <RadioButton {...inputProps} value="yellow">
-                Gul
-            </RadioButton>
-        </React.Fragment>
-    )}
-</RadioButtonInputGroup>;
+<React.Fragment>
+    <div className="ffe-button-group">
+        <SecondaryButton
+            onClick={() =>
+                setState(prevState => ({
+                    showErrors: !prevState.showErrors,
+                }))
+            }
+        >
+            Skru feilmeldinger av/på
+        </SecondaryButton>
+    </div>
+    <RadioButtonInputGroup
+        label="Hva er din favorittfarge?"
+        inline={true}
+        name="color"
+        fieldMessage={state.showErrors ? 'Feil farge.' : null}
+        tooltip={
+            <Tooltip>Din favorittfarge er viktig for oss. Vår er blå!</Tooltip>
+        }
+        selectedValue={state.selected}
+        onChange={e => setState({ selected: e.target.value })}
+    >
+        {inputProps => (
+            <React.Fragment>
+                <RadioButton {...inputProps} value="red">
+                    Rød
+                </RadioButton>
+                <RadioButton {...inputProps} value="blue">
+                    Blå
+                </RadioButton>
+                <RadioButton {...inputProps} value="yellow">
+                    Gul
+                </RadioButton>
+            </React.Fragment>
+        )}
+    </RadioButtonInputGroup>
+
+    <RadioButtonInputGroup
+        label="Hva er din favorittlukt?"
+        inline={true}
+        name="smell"
+        fieldMessage={state.showErrors ? 'Feil lukt.' : null}
+        selectedValue={state.selected}
+        onChange={e => setState({ selected: e.target.value })}
+    >
+        {inputProps => (
+            <React.Fragment>
+                <RadioButton {...inputProps} value="grass">
+                    Gress
+                </RadioButton>
+                <RadioButton {...inputProps} value="asphalt">
+                    Asfalt
+                </RadioButton>
+                <RadioButton {...inputProps} value="pollen">
+                    Pollen
+                </RadioButton>
+            </React.Fragment>
+        )}
+    </RadioButtonInputGroup>
+
+    <RadioButtonInputGroup
+        label="Velg ja eller nei"
+        name="switch"
+        fieldMessage={state.showErrors ? 'Feil valg' : null}
+    >
+        {inputProps => (
+            <RadioSwitch
+                leftLabel="Ja"
+                leftValue={true}
+                rightLabel="Nei"
+                rightValue={false}
+                {...inputProps}
+            />
+        )}
+    </RadioButtonInputGroup>
+
+    <RadioButtonInputGroup
+        label="Velg ja eller nei"
+        name="block1"
+        selectedValue="yes"
+        fieldMessage={state.showErrors ? 'Feil valg' : null}
+    >
+        {inputProps => (
+            <React.Fragment>
+                <RadioBlock {...inputProps} label="Ja" value="yes" />
+                <RadioBlock
+                    {...inputProps}
+                    label="Nei"
+                    showChildren={true}
+                    value="no"
+                >
+                    Vil ikke!
+                </RadioBlock>
+            </React.Fragment>
+        )}
+    </RadioButtonInputGroup>
+</React.Fragment>;
+```
+
+Default oppførsel er at det holdes av plass under inputfeltene for å vise en feilmelding uten at innholdet lengre ned endres. Dersom man ikke ønsker dette kan det skrus
+av med å sette `extraMargin` prop til `false`.
+
+```js
+const { RadioButton } = require('.');
+const { RadioBlock, RadioSwitch, Tooltip } = require('../../ffe-form-react');
+
+initialState = {
+    selected: 'red',
+    showErrors: false,
+};
+
+<React.Fragment>
+    <div className="ffe-button-group">
+        <SecondaryButton
+            onClick={() =>
+                setState(prevState => ({
+                    showErrors: !prevState.showErrors,
+                }))
+            }
+        >
+            Skru feilmeldinger av/på
+        </SecondaryButton>
+    </div>
+    <RadioButtonInputGroup
+        extraMargin={false}
+        label="Hva er din favorittfarge?"
+        inline={true}
+        name="color"
+        fieldMessage={state.showErrors ? 'Feil farge.' : null}
+        tooltip={
+            <Tooltip>Din favorittfarge er viktig for oss. Vår er blå!</Tooltip>
+        }
+        selectedValue={state.selected}
+        onChange={e => setState({ selected: e.target.value })}
+    >
+        {inputProps => (
+            <React.Fragment>
+                <RadioButton {...inputProps} value="red">
+                    Rød
+                </RadioButton>
+                <RadioButton {...inputProps} value="blue">
+                    Blå
+                </RadioButton>
+                <RadioButton {...inputProps} value="yellow">
+                    Gul
+                </RadioButton>
+            </React.Fragment>
+        )}
+    </RadioButtonInputGroup>
+
+    <RadioButtonInputGroup
+        extraMargin={false}
+        label="Hva er din favorittlukt?"
+        inline={true}
+        name="smell"
+        fieldMessage={state.showErrors ? 'Feil lukt.' : null}
+        selectedValue={state.selected}
+        onChange={e => setState({ selected: e.target.value })}
+    >
+        {inputProps => (
+            <React.Fragment>
+                <RadioButton {...inputProps} value="grass">
+                    Gress
+                </RadioButton>
+                <RadioButton {...inputProps} value="asphalt">
+                    Asfalt
+                </RadioButton>
+                <RadioButton {...inputProps} value="pollen">
+                    Pollen
+                </RadioButton>
+            </React.Fragment>
+        )}
+    </RadioButtonInputGroup>
+
+    <RadioButtonInputGroup
+        extraMargin={false}
+        label="Velg ja eller nei"
+        name="switch"
+        fieldMessage={state.showErrors ? 'Feil valg' : null}
+    >
+        {inputProps => (
+            <RadioSwitch
+                leftLabel="Ja"
+                leftValue={true}
+                rightLabel="Nei"
+                rightValue={false}
+                {...inputProps}
+            />
+        )}
+    </RadioButtonInputGroup>
+
+    <RadioButtonInputGroup
+        extraMargin={false}
+        label="Velg ja eller nei"
+        name="block2"
+        selectedValue="yes"
+        fieldMessage={state.showErrors ? 'Feil valg' : null}
+    >
+        {inputProps => (
+            <React.Fragment>
+                <RadioBlock {...inputProps} label="Ja" value="yes" />
+                <RadioBlock
+                    {...inputProps}
+                    label="Nei"
+                    showChildren={true}
+                    value="no"
+                >
+                    Vil ikke!
+                </RadioBlock>
+            </React.Fragment>
+        )}
+    </RadioButtonInputGroup>
+</React.Fragment>;
 ```
 
 Variant _dark_ for interne løsninger med mørk bakgrunn.

--- a/packages/ffe-form-react/src/index.d.ts
+++ b/packages/ffe-form-react/src/index.d.ts
@@ -22,9 +22,10 @@ export interface CheckboxProps
 }
 
 export interface BaseFieldMessageProps
-    extends React.HTMLAttributes<HTMLDivElement> {
+    extends React.HTMLAttributes<HTMLElement> {
     children: React.ReactNode;
     className?: string;
+    element?: string;
 }
 
 export interface InputProps
@@ -63,6 +64,7 @@ export interface InputGroupProps extends React.HTMLAttributes<HTMLDivElement> {
     /** Unless you only have one element in your `InputGroup` you will have to use the function-as-a-child pattern. */
     children: JSX.Element;
     className?: string;
+    extraMargin?: boolean;
     fieldMessage?: string | React.ReactNode;
     description?: string;
     label?: string | Label;
@@ -84,6 +86,12 @@ export interface RadioBlockProps
     checked?: boolean;
     children?: React.ReactNode;
     className?: string;
+    /* Support for the dark theme has not been added for this component
+     * but can still be passed down from a parent `RadioButtonInputGroup`.
+     * It should not be passed down manually unless support for dark theme
+     * is implemented.
+     */
+    dark?: boolean;
     label: string | React.ReactNode;
     name: string;
     selectedValue?: string;
@@ -115,6 +123,7 @@ export interface RadioButtonInputGroupProps
     extends React.FieldsetHTMLAttributes<HTMLFieldSetElement> {
     children: React.ReactNode;
     className?: string;
+    extraMargin?: boolean;
     fieldMessage?: string | React.ReactNode;
     inline?: boolean;
     label?: string | React.ReactNode;

--- a/packages/ffe-form/less/fieldset.less
+++ b/packages/ffe-form/less/fieldset.less
@@ -9,4 +9,40 @@
     border: 0;
     padding: 0;
     margin: 0;
+
+    .ffe-radio-button,
+    .ffe-radio-switch {
+        margin-bottom: 30px;
+    }
+
+    .ffe-field-error-message {
+        margin-top: -24px;
+        margin-bottom: 0;
+    }
+
+    .ffe-radio-block:last-of-type {
+        margin-bottom: 30px;
+    }
+
+    &--no-extra-margin {
+        .ffe-field-error-message {
+            margin: 5px 0 10px;
+        }
+
+        .ffe-radio-button {
+            margin: 10px 0;
+
+            &--inline {
+                margin-right: 20px;
+            }
+        }
+
+        .ffe-radio-switch {
+            margin-bottom: 0;
+        }
+
+        .ffe-radio-block:last-of-type {
+            margin-bottom: 0;
+        }
+    }
 }

--- a/packages/ffe-form/less/input-group.less
+++ b/packages/ffe-form/less/input-group.less
@@ -26,4 +26,32 @@
             border-top-style: none;
         }
     }
+
+    .ffe-checkbox,
+    .ffe-dropdown,
+    .ffe-input-field,
+    .ffe-textarea {
+        margin-bottom: 30px;
+    }
+
+    .ffe-field-error-message {
+        margin-top: -24px;
+        margin-bottom: 0;
+    }
+
+    &--no-extra-margin {
+        .ffe-field-error-message {
+            margin: 5px 0 10px;
+        }
+
+        .ffe-checkbox {
+            margin: 10px 0;
+        }
+
+        .ffe-dropdown,
+        .ffe-input-field,
+        .ffe-textarea {
+            margin: 0;
+        }
+    }
 }


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request! 🎉

If your changes include some kind of UI element, please attach a screenshot of 
how it looks.

Before submitting a pull request, please have a look through the CONTRIBUTING.md
document. TL;DR:

- Follow the conventional commit standard
- Write full, explanatory commit messages
- Follow our code standards
- Write tests where applicable
- Be courteous and respect our code of conduct
-->

I decided to err on the side of caution and make the CSS change breaking because I think people who update to it should be aware of this change and hopefully a major version makes it more likely that they check the changelog. We're release so many minor/patch versions all the time that we can't really expect people to check the changelog for every new version.

For the react-component, no breaking change is needed at all since we're just adding a new property and none of the changes will take effect without updating the CSS package anyway.
