### PR TITLE
fix(ffe-form-react): Tooltip handles aria-controls better

### DIFF
--- a/packages/ffe-form-react/src/Tooltip.js
+++ b/packages/ffe-form-react/src/Tooltip.js
@@ -23,6 +23,7 @@ class Tooltip extends React.Component {
 
     render() {
         const {
+            'aria-controls': ariaControls,
             'aria-label': ariaLabel,
             children,
             className,
@@ -44,7 +45,7 @@ class Tooltip extends React.Component {
             >
                 <button
                     aria-expanded={isOpen}
-                    aria-controls={this.tooltipId}
+                    aria-controls={children ? this.tooltipId : ariaControls}
                     aria-label={ariaLabel}
                     className={classNames('ffe-tooltip__icon', {
                         'ffe-tooltip--dark__icon': dark,
@@ -60,6 +61,7 @@ class Tooltip extends React.Component {
                         className="ffe-tooltip__text"
                         id={this.tooltipId}
                         isOpen={isOpen}
+                        unmountOnClose={false}
                     >
                         <div
                             className={classNames(
@@ -78,6 +80,8 @@ class Tooltip extends React.Component {
 }
 
 Tooltip.propTypes = {
+    /** Provide the id of the controlled element *unless* you're sending in children */
+    'aria-controls': string,
     /** Descriptive text for the Tooltip expand icon */
     'aria-label': string,
     /** The children are rendered in the expanded tooltip. */

--- a/packages/ffe-form-react/src/Tooltip.md
+++ b/packages/ffe-form-react/src/Tooltip.md
@@ -4,6 +4,24 @@ Om du ikke bruker InputGroup kan du fremdeles bruke deler av den, som f.eks. Too
 <Tooltip>Dette er lurt å tenke på</Tooltip>
 ```
 
+Dersom du bygger din egen hjelpefunksjon og kun trenger knappen så er det ikke nødvendig
+å sende med innholdet, du kan bruke `onClick` prop til å reagere på knappetrykk men da må du
+også sende med `aria-controls` som skal peke på iden til elementet som vises/skjules med knappen din.
+
+```js
+const initialState = { open: false };
+
+<>
+    <Tooltip
+        aria-controls="tooltip-text"
+        onClick={() => setState(prevState => ({ open: !prevState.open }))}
+    />
+    <div hidden={!state.open} id="tooltip-text">
+        Titt tei!
+    </div>
+</>;
+```
+
 Variant _dark_ for interne løsninger med mørk bakgrunn.
 
 ```js { "props": { "className": "sb1ds-example-dark" } }

--- a/packages/ffe-form-react/src/index.d.ts
+++ b/packages/ffe-form-react/src/index.d.ts
@@ -71,6 +71,7 @@ export interface InputGroupProps extends React.HTMLAttributes<HTMLDivElement> {
 }
 
 export interface TooltipProps extends React.HTMLAttributes<HTMLSpanElement> {
+    'aria-controls'?: string;
     children?: React.ReactNode;
     className?: string;
     isOpen?: boolean;


### PR DESCRIPTION
Fixes two minor bugs in `Tooltip` concerning `aria-controls`:
* If children is provided to Tooltip, keep them in the DOM when not expanded or aria-controls
will refer to a non-existing element
* If children is not provided to Tooltip, support letting the consumer provide one and use
it on the toggle-button

Fixes #633

<!-- 
Thanks for opening a pull request! 🎉

If your changes include some kind of UI element, please attach a screenshot of 
how it looks.

Before submitting a pull request, please have a look through the CONTRIBUTING.md
document. TL;DR:

- Follow the conventional commit standard
- Write full, explanatory commit messages
- Follow our code standards
- Write tests where applicable
- Be courteous and respect our code of conduct
-->
