### PR TITLE
fix(ffe-form-react): Fix tooltip bug in RadioButtonInputGroup

### DIFF
--- a/packages/ffe-form-react/src/RadioButtonInputGroup.js
+++ b/packages/ffe-form-react/src/RadioButtonInputGroup.js
@@ -4,15 +4,6 @@ import classNames from 'classnames';
 import ErrorFieldMessage from './ErrorFieldMessage';
 import Tooltip from './Tooltip';
 
-const ensureComponent = Comp => (input, dark) => {
-    if (input.type === Comp) {
-        return input;
-    }
-    return <Comp dark={dark}>{input}</Comp>;
-};
-
-const ensureTooltip = ensureComponent(Tooltip);
-
 const RadioButtonInputGroup = props => {
     const {
         'aria-invalid': ariaInvalid,
@@ -37,8 +28,6 @@ const RadioButtonInputGroup = props => {
         selectedValue,
     };
 
-    const tooltipContent = tooltip && ensureTooltip(tooltip, dark);
-
     return (
         <fieldset
             className={classNames(
@@ -58,7 +47,10 @@ const RadioButtonInputGroup = props => {
                     )}
                 >
                     {label}
-                    {tooltipContent}
+                    {typeof tooltip === 'string' && (
+                        <Tooltip dark={dark}>{tooltip}</Tooltip>
+                    )}
+                    {React.isValidElement(tooltip) && tooltip}
                 </legend>
             )}
             {children({ ...buttonProps, dark })}


### PR DESCRIPTION
When someone provided a `Tooltip` component as the `tooltip` prop to `RadioButtonInputGroup`, it
would be wrapped inside another `Tooltip` instance. It now acts the same way as the same prop in
`InputGroup`.

Fixes #631

<!-- 
Thanks for opening a pull request! 🎉

If your changes include some kind of UI element, please attach a screenshot of 
how it looks.

Before submitting a pull request, please have a look through the CONTRIBUTING.md
document. TL;DR:

- Follow the conventional commit standard
- Write full, explanatory commit messages
- Follow our code standards
- Write tests where applicable
- Be courteous and respect our code of conduct
-->
