### PR TITLE
feat(ffe-form-react): RadioButtonInputGroup supports "description"

### DIFF
--- a/packages/ffe-form-react/src/InputGroup.js
+++ b/packages/ffe-form-react/src/InputGroup.js
@@ -121,7 +121,7 @@ InputGroup.propTypes = {
     /** To just render a static, always visible tooltip, use this. */
     description: string,
     /** Use the Label component if you need more flexibility in how the content is rendered. */
-    label: oneOfType([string, instanceOfComponent(Label)]),
+    label: oneOfType([node, string]),
     onTooltipToggle: func,
     /** Use the Tooltip component if you need more flexibility in how the content is rendered. */
     tooltip: oneOfType([bool, string, instanceOfComponent(Tooltip)]),

--- a/packages/ffe-form-react/src/RadioButtonInputGroup.js
+++ b/packages/ffe-form-react/src/RadioButtonInputGroup.js
@@ -10,6 +10,7 @@ const RadioButtonInputGroup = props => {
         children,
         className,
         extraMargin,
+        description,
         fieldMessage,
         inline,
         label,
@@ -19,6 +20,12 @@ const RadioButtonInputGroup = props => {
         dark,
         ...rest
     } = props;
+
+    if (tooltip && description) {
+        throw new Error(
+            'Don\'t use both "tooltip" and "description" on an <RadioButtonInputGroup />, pick one of them',
+        );
+    }
 
     const buttonProps = {
         'aria-invalid': ariaInvalid || String(!!fieldMessage),
@@ -54,6 +61,9 @@ const RadioButtonInputGroup = props => {
                     {React.isValidElement(tooltip) && tooltip}
                 </legend>
             )}
+
+            {description && <div className="ffe-small-text">{description}</div>}
+
             {children({ ...buttonProps, dark })}
 
             {typeof fieldMessage === 'string' && (
@@ -80,6 +90,8 @@ RadioButtonInputGroup.propTypes = {
     children: func.isRequired,
     /** Additional class names applied to the fieldset */
     className: string,
+    /** To just render a static, always visible tooltip, use this. */
+    description: string,
     /** Reserve space for showing `fieldMessage`s so content below don't move
      *  vertically if an errormessage shows up. Note that this will only reserve
      *  space for one line of content, so keep messages short.

--- a/packages/ffe-form-react/src/RadioButtonInputGroup.md
+++ b/packages/ffe-form-react/src/RadioButtonInputGroup.md
@@ -74,6 +74,7 @@ initialState = {
     </RadioButtonInputGroup>
 
     <RadioButtonInputGroup
+        description="Du kan ikke velge begge"
         label="Velg ja eller nei"
         name="switch"
         fieldMessage={state.showErrors ? 'Feil valg' : null}
@@ -192,6 +193,7 @@ initialState = {
 
     <RadioButtonInputGroup
         extraMargin={false}
+        description="Du kan ikke velge begge"
         label="Velg ja eller nei"
         name="switch"
         fieldMessage={state.showErrors ? 'Feil valg' : null}

--- a/packages/ffe-form-react/src/Tooltip.js
+++ b/packages/ffe-form-react/src/Tooltip.js
@@ -61,7 +61,6 @@ class Tooltip extends React.Component {
                         className="ffe-tooltip__text"
                         id={this.tooltipId}
                         isOpen={isOpen}
-                        unmountOnClose={false}
                     >
                         <div
                             className={classNames(

--- a/packages/ffe-form-react/src/index.d.ts
+++ b/packages/ffe-form-react/src/index.d.ts
@@ -124,6 +124,7 @@ export interface RadioButtonInputGroupProps
     extends React.FieldsetHTMLAttributes<HTMLFieldSetElement> {
     children: React.ReactNode;
     className?: string;
+    description?: string;
     extraMargin?: boolean;
     fieldMessage?: string | React.ReactNode;
     inline?: boolean;


### PR DESCRIPTION
* The `description` prop that already exists for `InputGroup` is
also supported by `RadioButtonInputGroup`, use it if you want to
display an always-open tooltip.
* `InputGroup` now allows either `node` and `string` for the `label`
prop, just like `RadioButtonInputGroup`

<!-- 
Thanks for opening a pull request! 🎉

If your changes include some kind of UI element, please attach a screenshot of 
how it looks.

Before submitting a pull request, please have a look through the CONTRIBUTING.md
document. TL;DR:

- Follow the conventional commit standard
- Write full, explanatory commit messages
- Follow our code standards
- Write tests where applicable
- Be courteous and respect our code of conduct
-->
