### PR TITLE
Fix ffe lists

### DIFF
--- a/packages/ffe-lists-react/src/DescriptionList.md
+++ b/packages/ffe-lists-react/src/DescriptionList.md
@@ -29,3 +29,31 @@
     </DescriptionList>
 </div>
 ```
+
+##### Medium and large
+
+```js
+<div>
+    <h3 className="ffe-h5">Medium</h3>
+    <DescriptionList horizontal={true} medium={true}>
+        <DescriptionListTerm>
+            This is a very long term, so I might need some extra room
+        </DescriptionListTerm>
+        <DescriptionListDescription>
+            Enlarging the term will of course be at the cost of space for the
+            description
+        </DescriptionListDescription>
+    </DescriptionList>
+
+    <h3 className="ffe-h5">Large</h3>
+    <DescriptionList horizontal={true} large={true}>
+        <DescriptionListTerm>
+            This is a very long description, so I might need some extra room
+        </DescriptionListTerm>
+        <DescriptionListDescription>
+            Enlarging the term will of course be at the cost of space for the
+            description
+        </DescriptionListDescription>
+    </DescriptionList>
+</div>
+```

--- a/packages/ffe-lists/less/description-list.less
+++ b/packages/ffe-lists/less/description-list.less
@@ -95,37 +95,35 @@
             margin-left: 20%;
         }
     }
+}
 
-    &--md {
-        .ffe-description-list__term {
-            flex: 0 0 40%;
-        }
-
-        .ffe-description-list__description {
-            flex: 60% 0 0;
-            max-width: 60%;
-        }
-
-        .ffe-description-list__description
-            + .ffe-description-list__description {
-            margin-left: 40%;
-        }
+.ffe-description-list--md {
+    .ffe-description-list__term {
+        flex: 0 0 40%;
     }
 
-    &--lg {
-        .ffe-description-list__term {
-            flex: 0 0 50%;
-        }
+    .ffe-description-list__description {
+        flex: 60% 0 0;
+        max-width: 60%;
+    }
 
-        .ffe-description-list__description {
-            flex: 50% 0 0;
-            max-width: 50%;
-        }
+    .ffe-description-list__description + .ffe-description-list__description {
+        margin-left: 40%;
+    }
+}
 
-        .ffe-description-list__description
-            + .ffe-description-list__description {
-            margin-left: 50%;
-        }
+.ffe-description-list--lg {
+    .ffe-description-list__term {
+        flex: 0 0 50%;
+    }
+
+    .ffe-description-list__description {
+        flex: 50% 0 0;
+        max-width: 50%;
+    }
+
+    .ffe-description-list__description + .ffe-description-list__description {
+        margin-left: 50%;
     }
 }
 

--- a/packages/ffe-lists/less/description-list.less
+++ b/packages/ffe-lists/less/description-list.less
@@ -68,6 +68,7 @@
     .ffe-description-list__term {
         flex: 0 0 35%;
         overflow: hidden;
+        overflow-wrap: break-word;
     }
 
     .ffe-description-list__description {


### PR DESCRIPTION
This PR fixes a recent issue with ffe-lists where medium and large modifiers were broken.
I've also added this in the docs of ffe-lists-react:
![image](https://user-images.githubusercontent.com/435037/58480079-d8bf5100-8159-11e9-89b3-455c13ebbfa4.png)

The last commit in the PR is more of a suggestion, where we can allow long words in the description term, without cutting it off and without breaking the layout. Here's a screenshot of what it looks like:
![image](https://user-images.githubusercontent.com/435037/58480023-c0e7cd00-8159-11e9-9e2c-f89619a691be.png)
