### PR TITLE
fix(ffe-lists): no space when to dd folow each other

### DIFF
--- a/packages/ffe-lists/less/description-list.less
+++ b/packages/ffe-lists/less/description-list.less
@@ -52,10 +52,15 @@
     }
 
     /* Use padding rather than margin in bottom to avoid extra spacing overflowing to the top of the next column */
+
     .ffe-description-list__description {
         padding-bottom: @description-list-vertical-seperation;
         margin-left: 0;
         &:extend(.ffe-body-text);
+    }
+
+    .ffe-description-list__description + .ffe-description-list__description {
+        margin-top: -@description-list-vertical-seperation;
     }
 }
 


### PR DESCRIPTION
Looks strange with a lot of padding when 2 or more `<dd/>` follow each other. There is no prev-sibling selector to remove the padding so my options are limited if I dont do a bigger rewrite. 

![screencapture-localhost-6060-2019-06-12-14_18_05](https://user-images.githubusercontent.com/2248579/59351006-b9115680-8d1d-11e9-9daa-d3fb3c3872ad.png)
