### PR TITLE
Adding childId as an optional prop for InputGroup to be used as id on the Input child element

### DIFF
--- a/packages/ffe-form-react/src/InputGroup.js
+++ b/packages/ffe-form-react/src/InputGroup.js
@@ -10,11 +10,13 @@ class InputGroup extends Component {
     constructor(props) {
         super();
 
-        this.id = `input-${uuid.v4()}`;
+        this.id = props.inputId ? props.inputId : `input-${uuid.v4()}`;
     }
 
     render() {
         const {
+            // eslint-disable-next-line no-unused-vars
+            inputId,
             children,
             className,
             extraMargin,
@@ -108,6 +110,8 @@ class InputGroup extends Component {
 const instanceOfComponent = component => shape({ type: oneOf([component]) });
 
 InputGroup.propTypes = {
+    /** The id that will be used on the input child if you don't want a generated one */
+    inputId: string,
     /** Unless you only have one element in your `InputGroup` you will have to use the function-as-a-child pattern. */
     children: oneOfType([func, node]).isRequired,
     className: string,

--- a/packages/ffe-form-react/src/InputGroup.spec.js
+++ b/packages/ffe-form-react/src/InputGroup.spec.js
@@ -34,10 +34,19 @@ describe('<InputGroup>', () => {
         ).toMatch(/custom label/);
     });
 
-    it('renders a Label with htmlFor set to the same value of the children id', () => {
+    it('renders a Label with htmlFor set to the same generated value of the children input id', () => {
         const wrapper = getWrapper();
-
         const inputId = wrapper.find(Input).prop('id');
+
+        expect(inputId).toMatch(/input-*/);
+        expect(wrapper.find('Label').prop('htmlFor')).toBe(inputId);
+    });
+
+    it('renders a Label with htmlFor set to the same value of the inputId', () => {
+        const wrapper = getWrapper({ inputId: 'my_id' });
+        const inputId = wrapper.find(Input).prop('id');
+
+        expect(inputId).toBe('my_id');
         expect(wrapper.find('Label').prop('htmlFor')).toBe(inputId);
     });
 

--- a/packages/ffe-form-react/src/index.d.ts
+++ b/packages/ffe-form-react/src/index.d.ts
@@ -61,6 +61,7 @@ export interface LabelProps
 }
 
 export interface InputGroupProps extends React.HTMLAttributes<HTMLDivElement> {
+    inputId?: string;
     /** Unless you only have one element in your `InputGroup` you will have to use the function-as-a-child pattern. */
     children: JSX.Element;
     className?: string;


### PR DESCRIPTION
Solves #655 

The childId property will only be used when it is provided, when it is not provided the component will work exactly as it did before.

This will allow the developer to have more control of the code and allow autocomplete on the input field.

<!-- 
Thanks for opening a pull request! 🎉

If your changes include some kind of UI element, please attach a screenshot of 
how it looks.

Before submitting a pull request, please have a look through the CONTRIBUTING.md
document. TL;DR:

- Follow the conventional commit standard
- Write full, explanatory commit messages
- Follow our code standards
- Write tests where applicable
- Be courteous and respect our code of conduct
-->
