### PR TITLE
Avoid circular imports in grid package

### DIFF
--- a/packages/ffe-grid-react/src/utils.dev.js
+++ b/packages/ffe-grid-react/src/utils.dev.js
@@ -1,10 +1,15 @@
 import React from 'react';
 
-import { InlineGrid } from '.';
+const ALLOWED_NESTED_COMPONENTS = ['InlineGrid'];
 
 const checkForNestedComponent = (children, Component, componentName) =>
     React.Children.forEach(children, child => {
-        if (!child || child.type === InlineGrid) {
+        if (
+            !child ||
+            (child.type &&
+                child.type.name &&
+                ALLOWED_NESTED_COMPONENTS.some(c => c === child.type.name))
+        ) {
             return;
         } else if (child.type === Component) {
             console.error(`


### PR DESCRIPTION
Avoid importing InlineGrid into utils.dev.js which results in circular import chain. The only purpose is of the import is to do a type check. A simpler approach is to compare  child.type.name. against a whitelist registry of allowed nested components instead of comparing react functions.