### PR TITLE
feat(ffe-datepicker-react): Keep display state on validation error

### DIFF
--- a/packages/ffe-datepicker-react/src/datepicker/Datepicker.js
+++ b/packages/ffe-datepicker-react/src/datepicker/Datepicker.js
@@ -87,7 +87,12 @@ export default class Datepicker extends Component {
 
     validateDateIntervals() {
         let nextState = {};
-        const { onChange, value, onValidationComplete } = this.props;
+        const {
+            onChange,
+            value,
+            onValidationComplete,
+            keepDisplayStateOnError,
+        } = this.props;
 
         const error = type => {
             const errorMessage = this.onError(type);
@@ -96,7 +101,9 @@ export default class Datepicker extends Component {
                 errorMessage,
                 openOnFocus: true,
                 ariaInvalid: true,
-                displayDatePicker: true,
+                displayDatePicker: keepDisplayStateOnError
+                    ? this.state.displayDatePicker
+                    : true,
             };
         };
 
@@ -302,9 +309,9 @@ export default class Datepicker extends Component {
         const latestValue = validateDate(value) ? value : lastValidDate;
 
         if (this.state.ariaInvalid && !inputProps['aria-describedby']) {
-            inputProps['aria-describedby'] = `date-input-validation-${
-                this.datepickerId
-            }`;
+            inputProps[
+                'aria-describedby'
+            ] = `date-input-validation-${this.datepickerId}`;
         }
 
         const calendarClassName = classNames(
@@ -386,6 +393,7 @@ export default class Datepicker extends Component {
 
 Datepicker.defaultProps = {
     language: 'nb',
+    keepDisplayStateOnError: false,
     onValidationComplete: () => {},
 };
 
@@ -406,4 +414,5 @@ Datepicker.propTypes = {
     onChange: func.isRequired,
     onError: func,
     value: string.isRequired,
+    keepDisplayStateOnError: bool.isRequired,
 };

--- a/packages/ffe-datepicker-react/src/datepicker/Datepicker.spec.js
+++ b/packages/ffe-datepicker-react/src/datepicker/Datepicker.spec.js
@@ -320,6 +320,17 @@ describe('<Datepicker />', () => {
 
                 expect(wrapper.find(ERROR_CLASS).exists()).toBe(false);
             });
+
+            it('keeps datepicker display state when keepDisplayStateOnError is true', () => {
+                const wrapper = getMountedWrapper({
+                    ...overrides,
+                    keepDisplayStateOnError: true,
+                });
+                wrapper.setProps({ minDate: '01.01.2015' });
+                wrapper.update();
+
+                expect(wrapper.find(Calendar).exists()).toBe(false);
+            });
         });
     });
 
@@ -359,6 +370,17 @@ describe('<Datepicker />', () => {
                     wrapper.update();
                     expect(wrapper.find(ERROR_CLASS).exists()).toBe(false);
                 });
+            });
+
+            it('keeps datepicker display state when keepDisplayStateOnError is true', () => {
+                const wrapper = getMountedWrapper({
+                    ...overrides,
+                    keepDisplayStateOnError: true,
+                });
+                wrapper.setProps({ maxDate: '01.01.2014' });
+                wrapper.update();
+
+                expect(wrapper.find(Calendar).exists()).toBe(false);
             });
         });
     });


### PR DESCRIPTION
We have a use-case where we use two Datepickers in order to allow selection of a date range. In this use-case the `minDate` of the end-datepicker is given by the value of the start-datepicker and vice versa. Selecting a value in one of the datepickers may causes an invalid minDate/maxDate combination in the other, causing the datepicker with the now invalid combination to display its calendar. In this PR I have added a prop that allows us to override this behavior, keeping the value of `displayDatepicker` as is when such an invalid combination leads to a validation error.  