### PR TITLE
fix(ffe-datepicker-react): Fixes #660 (Calendar showing showing wrong year when manually entering date)

### DIFF
--- a/packages/ffe-datepicker-react/src/calendar/Calendar.js
+++ b/packages/ffe-datepicker-react/src/calendar/Calendar.js
@@ -41,14 +41,17 @@ export default class Calendar extends Component {
     /* eslint-disable react/no-did-update-set-state */
     componentDidUpdate(prevProps) {
         if (prevProps.selectedDate !== this.props.selectedDate) {
-            this.setState({
-                calendar: simpleCalendar(
-                    simpleDate.fromString(this.props.selectedDate),
-                    this.props.minDate,
-                    this.props.maxDate,
-                    this.props.language,
-                ),
-            });
+            this.setState(
+                {
+                    calendar: simpleCalendar(
+                        simpleDate.fromString(this.props.selectedDate),
+                        this.props.minDate,
+                        this.props.maxDate,
+                        this.props.language,
+                    ),
+                },
+                this.forceUpdate,
+            );
         }
     }
 


### PR DESCRIPTION
Fixes #660.