### PR TITLE
feat(ffe-icons): Added import script

### DIFF
--- a/packages/ffe-icons/.gitignore
+++ b/packages/ffe-icons/.gitignore
@@ -1,0 +1,1 @@
+import/*.svg

--- a/packages/ffe-icons/bin/import.js
+++ b/packages/ffe-icons/bin/import.js
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+
+const optimizer = require('./optimizer');
+const autoCrop = require('svg-autocrop');
+
+const importPath = path.join(__dirname, '../import');
+const destPath = path.join(__dirname, '../icons');
+
+const crop = true;
+
+const log = console.log;
+
+const normalizeName = fileName => {
+    let name = fileName.normalize('NFC');
+
+    name = name.toLowerCase();
+    name = name.replace('-ikon.svg', '');
+    name = name.replace('.svg', '');
+
+    name = name.replace('æ', 'ae');
+    name = name.replace('ø', 'o');
+    name = name.replace('å', 'aa');
+
+    //name = name.replace(/^[a-zA-Z0-9]/, '');
+
+    return `draft-${name}-ikon.svg`;
+};
+
+const main = async () => {
+    const importFolderExists = fs.existsSync(importPath);
+    const destPathExists = fs.existsSync(destPath);
+    if (!importFolderExists) {
+        throw new Error(`Import folder ($(importPath)) not found`);
+    }
+
+    if (!destPathExists) {
+        fs.mkdirSync(destPath);
+    }
+
+    const files = await fs.readdirSync(importPath, { encoding: 'utf-8' });
+
+    for (const file of files.filter(f => f.endsWith('.svg'))) {
+        log(`Processing: ${file}...`);
+
+        const name = normalizeName(file);
+        log(name);
+
+        const sourcePath = path.join(importPath, file);
+        const targetPath = path.join(destPath, name);
+
+        log(`- Reading source file: ${sourcePath}`);
+        const fileContent = fs.readFileSync(sourcePath, 'UTF-8');
+
+        log('- Optimizing svg');
+        const optimizationResult = await optimizer.optimize(fileContent);
+        let optimizedContent = optimizationResult.data;
+
+        if (crop) {
+            log('- Autocropping svg');
+            optimizedContent = await autoCrop(optimizedContent);
+        }
+
+        log(`- Writing target file: ${targetPath}`);
+        fs.writeFileSync(targetPath, optimizedContent);
+
+        log(`Processing: ${file}... done`);
+    }
+
+    process.exit(0);
+};
+
+main();

--- a/packages/ffe-icons/bin/optimizer/index.js
+++ b/packages/ffe-icons/bin/optimizer/index.js
@@ -1,0 +1,17 @@
+const Svgo = require('svgo');
+const convertDimensions = require('./plugins/convert-dimensions');
+const removePrefixedAttributes = require('./plugins/remove-prefixed-attributes');
+
+const svgo = new Svgo({
+    plugins: [
+        {
+            removeAttrs: {
+                attrs: ['*:fill:#002776', '*:fill:none', '*:fill-rule:*'],
+            },
+        }, //get rid off fill attributes. svgo will remove empty <g> elements
+        { convertDimensions: convertDimensions }, //move from height, width to viewbox
+        { removePrefixedAttributes: removePrefixedAttributes }, //remove attribute prefixes (e.g xmlns:link etc)
+    ],
+});
+
+module.exports = svgo;

--- a/packages/ffe-icons/bin/optimizer/plugins/convert-dimensions.js
+++ b/packages/ffe-icons/bin/optimizer/plugins/convert-dimensions.js
@@ -1,0 +1,28 @@
+exports.type = 'full';
+
+exports.active = false;
+
+exports.description = 'removes width and height in presence of viewBox';
+
+/**
+ * Convert width/height to viewBox. Remove width/height attributes when a viewBox attribute converted.
+ *
+ * @author Kirk Bentley / Fyrebase
+ */
+exports.fn = function(data) {
+    const svg = data.content[0];
+
+    if (svg.isElem('svg')) {
+        svg.addAttr({
+            name: 'viewBox',
+            value: `0 0 ${svg.attr('width').value} ${svg.attr('height').value}`,
+            prefix: '',
+            local: 'class',
+        });
+
+        svg.removeAttr('width');
+        svg.removeAttr('height');
+    }
+
+    return data;
+};

--- a/packages/ffe-icons/bin/optimizer/plugins/remove-prefixed-attributes.js
+++ b/packages/ffe-icons/bin/optimizer/plugins/remove-prefixed-attributes.js
@@ -1,0 +1,14 @@
+exports.type = 'preItem';
+
+exports.active = false;
+
+exports.description =
+    'remove prefixed attributes (e.g xmlns:xlink) since it is not supported in react';
+
+exports.fn = item => {
+    item.eachAttr(attr => {
+        if (attr.prefix && attr.local) {
+            item.removeAttr(attr.name);
+        }
+    });
+};

--- a/packages/ffe-icons/import/_README.md
+++ b/packages/ffe-icons/import/_README.md
@@ -1,0 +1,6 @@
+# Import folder
+
+1. Add icon svg files to be imported in this folder
+2. Run `npm run import`.
+3. Script optimizes svg files (minifies, transforms, crops) and puts the processed
+   files in `./icons` with a `draft-` prefix.

--- a/packages/ffe-icons/package.json
+++ b/packages/ffe-icons/package.json
@@ -14,11 +14,11 @@
   },
   "scripts": {
     "build": "mkdirp dist && node bin/build.js",
+    "import": "node bin/import",
     "lint": "eslint bin/.",
     "test": "npm run lint"
   },
   "dependencies": {
-    "mkdirp": "^0.5.1",
     "svgstore": "^2.0.3",
     "yargs": "^13.1.0"
   },
@@ -27,7 +27,11 @@
     "mkdirp": "^0.5.1",
     "npm-run-all": "^4.1.2",
     "run-p": "0.0.0",
-    "stylelint": "^10.0.0"
+    "sharp": "^0.22.1",
+    "stylelint": "^10.0.0",
+    "svg-autocrop": "^1.0.17",
+    "svg-path-bounds": "^1.0.1",
+    "svgo": "^1.2.2"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Automatically import svg icons using svgo and svg-crop to optimize the svg. The newly imported files is imported with a `draft-` prefix. See #667 for handling of draft icons.

<!-- 
Thanks for opening a pull request! 🎉

If your changes include some kind of UI element, please attach a screenshot of 
how it looks.

Before submitting a pull request, please have a look through the CONTRIBUTING.md
document. TL;DR:

- Follow the conventional commit standard
- Write full, explanatory commit messages
- Follow our code standards
- Write tests where applicable
- Be courteous and respect our code of conduct
-->
