### PR TITLE
fix(ffe-form-react): Fixing typescript type definition for InputGroup…

### DIFF
--- a/packages/ffe-form-react/src/InputGroup.js
+++ b/packages/ffe-form-react/src/InputGroup.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { bool, func, node, oneOf, oneOfType, shape, string } from 'prop-types';
+import { bool, func, node, oneOfType, string } from 'prop-types';
 import uuid from 'uuid';
 import Tooltip from './Tooltip';
 import Label from './Label';
@@ -107,8 +107,6 @@ class InputGroup extends Component {
     }
 }
 
-const instanceOfComponent = component => shape({ type: oneOf([component]) });
-
 InputGroup.propTypes = {
     /** The id that will be used on the input child if you don't want a generated one */
     inputId: string,
@@ -128,7 +126,7 @@ InputGroup.propTypes = {
     label: oneOfType([node, string]),
     onTooltipToggle: func,
     /** Use the Tooltip component if you need more flexibility in how the content is rendered. */
-    tooltip: oneOfType([bool, string, instanceOfComponent(Tooltip)]),
+    tooltip: oneOfType([bool, node]),
 };
 
 InputGroup.defaultProps = {

--- a/packages/ffe-form-react/src/index.d.ts
+++ b/packages/ffe-form-react/src/index.d.ts
@@ -63,14 +63,14 @@ export interface LabelProps
 export interface InputGroupProps extends React.HTMLAttributes<HTMLDivElement> {
     inputId?: string;
     /** Unless you only have one element in your `InputGroup` you will have to use the function-as-a-child pattern. */
-    children: JSX.Element;
+    children: React.ReactNode;
     className?: string;
     extraMargin?: boolean;
     fieldMessage?: string | React.ReactNode;
     description?: string;
     label?: string | Label;
     onTooltipToggle?: (e: React.MouseEvent | undefined) => void;
-    tooltip?: boolean | string | Tooltip;
+    tooltip?: React.ReactNode;
 }
 
 export interface TooltipProps extends React.HTMLAttributes<HTMLSpanElement> {


### PR DESCRIPTION
…Props.tooltip to make it possible to send in a Tooltip-component.

This PR fixes #670. The change is tested and verified in a project locally.