### PR TITLE
Collapse component

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -22,6 +22,7 @@ module.exports = {
                 'ffe-context-message-react',
                 'ffe-core',
                 'ffe-core-react',
+                'ffe-collapse-react',
                 'ffe-datepicker',
                 'ffe-datepicker-react',
                 'ffe-decorators-react',

--- a/packages/ffe-accordion-react/package.json
+++ b/packages/ffe-accordion-react/package.json
@@ -26,10 +26,10 @@
     "setupTestFrameworkScriptFile": "../../test-setup.js"
   },
   "dependencies": {
+    "@sb1/ffe-collapse-react": "^0.0.0",
     "@sb1/ffe-icons-react": "^7.0.0",
     "classnames": "^2.2.5",
     "prop-types": "^15.6.0",
-    "react-css-collapse": "^3.6.0",
     "uuid": "^3.1.0"
   },
   "devDependencies": {

--- a/packages/ffe-accordion-react/src/AccordionItem.js
+++ b/packages/ffe-accordion-react/src/AccordionItem.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import { arrayOf, bool, func, node, number, string } from 'prop-types';
-import Collapse from 'react-css-collapse';
+import Collapse from '@sb1/ffe-collapse-react';
 import ChevronIkon from '@sb1/ffe-icons-react/lib/chevron-ikon';
 import classNames from 'classnames';
 

--- a/packages/ffe-all.less
+++ b/packages/ffe-all.less
@@ -19,3 +19,4 @@
 @import './ffe-system-message/less/ffe-system-message';
 @import './ffe-tables/less/tables';
 @import './ffe-tabs/less/tabs';
+@import './ffe-collapse-react/less/collapse';

--- a/packages/ffe-collapse-react/.npmrc
+++ b/packages/ffe-collapse-react/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/packages/ffe-collapse-react/README.md
+++ b/packages/ffe-collapse-react/README.md
@@ -1,0 +1,25 @@
+# @sb1/ffe-collapse-react
+
+React component for expand/collapse
+
+## Install
+
+```
+npm install --save @sb1/ffe-collapse-react
+```
+
+## Usage
+
+Run Styleguidist from the repository root to see live examples and documentation,
+or see the markdown files next to the component code in `src/`.
+
+Please note the component depends on transition styling for `height`.\
+This can preferably be done by importing the less-file from the less-folder
+in the package.\
+Alternatively you can do it by adding style to the class
+`.ffe-collapse-transition`\, adding it to your own class and provide the class
+through the `className` property or by styling it directly through the `style` property.
+
+## TypeScript definition files
+
+This component does not yet have TypeScript definitions.

--- a/packages/ffe-collapse-react/less/collapse.less
+++ b/packages/ffe-collapse-react/less/collapse.less
@@ -1,0 +1,3 @@
+.ffe-collapse-transition {
+    transition: height @ffe-transition-duration @ffe-ease-in-out-back;
+}

--- a/packages/ffe-collapse-react/package.json
+++ b/packages/ffe-collapse-react/package.json
@@ -1,0 +1,49 @@
+{
+    "name": "@sb1/ffe-collapse-react",
+    "version": "0.0.0",
+    "description": "React component for expand/collapse",
+    "keywords": [
+        "ffe"
+    ],
+    "license": "MIT",
+    "author": "SpareBank 1",
+    "files": [
+        "lib",
+        "es"
+    ],
+    "main": "lib/index.js",
+    "module": "es/index.js",
+    "sideEffects": false,
+    "repository": {
+        "type": "git",
+        "url": "ssh://git@github.com:SpareBank1/designsystem.git"
+    },
+    "scripts": {
+        "build": "npm run build:cjs && npm run build:es",
+        "build:cjs": "babel -d lib/. --root-mode=upward  --env-name=cjs --ignore=*.spec.js src/.",
+        "build:es": "babel -d es/. --root-mode=upward --env-name=es --ignore=*.spec.js src/.",
+        "lint": "eslint src/.",
+        "test": "jest",
+        "test:watch": "jest --watch"
+    },
+    "jest": {
+        "setupTestFrameworkScriptFile": "../../test-setup.js"
+    },
+    "dependencies": {
+        "classnames": "^2.2.5"
+    },
+    "devDependencies": {
+        "eslint": "^5.9.0",
+        "jest": "^23.4.2",
+        "prop-types": "^15.6.0",
+        "react": "^16.9.0",
+        "react-dom": "^16.9.0"
+    },
+    "peerDependencies": {
+        "@sb1/ffe-core": "^14.0.0",
+        "react": "^16.9.0"
+    },
+    "publishConfig": {
+        "access": "public"
+    }
+}

--- a/packages/ffe-collapse-react/src/Collapse.js
+++ b/packages/ffe-collapse-react/src/Collapse.js
@@ -1,0 +1,82 @@
+import React, { useRef, useState, useEffect } from 'react';
+import { string, bool, func, object } from 'prop-types';
+import classNames from 'classnames';
+
+const Collapse = ({ className, style, isOpen, onRest, ...rest }) => {
+    const content = useRef();
+    const [height, setHeight] = useState(() => (isOpen ? 'auto' : '0'));
+    const [overflow, setOverflow] = useState(() =>
+        isOpen ? 'visible' : 'hidden',
+    );
+    const [visibility, setVisibility] = useState(() =>
+        isOpen ? 'visible' : 'hidden',
+    );
+
+    const setExpanded = () => {
+        setHeight('auto');
+        setOverflow('visible');
+    };
+
+    const setCollapsed = () => {
+        setVisibility('hidden');
+    };
+
+    useEffect(() => {
+        if (content.current) {
+            if (isOpen && height !== 'auto') {
+                setHeight(`${content.current.scrollHeight}px`);
+                setVisibility('visible');
+            } else if (!isOpen && height !== '0') {
+                setHeight(`${content.current.scrollHeight}px`);
+                window.requestAnimationFrame(() =>
+                    setTimeout(() => {
+                        setHeight('0');
+                        setOverflow('hidden');
+                    }),
+                );
+            }
+        }
+    }, [isOpen, height]);
+
+    const onTransitionEnd = e => {
+        if (e.target === content.current && e.propertyName === 'height') {
+            if (isOpen) {
+                setExpanded();
+            } else {
+                setCollapsed();
+            }
+            if (onRest) {
+                onRest();
+            }
+        }
+    };
+
+    const mergedStyles = {
+        ...style,
+        willChange: 'height',
+        height,
+        overflow,
+        visibility,
+    };
+
+    return (
+        <div
+            {...rest}
+            ref={content}
+            style={mergedStyles}
+            className={classNames('ffe-collapse-transition', className)}
+            onTransitionEnd={onTransitionEnd}
+        />
+    );
+};
+
+Collapse.displayName = 'Collapse';
+
+Collapse.propTypes = {
+    className: string,
+    style: object,
+    isOpen: bool,
+    onRest: func,
+};
+
+export default Collapse;

--- a/packages/ffe-collapse-react/src/Collapse.md
+++ b/packages/ffe-collapse-react/src/Collapse.md
@@ -1,0 +1,42 @@
+Hvorvidt området er ekspandert eller ikke styres av konsumenten via property `isOpen`.
+
+```js
+const Collapse = require('.').default;
+
+initialState = { isOpen: false };
+
+<React.Fragment>
+    <button onClick={() => setState(({ isOpen }) => ({ isOpen: !isOpen }))}>
+        {state.isOpen ? 'Collapse' : 'Expand'}
+    </button>
+    <Collapse isOpen={state.isOpen}>
+        <div>
+            <p>Hello world</p>
+            <p>Hello world</p>
+        </div>
+    </Collapse>
+</React.Fragment>;
+```
+
+Et callback kan gis via property `onRest` som kjøres når transisjonen er ferdig.
+
+```js
+const Collapse = require('.').default;
+
+initialState = { isOpen: false, rand: Math.random() };
+
+const onRest = () => setState({ rand: Math.random() });
+
+<React.Fragment>
+    <button onClick={() => setState(({ isOpen }) => ({ isOpen: !isOpen }))}>
+        {state.isOpen ? 'Collapse' : 'Expand'}
+    </button>
+    <Collapse isOpen={state.isOpen} onRest={onRest}>
+        <div>
+            <p>Hello world</p>
+            <p>Hello world</p>
+        </div>
+    </Collapse>
+    <p>This number will change on transition complete: {state.rand}</p>
+</React.Fragment>;
+```

--- a/packages/ffe-collapse-react/src/index.js
+++ b/packages/ffe-collapse-react/src/index.js
@@ -1,0 +1,1 @@
+export { default } from './Collapse';

--- a/packages/ffe-form-react/package.json
+++ b/packages/ffe-form-react/package.json
@@ -30,8 +30,8 @@
     "setupTestFrameworkScriptFile": "../../test-setup.js"
   },
   "dependencies": {
+    "@sb1/ffe-collapse-react": "^0.0.0",
     "classnames": "^2.2.5",
-    "react-css-collapse": "^3.6.0",
     "uuid": "^3.1.0"
   },
   "devDependencies": {

--- a/packages/ffe-form-react/src/Tooltip.js
+++ b/packages/ffe-form-react/src/Tooltip.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { bool, func, node, string, number } from 'prop-types';
 import classNames from 'classnames';
-import Collapse from 'react-css-collapse';
+import Collapse from '@sb1/ffe-collapse-react';
 import uuid from 'uuid';
 
 class Tooltip extends React.Component {

--- a/styleguide-content/komponenter/collapse.md
+++ b/styleguide-content/komponenter/collapse.md
@@ -1,0 +1,15 @@
+```jsx
+const { InfoIkon } = require('../../packages/ffe-icons-react/lib');
+
+<ContextInfoMessage icon={<InfoIkon />}>
+    Denne seksjonen er ikke skrevet enda
+</ContextInfoMessage>;
+```
+
+Komponent for å enkelt lage ekspanderbart område.
+
+Merk at komponenten er avhengig av å få angitt transition styling for `height`.\
+Dette gjøres helst ved å importere less-filen fra pakkens less-mappe.\
+Alternativt kan man gjøre det ved å selv legge styling i klassen
+`.ffe-collapse-transition`, legge det på en egen klasse og sende inn via
+property `className` eller style det direkte via property `style`.

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -16,6 +16,7 @@ const PACKAGES_WITH_DEFAULT_EXPORT = [
     'ffe-searchable-dropdown-react',
     'ffe-spinner-react',
     'ffe-tables-react',
+    'ffe-collapse-react',
 ];
 
 const ignore = [
@@ -447,6 +448,20 @@ module.exports = {
                     name: 'Fanekomponenter',
                     components:
                         'packages/ffe-tabs-react/src/[A-Z]+([A-Za-z]).js',
+                },
+            ],
+        },
+        {
+            name: 'Collapse',
+            sections: [
+                {
+                    name: 'Bruk av Collapse',
+                    content: 'styleguide-content/komponenter/collapse.md',
+                },
+                {
+                    name: 'Komponenten',
+                    components:
+                        'packages/ffe-collapse-react/src/[A-Z]+([A-Za-z]).js',
                 },
             ],
         },


### PR DESCRIPTION
Add new package with a collapse component to replace the outdated react-css-collapse.

This component is now used in ffe-accordion-react and ffe-form-react.