### PR TITLE
Remove deprecated lifecycles

### DIFF
--- a/linting/eslint-config-ffe/index.js
+++ b/linting/eslint-config-ffe/index.js
@@ -1,17 +1,14 @@
 module.exports = {
-    'extends': [
+    extends: [
         '@sb1/eslint-config-ffe-base',
         './rules/jsx',
-        './rules/jsx-a11y'
+        './rules/jsx-a11y',
     ].map(require.resolve),
-    'plugins': [
-        'react',
-        'jsx-a11y'
-    ],
-    'parserOptions': {
-        'ecmaFeatures': {
-            'jsx': true
+    plugins: ['react', 'jsx-a11y', 'react-hooks'],
+    parserOptions: {
+        ecmaFeatures: {
+            jsx: true,
         },
     },
-    'rules': {}
+    rules: {},
 };

--- a/linting/eslint-config-ffe/package.json
+++ b/linting/eslint-config-ffe/package.json
@@ -23,12 +23,14 @@
     "eslint": "^5.9.0",
     "eslint-plugin-import": "^2.0.1",
     "eslint-plugin-jsx-a11y": "^6.0.3",
-    "eslint-plugin-react": "^7.0.0"
+    "eslint-plugin-react": "^7.0.0",
+    "eslint-plugin-react-hooks": "^2.0.1"
   },
   "peerDependencies": {
     "eslint": "^5.9.0",
     "eslint-plugin-jsx-a11y": "^6.0.3",
-    "eslint-plugin-react": ">=6"
+    "eslint-plugin-react": ">=6",
+    "eslint-plugin-react-hooks": "^2.0.1"
   },
   "publishConfig": {
     "access": "public"

--- a/linting/eslint-config-ffe/rules/jsx.js
+++ b/linting/eslint-config-ffe/rules/jsx.js
@@ -1,8 +1,8 @@
 module.exports = {
-    'rules': {
+    rules: {
         // Enforce boolean attributes notation in JSX
         // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-boolean-value.md
-        'react/jsx-boolean-value': [2, 'always' ],
+        'react/jsx-boolean-value': [2, 'always'],
 
         // Validate JSX has key prop when in array or iterator
         // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-key.md
@@ -30,11 +30,11 @@ module.exports = {
 
         // Ensure correct position of the first property.
         // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-first-prop-new-line.md
-        'react/jsx-first-prop-new-line' : [2, "multiline"],
+        'react/jsx-first-prop-new-line': [2, 'multiline'],
 
         // Enforce the closing bracket location for JSX multiline elements.
         // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-closing-bracket-location.md
-        'react/jsx-closing-bracket-location' : [2],
+        'react/jsx-closing-bracket-location': [2],
 
         // Prevent usage of dangerous JSX properties
         // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-danger.md
@@ -58,7 +58,7 @@ module.exports = {
 
         // Prevent multiple component definition per file
         // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-multi-comp.md
-        'react/no-multi-comp': [2, {'ignoreStateless': true}],
+        'react/no-multi-comp': [2, { ignoreStateless: true }],
 
         // Prevent usage of unknown DOM property
         // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-unknown-property.md
@@ -86,6 +86,14 @@ module.exports = {
 
         // Prevent missing props validation in a React component definition
         // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/prop-types.md
-        'react/prop-types': [2]
-    }
+        'react/prop-types': [2],
+
+        // Prevent breaking rules of hooks
+        // https://reactjs.org/docs/hooks-rules.html
+        'react-hooks/rules-of-hooks': 'error',
+
+        // Warn about hook usage that is probably wrong
+        // https://reactjs.org/docs/hooks-rules.html
+        'react-hooks/exhaustive-deps': 'warn',
+    },
 };

--- a/packages/ffe-account-selector-react/src/subcomponents/input-field/InputField.js
+++ b/packages/ffe-account-selector-react/src/subcomponents/input-field/InputField.js
@@ -1,147 +1,116 @@
 /* Because we are missing aria-controls (http://www.heydonworks.com/article/aria-controls-is-poop): */
 /* eslint jsx-a11y/role-has-required-aria-props:0 */
-import React, { Component } from 'react';
+import React from 'react';
 import { func, string, bool, number } from 'prop-types';
-import autoBind from 'react-auto-bind';
-import KryssIkon from '@sb1/ffe-icons-react/lib/kryss-ikon';
-import ChevronIkon from '@sb1/ffe-icons-react/lib/chevron-ikon';
+import { KryssIkon, ChevronIkon } from '@sb1/ffe-icons-react';
 import classNames from 'classnames';
 import txt from '../../i18n/i18n';
 import { Locale } from '../../util/types';
 
-class Input extends Component {
-    constructor(props) {
-        super(props);
-        autoBind(this);
-        this.state = {
-            value: props.value,
-            isFocused: false,
-        };
-    }
+const InputField = props => {
+    const {
+        onKeyDown,
+        id,
+        placeholder,
+        isSuggestionsShowing,
+        ariaInvalid,
+        onClick,
+        inputFieldRef,
+        highlightedIndex,
+        suggestionListId,
+        name,
+        readOnly,
+        locale,
+        value,
+        onBlur,
+        onFocus,
+        onChange,
+        onReset,
+    } = props;
+    const handleChange = ({ target: { value: newValue } }) =>
+        onChange(newValue);
 
-    onChange(e) {
-        const value = e.target.value;
-        this.setState({ value });
-        this.props.onChange(value);
-    }
-
-    onFocus() {
-        this.setState({ isFocused: true });
-        this.props.onFocus();
-    }
-
-    onBlur() {
-        this.setState({ isFocused: false });
-        this.props.onBlur();
-    }
-
-    onReset(e) {
+    const handleReset = e => {
         e.preventDefault();
-        this.props.onReset();
-    }
+        onReset();
+    };
 
-    onExpandOrCollapse(e) {
+    const onExpandOrCollapse = e => {
         e.preventDefault();
-
-        const { isSuggestionsShowing } = this.props;
         if (isSuggestionsShowing) {
-            this.onBlur();
+            onBlur();
         } else {
             e.currentTarget.previousElementSibling.focus();
-            this.onFocus();
+            onFocus();
         }
-    }
+    };
 
-    componentWillReceiveProps(nextProps) {
-        if (!this.state.isFocused || this.state.value !== nextProps.value) {
-            this.setState({ value: nextProps.value });
-        }
-    }
+    const showReset = !readOnly && value.length > 0;
 
-    render() {
-        const {
-            onKeyDown,
-            value,
-            id,
-            placeholder,
-            isSuggestionsShowing,
-            ariaInvalid,
-            onClick,
-            inputFieldRef,
-            highlightedIndex,
-            suggestionListId,
-            name,
-            readOnly,
-            locale,
-        } = this.props;
-
-        const showReset = !readOnly && value.length > 0;
-
-        return (
-            <div
-                role="combobox"
-                aria-expanded={isSuggestionsShowing}
-                onFocus={this.onFocus}
-                onBlur={this.onBlur}
-                aria-activedescendant={
-                    highlightedIndex > -1
-                        ? `suggestion-item-${highlightedIndex}`
-                        : null
-                }
-                aria-owns={suggestionListId}
-            >
-                <input
-                    className="ffe-input-field ffe-base-selector__input-field"
-                    onKeyDown={onKeyDown}
-                    autoComplete="off"
-                    value={this.state.value}
-                    id={id}
-                    placeholder={placeholder}
-                    ref={inputFieldRef}
-                    aria-invalid={ariaInvalid}
-                    aria-autocomplete="list"
-                    name={name}
-                    onClick={onClick}
-                    onChange={this.onChange}
-                    readOnly={readOnly}
-                />
-                {showReset && (
-                    <button
-                        className="ffe-base-selector__reset-button"
-                        onMouseDown={this.onReset}
-                        tabIndex={-1}
-                        type="button"
-                        aria-label={txt[locale].RESET_SEARCH}
-                    >
-                        <KryssIkon className="ffe-base-selector__reset-button-icon" />
-                    </button>
-                )}
+    return (
+        <div
+            role="combobox"
+            aria-expanded={isSuggestionsShowing}
+            onFocus={onFocus}
+            onBlur={onBlur}
+            aria-activedescendant={
+                highlightedIndex > -1
+                    ? `suggestion-item-${highlightedIndex}`
+                    : null
+            }
+            aria-owns={suggestionListId}
+        >
+            <input
+                className="ffe-input-field ffe-base-selector__input-field"
+                onKeyDown={onKeyDown}
+                autoComplete="off"
+                value={value}
+                id={id}
+                placeholder={placeholder}
+                ref={inputFieldRef}
+                aria-invalid={ariaInvalid}
+                aria-autocomplete="list"
+                name={name}
+                onClick={onClick}
+                onChange={handleChange}
+                readOnly={readOnly}
+            />
+            {showReset && (
                 <button
-                    className="ffe-base-selector__expand-button"
-                    onMouseDown={this.onExpandOrCollapse}
+                    className="ffe-base-selector__reset-button"
+                    onMouseDown={handleReset}
                     tabIndex={-1}
                     type="button"
-                    aria-label={
-                        isSuggestionsShowing
-                            ? txt[locale].ACCOUNTSLIST_CLOSE
-                            : txt[locale].ACCOUNTSLIST_OPEN
-                    }
+                    aria-label={txt[locale].RESET_SEARCH}
                 >
-                    <ChevronIkon
-                        className={classNames(
-                            'ffe-base-selector__expand-button-icon ',
-                            {
-                                'ffe-base-selector__expand-button-icon--invalid': ariaInvalid,
-                            },
-                        )}
-                    />
+                    <KryssIkon className="ffe-base-selector__reset-button-icon" />
                 </button>
-            </div>
-        );
-    }
-}
+            )}
+            <button
+                className="ffe-base-selector__expand-button"
+                onMouseDown={onExpandOrCollapse}
+                tabIndex={-1}
+                type="button"
+                aria-label={
+                    isSuggestionsShowing
+                        ? txt[locale].ACCOUNTSLIST_CLOSE
+                        : txt[locale].ACCOUNTSLIST_OPEN
+                }
+            >
+                <ChevronIkon
+                    className={classNames(
+                        'ffe-base-selector__expand-button-icon ',
+                        {
+                            'ffe-base-selector__expand-button-icon--invalid': ariaInvalid,
+                        },
+                    )}
+                />
+            </button>
+        </div>
+    );
+};
 
-Input.propTypes = {
+InputField.propTypes = {
     onChange: func.isRequired,
     onKeyDown: func.isRequired,
     value: string.isRequired,
@@ -161,7 +130,7 @@ Input.propTypes = {
     locale: Locale.isRequired,
 };
 
-Input.defaultProps = {
+InputField.defaultProps = {
     onBlur: () => {},
     onFocus: () => {},
     inputFieldRef: () => {},
@@ -169,4 +138,4 @@ Input.defaultProps = {
     readOnly: false,
 };
 
-export default Input;
+export default InputField;


### PR DESCRIPTION
This PR removes the final deprecated React lifecycle from our components.

While the issue #372 also mentions `ffe-tables-react` I can't find any deprecated methods there. However, there is made use of `getDerivedStateFromProps` which in most cases can (and should) be replaced or rewritten. I think a separate issue should be raised for this component, or it could be solved by solving #132 

The PR also adds rules for hooks to our eslint config.

Fixes #372 