### PR TITLE
feat(ffe-buttons-react): accept refs created by useRef

### DIFF
--- a/packages/ffe-buttons-react/src/ActionButton.js
+++ b/packages/ffe-buttons-react/src/ActionButton.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { bool, func, node, string, oneOfType } from 'prop-types';
+import { bool, func, node, string, oneOfType, object, shape } from 'prop-types';
 import classNames from 'classnames';
 
 import Button from './BaseButton';
@@ -38,8 +38,8 @@ ActionButton.propTypes = {
     element: oneOfType([func, string]),
     /** Applies the ghost modifier if true. */
     ghost: bool,
-    /** Ref-setting function passed to the button element */
-    innerRef: func,
+    /** Ref-setting function, or ref created by useRef, passed to the button element */
+    innerRef: oneOfType([func, shape({ current: object })]),
     /** Shows a loader if true */
     isLoading: bool,
     /** Icon shown to the left of the label */

--- a/packages/ffe-buttons-react/src/BackButton.js
+++ b/packages/ffe-buttons-react/src/BackButton.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { oneOfType, func, node, string, bool } from 'prop-types';
+import { oneOfType, func, node, string, bool, object, shape } from 'prop-types';
 import InlineButton from './InlineBaseButton';
 
 const BackButton = props => <InlineButton buttonType="back" {...props} />;
@@ -11,8 +11,8 @@ BackButton.propTypes = {
     className: string,
     /** The rendered element, like an `<a />` or `<Link />` */
     element: oneOfType([func, string]),
-    /** Ref-setting function passed to the button element */
-    innerRef: func,
+    /** Ref-setting function, or ref created by useRef, passed to the button element */
+    innerRef: oneOfType([func, shape({ current: object })]),
     /** Dark variant */
     dark: bool,
 };

--- a/packages/ffe-buttons-react/src/BaseButton.js
+++ b/packages/ffe-buttons-react/src/BaseButton.js
@@ -1,5 +1,14 @@
 import React from 'react';
-import { bool, func, node, oneOf, oneOfType, string } from 'prop-types';
+import {
+    bool,
+    func,
+    node,
+    oneOf,
+    oneOfType,
+    string,
+    object,
+    shape,
+} from 'prop-types';
 import classNames from 'classnames';
 
 /**
@@ -81,8 +90,8 @@ BaseButton.propTypes = {
     disabled: bool,
     /** The rendered element, like an `<a />` or `<Link />` */
     element: oneOfType([func, string]),
-    /** Ref-setting function passed to the button element */
-    innerRef: func,
+    /** Ref-setting function, or ref created by useRef, passed to the button element */
+    innerRef: oneOfType([func, shape({ current: object })]),
     /** Shows a loader if true */
     isLoading: bool,
     /** Icon shown to the left of the label */

--- a/packages/ffe-buttons-react/src/ExpandButton.js
+++ b/packages/ffe-buttons-react/src/ExpandButton.js
@@ -1,5 +1,5 @@
 import React, { Fragment } from 'react';
-import { bool, func, oneOfType, string, node } from 'prop-types';
+import { bool, func, oneOfType, string, node, object, shape } from 'prop-types';
 import classNames from 'classnames';
 import KryssIkon from '@sb1/ffe-icons-react/lib/kryss-ikon';
 
@@ -61,8 +61,8 @@ ExpandButton.propTypes = {
     leftIcon: node,
     /** Icon shown to the right of the label */
     rightIcon: node,
-    /** Ref-setting function passed to the button element */
-    innerRef: func,
+    /** Ref-setting function, or ref created by useRef, passed to the button element */
+    innerRef: oneOfType([func, shape({ current: object })]),
     /** When true the component will render a circle with an X indicating whatever is controlled is in an expanded state. */
     isExpanded: bool.isRequired,
     /** Use to listen for clicks and toggle the `isExpanded` property together with whatever it is you're expanding. */

--- a/packages/ffe-buttons-react/src/InlineBaseButton.js
+++ b/packages/ffe-buttons-react/src/InlineBaseButton.js
@@ -1,5 +1,14 @@
 import React from 'react';
-import { func, string, oneOf, oneOfType, node, bool } from 'prop-types';
+import {
+    func,
+    string,
+    oneOf,
+    oneOfType,
+    node,
+    bool,
+    object,
+    shape,
+} from 'prop-types';
 import classNames from 'classnames';
 
 /**
@@ -57,8 +66,8 @@ InlineBaseButton.propTypes = {
     className: string,
     /** The rendered element, like an `<a />` or `<Link />` */
     element: oneOfType([string, func]),
-    /** Ref-setting function passed to the button element */
-    innerRef: func,
+    /** Ref-setting function, or ref created by useRef, passed to the button element */
+    innerRef: oneOfType([func, shape({ current: object })]),
     /** Icon shown to the left of the label */
     leftIcon: node,
     /** Icon shown to the right of the label */

--- a/packages/ffe-buttons-react/src/InlineExpandButton.js
+++ b/packages/ffe-buttons-react/src/InlineExpandButton.js
@@ -1,29 +1,33 @@
 import React from 'react';
-import { bool, func, node } from 'prop-types';
+import { bool, func, node, oneOfType, object, shape } from 'prop-types';
 import ChevronIkon from '@sb1/ffe-icons-react/lib/chevron-ikon';
 
 import InlineButton from './InlineBaseButton';
 
-const InlineExpandButton = (props) => {
-    const {
-        isExpanded,
-        ...rest
-    } = props;
+const InlineExpandButton = props => {
+    const { isExpanded, ...rest } = props;
 
     return (
         <InlineButton
             buttonType="expand"
-            rightIcon={<ChevronIkon style={{ marginLeft: '5px', transform: isExpanded ? 'rotateX(180deg)' : 'none' }} />}
+            rightIcon={
+                <ChevronIkon
+                    style={{
+                        marginLeft: '5px',
+                        transform: isExpanded ? 'rotateX(180deg)' : 'none',
+                    }}
+                />
+            }
             {...rest}
         />
     );
-}
+};
 
 InlineExpandButton.propTypes = {
     /** Text that should reflect the isExpanded state. */
     children: node,
-    /** Ref-setting function passed to the button element */
-    innerRef: func,
+    /** Ref-setting function, or ref created by useRef, passed to the button element */
+    innerRef: oneOfType([func, shape({ current: object })]),
     /** When true it will indicate the button is in its open state */
     isExpanded: bool.isRequired,
     /** Listen for clicks to toggle the isExpanded state. */

--- a/packages/ffe-buttons-react/src/PrimaryButton.js
+++ b/packages/ffe-buttons-react/src/PrimaryButton.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { bool, func, oneOfType, node, string } from 'prop-types';
+import { bool, func, oneOfType, node, string, object, shape } from 'prop-types';
 import Button from './BaseButton';
 
 const PrimaryButton = props => <Button buttonType="primary" {...props} />;
@@ -17,8 +17,8 @@ PrimaryButton.propTypes = {
     disabled: bool,
     /** The rendered element, like an `<a />` or `<Link />` */
     element: oneOfType([func, string]),
-    /** Ref-setting function passed to the button element */
-    innerRef: func,
+    /** Ref-setting function, or ref created by useRef, passed to the button element */
+    innerRef: oneOfType([func, shape({ current: object })]),
     /** Shows a loader if true */
     isLoading: bool,
     /** Icon shown to the left of the label */

--- a/packages/ffe-buttons-react/src/SecondaryButton.js
+++ b/packages/ffe-buttons-react/src/SecondaryButton.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { bool, func, oneOfType, string, node } from 'prop-types';
+import { bool, func, oneOfType, string, node, object, shape } from 'prop-types';
 import Button from './BaseButton';
 
 const SecondaryButton = props => <Button buttonType="secondary" {...props} />;
@@ -17,8 +17,8 @@ SecondaryButton.propTypes = {
     disabled: bool,
     /** The rendered element, like an `<a />` or `<Link />` */
     element: oneOfType([func, string]),
-    /** Ref-setting function passed to the button element */
-    innerRef: func,
+    /** Ref-setting function, or ref created by useRef, passed to the button element */
+    innerRef: oneOfType([func, shape({ current: object })]),
     /**  Shows a loader if true */
     isLoading: bool,
     /** Icon shown to the left of the label */

--- a/packages/ffe-buttons-react/src/ShortcutButton.js
+++ b/packages/ffe-buttons-react/src/ShortcutButton.js
@@ -1,14 +1,10 @@
 import React from 'react';
-import { bool, func, node, string, oneOfType } from 'prop-types';
+import { bool, func, node, string, oneOfType, object, shape } from 'prop-types';
 import ChevronIkon from '@sb1/ffe-icons-react/lib/chevron-ikon';
 import Button from './BaseButton';
 
 const ShortcutButton = props => (
-    <Button
-        buttonType="shortcut"
-        rightIcon={<ChevronIkon />}
-        {...props}
-    />
+    <Button buttonType="shortcut" rightIcon={<ChevronIkon />} {...props} />
 );
 
 ShortcutButton.propTypes = {
@@ -22,8 +18,8 @@ ShortcutButton.propTypes = {
     disabled: bool,
     /** The rendered element, like an `<a />` or `<Link />` */
     element: oneOfType([func, string]),
-    /** Ref-setting function passed to the button element */
-    innerRef: func,
+    /** Ref-setting function, or ref created by useRef, passed to the button element */
+    innerRef: oneOfType([func, shape({ current: object })]),
     /** Icon shown to the left of the label */
     leftIcon: node,
 };

--- a/packages/ffe-buttons-react/src/TaskButton.js
+++ b/packages/ffe-buttons-react/src/TaskButton.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { bool, func, node, string, oneOfType } from 'prop-types';
+import { bool, func, node, string, oneOfType, object, shape } from 'prop-types';
 import Button from './BaseButton';
 
 const TaskButton = ({ icon, ...rest }) => (
@@ -19,8 +19,8 @@ TaskButton.propTypes = {
     element: oneOfType([func, string]),
     /** Task icon, show to the left of the label */
     icon: node.isRequired,
-    /** Ref-setting function passed to the button element */
-    innerRef: func,
+    /** Ref-setting function, or ref created by useRef, passed to the button element */
+    innerRef: oneOfType([func, shape({ current: object })]),
 };
 
 export default TaskButton;

--- a/packages/ffe-buttons-react/src/TertiaryButton.js
+++ b/packages/ffe-buttons-react/src/TertiaryButton.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { func, node, oneOfType, string, bool } from 'prop-types';
+import { func, node, oneOfType, string, bool, object, shape } from 'prop-types';
 import InlineButton from './InlineBaseButton';
 
 const TertiaryButton = props => (
@@ -13,8 +13,8 @@ TertiaryButton.propTypes = {
     className: string,
     /** The rendered element, like an `<a />` or `<Link />` */
     element: oneOfType([func, string]),
-    /** Ref-setting function passed to the button element */
-    innerRef: func,
+    /** Ref-setting function, or ref created by useRef, passed to the button element */
+    innerRef: oneOfType([func, shape({ current: object })]),
     /** Icon shown to the left of the label */
     leftIcon: node,
     /** Icon shown to the right of the label */


### PR DESCRIPTION
The prop-type `innerRef` now accepts objects, in addition to functions.
With hooks it's now possible to create refs using the `useRef` hook.
These refs are objects which can be passed directly, instead of using a
ref-creating function.