### PR TITLE
Add white as background color to gridCol and gridRow

### DIFF
--- a/packages/ffe-grid-react/src/GridCol.js
+++ b/packages/ffe-grid-react/src/GridCol.js
@@ -151,6 +151,7 @@ GridCol.propTypes = {
         'orange-salmon',
         'red',
         'blue-sky',
+        'white',
     ]),
     /** Any extra classes are attached to the root node, in addition to ffe-grid__col classes */
     className: string,

--- a/packages/ffe-grid-react/src/GridRow.js
+++ b/packages/ffe-grid-react/src/GridRow.js
@@ -74,6 +74,7 @@ GridRow.propTypes = {
         'orange-salmon',
         'red',
         'blue-sky',
+        'white',
     ]),
     /** Any extra classes are attached to the root node, in addition to ffe-grid__row classes */
     className: string,

--- a/packages/ffe-grid-react/src/background-colors.js
+++ b/packages/ffe-grid-react/src/background-colors.js
@@ -8,6 +8,7 @@ export default [
     'orange-salmon',
     'red',
     'blue-sky',
+    'white',
 ];
 
 export const removedColors = ['blue-cobalt', 'blue-royal', 'purple-magenta'];

--- a/packages/ffe-grid-react/src/index.d.ts
+++ b/packages/ffe-grid-react/src/index.d.ts
@@ -23,7 +23,8 @@ type BackgroundColors =
     | 'grey-warm'
     | 'orange-salmon'
     | 'red'
-    | 'blue-sky';
+    | 'blue-sky'
+    | 'white';
 
 export interface GridRowProps extends React.HTMLAttributes<HTMLElement> {
     background?: BackgroundColors;

--- a/packages/ffe-grid/less/ffe-grid.less
+++ b/packages/ffe-grid/less/ffe-grid.less
@@ -67,6 +67,7 @@
 // --bg-orange-salmon      - Orange salmon background
 // --bg-red                - Red background
 // --bg-blue-sky           - Blue sky background
+// --bg-white              - White background
 //
 // Styleguide ffe-grid.grid.3
 
@@ -93,6 +94,7 @@
 // --bg-orange-salmon      - Orange salmon background
 // --bg-red                - Red background
 // --bg-blue-sky           - Blue sky background
+// --bg-white              - White background
 // --horizontal            - Set column direction to horizontal
 // --start                 - Align content to start
 // --center                - Center contents
@@ -209,6 +211,10 @@
 
     &--bg-blue-sky {
         background-color: @ffe-blue-sky;
+    }
+
+    &--bg-white {
+        background-color: @ffe-white;
     }
 
     &--reverse,
@@ -342,6 +348,10 @@
 
     &--bg-blue-sky {
         background-color: @ffe-blue-sky;
+    }
+
+    &--bg-white {
+        background-color: @ffe-white;
     }
 
     &--reverse {


### PR DESCRIPTION
In some cases in KFP-applications we have a background color on the body or a wrapper div, and use the grid to contain the content. As it's now we have to color the content inside the grid and add margin to that to get the desired look, if we want a white background on the content. This is not a problem when adding a blue background to the grid, then we can use the color and margin from the grid.

With this change we can explisitly set white as background color, that will be over the body color and we can use the grid properly in the case of white grid over colored background.