### PR TITLE
fix(ffe-buttons-react): elementType prop type

### DIFF
--- a/packages/ffe-buttons-react/src/ActionButton.js
+++ b/packages/ffe-buttons-react/src/ActionButton.js
@@ -1,5 +1,14 @@
 import React from 'react';
-import { bool, func, node, string, oneOfType, object, shape } from 'prop-types';
+import {
+    bool,
+    func,
+    node,
+    string,
+    oneOfType,
+    object,
+    shape,
+    elementType,
+} from 'prop-types';
 import classNames from 'classnames';
 
 import Button from './BaseButton';
@@ -35,7 +44,7 @@ ActionButton.propTypes = {
     /** Disable a button in certain situations */
     disabled: bool,
     /** The rendered element, like an `<a />` or `<Link />` */
-    element: oneOfType([func, string]),
+    element: oneOfType([func, string, elementType]),
     /** Applies the ghost modifier if true. */
     ghost: bool,
     /** Ref-setting function, or ref created by useRef, passed to the button element */

--- a/packages/ffe-buttons-react/src/BackButton.js
+++ b/packages/ffe-buttons-react/src/BackButton.js
@@ -1,5 +1,14 @@
 import React from 'react';
-import { oneOfType, func, node, string, bool, object, shape } from 'prop-types';
+import {
+    oneOfType,
+    func,
+    node,
+    string,
+    bool,
+    object,
+    shape,
+    elementType,
+} from 'prop-types';
 import InlineButton from './InlineBaseButton';
 
 const BackButton = props => <InlineButton buttonType="back" {...props} />;
@@ -10,7 +19,7 @@ BackButton.propTypes = {
     /** Extra class names */
     className: string,
     /** The rendered element, like an `<a />` or `<Link />` */
-    element: oneOfType([func, string]),
+    element: oneOfType([func, string, elementType]),
     /** Ref-setting function, or ref created by useRef, passed to the button element */
     innerRef: oneOfType([func, shape({ current: object })]),
     /** Dark variant */

--- a/packages/ffe-buttons-react/src/BaseButton.js
+++ b/packages/ffe-buttons-react/src/BaseButton.js
@@ -8,6 +8,7 @@ import {
     string,
     object,
     shape,
+    elementType,
 } from 'prop-types';
 import classNames from 'classnames';
 
@@ -89,7 +90,7 @@ BaseButton.propTypes = {
     /** Disable a button in certain situations */
     disabled: bool,
     /** The rendered element, like an `<a />` or `<Link />` */
-    element: oneOfType([func, string]),
+    element: oneOfType([func, string, elementType]),
     /** Ref-setting function, or ref created by useRef, passed to the button element */
     innerRef: oneOfType([func, shape({ current: object })]),
     /** Shows a loader if true */

--- a/packages/ffe-buttons-react/src/ExpandButton.js
+++ b/packages/ffe-buttons-react/src/ExpandButton.js
@@ -1,5 +1,14 @@
 import React, { Fragment } from 'react';
-import { bool, func, oneOfType, string, node, object, shape } from 'prop-types';
+import {
+    bool,
+    func,
+    oneOfType,
+    string,
+    node,
+    object,
+    shape,
+    elementType,
+} from 'prop-types';
 import classNames from 'classnames';
 import KryssIkon from '@sb1/ffe-icons-react/lib/kryss-ikon';
 
@@ -54,7 +63,7 @@ ExpandButton.propTypes = {
     /** Extra class names */
     className: string,
     /** The rendered element, like an `<a />` or `<Link />` */
-    element: oneOfType([func, string]),
+    element: oneOfType([func, string, elementType]),
     /** An accessible label for the close-button, only shown in the "isExpanded" state  */
     closeLabel: string,
     /** Icon shown to the left of the label */

--- a/packages/ffe-buttons-react/src/InlineBaseButton.js
+++ b/packages/ffe-buttons-react/src/InlineBaseButton.js
@@ -8,6 +8,7 @@ import {
     bool,
     object,
     shape,
+    elementType,
 } from 'prop-types';
 import classNames from 'classnames';
 
@@ -65,7 +66,7 @@ InlineBaseButton.propTypes = {
     /** Extra class names */
     className: string,
     /** The rendered element, like an `<a />` or `<Link />` */
-    element: oneOfType([string, func]),
+    element: oneOfType([string, func, elementType]),
     /** Ref-setting function, or ref created by useRef, passed to the button element */
     innerRef: oneOfType([func, shape({ current: object })]),
     /** Icon shown to the left of the label */

--- a/packages/ffe-buttons-react/src/PrimaryButton.js
+++ b/packages/ffe-buttons-react/src/PrimaryButton.js
@@ -1,5 +1,14 @@
 import React from 'react';
-import { bool, func, oneOfType, node, string, object, shape } from 'prop-types';
+import {
+    bool,
+    func,
+    oneOfType,
+    node,
+    string,
+    object,
+    shape,
+    elementType,
+} from 'prop-types';
 import Button from './BaseButton';
 
 const PrimaryButton = props => <Button buttonType="primary" {...props} />;
@@ -16,7 +25,7 @@ PrimaryButton.propTypes = {
     /** Disable a button in certain situations */
     disabled: bool,
     /** The rendered element, like an `<a />` or `<Link />` */
-    element: oneOfType([func, string]),
+    element: oneOfType([func, string, elementType]),
     /** Ref-setting function, or ref created by useRef, passed to the button element */
     innerRef: oneOfType([func, shape({ current: object })]),
     /** Shows a loader if true */

--- a/packages/ffe-buttons-react/src/SecondaryButton.js
+++ b/packages/ffe-buttons-react/src/SecondaryButton.js
@@ -1,5 +1,14 @@
 import React from 'react';
-import { bool, func, oneOfType, string, node, object, shape } from 'prop-types';
+import {
+    bool,
+    func,
+    oneOfType,
+    string,
+    node,
+    object,
+    shape,
+    elementType,
+} from 'prop-types';
 import Button from './BaseButton';
 
 const SecondaryButton = props => <Button buttonType="secondary" {...props} />;
@@ -16,7 +25,7 @@ SecondaryButton.propTypes = {
     /** Disable a button in certain situations */
     disabled: bool,
     /** The rendered element, like an `<a />` or `<Link />` */
-    element: oneOfType([func, string]),
+    element: oneOfType([func, string, elementType]),
     /** Ref-setting function, or ref created by useRef, passed to the button element */
     innerRef: oneOfType([func, shape({ current: object })]),
     /**  Shows a loader if true */

--- a/packages/ffe-buttons-react/src/ShortcutButton.js
+++ b/packages/ffe-buttons-react/src/ShortcutButton.js
@@ -1,5 +1,14 @@
 import React from 'react';
-import { bool, func, node, string, oneOfType, object, shape } from 'prop-types';
+import {
+    bool,
+    func,
+    node,
+    string,
+    oneOfType,
+    object,
+    shape,
+    elementType,
+} from 'prop-types';
 import ChevronIkon from '@sb1/ffe-icons-react/lib/chevron-ikon';
 import Button from './BaseButton';
 
@@ -17,7 +26,7 @@ ShortcutButton.propTypes = {
     /** Disable a button in certain situations */
     disabled: bool,
     /** The rendered element, like an `<a />` or `<Link />` */
-    element: oneOfType([func, string]),
+    element: oneOfType([func, string, elementType]),
     /** Ref-setting function, or ref created by useRef, passed to the button element */
     innerRef: oneOfType([func, shape({ current: object })]),
     /** Icon shown to the left of the label */

--- a/packages/ffe-buttons-react/src/TaskButton.js
+++ b/packages/ffe-buttons-react/src/TaskButton.js
@@ -1,5 +1,14 @@
 import React from 'react';
-import { bool, func, node, string, oneOfType, object, shape } from 'prop-types';
+import {
+    bool,
+    func,
+    node,
+    string,
+    oneOfType,
+    object,
+    shape,
+    elementType,
+} from 'prop-types';
 import Button from './BaseButton';
 
 const TaskButton = ({ icon, ...rest }) => (
@@ -16,7 +25,7 @@ TaskButton.propTypes = {
     /** Disable a button in certain situations */
     disabled: bool,
     /** The rendered element, like an `<a />` or `<Link />` */
-    element: oneOfType([func, string]),
+    element: oneOfType([func, string, elementType]),
     /** Task icon, show to the left of the label */
     icon: node.isRequired,
     /** Ref-setting function, or ref created by useRef, passed to the button element */

--- a/packages/ffe-buttons-react/src/TertiaryButton.js
+++ b/packages/ffe-buttons-react/src/TertiaryButton.js
@@ -1,5 +1,14 @@
 import React from 'react';
-import { func, node, oneOfType, string, bool, object, shape } from 'prop-types';
+import {
+    func,
+    node,
+    oneOfType,
+    string,
+    bool,
+    object,
+    shape,
+    elementType,
+} from 'prop-types';
 import InlineButton from './InlineBaseButton';
 
 const TertiaryButton = props => (
@@ -12,7 +21,7 @@ TertiaryButton.propTypes = {
     /** Extra class names */
     className: string,
     /** The rendered element, like an `<a />` or `<Link />` */
-    element: oneOfType([func, string]),
+    element: oneOfType([func, string, elementType]),
     /** Ref-setting function, or ref created by useRef, passed to the button element */
     innerRef: oneOfType([func, shape({ current: object })]),
     /** Icon shown to the left of the label */


### PR DESCRIPTION
løser https://github.com/SpareBank1/designsystem/issues/707

Hvordan får jag in elemenType her for de som bruker ts?
```
export interface MinimalBaseButtonProps extends React.HTMLProps<HTMLElement> {
    className?: string;
    element?: HTMLElement | string;
    innerRef?: React.RefObject<HTMLElement>;
}
```