### PR TITLE
feat(ffe-datepicker-react): Option for full width Datepicker

### DIFF
--- a/packages/ffe-datepicker-react/src/datepicker/Datepicker.js
+++ b/packages/ffe-datepicker-react/src/datepicker/Datepicker.js
@@ -299,6 +299,7 @@ export default class Datepicker extends Component {
             language,
             onChange,
             value,
+            fullWidth,
         } = this.props;
         const {
             focusOnCalendarOpen,
@@ -319,6 +320,10 @@ export default class Datepicker extends Component {
             { 'ffe-calendar--datepicker--above': this.props.calendarAbove },
         );
 
+        const datepickerClassName = classNames('ffe-datepicker', {
+            'ffe-datepicker--full-width': fullWidth,
+        });
+
         return (
             <div>
                 {label && (
@@ -337,7 +342,7 @@ export default class Datepicker extends Component {
                             : undefined
                     }
                     aria-label={label ? undefined : i18n[language].CHOOSE_DATE}
-                    className="ffe-datepicker"
+                    className={datepickerClassName}
                     onClick={this.clickHandler}
                     ref={c => {
                         this._datepickerNode = c;
@@ -357,6 +362,7 @@ export default class Datepicker extends Component {
                             this.dateInputRef = c;
                         }}
                         value={value}
+                        fullWidth={fullWidth}
                     />
 
                     {this.state.displayDatePicker && (
@@ -395,6 +401,7 @@ Datepicker.defaultProps = {
     language: 'nb',
     keepDisplayStateOnError: false,
     onValidationComplete: () => {},
+    fullWidth: false,
 };
 
 Datepicker.propTypes = {
@@ -415,4 +422,5 @@ Datepicker.propTypes = {
     onError: func,
     value: string.isRequired,
     keepDisplayStateOnError: bool.isRequired,
+    fullWidth: bool,
 };

--- a/packages/ffe-datepicker-react/src/datepicker/Datepicker.md
+++ b/packages/ffe-datepicker-react/src/datepicker/Datepicker.md
@@ -43,6 +43,22 @@ initialState = { date: '01.01.2016' };
 />;
 ```
 
+Kan rendres i full bredde:
+
+```js
+initialState = { date: '01.01.2016' };
+<Datepicker
+    inputProps={{ id: 'datepicker-example' }}
+    label="Velg dato"
+    language="nb"
+    maxDate="31.12.2016"
+    minDate="01.01.2016"
+    onChange={date => setState({ date })}
+    value={state.date}
+    fullWidth={true}
+/>;
+```
+
 Kan rendres på engelsk og nynorsk, i tillegg til bokmål:
 
 ```js

--- a/packages/ffe-datepicker-react/src/datepicker/Datepicker.spec.js
+++ b/packages/ffe-datepicker-react/src/datepicker/Datepicker.spec.js
@@ -207,6 +207,18 @@ describe('<Datepicker />', () => {
                 );
             });
         });
+
+        describe('fullWidth', () => {
+            it('has correct full width class', () => {
+                const wrapper = getMountedWrapper({ fullWidth: true });
+
+                expect(
+                    wrapper
+                        .find('.ffe-datepicker')
+                        .hasClass('ffe-datepicker--full-width'),
+                ).toBe(true);
+            });
+        });
     });
 
     describe('validating input on blur', () => {

--- a/packages/ffe-datepicker-react/src/input/Input.js
+++ b/packages/ffe-datepicker-react/src/input/Input.js
@@ -16,6 +16,12 @@ export default class Input extends Component {
         );
     }
 
+    dateInputClassNames() {
+        return classNames('ffe-dateinput', {
+            'ffe-dateinput--full-width': this.props.fullWidth,
+        });
+    }
+
     render() {
         const {
             ariaInvalid,
@@ -28,7 +34,7 @@ export default class Input extends Component {
         } = this.props;
 
         return (
-            <div className="ffe-dateinput">
+            <div className={this.dateInputClassNames()}>
                 <input
                     aria-invalid={String(
                         this.props['aria-invalid'] || ariaInvalid,
@@ -62,4 +68,5 @@ Input.propTypes = {
     onFocus: func,
     onKeyDown: func,
     value: string.isRequired,
+    fullWidth: bool,
 };

--- a/packages/ffe-datepicker-react/src/input/Input.spec.js
+++ b/packages/ffe-datepicker-react/src/input/Input.spec.js
@@ -17,9 +17,21 @@ const defaultProps = {
 const getWrapper = props => shallow(<Input {...defaultProps} {...props} />);
 
 describe('<Input />', () => {
-    it('should render a wrapper for the input field', () => {
-        const wrapper = getWrapper();
-        expect(wrapper.hasClass('ffe-dateinput')).toBe(true);
+    describe('wrapper', () => {
+        it('should render a wrapper for the input field', () => {
+            const wrapper = getWrapper();
+            expect(wrapper.hasClass('ffe-dateinput')).toBe(true);
+        });
+
+        it('should not have full-width element class name if not fullWidth prop is true', () => {
+            const dateInput = getWrapper();
+            expect(dateInput.hasClass('ffe-dateinput--full-width')).toBe(false);
+        });
+
+        it('should have full-width element class name if fullWidth prop is true', () => {
+            const dateInput = getWrapper({ fullWidth: true });
+            expect(dateInput.hasClass('ffe-dateinput--full-width')).toBe(true);
+        });
     });
 
     describe('nested input field', () => {


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request! 🎉

If your changes include some kind of UI element, please attach a screenshot of 
how it looks.

Before submitting a pull request, please have a look through the CONTRIBUTING.md
document. TL;DR:

- Follow the conventional commit standard
- Write full, explanatory commit messages
- Follow our code standards
- Write tests where applicable
- Be courteous and respect our code of conduct
-->

Innfør `fullWidth` prop som gjør det mulig å ha `Datepicker` i fullbredde-modus. Tar i bruk stylingen fra https://github.com/SpareBank1/designsystem/pull/717.

![image](https://user-images.githubusercontent.com/3830142/66485940-f3abb580-eaa9-11e9-97c6-2d5ba3e346d5.png)
