### PR TITLE
feat(ffe-core-react): center leading paragraph

### DIFF
--- a/packages/ffe-core-react/src/typography/Paragraph.js
+++ b/packages/ffe-core-react/src/typography/Paragraph.js
@@ -13,15 +13,19 @@ export default function Paragraph(props) {
         ...rest
     } = props;
 
+    const [mainClass] = [
+        lead && 'ffe-lead-paragraph',
+        subLead && 'ffe-sub-lead-paragraph',
+        'ffe-body-paragraph',
+    ].filter(Boolean);
+
     return (
         <p
             className={classNames(
-                { 'ffe-body-paragraph': !lead && !subLead },
-                { 'ffe-body-paragraph--text-center': !lead && !subLead && textCenter },
-                { 'ffe-body-paragraph--text-left': !lead && !subLead && textLeft },
-                { 'ffe-lead-paragraph': lead },
-                { 'ffe-sub-lead-paragraph': subLead },
-                className
+                mainClass,
+                { 'ffe-body-paragraph--text-center': textCenter },
+                { 'ffe-body-paragraph--text-left': textLeft },
+                className,
             )}
             {...rest}
         >

--- a/packages/ffe-core-react/src/typography/Paragraph.spec.js
+++ b/packages/ffe-core-react/src/typography/Paragraph.spec.js
@@ -5,7 +5,8 @@ import Paragraph from './Paragraph';
 
 const defaultProps = { children: 'Test!' };
 
-const getWrapper = (props = {}) => shallow(<Paragraph {...defaultProps} {...props} />);
+const getWrapper = (props = {}) =>
+    shallow(<Paragraph {...defaultProps} {...props} />);
 
 describe('<Paragraph />', () => {
     test('renders without exploding', () => {
@@ -26,20 +27,6 @@ describe('<Paragraph />', () => {
     test('adds --text-left modifier if textLeft prop is true', () => {
         const wrapper = getWrapper({ textLeft: true });
         expect(wrapper.hasClass('ffe-body-paragraph--text-left')).toBe(true);
-    });
-
-    test('does not add --text-left or --text-center modifiers if lead or subLead props are true', () => {
-        const leftLeadWrapper = getWrapper({ textLeft: true, lead: true });
-        expect(leftLeadWrapper.hasClass('ffe-body-paragraph--text-left')).toBe(false);
-
-        const centerLeadWrapper = getWrapper({ textCenter: true, lead: true });
-        expect(centerLeadWrapper.hasClass('ffe-body-paragraph--text-center')).toBe(false);
-
-        const leftSubLeadWrapper = getWrapper({ textLeft: true, subLead: true });
-        expect(leftSubLeadWrapper.hasClass('ffe-body-paragraph--text-left')).toBe(false);
-
-        const centerSubLeadWrapper = getWrapper({ textCenter: true, subLead: true });
-        expect(centerSubLeadWrapper.hasClass('ffe-body-paragraph--text-center')).toBe(false);
     });
 
     test('adds ffe-lead-paragraph class if lead prop is true', () => {


### PR DESCRIPTION
Paragraph can now operate with textCenter and lead/subLead togheter. 