### PR TITLE
feat(ffe-webfonts): set font loading behavior to fallback

### DIFF
--- a/packages/ffe-webfonts/fonts-inline.less
+++ b/packages/ffe-webfonts/fonts-inline.less
@@ -42,30 +42,35 @@
 
 @font-face {
     font-family: 'MuseoSans-300';
+    font-display: fallback;
     src: data-uri('./fonts/2FDE32_0_0.woff2') format('woff2'),
         data-uri('./fonts/2FDE32_0_0.woff') format('woff');
 }
 
 @font-face {
     font-family: 'MuseoSans-500';
+    font-display: fallback;
     src: data-uri('./fonts/2FDE32_1_0.woff2') format('woff2'),
         data-uri('./fonts/2FDE32_1_0.woff') format('woff');
 }
 
 @font-face {
     font-family: 'MuseoSansRounded-300';
+    font-display: fallback;
     src: data-uri('./fonts/2FDE32_2_0.woff2') format('woff2'),
         data-uri('./fonts/2FDE32_2_0.woff') format('woff');
 }
 
 @font-face {
     font-family: 'MuseoSansRounded-500';
+    font-display: fallback;
     src: data-uri('./fonts/2FDE32_3_0.woff2') format('woff2'),
         data-uri('./fonts/2FDE32_3_0.woff') format('woff');
 }
 
 @font-face {
     font-family: 'MuseoSansRounded-700';
+    font-display: fallback;
     src: data-uri('./fonts/2FDE32_4_0.woff2') format('woff2'),
         data-uri('./fonts/2FDE32_4_0.woff') format('woff');
 }

--- a/packages/ffe-webfonts/fonts.less
+++ b/packages/ffe-webfonts/fonts.less
@@ -42,30 +42,35 @@
 
 @font-face {
     font-family: 'MuseoSans-300';
+    font-display: fallback;
     src: url('@{fonts-url}/2FDE32_0_0.woff2') format('woff2'),
         url('@{fonts-url}/2FDE32_0_0.woff') format('woff');
 }
 
 @font-face {
     font-family: 'MuseoSans-500';
+    font-display: fallback;
     src: url('@{fonts-url}/2FDE32_1_0.woff2') format('woff2'),
         url('@{fonts-url}/2FDE32_1_0.woff') format('woff');
 }
 
 @font-face {
     font-family: 'MuseoSansRounded-300';
+    font-display: fallback;
     src: url('@{fonts-url}/2FDE32_2_0.woff2') format('woff2'),
         url('@{fonts-url}/2FDE32_2_0.woff') format('woff');
 }
 
 @font-face {
     font-family: 'MuseoSansRounded-500';
+    font-display: fallback;
     src: url('@{fonts-url}/2FDE32_3_0.woff2') format('woff2'),
         url('@{fonts-url}/2FDE32_3_0.woff') format('woff');
 }
 
 @font-face {
     font-family: 'MuseoSansRounded-700';
+    font-display: fallback;
     src: url('@{fonts-url}/2FDE32_4_0.woff2') format('woff2'),
         url('@{fonts-url}/2FDE32_4_0.woff') format('woff');
 }


### PR DESCRIPTION
Setter oppførselen til browseren eksplisitt før fonten blir lastet.

Ref: https://developers.google.com/web/updates/2016/02/font-display?utm_source=lighthouse&utm_medium=devtools

CLOSES: #721