### PR TITLE
fix(ffe-buttons-react): invalid markup

### DIFF
--- a/packages/ffe-buttons-react/src/BaseButton.js
+++ b/packages/ffe-buttons-react/src/BaseButton.js
@@ -63,7 +63,7 @@ const BaseButton = props => {
                     })}
             </span>
             {supportsSpinner && (
-                <div
+                <span
                     aria-hidden={!isLoading}
                     aria-label={ariaLoadingMessage}
                     className="ffe-button__spinner"


### PR DESCRIPTION
A button tag must have phrasing content children.