### PR TITLE
fix(ffe-form): Fix vertical alignment of ffe-tooltip

### DIFF
--- a/packages/ffe-form/less/tooltip.less
+++ b/packages/ffe-form/less/tooltip.less
@@ -23,7 +23,7 @@
         cursor: help;
         display: inline-block;
         height: @ffe-tooltip-size;
-        line-height: 22px;
+        line-height: 24px;
         margin: 0 0 4px 13px;
         padding: 0 0 0 1px;
         text-align: center;


### PR DESCRIPTION
Changes line-height from 22px to 24px to better center the ?
vertically.

Fixes #731

<!-- 
Thanks for opening a pull request! 🎉

If your changes include some kind of UI element, please attach a screenshot of 
how it looks.

Before submitting a pull request, please have a look through the CONTRIBUTING.md
document. TL;DR:

- Follow the conventional commit standard
- Write full, explanatory commit messages
- Follow our code standards
- Write tests where applicable
- Be courteous and respect our code of conduct
-->
