### PR TITLE
feat(ffe-form-react): InputGroup `hideErrorOnChange` set to `true` hi…

### DIFF
--- a/packages/ffe-form-react/src/InputGroup.md
+++ b/packages/ffe-form-react/src/InputGroup.md
@@ -200,6 +200,25 @@ const { Input } = require('.');
 </InputGroup>;
 ```
 
+Dersom du vil skjule error-meldingen ved endringer, og kun vise den når `InputGroup` mister fokus, sett `hideErrorOnChange` til `true`.
+
+```js
+const { Input } = require('.');
+
+<InputGroup
+    label="Telefonnummer"
+    fieldMessage="Jeg er en feilmelding som forsvinner ved endring"
+    hideErrorOnChange={true}
+>
+    <Input
+        type="tel"
+        name="mobile"
+        onChange={e => console.log('onChange', e.target.value)}
+        onBlur={e => console.log('onBlur', e.target.value)}
+    />
+</InputGroup>;
+```
+
 Utviklere bør merke seg at man er nødt til å bruke det såkalte _function-as-a-child_-patternet med mindre man bare har
 ett child-element til InputGroup. Dette er fordi InputGroup setter properties som ID og liknende på rot-elementet, og
 det forventes at det er et skjemaelement.

--- a/packages/ffe-form-react/src/InputGroup.spec.js
+++ b/packages/ffe-form-react/src/InputGroup.spec.js
@@ -65,6 +65,24 @@ describe('<InputGroup>', () => {
         expect(wrapper.find(Input).prop('aria-invalid')).toBe('true');
     });
 
+    it('renders error only on blur, and hides it on change when hideErrorOnChange is true', () => {
+        const wrapper = getWrapper({
+            fieldMessage: 'such error',
+            hideErrorOnChange: true,
+        });
+        wrapper.simulate('change', { target: { value: 'im a value' } });
+
+        expect(wrapper.find('ErrorFieldMessage').exists()).toBe(false);
+        expect(wrapper.find(Input).prop('aria-invalid')).toBe('false');
+
+        wrapper.simulate('blur');
+
+        expect(wrapper.find('ErrorFieldMessage').prop('children')).toBe(
+            'such error',
+        );
+        expect(wrapper.find(Input).prop('aria-invalid')).toBe('true');
+    });
+
     it('renders a Label component if passed a label prop', () => {
         const wrapper = getWrapper({ label: <Label>Label text</Label> });
 

--- a/packages/ffe-form-react/src/index.d.ts
+++ b/packages/ffe-form-react/src/index.d.ts
@@ -71,6 +71,7 @@ export interface InputGroupProps extends React.HTMLAttributes<HTMLDivElement> {
     label?: string | Label;
     onTooltipToggle?: (e: React.MouseEvent | undefined) => void;
     tooltip?: React.ReactNode;
+    hideErrorOnChange?: boolean;
 }
 
 export interface TooltipProps extends React.HTMLAttributes<HTMLSpanElement> {


### PR DESCRIPTION
…des error message on change and renders it on blur

Setting the `hideErrorOnChange` prop to `true` hides the error message on change, and renders it on blur. This means that you won't see an error message until the `InputGroup` has lost focus.

Example:
With `hideErrorOnChange` set to false (default), writing an email address into an input field will display an error message while the user is typing, until the complete valid email is typed.
With `hideErrorOnChange` set to true, the error message will only display after the input group loses focus, and will be hidden again if the user goes back to the input field and starts to type.
