### PR TITLE
feat(ffe-core): export spacing to JS

### DIFF
--- a/packages/ffe-core/bin/build.js
+++ b/packages/ffe-core/bin/build.js
@@ -4,7 +4,7 @@ const Case = require('case');
 const mkdirp = require('mkdirp');
 
 // These are the files we want to convert to JavaScript
-const FILES_WITH_VARIABLES = ['colors', 'breakpoints'];
+const FILES_WITH_VARIABLES = ['colors', 'breakpoints', 'spacing'];
 
 // First, create the lib directory if it doesn't exist
 mkdirp.sync(path.resolve(__dirname, '..', 'lib'));
@@ -22,9 +22,10 @@ FILES_WITH_VARIABLES.forEach(filename => {
         .split('\n')
         .map(line => line.trim())
         .filter(line => line.startsWith('@') && !line.startsWith('@import'))
-        .map(line => line.replace('@ffe-', ''))
-        .map(line => line.replace('@', ''))
         .map(line => line.split(': '))
+        .filter(([, value]) => !value.includes('@'))
+        .map(([key, value]) => [key.replace('@ffe-', ''), value])
+        .map(([key, value]) => [key.replace('@', ''), value])
         .reduce(
             (allVars, [key, value]) => ({
                 ...allVars,


### PR DESCRIPTION
This makes some slight changes to the build script used to export less variables as JS variables.

In order to export the spacing variable from spacing.less we need to somehow handle variables pointing to other variables. For example `@ffe-spacing-2xs: (@ffe-spacing * 0.5); // 4px`.

My approach to this is simply to filter out any variables that points to other variables.

These changes does not cause any changes to the generated `breakpoints.js` or `colors.js`.