### PR TITLE
fix(ffe-form-react): allow number values in prop types

### DIFF
--- a/packages/ffe-form-react/src/BaseRadioButton.js
+++ b/packages/ffe-form-react/src/BaseRadioButton.js
@@ -1,6 +1,14 @@
 import React, { Component, Fragment } from 'react';
 import classNames from 'classnames';
-import { bool, node, oneOf, oneOfType, shape, string } from 'prop-types';
+import {
+    bool,
+    node,
+    oneOf,
+    oneOfType,
+    shape,
+    string,
+    number,
+} from 'prop-types';
 import uuid from 'uuid';
 
 import Tooltip from './Tooltip';
@@ -78,13 +86,13 @@ BaseRadioButton.propTypes = {
     /** The name of the radio button */
     name: string.isRequired,
     /** The selected value of the radio button set */
-    selectedValue: oneOfType([bool, string]),
+    selectedValue: oneOfType([bool, string, number]),
     /** Tooltip providing further detail about the choice */
     tooltip: string,
     /** Additional props passed to the Tooltip component */
     tooltipProps: shape({}),
     /** The value of the radio button */
-    value: oneOfType([bool, string]).isRequired,
+    value: oneOfType([bool, string, number]).isRequired,
     /** Dark variant */
     dark: bool,
 };

--- a/packages/ffe-form-react/src/RadioButtonInputGroup.js
+++ b/packages/ffe-form-react/src/RadioButtonInputGroup.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { bool, func, oneOfType, oneOf, node, string } from 'prop-types';
+import { bool, func, oneOfType, oneOf, node, string, number } from 'prop-types';
 import classNames from 'classnames';
 import ErrorFieldMessage from './ErrorFieldMessage';
 import Tooltip from './Tooltip';
@@ -115,7 +115,7 @@ RadioButtonInputGroup.propTypes = {
     /** Change handler, receives value of selected radio button */
     onChange: func,
     /** The currently selected value */
-    selectedValue: oneOfType([bool, string]),
+    selectedValue: oneOfType([bool, string, number]),
     /**
      * String or Tooltip component with further detail about the radio button
      * set

--- a/packages/ffe-form-react/src/RadioSwitch.js
+++ b/packages/ffe-form-react/src/RadioSwitch.js
@@ -1,5 +1,5 @@
 import React, { Fragment } from 'react';
-import { bool, oneOf, oneOfType, string } from 'prop-types';
+import { bool, oneOf, oneOfType, string, number } from 'prop-types';
 import classNames from 'classnames';
 
 import BaseRadioButton from './BaseRadioButton';
@@ -61,13 +61,13 @@ RadioSwitch.propTypes = {
     /** The label of the choice to the left */
     leftLabel: string.isRequired,
     /** The value of the choice to the left */
-    leftValue: oneOfType([bool, string]).isRequired,
+    leftValue: oneOfType([bool, string, number]).isRequired,
     /** The label of the choice to the right */
     rightLabel: string.isRequired,
     /** The value of the choice to the right */
-    rightValue: oneOfType([bool, string]).isRequired,
+    rightValue: oneOfType([bool, string, number]).isRequired,
     /** The selected value of the radio button set */
-    selectedValue: oneOfType([bool, string]),
+    selectedValue: oneOfType([bool, string, number]),
     /** Condensed modifier. Use in condensed designs */
     condensed: bool,
     /** Dark variant */

--- a/packages/ffe-form-react/src/index.d.ts
+++ b/packages/ffe-form-react/src/index.d.ts
@@ -114,10 +114,10 @@ export interface RadioButtonProps extends WeakInputAttributes {
     labelProps?: object;
     inline?: boolean;
     name: string;
-    selectedValue?: boolean | string;
+    selectedValue?: boolean | string | number;
     tooltip?: string;
     tooltipProps?: TooltipProps;
-    value: boolean | string;
+    value: boolean | string | number;
     dark?: boolean;
 }
 
@@ -132,7 +132,7 @@ export interface RadioButtonInputGroupProps
     label?: string | React.ReactNode;
     name?: string;
     onChange?: React.FormEventHandler<HTMLElement>;
-    selectedValue?: string | boolean;
+    selectedValue?: string | boolean | number;
     tooltip?: string | React.ReactNode;
     dark?: boolean;
 }
@@ -144,11 +144,11 @@ export interface RadioSwitchProps
     className?: string;
     labelProps?: object;
     leftLabel: string;
-    leftValue: boolean | string;
+    leftValue: boolean | string | number;
     rightLabel: string;
-    rightValue: boolean | string;
+    rightValue: boolean | string | number;
     name: string;
-    selectedValue?: boolean | string;
+    selectedValue?: boolean | string | number;
     tooltip?: string;
     tooltipProps?: TooltipProps;
     condensed?: boolean;


### PR DESCRIPTION
This will make it easier to work with numerical values in forms, as you will only have to parse the value when it is read from the field (because fields always "returns" strings)
Prior to this change you would need to parse numbers to strings just to satisfy prop types, or settle for having numerical values as strings in your form state.

