### PR TITLE
docs(ffe-grid-react): Reword GridCol size validity warning.

### DIFF
--- a/packages/ffe-grid-react/src/GridCol.spec.js
+++ b/packages/ffe-grid-react/src/GridCol.spec.js
@@ -301,7 +301,7 @@ describe('GridCol', () => {
 
                 expect(console.error).toHaveBeenCalledTimes(1);
                 expect(console.error.mock.calls[0][0]).toContain(
-                    'The grid should have 6 columns for "md" screens',
+                    'For "md" screensizes, both cols and offset should be multiples of 2',
                 );
             });
 
@@ -310,7 +310,7 @@ describe('GridCol', () => {
 
                 expect(console.error).toHaveBeenCalledTimes(1);
                 expect(console.error.mock.calls[0][0]).toContain(
-                    'The grid should have 6 columns for "md" screens',
+                    'For "md" screensizes, both cols and offset should be multiples of 2',
                 );
             });
 
@@ -319,7 +319,7 @@ describe('GridCol', () => {
 
                 expect(console.error).toHaveBeenCalledTimes(1);
                 expect(console.error.mock.calls[0][0]).toContain(
-                    'The grid should have 4 columns for "sm" screens',
+                    'For "sm" screensizes, both cols and offset should be multiples of 3',
                 );
             });
 
@@ -328,7 +328,7 @@ describe('GridCol', () => {
 
                 expect(console.error).toHaveBeenCalledTimes(1);
                 expect(console.error.mock.calls[0][0]).toContain(
-                    'The grid should have 4 columns for "sm" screens',
+                    'For "sm" screensizes, both cols and offset should be multiples of 3',
                 );
             });
 

--- a/packages/ffe-grid-react/src/utils.dev.js
+++ b/packages/ffe-grid-react/src/utils.dev.js
@@ -51,8 +51,7 @@ const checkValidMdColumns = modifier => {
         )
     ) {
         console.error(`
-            The grid should have 6 columns for "md" screens, please stick to a total of 6 columns.
-            For "md" screensizes this means you need to stick to multiples of 2 for cols+offset.
+            For "md" screensizes, both cols and offset should be multiples of 2.
             Please consult the ffe-grid README.md for details.
 
             You've provided a <GridCol> with md={${JSON.stringify(modifier)}}
@@ -74,8 +73,7 @@ const checkValidSmColumns = modifier => {
         )
     ) {
         console.error(`
-            The grid should have 4 columns for "sm" screens, please stick to a total of 4 columns.
-            For "sm" screensizes this means you need to stick to multiples of 3 for cols+offset.
+            For "sm" screensizes, both cols and offset should be multiples of 3.
             Please consult the ffe-grid README.md for details.
 
             You've provided a <GridCol> with sm={${JSON.stringify(modifier)}}


### PR DESCRIPTION
Our team spent a long time to understand what the `GridCol` warning meant.
For example, we got this warning
```
The grid should have 4 columns for "sm" screens, please stick to a total of 4 columns.
For "sm" screensizes this means you need to stick to multiples of 3 for cols+offset.
Please consult the ffe-grid README.md for details.
You've provided a <GridCol> with sm={{"cols":4,"offset":0}}
```
It says we should stick to 4 columns, but as the warning itself says, we have supplied `cols: 4`, so from our point of view we **did** stick to 4 columns.

This edit makes it clear that the only thing that matters is that you stick to the correct multiples.