### PR TITLE
fix(ffe-form-react): Ensure type definitions for type script is correct.

### DIFF
--- a/packages/ffe-form-react/src/index.d.ts
+++ b/packages/ffe-form-react/src/index.d.ts
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { isRequiredIf } from 'react-proptype-conditional-require';
 
 export interface CheckboxProps
     extends React.InputHTMLAttributes<HTMLInputElement> {
@@ -68,7 +67,7 @@ export interface InputGroupProps extends React.HTMLAttributes<HTMLDivElement> {
     extraMargin?: boolean;
     fieldMessage?: string | React.ReactNode;
     description?: string;
-    label?: string | Label;
+    label?: string | React.ReactNode;
     onTooltipToggle?: (e: React.MouseEvent | undefined) => void;
     tooltip?: React.ReactNode;
 }


### PR DESCRIPTION
This version includes a fix for the type definition for InputGroup which actually works when InputGroup is used with a Label component, and an unneccessary import of react-prototype-conditional-require has been removed to avoid errors.

<!-- 
Thanks for opening a pull request! 🎉

If your changes include some kind of UI element, please attach a screenshot of 
how it looks.

Before submitting a pull request, please have a look through the CONTRIBUTING.md
document. TL;DR:

- Follow the conventional commit standard
- Write full, explanatory commit messages
- Follow our code standards
- Write tests where applicable
- Be courteous and respect our code of conduct
-->
