### PR TITLE
fix(ffe-datepicker-react): fix broken datepicker for JS users

### DIFF
--- a/packages/ffe-datepicker-react/src/index.d.ts
+++ b/packages/ffe-datepicker-react/src/index.d.ts
@@ -1,6 +1,6 @@
 import React from 'react';
 
-interface IinputProps {
+interface InputProps {
     className?: string;
     id?: string;
 }
@@ -12,7 +12,7 @@ export interface DatepickerProps
     calendarAbove?: boolean;
     hideErrors?: boolean;
     onValidationComplete?: Function;
-    inputProps?: IinputProps;
+    inputProps?: InputProps;
     label?: string;
     language?: string;
     maxDate?: string;

--- a/packages/ffe-datepicker-react/src/index.js
+++ b/packages/ffe-datepicker-react/src/index.js
@@ -1,4 +1,4 @@
-import Datepicker from './index';
+import Datepicker from './datepicker';
 
 export { default as DateInput } from './input';
 export { default as Calendar } from './calendar';


### PR DESCRIPTION
Fix for import statement in index at root where import for the Datepicker component was instead referencing index at root level (itself).

Also changed interface name for `InputProps` in `index.d.ts` at root since prefixing name with I for interface is a bit redundant.