### PR TITLE
fix(ffe-searchable-dropdown-react): clear button was not working on d…

### DIFF
--- a/packages/ffe-searchable-dropdown-react/less/searchable-dropdown.less
+++ b/packages/ffe-searchable-dropdown-react/less/searchable-dropdown.less
@@ -2,8 +2,7 @@
     position: relative;
     @button-width: 40px;
 
-    &--expanded .ffe-dropdown {
-        background-image: none;
+    .ffe-input-field {
         padding-right: calc(@button-width + 3px);
     }
 
@@ -84,6 +83,12 @@
             display: block;
             height: 16px;
             width: 16px;
+        }
+
+        &--flip {
+            svg {
+                transform: rotate(180deg);
+            }
         }
     }
 }

--- a/packages/ffe-searchable-dropdown-react/src/SearchableDropdown.js
+++ b/packages/ffe-searchable-dropdown-react/src/SearchableDropdown.js
@@ -15,13 +15,18 @@ import Downshift from 'downshift';
 import { Scrollbars } from 'react-custom-scrollbars';
 import isEqual from 'lodash.isequal';
 
-import { KryssIkon } from '@sb1/ffe-icons-react';
+import { KryssIkon, ChevronIkon } from '@sb1/ffe-icons-react';
 import { Paragraph } from '@sb1/ffe-core-react';
 
 import filterDropdownList from './filterDropdownList';
 import ListItemContainer from './ListItemContainer';
 import ListItemBody from './ListItemBody';
-import { locales, getButtonLabel } from './translations';
+import {
+    locales,
+    getButtonLabelClear,
+    getButtonLabelClose,
+    getButtonLabelOpen,
+} from './translations';
 import findSelectedItem from './findSelectedItem';
 
 const SearchableDropdown = ({
@@ -74,8 +79,8 @@ const SearchableDropdown = ({
                 highlightedIndex,
                 selectedItem,
                 openMenu,
-                reset,
-                selectItem,
+                closeMenu,
+                clearSelection,
             }) => {
                 const dropdownListFiltered = filterDropdownList(
                     dropdownList,
@@ -93,8 +98,6 @@ const SearchableDropdown = ({
                             className,
                             'ffe-searchable-dropdown',
                             {
-                                'ffe-searchable-dropdown--expanded':
-                                    isOpen || selectedItem,
                                 'ffe-searchable-dropdown--dark': dark,
                             },
                         )}
@@ -102,15 +105,8 @@ const SearchableDropdown = ({
                         <input
                             ref={inputEl}
                             {...getInputProps({
-                                className: 'ffe-dropdown',
+                                className: 'ffe-input-field',
                                 ...inputProps,
-                                onFocus:
-                                    typeof inputProps.onFocus === 'function'
-                                        ? e => {
-                                              openMenu();
-                                              inputProps.onFocus(e);
-                                          }
-                                        : openMenu,
                             })}
                             aria-invalid={
                                 typeof ariaInvalid === 'string'
@@ -118,19 +114,32 @@ const SearchableDropdown = ({
                                     : String(ariaInvalid)
                             }
                         />
-                        {(selectedItem || isOpen) && (
+                        {selectedItem ? (
                             <button
                                 type="button"
-                                aria-label={getButtonLabel(locale)}
-                                tabIndex={selectedItem ? 0 : -1}
+                                aria-label={getButtonLabelClear(locale)}
                                 className="ffe-searchable-dropdown__button"
-                                onClick={() => {
-                                    selectItem(null);
-                                    reset();
-                                    inputEl.current.focus();
-                                }}
+                                onClick={clearSelection}
                             >
                                 <KryssIkon />
+                            </button>
+                        ) : (
+                            <button
+                                type="button"
+                                aria-label={
+                                    isOpen
+                                        ? getButtonLabelClose(locale)
+                                        : getButtonLabelOpen(locale)
+                                }
+                                className={classNames(
+                                    'ffe-searchable-dropdown__button',
+                                    {
+                                        'ffe-searchable-dropdown__button--flip': isOpen,
+                                    },
+                                )}
+                                onClick={isOpen ? closeMenu : openMenu}
+                            >
+                                <ChevronIkon />
                             </button>
                         )}
                         <div

--- a/packages/ffe-searchable-dropdown-react/src/SearchableDropdown.spec.js
+++ b/packages/ffe-searchable-dropdown-react/src/SearchableDropdown.spec.js
@@ -38,15 +38,6 @@ describe('SearchableDropdown', () => {
 
         const input = getByPlaceholderText(placeholder);
 
-        fireEvent.focus(input);
-
-        expect(getByText('Bedriften')).toBeInTheDocument();
-        expect(getByText('912602370')).toBeInTheDocument();
-        expect(getByText('Sønn & co')).toBeInTheDocument();
-        expect(getByText('812602372')).toBeInTheDocument();
-        expect(getByText('Beslag skytter')).toBeInTheDocument();
-        expect(getByText('812602552')).toBeInTheDocument();
-
         fireEvent.change(input, { target: { value: 'Be' } });
 
         expect(getByText('Bedriften')).toBeInTheDocument();
@@ -83,7 +74,8 @@ describe('SearchableDropdown', () => {
         );
 
         const input = getByPlaceholderText(placeholder);
-        fireEvent.focus(input);
+
+        fireEvent.change(input, { target: { value: 'Be' } });
 
         fireEvent.click(getByText('Bedriften'), { button: 1 });
 
@@ -191,7 +183,7 @@ describe('SearchableDropdown', () => {
         );
 
         const input = getByPlaceholderText(placeholder);
-        fireEvent.focus(input);
+        fireEvent.change(input, { target: { value: 'Be' } });
 
         fireEvent.click(getByText('Bedriften'), { button: 1 });
 
@@ -199,7 +191,7 @@ describe('SearchableDropdown', () => {
         expect(onChange).toHaveBeenLastCalledWith(companies[0]);
         expect(input.value).toEqual('Bedriften');
 
-        const clearButton = getByLabelText('tøm feltet');
+        const clearButton = getByLabelText('fjern valgt');
 
         fireEvent.click(clearButton, { button: 1 });
 
@@ -283,5 +275,40 @@ describe('SearchableDropdown', () => {
 
         const input = getByPlaceholderText(placeholder);
         expect(input.value).toEqual('Sønn & co');
+    });
+
+    it('should open and close', function() {
+        const placeholder = 'placeholder';
+        const { getByLabelText, getByText, queryByText } = render(
+            <SearchableDropdown
+                id="id"
+                labelId="labelId"
+                inputProps={{ placeholder }}
+                dropdownAttributes={['organizationName', 'organizationNumber']}
+                dropdownList={companies}
+                searchAttributes={['organizationName', 'organizationNumber']}
+                locale="nb"
+            />,
+        );
+
+        const openButton = getByLabelText('åpne meny');
+        fireEvent.click(openButton, { button: 1 });
+
+        expect(getByText('Bedriften')).toBeInTheDocument();
+        expect(getByText('912602370')).toBeInTheDocument();
+        expect(getByText('Sønn & co')).toBeInTheDocument();
+        expect(getByText('812602372')).toBeInTheDocument();
+        expect(getByText('Beslag skytter')).toBeInTheDocument();
+        expect(getByText('812602552')).toBeInTheDocument();
+
+        const closeButton = getByLabelText('lukk meny');
+        fireEvent.click(closeButton, { button: 1 });
+
+        expect(queryByText('Bedriften')).toBeNull();
+        expect(queryByText('912602370')).toBeNull();
+        expect(queryByText('Sønn & co')).toBeNull();
+        expect(queryByText('812602372')).toBeNull();
+        expect(queryByText('Beslag skytter')).toBeNull();
+        expect(queryByText('812602552')).toBeNull();
     });
 });

--- a/packages/ffe-searchable-dropdown-react/src/translations.js
+++ b/packages/ffe-searchable-dropdown-react/src/translations.js
@@ -4,13 +4,35 @@ const en = 'en';
 
 export const locales = { nb, nn, en };
 
-export const getButtonLabel = locale => {
+export const getButtonLabelClear = locale => {
     switch (locale) {
         case nn:
-            return 'tøm feltet';
+            return 'fjern valgt';
         case en:
             return 'clear the field';
         default:
-            return 'tøm feltet';
+            return 'fjern valgt';
+    }
+};
+
+export const getButtonLabelClose = locale => {
+    switch (locale) {
+        case nn:
+            return 'lukk meny';
+        case en:
+            return 'close menu';
+        default:
+            return 'lukk meny';
+    }
+};
+
+export const getButtonLabelOpen = locale => {
+    switch (locale) {
+        case nn:
+            return 'åpne meny';
+        case en:
+            return 'open menu';
+        default:
+            return 'åpne meny';
     }
 };


### PR DESCRIPTION
clear button og autofocus bjød på en del utfordringar på mobil. Løste det istellet slik:
https://codesandbox.io/s/github/kentcdodds/downshift-examples/tree/master/?module=%2Fsrc%2Fordered-examples%2F02-complete-autocomplete.js&moduleview=1

Alltså expand/collapse med knappetrykk.

Tenker det oansett er en bedre løsning.

Ja noen tester brakk men det er naturligt når komponten virker annledes.