### PR TITLE
Support for easily picking year in datepicker's calendar component

### DIFF
--- a/packages/ffe-datepicker-react/package.json
+++ b/packages/ffe-datepicker-react/package.json
@@ -28,7 +28,11 @@
     "setupTestFrameworkScriptFile": "../../test-setup.js"
   },
   "dependencies": {
+    "@sb1/ffe-buttons": "^8.2.6",
+    "@sb1/ffe-buttons-react": "^12.1.5",
     "@sb1/ffe-datepicker": "^5.1.4",
+    "@sb1/ffe-dropdown-react": "^5.0.0",
+    "@sb1/ffe-form": "^12.0.6",
     "@sb1/ffe-icons-react": "^7.0.3",
     "classnames": "^2.2.5",
     "prop-types": "^15.6.0",

--- a/packages/ffe-datepicker-react/src/calendar/Calendar.js
+++ b/packages/ffe-datepicker-react/src/calendar/Calendar.js
@@ -30,6 +30,8 @@ export default class Calendar extends Component {
         this.mouseClick = this.mouseClick.bind(this);
         this.nextMonth = this.nextMonth.bind(this);
         this.previousMonth = this.previousMonth.bind(this);
+        this.selectYear = this.selectYear.bind(this);
+        this.today = this.today.bind(this);
         this.focusHandler = this.focusHandler.bind(this);
         this.wrapperBlurHandler = this.wrapperBlurHandler.bind(this);
 
@@ -162,6 +164,18 @@ export default class Calendar extends Component {
         this.forceUpdate();
     }
 
+    selectYear(evt) {
+        const selectedYear = parseInt(evt.currentTarget.value);
+        this.state.calendar.setYear(selectedYear);
+        this.forceUpdate();
+    }
+
+    today(evt) {
+        evt.preventDefault();
+        this.state.calendar.today();
+        this.forceUpdate();
+    }
+
     renderDate(date, index) {
         if (date.isLead) {
             return <LeadDate key={date.date} date={date} />;
@@ -217,11 +231,12 @@ export default class Calendar extends Component {
                 <Header
                     datepickerId={this.datepickerId}
                     month={calendar.focusedMonth()}
-                    nextMonthHandler={this.nextMonth}
-                    nextMonthLabel={calendar.nextName()}
-                    previousMonthHandler={this.previousMonth}
-                    previousMonthLabel={calendar.previousName()}
                     year={calendar.focusedYear()}
+                    language={this.props.language}
+                    nextMonthHandler={this.nextMonth}
+                    previousMonthHandler={this.previousMonth}
+                    todayHandler={this.today}
+                    selectYearHandler={this.selectYear}
                 />
                 <table
                     className="ffe-calendar__grid"

--- a/packages/ffe-datepicker-react/src/calendar/Header.js
+++ b/packages/ffe-datepicker-react/src/calendar/Header.js
@@ -1,50 +1,139 @@
 import React from 'react';
 import { func, number, string } from 'prop-types';
-import ChevronIkon from '@sb1/ffe-icons-react/lib/chevron-ikon';
+import { SecondaryButton } from '@sb1/ffe-buttons-react';
+import Dropdown from '@sb1/ffe-dropdown-react';
+import MonthPicker from './MonthPicker';
+import i18n from '../i18n/i18n';
 
 export default function Header(props) {
     const {
         datepickerId,
         month,
-        nextMonthHandler,
-        nextMonthLabel,
-        previousMonthHandler,
-        previousMonthLabel,
         year,
+        language,
+        nextMonthHandler,
+        previousMonthHandler,
+        todayHandler,
+        selectYearHandler,
     } = props;
 
+    function renderYearOptions() {
+        const distribution = 5;
+        const minYear = year - distribution;
+        const maxYear = year + distribution;
+        const options = [];
+        let currentYear = minYear;
+        let option;
+
+        while (currentYear <= maxYear) {
+            option = (
+                <option key={currentYear} value={currentYear}>
+                    {currentYear}
+                </option>
+            );
+            options.push(option);
+            currentYear += 1;
+        }
+
+        return options;
+    }
+
+    const todayLabel = i18n[language].TODAY;
+
     return (
-        <div className="ffe-calendar__header">
-            <div className="ffe-calendar__header-inner-wrapper">
-                <button
-                    className="ffe-calendar__month-nav ffe-calendar__previous"
-                    onClick={previousMonthHandler}
-                    tabIndex="-1"
-                    title={previousMonthLabel}
-                    type="button"
-                >
-                    <ChevronIkon className="ffe-calendar__icon-prev" />
-                </button>
-                <header
-                    aria-live="assertive"
-                    aria-atomic="true"
-                    className="ffe-calendar__title"
-                    id={`${datepickerId}-title`}
-                >
-                    <div id={`${datepickerId}__month-label`}>
-                        <span className="ffe-calendar__month">{month}</span>
-                        <span className="ffe-calendar__year">{year}</span>
+        <div id={`${datepickerId}-header`} className="ffe-calendar__header">
+            <div
+                id={`${datepickerId}-settings`}
+                className="ffe-calendar__header-container"
+            >
+                <div className="ffe-calendar__header-wrapper">
+                    <div className="ffe-calendar__header-define" />
+                    <div className="ffe-calendar__header-break ffe-calendar__header-break-1" />
+                    <div className="ffe-calendar__header-block" />
+                    <div className="ffe-calendar__header-define" />
+                    <div className="ffe-calendar__header-break ffe-calendar__header-break-2" />
+                    <div className="ffe-calendar__header-block" />
+
+                    <div
+                        id={`${datepickerId}-view1`}
+                        className="ffe-calendar__header-content"
+                    >
+                        <div className="ffe-calendar__header-inner-1">
+                            <div>
+                                <Dropdown
+                                    value={year}
+                                    tabIndex="-1"
+                                    onChange={selectYearHandler}
+                                >
+                                    {renderYearOptions()}
+                                </Dropdown>
+                            </div>
+                            <div>
+                                <MonthPicker
+                                    previousMonthHandler={previousMonthHandler}
+                                    nextMonthHandler={nextMonthHandler}
+                                    month={month}
+                                />
+                            </div>
+                        </div>
                     </div>
-                </header>
-                <button
-                    className="ffe-calendar__month-nav ffe-calendar__next"
-                    onClick={nextMonthHandler}
-                    title={nextMonthLabel}
-                    tabIndex="-1"
-                    type="button"
-                >
-                    <ChevronIkon className="ffe-calendar__icon-next" />
-                </button>
+                    <div
+                        id={`${datepickerId}-view2`}
+                        className="ffe-calendar__header-content"
+                    >
+                        <div className="ffe-calendar__header-inner-2">
+                            <div>
+                                <Dropdown
+                                    value={year}
+                                    tabIndex="-1"
+                                    onChange={selectYearHandler}
+                                >
+                                    {renderYearOptions()}
+                                </Dropdown>
+                            </div>
+                            <div>
+                                <MonthPicker
+                                    previousMonthHandler={previousMonthHandler}
+                                    nextMonthHandler={nextMonthHandler}
+                                    month={month}
+                                />
+                            </div>
+                            <div>
+                                <SecondaryButton onClick={todayHandler}>
+                                    {todayLabel}
+                                </SecondaryButton>
+                            </div>
+                        </div>
+                    </div>
+                    <div
+                        id={`${datepickerId}-view3`}
+                        className="ffe-calendar__header-content"
+                    >
+                        <div className="ffe-calendar__header-inner-3">
+                            <div>
+                                <Dropdown
+                                    value={year}
+                                    tabIndex="-1"
+                                    onChange={selectYearHandler}
+                                >
+                                    {renderYearOptions()}
+                                </Dropdown>
+                            </div>
+                            <div>
+                                <MonthPicker
+                                    previousMonthHandler={previousMonthHandler}
+                                    nextMonthHandler={nextMonthHandler}
+                                    month={month}
+                                />
+                            </div>
+                            <div>
+                                <SecondaryButton onClick={todayHandler}>
+                                    {todayLabel}
+                                </SecondaryButton>
+                            </div>
+                        </div>
+                    </div>
+                </div>
             </div>
         </div>
     );
@@ -53,9 +142,10 @@ export default function Header(props) {
 Header.propTypes = {
     datepickerId: string.isRequired,
     month: string.isRequired,
-    nextMonthHandler: func.isRequired,
-    nextMonthLabel: string.isRequired,
-    previousMonthHandler: func.isRequired,
-    previousMonthLabel: string.isRequired,
     year: number.isRequired,
+    language: string.isRequired,
+    nextMonthHandler: func.isRequired,
+    previousMonthHandler: func.isRequired,
+    todayHandler: func.isRequired,
+    selectYearHandler: func.isRequired,
 };

--- a/packages/ffe-datepicker-react/src/calendar/MonthPicker.js
+++ b/packages/ffe-datepicker-react/src/calendar/MonthPicker.js
@@ -1,0 +1,40 @@
+import React from 'react';
+import { func, string } from 'prop-types';
+
+export default function MonthPicker(props) {
+    const { previousMonthHandler, nextMonthHandler, month } = props;
+
+    function left(evt) {
+        previousMonthHandler(evt);
+    }
+
+    function right(evt) {
+        nextMonthHandler(evt);
+    }
+
+    return (
+        <div className="ffe-calendar__monthpicker">
+            <div className="ffe-calendar__monthpicker-center">{month}</div>
+            <div
+                role="none"
+                onClick={left}
+                className="ffe-calendar__monthpicker-left"
+            >
+                <div />
+            </div>
+            <div
+                role="none"
+                onClick={right}
+                className="ffe-calendar__monthpicker-right"
+            >
+                <div />
+            </div>
+        </div>
+    );
+}
+
+MonthPicker.propTypes = {
+    previousMonthHandler: func.isRequired,
+    nextMonthHandler: func.isRequired,
+    month: string.isRequired,
+};

--- a/packages/ffe-datepicker-react/src/datelogic/simplecalendar.js
+++ b/packages/ffe-datepicker-react/src/datelogic/simplecalendar.js
@@ -118,6 +118,14 @@ SimpleCalendar.prototype.dayNames = function dayNames() {
     return result;
 };
 
+SimpleCalendar.prototype.setYear = function setYear(year) {
+    this.focusedDate.setYear(year);
+};
+
+SimpleCalendar.prototype.today = function today() {
+    this.focusedDate = simpleDate.today();
+};
+
 SimpleCalendar.prototype.previousName = function prevName() {
     return i18n[this.locale].PREVIOUS;
 };

--- a/packages/ffe-datepicker-react/src/datepicker/Datepicker.md
+++ b/packages/ffe-datepicker-react/src/datepicker/Datepicker.md
@@ -4,8 +4,8 @@ initialState = { date: '01.01.2016' };
     inputProps={{ id: 'datepicker-example' }}
     label="Velg dato"
     language="nb"
-    maxDate="31.12.2016"
-    minDate="01.01.2016"
+    maxDate="31.12.2020"
+    minDate="01.01.2000"
     onChange={date => setState({ date })}
     value={state.date}
 />;
@@ -20,8 +20,8 @@ initialState = { date: '01.01.2016' };
     inputProps={{ id: 'datepicker-example-aria-invalid' }}
     label="Velg dato"
     language="nn"
-    maxDate="31.12.2016"
-    minDate="01.01.2016"
+    maxDate="31.12.2020"
+    minDate="01.01.2000"
     onChange={date => setState({ date })}
     value={state.date}
 />;
@@ -36,8 +36,8 @@ initialState = { date: '01.01.2016' };
     inputProps={{ id: 'datepicker-example-calendar-above' }}
     label="Velg en dato"
     language="nb"
-    maxDate="31.12.2016"
-    minDate="01.01.2016"
+    maxDate="31.12.2020"
+    minDate="01.01.2000"
     onChange={date => setState({ date })}
     value={state.date}
 />;
@@ -51,8 +51,8 @@ initialState = { date: '01.01.2016' };
     inputProps={{ id: 'datepicker-example' }}
     label="Velg dato"
     language="nb"
-    maxDate="31.12.2016"
-    minDate="01.01.2016"
+    maxDate="31.12.2020"
+    minDate="01.01.2000"
     onChange={date => setState({ date })}
     value={state.date}
     fullWidth={true}
@@ -67,8 +67,8 @@ initialState = { date: '01.01.2016' };
     inputProps={{ id: 'datepicker-example-en' }}
     label="Pick a date"
     language="en"
-    maxDate="31.12.2016"
-    minDate="01.01.2016"
+    maxDate="31.12.2020"
+    minDate="01.01.2000"
     onChange={date => setState({ date })}
     value={state.date}
 />;
@@ -80,8 +80,8 @@ initialState = { date: '01.01.2016' };
     inputProps={{ id: 'datepicker-example-nn' }}
     label="Velg dato"
     language="nn"
-    maxDate="31.12.2016"
-    minDate="01.01.2016"
+    maxDate="31.12.2020"
+    minDate="01.01.2000"
     onChange={date => setState({ date })}
     value={state.date}
 />;

--- a/packages/ffe-datepicker-react/src/i18n/en.js
+++ b/packages/ffe-datepicker-react/src/i18n/en.js
@@ -37,6 +37,7 @@ export default {
     MONTH_10: 'October',
     MONTH_11: 'November',
     MONTH_12: 'December',
+    TODAY: 'Today',
     PREVIOUS: 'Previous',
     NEXT: 'Next',
     PREVIOUS_SHORT: 'Prev',

--- a/packages/ffe-datepicker-react/src/i18n/nb.js
+++ b/packages/ffe-datepicker-react/src/i18n/nb.js
@@ -37,6 +37,7 @@ export default {
     MONTH_10: 'Oktober',
     MONTH_11: 'November',
     MONTH_12: 'Desember',
+    TODAY: 'I dag',
     PREVIOUS: 'Forrige',
     NEXT: 'Neste',
     PREVIOUS_SHORT: 'Forrige',

--- a/packages/ffe-datepicker-react/src/i18n/nn.js
+++ b/packages/ffe-datepicker-react/src/i18n/nn.js
@@ -37,6 +37,7 @@ export default {
     MONTH_10: 'Oktober',
     MONTH_11: 'November',
     MONTH_12: 'Desember',
+    TODAY: 'I dag',
     PREVIOUS: 'Forrige',
     NEXT: 'Neste',
     PREVIOUS_SHORT: 'Forrige',

--- a/packages/ffe-datepicker/less/calendar.less
+++ b/packages/ffe-datepicker/less/calendar.less
@@ -17,12 +17,6 @@
         }
     }
 
-    &__header {
-        text-align: center;
-        padding: 1em 0.25em 0.25em;
-        width: 100%;
-    }
-
     &__month {
         padding-right: 0.4em;
     }
@@ -154,6 +148,253 @@
 
         &--disabled-focus {
             border: 2px solid @ffe-grey-silver;
+        }
+    }
+}
+
+.ffe-calendar__header {
+    @margin-top: 0;
+    @margin-bottom: 5px;
+    @margin-left: 0;
+    @margin-right: 0;
+    @margin-between: 13px;
+
+    @breakpoint-1: 520px;
+    @breakpoint-2: 650px;
+
+    @breakpoints: 2;
+    @height: 63px;
+
+    position: relative;
+    width: 100%;
+    height: @margin-bottom + @height + @margin-top;
+
+    &-container {
+        position: absolute;
+        top: @margin-top;
+        left: @margin-left;
+        right: @margin-right;
+        bottom: @margin-bottom;
+        overflow: hidden;
+    }
+
+    &-wrapper {
+        font-size: 0;
+        position: relative;
+        top: -(3 * @breakpoints) * @height;
+        height: auto;
+        width: 100%;
+    }
+
+    &-define {
+        position: relative;
+        display: inline-block;
+        height: @height;
+        width: 50%;
+    }
+
+    &-break {
+        position: relative;
+        display: inline-block;
+        height: @height;
+    }
+
+    &-block {
+        position: relative;
+        display: inline-block;
+        height: @height;
+        width: 100%;
+    }
+
+    &-content {
+        position: relative;
+        display: inline-block;
+        height: @height;
+        width: 100%;
+        font-size: initial;
+    }
+
+    &-break-1 {
+        width: 0.5 * @breakpoint-1;
+    }
+
+    &-break-2 {
+        width: 0.5 * @breakpoint-2;
+    }
+
+    &-inner-1 {
+        position: absolute;
+        left: 9px;
+        right: 9px;
+        top: 9px;
+        bottom: 9px;
+        display: flex;
+
+        > div:nth-child(1) {
+            height: 100%;
+            width: 40%;
+            margin-right: 0.5 * @margin-between;
+        }
+
+        > div:nth-child(2) {
+            height: 100%;
+            width: 60%;
+            margin-left: 0.5 * @margin-between;
+        }
+    }
+
+    &-inner-2 {
+        position: absolute;
+        left: 9px;
+        right: 9px;
+        top: 9px;
+        bottom: 9px;
+        display: flex;
+        justify-content: space-between;
+
+        > div:nth-child(1) {
+            height: 100%;
+            flex-grow: 1;
+            width: 14%;
+            margin-right: 0.5 * @margin-between;
+        }
+
+        > div:nth-child(2) {
+            height: 100%;
+            flex-grow: 3;
+            margin: 0 0.5 * @margin-between;
+        }
+
+        > div:nth-child(3) {
+            height: 100%;
+            flex-grow: 1;
+            width: 14%;
+            margin-left: 0.5 * @margin-between;
+            > * {
+                width: 100%;
+                height: 100%;
+                margin: 0;
+            }
+        }
+    }
+
+    &-inner-3 {
+        position: absolute;
+        left: 9px;
+        right: 9px;
+        top: 9px;
+        bottom: 9px;
+        display: flex;
+        justify-content: space-between;
+
+        > div:nth-child(1) {
+            height: 100%;
+            width: 150px;
+        }
+
+        > div:nth-child(2) {
+            height: 100%;
+            width: 230px;
+        }
+
+        > div:nth-child(3) {
+            height: 100%;
+            width: 150px;
+            > * {
+                width: 100%;
+                height: 100%;
+                margin: 0;
+            }
+        }
+    }
+}
+
+.ffe-calendar__monthpicker {
+    background-color: @ffe-white;
+    border: 2px solid @ffe-grey-silver;
+    border-radius: 4px;
+    box-shadow: 0 1px 1px 0 @ffe-grey-cloud;
+    color: @ffe-black;
+    font-family: MuseoSans-500, arial, sans-serif;
+    height: 45px;
+    line-height: 20px;
+    transition: all @ffe-transition-duration @ffe-ease;
+    width: 100%;
+    position: relative;
+
+    @media (any-hover: hover) {
+        &-left:hover {
+            > div {
+                background-position: 50% 70%;
+            }
+        }
+    }
+
+    &-left {
+        position: absolute;
+        left: 0;
+        top: 0;
+        bottom: 0;
+        width: 45px;
+        cursor: pointer;
+
+        > div {
+            transition: all @ffe-transition-duration @ffe-ease;
+            position: relative;
+            margin: 0 auto;
+            height: 100%;
+            width: 30px;
+            transform-origin: 50% 50%;
+            background-position: 50% 80%;
+            transform: rotate(90deg);
+            background-repeat: no-repeat;
+            @bare-color: escape(@ffe-blue-azure);
+
+            background-image: url('data:image/svg+xml;charset=utf8,%3Csvg%20xmlns%3Asvg%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20version%3D%221.1%22%20x%3D%220%22%20y%3D%220%22%20viewBox%3D%220%200%201000%201000%22%20width%3D%2218%22%20height%3D%2218%22%20xml%3Aspace%3D%22preserve%22%3E%0A%20%20%20%20%3Cpath%20fill%3D%22@{bare-color}%22%20d%3D%22M111.1%20228.6c19.2%200%2038.4%207.3%2053%2022l336.7%20336.7%20334.5-334.5c29.3-29.3%2076.8-29.3%20106.1%200%2029.3%2029.3%2029.3%2076.8%200%20106.1L553.8%20746.3c-29.3%2029.3-76.8%2029.3-106.1%200L58.1%20356.6c-29.3-29.3-29.3-76.8%200-106.1C72.7%20235.9%2091.9%20228.6%20111.1%20228.6z%22%20%2F%3E%0A%3C%2Fsvg%3E%0A');
+        }
+    }
+
+    &-center {
+        position: absolute;
+        left: 0;
+        right: 0;
+        top: 0;
+        bottom: 0;
+        overflow: hidden;
+        text-align: center;
+        line-height: 43px;
+        cursor: default;
+    }
+
+    @media (any-hover: hover) {
+        &-right:hover {
+            > div {
+                background-position: 50% 70%;
+            }
+        }
+    }
+
+    &-right {
+        position: absolute;
+        right: 0;
+        top: 0;
+        bottom: 0;
+        width: 45px;
+        cursor: pointer;
+
+        > div {
+            transition: all @ffe-transition-duration @ffe-ease;
+            position: relative;
+            margin: 0 auto;
+            height: 100%;
+            width: 30px;
+            transform-origin: 50% 50%;
+            background-position: 50% 80%;
+            transform: rotate(-90deg);
+            background-repeat: no-repeat;
+            @bare-color: escape(@ffe-blue-azure);
+
+            background-image: url('data:image/svg+xml;charset=utf8,%3Csvg%20xmlns%3Asvg%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20version%3D%221.1%22%20x%3D%220%22%20y%3D%220%22%20viewBox%3D%220%200%201000%201000%22%20width%3D%2218%22%20height%3D%2218%22%20xml%3Aspace%3D%22preserve%22%3E%0A%20%20%20%20%3Cpath%20fill%3D%22@{bare-color}%22%20d%3D%22M111.1%20228.6c19.2%200%2038.4%207.3%2053%2022l336.7%20336.7%20334.5-334.5c29.3-29.3%2076.8-29.3%20106.1%200%2029.3%2029.3%2029.3%2076.8%200%20106.1L553.8%20746.3c-29.3%2029.3-76.8%2029.3-106.1%200L58.1%20356.6c-29.3-29.3-29.3-76.8%200-106.1C72.7%20235.9%2091.9%20228.6%20111.1%20228.6z%22%20%2F%3E%0A%3C%2Fsvg%3E%0A');
         }
     }
 }


### PR DESCRIPTION
**This will**;

add support for easily picking year in datepicker's calendar component

**See issue**;
https://github.com/SpareBank1/designsystem/issues/650#issue-454622687

**Here is a design made before implementing**;

![calender](https://user-images.githubusercontent.com/25029220/69768967-19d50400-1183-11ea-9bfa-dbe02e29e050.jpg)

**Notes**;

This implementation serves first and foremost as an example of how the [desired feature](https://github.com/SpareBank1/designsystem/issues/650#issue-454622687) could be implemented.

Since the calendar's width may vary; I thought it should have built-in breakpoints - independent of viewport - for showing more functionality for greater widths. For this reason I created a technique called 'artificial element breakpoints' for creating element breakpoints based solely on html and css. Make sure to see the [Demo](https://artificial-element-breakpoints.netlify.com), and read the advantages, drawbacks, and general docs here; https://github.com/johann1301h/artificialElementBreakpoints.

I think a better solution for breakpoints going forward would be css-element-queries. Read more about it here; https://github.com/marcj/css-element-queries.