### PR TITLE
fix(ffe-searchable-dropdown-react): ie11 did not support heigth unset

### DIFF
--- a/packages/ffe-searchable-dropdown-react/less/searchable-dropdown.less
+++ b/packages/ffe-searchable-dropdown-react/less/searchable-dropdown.less
@@ -15,7 +15,7 @@
         height: 0;
 
         &--open {
-            height: unset;
+            height: auto;
             border: 1px solid @ffe-grey-silver;
         }
     }


### PR DESCRIPTION
IE fix

På sidan:
IE11 issues gjør veldigt hvont og fikse.
`react-styleguidist` virket ikke alls i IE11. Oppgraderte temporert til 7.3.11 medans jag utveckla men tog ikke med det i PR då jag fikk en høg med varningar i consolet. Navigering mellom komponenter virket ikke heller i 7.3.11 utan jab måtte legge det sammen med Buttons medan jag fixade.  