### PR TITLE
feat: add classes for disabling and activating user highlight selection

### DIFF
--- a/packages/ffe-core/less/typography.less
+++ b/packages/ffe-core/less/typography.less
@@ -318,6 +318,16 @@
     margin: 0 4px;
 }
 
+.ffe-no-select {
+    user-select: none;
+    -webkit-touch-callout: none;
+}
+
+.ffe-select {
+    user-select: auto;
+    -webkit-touch-callout: default;
+}
+
 @media (min-width: @breakpoint-sm) {
     .ffe-h1 {
         line-height: 56px;


### PR DESCRIPTION
**This will;**

add classes for disabling and activating user highlight selection

![IMG_1716](https://user-images.githubusercontent.com/25029220/70273460-6aafb280-17aa-11ea-8125-2e8539642392.png)

As show in screenshot; there is universal functionality for highlighting and selecting content. In some cases this is wanted behavior, and in other cases not.

I added two classes which can be utilized in components for activating and deactivating this behavior.