### PR TITLE
Set default text styling to be non selectable 

### DIFF
--- a/packages/ffe-core-react/src/typography/Paragraph.md
+++ b/packages/ffe-core-react/src/typography/Paragraph.md
@@ -7,6 +7,15 @@
 </Paragraph>
 ```
 
+**_Tekst som kan velges_**
+
+```js
+<Paragraph>
+    Her kan du velge tekst, f.eks med kontonr{' '}
+    <span className="ffe-body-text ffe-select">123456789101</span>
+</Paragraph>
+```
+
 **Lead paragraph**
 
 ```js

--- a/packages/ffe-core/less/typography.less
+++ b/packages/ffe-core/less/typography.less
@@ -231,13 +231,14 @@
     font-family: 'MuseoSans-500', arial, sans-serif;
     line-height: 24px;
     .ffe-fontsize-body-text;
+    .ffe-no-select;
 }
 
 .ffe-body-paragraph {
     margin-bottom: 1em;
     margin-top: 0;
     line-height: 24px;
-
+    .ffe-no-select;
     &--text-center {
         text-align: center;
     }
@@ -251,6 +252,7 @@
 .ffe-sub-lead-paragraph {
     font-family: 'MuseoSans-500', arial, sans-serif;
     margin-top: 0;
+    .ffe-no-select;
 }
 
 .ffe-lead-paragraph {

--- a/packages/ffe-core/less/typography.less
+++ b/packages/ffe-core/less/typography.less
@@ -318,6 +318,16 @@
     margin: 0 4px;
 }
 
+.ffe-no-select {
+    user-select: none;
+    -webkit-touch-callout: none;
+}
+
+.ffe-select {
+    user-select: auto;
+    -webkit-touch-callout: default;
+}
+
 @media (min-width: @breakpoint-sm) {
     .ffe-h1 {
         line-height: 56px;


### PR DESCRIPTION
This will set paragraphs and body text to be not selectable by default.
This an issue especially in the mobile app. When we use the base text components in a context where users are frequently pressing buttons and then experiences the unintended of text highlighting in other elements.
![1](https://user-images.githubusercontent.com/10694878/70287085-04d52200-17ce-11ea-9423-7c99b17896cb.png)
In the cases where one intends the user to be able to select and copy text, one should be explicit.

It is based on the [pending pull request](https://github.com/SpareBank1/designsystem/pull/784).