### PR TITLE
fix(stylelint-config-ffe): increase nesting depth

### DIFF
--- a/linting/stylelint-config-ffe/index.js
+++ b/linting/stylelint-config-ffe/index.js
@@ -18,7 +18,12 @@ module.exports = {
         ],
         'no-missing-end-of-source-newline': null,
         'number-leading-zero': null,
-        'max-nesting-depth': 3,
+        'max-nesting-depth': [
+            4,
+            {
+                ignoreAtRules: ['media'],
+            },
+        ],
         'media-feature-name-no-vendor-prefix': true,
         'property-no-vendor-prefix': true,
         'selector-list-comma-newline-after': [


### PR DESCRIPTION
During the process of adding dark mode overrides, the need to increase the `max-nesting-depth` rule has surfaced, as every override is a nested rule. This prevents the builds from failing and removes the need to disable stylelint rules in individual less files.