### PR TITLE
fix(ffe-buttons-react): ensuring typedefinition for the to prop for B…

### DIFF
--- a/packages/ffe-buttons-react/src/index.d.ts
+++ b/packages/ffe-buttons-react/src/index.d.ts
@@ -4,6 +4,7 @@ export interface MinimalBaseButtonProps extends React.HTMLProps<HTMLElement> {
     className?: string;
     element?: HTMLElement | string | React.ElementType;
     innerRef?: React.RefObject<HTMLElement>;
+    to?: string; //used in order to make buttons work with react-router functionality in typescript-files.
 }
 
 export interface BaseButtonProps extends MinimalBaseButtonProps {


### PR DESCRIPTION
The `to` prop belonging to `BaseButtonProps`, making a button function as a link missed typedefinitions for use in TypeScript code was missing. Therefore this is added in this PR.