### PR TITLE
fix(ffe-system-message): text does not take full with

### DIFF
--- a/packages/ffe-system-message/less/ffe-system-message.less
+++ b/packages/ffe-system-message/less/ffe-system-message.less
@@ -117,6 +117,7 @@
         margin: 0;
         padding: 0;
         font-size: 14px;
+        flex: 1 1 auto;
 
         @media (min-width: 600px) {
             font-size: 16px;
@@ -133,7 +134,7 @@
         cursor: pointer;
         align-self: flex-start;
         height: 16px;
-        margin: 5px 0 5px 0;
+        margin: 5px 0 5px 5px;
         padding: 0;
         width: 16px;
 


### PR DESCRIPTION
fix for system-info.message

before: 
![odelagt-systeminfo](https://user-images.githubusercontent.com/2248579/70914932-3c876980-2019-11ea-96a6-8483b6abea36.png)
after:
![fix](https://user-images.githubusercontent.com/2248579/70914950-41e4b400-2019-11ea-8eaa-d9a80e4ac682.png)
