### PR TITLE
fix(ffe-searchable-dropdown-react): use ffe-spacing

### DIFF
--- a/packages/ffe-searchable-dropdown-react/less/searchable-dropdown.less
+++ b/packages/ffe-searchable-dropdown-react/less/searchable-dropdown.less
@@ -21,7 +21,7 @@
     }
 
     &__no-match {
-        padding: 8px 13px;
+        padding: @ffe-spacing @ffe-spacing-sm;
 
         & + .ffe-searchable-dropdown__list-item-container {
             border-top: 1px solid @ffe-grey-silver;
@@ -37,7 +37,7 @@
     }
 
     &__list-item-body {
-        padding: 8px 13px;
+        padding: @ffe-spacing @ffe-spacing-sm;
         color: @ffe-blue-cobalt;
         cursor: pointer;
 
@@ -102,8 +102,8 @@
         &--arrow {
             svg {
                 fill: @ffe-blue-azure;
-                width: 17px;
                 height: 17px;
+                width: 17px;
             }
         }
     }


### PR DESCRIPTION
Tar i bruk variablerna i spacing.less, den stora visuella forskellen er att det krysset blir litt større? Ær det greit eller skall jag bruke 11px der forsatt? 
Så har jag ikke lagt op til att dette blir publisert som en breaking change? Ønsker vi det? Selv synes jag forskellen er så liten så det ikke trengs.

![image](https://user-images.githubusercontent.com/2248579/71107217-f53bdd00-21c0-11ea-9dd5-4fe9c860fceb.png)

Beklager men råkade pusha rett på dev. Vart lite sjapp, men skall vara revertat.