### PR TITLE
feat(ffe-dropdown-react): added optional property innerref

### DIFF
--- a/packages/ffe-dropdown-react/src/Dropdown.js
+++ b/packages/ffe-dropdown-react/src/Dropdown.js
@@ -1,9 +1,9 @@
 import React from 'react';
-import { bool, node, string } from 'prop-types';
+import { bool, node, string, object, func, shape, oneOfType } from 'prop-types';
 import classNames from 'classnames';
 
 const Dropdown = props => {
-    const { className, inline, dark, ...rest } = props;
+    const { className, inline, dark, innerRef, ...rest } = props;
 
     return (
         <select
@@ -13,6 +13,7 @@ const Dropdown = props => {
                 { 'ffe-dropdown--dark': dark },
                 className,
             )}
+            ref={innerRef}
             {...rest}
         />
     );
@@ -24,6 +25,8 @@ Dropdown.propTypes = {
     className: string,
     /** Dark variant */
     dark: bool,
+    /** Ref-setting function, or ref created by useRef, passed to the select element */
+    innerRef: oneOfType([func, shape({ current: object })]),
 };
 
 Dropdown.defaultProps = {

--- a/packages/ffe-dropdown-react/src/index.d.ts
+++ b/packages/ffe-dropdown-react/src/index.d.ts
@@ -6,6 +6,7 @@ export interface DropdownProps
     className?: string;
     inline?: boolean;
     dark?: boolean;
+    innerRef?: React.RefObject<T>;
 }
 
 declare class Dropdown extends React.Component<DropdownProps, any> {}


### PR DESCRIPTION
This version offers a new optional property, innerRef, which is passed as ref to the select element.

We need to pass in a ref to the generated select element, this PR makes it possible.
The property name is the same as is used in other components in the designsystem.

There are no capital letters in the subject of the commit message as it is no longer allowed.