### PR TITLE
fix(ffe-form): Changing margin in input-group from initial to auto

### DIFF
--- a/packages/ffe-form/less/input-group.less
+++ b/packages/ffe-form/less/input-group.less
@@ -58,11 +58,11 @@
 
     &--no-extra-margin {
         > *:nth-last-child(1) {
-            margin-bottom: initial;
+            margin-bottom: auto;
         }
 
         > *:nth-last-child(2) {
-            margin-bottom: initial;
+            margin-bottom: auto;
         }
 
         .ffe-field-error-message {


### PR DESCRIPTION
Initial does not work for IE11, while auto does. This introduced problems in IE where the 32px margin would not be overridden to initial (this creates a unwanted 32px margin in account-selector between dropdown and selected account-number)

Example of bug:
![bilde](https://user-images.githubusercontent.com/2163425/71978694-46694a80-321c-11ea-82d4-1172d7681804.png)