### PR TITLE
fix(ffe-form-react): fix type definition for inputgroup

### DIFF
--- a/packages/ffe-form-react/src/index.d.ts
+++ b/packages/ffe-form-react/src/index.d.ts
@@ -68,6 +68,7 @@ export interface InputGroupProps extends React.HTMLAttributes<HTMLDivElement> {
     fieldMessage?: string | React.ReactNode;
     description?: string;
     label?: string | React.ReactNode;
+    labelId?: string;
     onTooltipToggle?: (e: React.MouseEvent | undefined) => void;
     tooltip?: React.ReactNode;
 }


### PR DESCRIPTION
This version adds the optional property labelId for InputGroup to the typescript type definition.