### PR TITLE
fix(ffe-dropdown-react): fixed type definition of innerref

### DIFF
--- a/packages/ffe-dropdown-react/src/index.d.ts
+++ b/packages/ffe-dropdown-react/src/index.d.ts
@@ -6,7 +6,7 @@ export interface DropdownProps
     className?: string;
     inline?: boolean;
     dark?: boolean;
-    innerRef?: React.RefObject<T>;
+    innerRef?: React.Ref<T>;
 }
 
 declare class Dropdown extends React.Component<DropdownProps, any> {}


### PR DESCRIPTION
This version changes the innerRef type to Ref<T>, which supports both callback refs and forwarding refs.

<!-- 
Thanks for opening a pull request! 🎉

If your changes include some kind of UI element, please attach a screenshot of 
how it looks.

Before submitting a pull request, please have a look through the CONTRIBUTING.md
document. TL;DR:

- Follow the conventional commit standard
- Write full, explanatory commit messages
- Follow our code standards
- Write tests where applicable
- Be courteous and respect our code of conduct
-->
