### PR TITLE
fix(ffe-buttons-react): fixed type definition of innerref

### DIFF
--- a/packages/ffe-buttons-react/src/index.d.ts
+++ b/packages/ffe-buttons-react/src/index.d.ts
@@ -3,7 +3,7 @@ import * as React from 'react';
 export interface MinimalBaseButtonProps extends React.HTMLProps<HTMLElement> {
     className?: string;
     element?: HTMLElement | string | React.ElementType;
-    innerRef?: React.RefObject<HTMLElement>;
+    innerRef?: React.Ref<T>;
     to?: string; //used in order to make buttons work with react-router functionality in typescript-files.
 }
 
@@ -44,7 +44,7 @@ export interface ExpandButtonProps extends MinimalBaseButtonProps {
 
 export interface InlineExpandButtonProps {
     children?: React.ReactNode;
-    innerRef?: React.RefObject<HTMLElement>;
+    innerRef?: React.Ref<T>;
     isExpanded: boolean;
     onClick: (e: React.MouseEvent | undefined) => void;
 }


### PR DESCRIPTION
This version changes the innerRef type to Ref<T>, which supports both callback refs and forwarding refs.

<!-- 
Thanks for opening a pull request! 🎉

If your changes include some kind of UI element, please attach a screenshot of 
how it looks.

Before submitting a pull request, please have a look through the CONTRIBUTING.md
document. TL;DR:

- Follow the conventional commit standard
- Write full, explanatory commit messages
- Follow our code standards
- Write tests where applicable
- Be courteous and respect our code of conduct
-->
