### PR TITLE
feat(ffe-form-react): added support for passing ref to input elements

### DIFF
--- a/packages/ffe-form-react/src/Checkbox.js
+++ b/packages/ffe-form-react/src/Checkbox.js
@@ -1,5 +1,5 @@
 import React, { Fragment } from 'react';
-import { bool, node, string, func, oneOfType } from 'prop-types';
+import { bool, node, string, func, oneOfType, shape, object } from 'prop-types';
 import { v4 as hash } from 'uuid';
 import classNames from 'classnames';
 
@@ -9,6 +9,7 @@ export default function Checkbox(props) {
         hiddenLabel,
         inline,
         invalid,
+        innerRef,
         label,
         noMargins,
         dark,
@@ -36,6 +37,7 @@ export default function Checkbox(props) {
                 id={id}
                 type="checkbox"
                 aria-invalid={String(invalid)}
+                ref={innerRef}
                 {...rest}
             />
             {typeof children === 'function' ? (
@@ -68,6 +70,8 @@ Checkbox.propTypes = {
      * Use `aria-invalid` directly instead
      */
     invalid: bool,
+    /** Ref-setting function, or ref created by useRef, passed to the input element */
+    innerRef: oneOfType([func, shape({ current: object })]),
     /** The label for the checkbox */
     children: oneOfType([node, func]),
     /** Dark variant */

--- a/packages/ffe-form-react/src/PhoneNumber.js
+++ b/packages/ffe-form-react/src/PhoneNumber.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { string, bool, func } from 'prop-types';
+import { string, bool, func, oneOfType, object, shape } from 'prop-types';
 import uuid from 'uuid';
 import classNames from 'classnames';
 
@@ -22,6 +22,8 @@ export default class PhoneNumber extends React.Component {
             numberInvalid,
             className,
             dark,
+            countryCodeRef,
+            numberRef,
         } = this.props;
 
         const supportedLocales = ['nb', 'nn', 'en'];
@@ -66,6 +68,7 @@ export default class PhoneNumber extends React.Component {
                                 aria-invalid={countryCodeInvalid}
                                 onChange={onCountryCodeChange}
                                 onBlur={onCountryCodeBlur}
+                                ref={countryCodeRef}
                             />
                         </div>
                     </div>
@@ -91,6 +94,7 @@ export default class PhoneNumber extends React.Component {
                             value={number}
                             aria-invalid={numberInvalid}
                             disabled={disabled}
+                            ref={numberRef}
                         />
                     </div>
                 </div>
@@ -115,6 +119,10 @@ PhoneNumber.propTypes = {
     className: string,
     /** Dark variant */
     dark: bool,
+    /** Ref-setting function, or ref created by useRef, passed to the country code input element */
+    countryCodeRef: oneOfType([func, shape({ current: object })]),
+    /** Ref-setting function, or ref created by useRef, passed to the number input element */
+    numberRef: oneOfType([func, shape({ current: object })]),
 };
 
 PhoneNumber.defaultProps = {

--- a/packages/ffe-form-react/src/index.d.ts
+++ b/packages/ffe-form-react/src/index.d.ts
@@ -11,6 +11,7 @@ export interface CheckboxProps
     hiddenLabel?: boolean;
     id?: string;
     inline?: boolean;
+    innerRef?: React.Ref<T>;
     /**
      * @deprecated
      * Use `aria-invalid` directly instead
@@ -48,6 +49,8 @@ export interface PhoneNumberProps {
     numberInvalid?: boolean;
     className?: string;
     dark?: boolean;
+    countryCodeRef?: React.Ref<T>;
+    numberRef?: React.Ref<T>;
 }
 
 export interface LabelProps


### PR DESCRIPTION
This version offers new optional properties, innerRef, which is passed as refs to input elements.
