### PR TITLE
fix(ffe-form-react): fix type definition on onchange

### DIFF
--- a/packages/ffe-form-react/src/index.d.ts
+++ b/packages/ffe-form-react/src/index.d.ts
@@ -132,7 +132,7 @@ export interface RadioButtonInputGroupProps
     inline?: boolean;
     label?: string | React.ReactNode;
     name?: string;
-    onChange?: React.FormEventHandler<HTMLElement>;
+    onChange?: React.ChangeEventHandler<HTMLInputElement>;
     selectedValue?: string | boolean | number;
     tooltip?: string | React.ReactNode;
     dark?: boolean;


### PR DESCRIPTION
This version fixes the type definition for RadioButtonInputGroup onChange property

ChangeEventHandler is more correct than the previous FormEventHandler