### PR TITLE
feat(ffe-form-react): added support for passing ref to radio buttons

### DIFF
--- a/packages/ffe-form-react/src/BaseRadioButton.js
+++ b/packages/ffe-form-react/src/BaseRadioButton.js
@@ -7,6 +7,8 @@ import {
     oneOfType,
     shape,
     string,
+    func,
+    object,
     number,
 } from 'prop-types';
 import uuid from 'uuid';
@@ -27,6 +29,7 @@ class BaseRadioButton extends Component {
             tooltip,
             tooltipProps,
             value,
+            innerRef,
             dark,
             ...inputProps
         } = this.props;
@@ -38,7 +41,7 @@ class BaseRadioButton extends Component {
             className,
         );
 
-        const isSelected = checked || selectedValue === value;
+        const isSelected = selectedValue ? selectedValue === value : checked;
 
         return (
             <Fragment>
@@ -48,6 +51,7 @@ class BaseRadioButton extends Component {
                         'ffe-radio-input--dark': dark,
                     })}
                     id={this.id}
+                    ref={innerRef}
                     type="radio"
                     checked={isSelected}
                     value={value}
@@ -93,6 +97,8 @@ BaseRadioButton.propTypes = {
     tooltipProps: shape({}),
     /** The value of the radio button */
     value: oneOfType([bool, string, number]).isRequired,
+    /** Ref-setting function, or ref created by useRef, passed to the input element */
+    innerRef: oneOfType([func, shape({ current: object })]),
     /** Dark variant */
     dark: bool,
 };

--- a/packages/ffe-form-react/src/BaseRadioButton.spec.js
+++ b/packages/ffe-form-react/src/BaseRadioButton.spec.js
@@ -17,6 +17,17 @@ describe('<BaseRadioButton />', () => {
         const wrapper = getWrapper();
         expect(wrapper.exists()).toBe(true);
     });
+    it('is checked undefined if checked prop is undefined and selectedValue is undefined', () => {
+        const wrapper = getWrapper({});
+
+        expect(wrapper.find('input').props()).toHaveProperty(
+            'checked',
+            undefined,
+        );
+        wrapper.setProps({ checked: true });
+
+        expect(wrapper.find('input').props()).toHaveProperty('checked', true);
+    });
     it('is checked if checked prop is true', () => {
         const wrapper = getWrapper({ checked: false });
 

--- a/packages/ffe-form-react/src/RadioBlock.js
+++ b/packages/ffe-form-react/src/RadioBlock.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { bool, node, oneOfType, string } from 'prop-types';
+import { bool, node, oneOfType, string, func, object, shape } from 'prop-types';
 import classNames from 'classnames';
 import uuid from 'uuid';
 
@@ -17,6 +17,7 @@ class RadioBlock extends Component {
              * used but can still be passed down from a parent `RadioButtonInputGroup`.
              */
             dark, //eslint-disable-line
+            innerRef,
             label,
             labelClass,
             name,
@@ -34,6 +35,7 @@ class RadioBlock extends Component {
                     checked={isSelected}
                     className="ffe-radio-input"
                     id={this.id}
+                    ref={innerRef}
                     type="radio"
                     name={name}
                     value={value}
@@ -71,6 +73,8 @@ RadioBlock.propTypes = {
     children: node,
     /** Additional class names applied to the outer div */
     className: string,
+    /** Ref-setting function, or ref created by useRef, passed to the input element */
+    innerRef: oneOfType([func, shape({ current: object })]),
     /** The always visible label of the radio block */
     label: oneOfType([node, string]).isRequired,
     /** Additional class names applied to the label element */

--- a/packages/ffe-form-react/src/RadioSwitch.js
+++ b/packages/ffe-form-react/src/RadioSwitch.js
@@ -1,5 +1,14 @@
 import React, { Fragment } from 'react';
-import { bool, oneOf, oneOfType, string, number } from 'prop-types';
+import {
+    bool,
+    oneOf,
+    oneOfType,
+    string,
+    number,
+    func,
+    object,
+    shape,
+} from 'prop-types';
 import classNames from 'classnames';
 
 import BaseRadioButton from './BaseRadioButton';
@@ -9,8 +18,10 @@ const RadioSwitch = props => {
         className,
         leftLabel,
         leftValue,
+        leftInnerRef,
         rightLabel,
         rightValue,
+        rightInnerRef,
         condensed,
         dark,
         'aria-invalid': ariaInvalid,
@@ -27,6 +38,7 @@ const RadioSwitch = props => {
                     'ffe-radio-switch--dark': dark,
                 })}
                 value={leftValue}
+                innerRef={leftInnerRef}
                 dark={dark}
                 aria-invalid={String(
                     ariaInvalid === 'true' &&
@@ -42,6 +54,7 @@ const RadioSwitch = props => {
                     'ffe-radio-switch--dark': dark,
                 })}
                 value={rightValue}
+                innerRef={rightInnerRef}
                 dark={dark}
                 aria-invalid={String(
                     ariaInvalid === 'true' &&
@@ -62,10 +75,14 @@ RadioSwitch.propTypes = {
     leftLabel: string.isRequired,
     /** The value of the choice to the left */
     leftValue: oneOfType([bool, string, number]).isRequired,
+    /** Ref-setting function, or ref created by useRef, passed to the input element */
+    leftInnerRef: oneOfType([func, shape({ current: object })]),
     /** The label of the choice to the right */
     rightLabel: string.isRequired,
     /** The value of the choice to the right */
     rightValue: oneOfType([bool, string, number]).isRequired,
+    /** Ref-setting function, or ref created by useRef, passed to the input element */
+    rightInnerRef: oneOfType([func, shape({ current: object })]),
     /** The selected value of the radio button set */
     selectedValue: oneOfType([bool, string, number]),
     /** Condensed modifier. Use in condensed designs */

--- a/packages/ffe-form-react/src/RadioSwitch.md
+++ b/packages/ffe-form-react/src/RadioSwitch.md
@@ -10,7 +10,7 @@ initialState = { selected: undefined };
 <RadioButtonInputGroup
     label="Vil bilen bli kjørt av sjåfører under 23 år?"
     tooltip="Unge sjåfører har en statistisk høyere sjanse for å bulke bilen."
-    name="under23"
+    name="radioButtonInputGroup"
     onChange={e => setState({ selected: e.target.value })}
     selectedValue={state.selected}
 >
@@ -36,7 +36,7 @@ initialState = { selected: 'false' };
 <RadioButtonInputGroup
     label="Vil bilen bli kjørt av sjåfører under 23 år?"
     tooltip="Unge sjåfører har en statistisk høyere sjanse for å bulke bilen."
-    name="under23"
+    name="radioButtonInputGroupWithDefault"
     onChange={e => setState({ selected: e.target.value })}
     selectedValue={state.selected}
 >
@@ -92,7 +92,7 @@ initialState = { selected: undefined, fieldMessage: 'Du må gjøre et valg' };
 <RadioButtonInputGroup
     label="Vil bilen bli kjørt av sjåfører under 23 år?"
     tooltip="Unge sjåfører har en statistisk høyere sjanse for å bulke bilen."
-    name="under23"
+    name="radioButtonInputGroupWithFieldMessage"
     onChange={e => setState({ selected: e.target.value })}
     selectedValue={state.selected}
     fieldMessage={state.fieldMessage}

--- a/packages/ffe-form-react/src/index.d.ts
+++ b/packages/ffe-form-react/src/index.d.ts
@@ -97,6 +97,7 @@ export interface RadioBlockProps
      * is implemented.
      */
     dark?: boolean;
+    innerRef?: React.Ref<T>;
     label: string | React.ReactNode;
     labelClass?: string;
     name: string;
@@ -117,6 +118,7 @@ export interface RadioButtonProps extends WeakInputAttributes {
     className?: string;
     labelProps?: object;
     inline?: boolean;
+    innerRef?: React.Ref<T>;
     name: string;
     selectedValue?: boolean | string | number;
     tooltip?: string;
@@ -149,8 +151,10 @@ export interface RadioSwitchProps
     labelProps?: object;
     leftLabel: string;
     leftValue: boolean | string | number;
+    leftInnerRef?: React.Ref<T>;
     rightLabel: string;
     rightValue: boolean | string | number;
+    rightInnerRef?: React.Ref<T>;
     name: string;
     selectedValue?: boolean | string | number;
     tooltip?: string;


### PR DESCRIPTION
This version offers new optional properties (innerRef on RadioButton and RadioBlock, leftInnerRef and rightInnerRef on RadioSwitch), which is passed as refs to input elements
On BaseRadioButton, selectedValue updates the defaultChecked attribute instead of checked attribute, so that re-render is no longer required when radio buttons are clicked

<!-- 
Thanks for opening a pull request! 🎉

If your changes include some kind of UI element, please attach a screenshot of 
how it looks.

Before submitting a pull request, please have a look through the CONTRIBUTING.md
document. TL;DR:

- Follow the conventional commit standard
- Write full, explanatory commit messages
- Follow our code standards
- Write tests where applicable
- Be courteous and respect our code of conduct
-->
