### PR TITLE
fix(ffe-grid): larger GridCol padding on small devices

### DIFF
--- a/packages/ffe-grid/less/ffe-grid.less
+++ b/packages/ffe-grid/less/ffe-grid.less
@@ -300,7 +300,7 @@
     flex: 1 1;
     flex-direction: column;
     max-width: 100%;
-    padding: 0 (@ffe-grid-gutter-sm / 2) @ffe-grid-gutter-sm;
+    padding: 0 @ffe-grid-gutter-sm @ffe-grid-gutter-sm;
 
     @media (min-width: @breakpoint-lg) {
         padding: 0 (@ffe-grid-gutter-lg / 2) @ffe-grid-gutter-lg;


### PR DESCRIPTION
We have an issue with GridCol having a horizontal padding of only `8px` on small devices. This makes content closer to the edge of the screen than we like it to be, and escpecially close for devices with curved glass.

The proposed solution is to increase horizontal padding on `GridCol` for small devices from `8px` to `16px`.
