### PR TITLE
fix(ffe-form-react): correctly handle non-undefined selected value

### DIFF
--- a/packages/ffe-form-react/src/BaseRadioButton.js
+++ b/packages/ffe-form-react/src/BaseRadioButton.js
@@ -41,7 +41,8 @@ class BaseRadioButton extends Component {
             className,
         );
 
-        const isSelected = selectedValue ? selectedValue === value : checked;
+        const isSelected =
+            selectedValue !== undefined ? selectedValue === value : checked;
 
         return (
             <Fragment>

--- a/packages/ffe-form-react/src/BaseRadioButton.spec.js
+++ b/packages/ffe-form-react/src/BaseRadioButton.spec.js
@@ -47,6 +47,19 @@ describe('<BaseRadioButton />', () => {
         const wrapper = getWrapper({ checked: false, selectedValue: 'nope' });
         expect(wrapper.find('input').props()).toHaveProperty('checked', false);
     });
+    it('is not checked if checked === undefined and selectedValue is falsy, but not undefined', () => {
+        const wrapperWithNull = getWrapper({ selectedValue: null });
+        expect(wrapperWithNull.find('input').props()).toHaveProperty(
+            'checked',
+            false,
+        );
+
+        const wrapperWithEmptyString = getWrapper({ selectedValue: '' });
+        expect(wrapperWithEmptyString.find('input').props()).toHaveProperty(
+            'checked',
+            false,
+        );
+    });
     it('accepts boolean values and checks the input if it is selected', () => {
         const wrapper = getWrapper({ selectedValue: true, value: true });
         expect(wrapper.find('input').props()).toHaveProperty('checked', true);


### PR DESCRIPTION
When a selected value is provided it should be used to compare it to the
radio button value. Any value except undefined should be considered as a
provided value, even if it is falsy.

In my code my selected value is `''` (empty string) when no button is selected, and I don't provide any value for `checked`. This caused `isSelected` to become `undefined`, and React treats the input as an uncontrolled component.
When a radio button was selected, I got a warning about uncontrolled->controlled component in the console.