### PR TITLE
fix(ffe-account-selector): Legger til margin for feilmeldinger

### DIFF
--- a/packages/ffe-account-selector-react/less/ffe-account-selector.less
+++ b/packages/ffe-account-selector-react/less/ffe-account-selector.less
@@ -5,6 +5,7 @@
 
     position: relative;
     display: block;
+    margin-bottom: 30px;
 
     &__details {
         font-size: 14px;


### PR DESCRIPTION
Komponenten ffe-account-selector manglet margin for å sette av plass til feilmeldinger.
Dette blir litt breaking - men sørger for at komponenten oppfører seg likt som de andre komponentene.

Før:
![image](https://user-images.githubusercontent.com/2163425/73434499-2a525800-4347-11ea-8545-7897549f60f2.png)

Etter:
![image](https://user-images.githubusercontent.com/2163425/73434475-1ad30f00-4347-11ea-8ae2-3a10e63a6d7a.png)
