### PR TITLE
feat(ffe-core): auto-generate type declarations for core vars

### DIFF
--- a/packages/ffe-core/bin/build.js
+++ b/packages/ffe-core/bin/build.js
@@ -36,33 +36,29 @@ FILES_WITH_VARIABLES.forEach(filename => {
 
     // Create the output string, complete with a header explaining where it came
     // from and how to change it.
-    const jsContent = `// DO NOT MODIFY!
+    const tsContent = `// DO NOT MODIFY!
 // This file is created automatically by ffe-core/bin/build.js, and is based on
 // the ffe-core/less/${filename}.less file. Change the value there instead.
-
-module.exports = ${JSON.stringify(variables, null, 4)};
+${Object.entries(variables)
+    .map(([key, value]) => `export const ${key} = "${value}";`)
+    .join('\n')}
 `;
-
     // Write the formatted string to its own file
     fs.writeFileSync(
-        path.resolve(__dirname, '..', 'lib', `${filename}.js`),
-        jsContent,
+        path.resolve(__dirname, '..', 'lib', `${filename}.ts`),
+        tsContent,
     );
 });
 
 // Finally, let's create an index file that exports all variables
 const indexContent = `// DO NOT MODIFY!
 // This file is created automatically by ffe-core/bin/build.js.
-
-module.exports = Object.assign(
-    {},
-${FILES_WITH_VARIABLES.map(filename => `    require('./${filename}')`).join(
-    ',\n',
+${FILES_WITH_VARIABLES.map(filename => `export * from './${filename}';`).join(
+    '\n',
 )}
-);
 `;
 
 fs.writeFileSync(
-    path.resolve(__dirname, '..', 'lib', 'index.js'),
+    path.resolve(__dirname, '..', 'lib', 'index.ts'),
     indexContent,
 );

--- a/packages/ffe-core/package.json
+++ b/packages/ffe-core/package.json
@@ -10,6 +10,7 @@
     "less"
   ],
   "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "repository": {
     "type": "git",
     "url": "ssh://git@github.com:SpareBank1/designsystem.git"
@@ -17,12 +18,13 @@
   "scripts": {
     "lint": "stylelint less/*.less",
     "test": "npm run lint",
-    "build": "node ./bin/build.js"
+    "build": "node ./bin/build.js; tsc lib/index.ts --declaration"
   },
   "devDependencies": {
     "case": "^1.5.5",
     "mkdirp": "^0.5.1",
-    "stylelint": "^10.0.0"
+    "stylelint": "^10.0.0",
+    "typescript": "^3.7.5"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
**Problem**
I am trying to import core variables (colors, spacing, breakpoints) from  `@sb1/ffe-core` in a typescript app, but there are no available type declarations for these variables.

**Proposed solution**
Since these variables are extracted from `.less`-files and written into `.js`-files in the build process, I thought it would be cool to use this process to also generate the type declarations for these variables. Luckily the typescript compiler has a `--declaration` flag which automatically generates type declaration files, which reduces the problem to outputting `.ts` instead of `.js` and use `tsc` to compile it to `.js` while also generating type declarations (`.d.ts`).

*Previous build process:*
`less --> .js`

*Proposed process:*
`.less --> .ts --> .js and .d.ts`

This should not lead to any breaking changes, all variables can be imported as before, but now with the added bonus of type declarations for typescript.
