### PR TITLE
fix(ffe-buttons-react): fixing incorrect types

### DIFF
--- a/packages/ffe-buttons-react/src/index.d.ts
+++ b/packages/ffe-buttons-react/src/index.d.ts
@@ -3,7 +3,7 @@ import * as React from 'react';
 export interface MinimalBaseButtonProps extends React.HTMLProps<HTMLElement> {
     className?: string;
     element?: HTMLElement | string | React.ElementType;
-    innerRef?: React.Ref<T>;
+    innerRef?: React.Ref<HTMLElement>;
     to?: string; //used in order to make buttons work with react-router functionality in typescript-files.
 }
 
@@ -44,7 +44,7 @@ export interface ExpandButtonProps extends MinimalBaseButtonProps {
 
 export interface InlineExpandButtonProps {
     children?: React.ReactNode;
-    innerRef?: React.Ref<T>;
+    innerRef?: React.Ref<HTMLElement>;
     isExpanded: boolean;
     onClick: (e: React.MouseEvent | undefined) => void;
 }


### PR DESCRIPTION
This version fixes incorrect use of generic types for refs

This PR fixes issue 840 for ffe-buttons-react.
