### PR TITLE
fix(ffe-dropdown-react): fixing incorrect types

### DIFF
--- a/packages/ffe-dropdown-react/src/index.d.ts
+++ b/packages/ffe-dropdown-react/src/index.d.ts
@@ -6,7 +6,7 @@ export interface DropdownProps
     className?: string;
     inline?: boolean;
     dark?: boolean;
-    innerRef?: React.Ref<T>;
+    innerRef?: React.Ref<HTMLSelectElement>;
 }
 
 declare class Dropdown extends React.Component<DropdownProps, any> {}


### PR DESCRIPTION
This version fixes incorrect use of generic types for refs

This PR fixes 840 for ffe-dropdown-react.