### PR TITLE
Generate typescript variable declarations

### DIFF
--- a/packages/ffe-core/bin/build.js
+++ b/packages/ffe-core/bin/build.js
@@ -6,7 +6,8 @@ const mkdirp = require('mkdirp');
 // These are the files we want to convert to JavaScript
 const FILES_WITH_VARIABLES = ['colors', 'breakpoints', 'spacing'];
 
-// First, create the lib directory if it doesn't exist
+// First, create the lib and tmp directories if they don't exist
+mkdirp.sync(path.resolve(__dirname, '..', 'tmp'));
 mkdirp.sync(path.resolve(__dirname, '..', 'lib'));
 
 // Then, let's process each file!
@@ -45,7 +46,7 @@ ${Object.entries(variables)
 `;
     // Write the formatted string to its own file
     fs.writeFileSync(
-        path.resolve(__dirname, '..', 'lib', `${filename}.ts`),
+        path.resolve(__dirname, '..', 'tmp', `${filename}.ts`),
         tsContent,
     );
 });
@@ -59,6 +60,6 @@ ${FILES_WITH_VARIABLES.map(filename => `export * from './${filename}';`).join(
 `;
 
 fs.writeFileSync(
-    path.resolve(__dirname, '..', 'lib', 'index.ts'),
+    path.resolve(__dirname, '..', 'tmp', 'index.ts'),
     indexContent,
 );

--- a/packages/ffe-core/package.json
+++ b/packages/ffe-core/package.json
@@ -18,7 +18,7 @@
   "scripts": {
     "lint": "stylelint less/*.less",
     "test": "npm run lint",
-    "build": "node ./bin/build.js; tsc lib/index.ts --declaration"
+    "build": "node ./bin/build.js && tsc tmp/index.ts --declaration --outDir lib && rm -rf tmp"
   },
   "devDependencies": {
     "case": "^1.5.5",

--- a/packages/ffe-icons-react/.gitignore
+++ b/packages/ffe-icons-react/.gitignore
@@ -1,3 +1,4 @@
 # Specific ignores for ffe-icons-react
 jsx/
 es/
+tsx/

--- a/packages/ffe-icons-react/package.json
+++ b/packages/ffe-icons-react/package.json
@@ -8,6 +8,7 @@
     "es"
   ],
   "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "module": "es/index.js",
   "sideEffects": false,
   "repository": {
@@ -15,11 +16,11 @@
     "url": "ssh://git@github.com:SpareBank1/designsystem.git"
   },
   "scripts": {
-    "build": "npm run build:jsx-components && npm run build:cjs && npm run build:es",
-    "build:cjs": "babel -d lib --env-name=cjs --root-mode=upward jsx",
-    "build:es": "babel -d es --env-name=es --root-mode=upward jsx",
-    "build:jsx-components": "node ./src/build-jsx-components.js",
-    "clean": "rimraf tmp jsx lib es",
+    "build": "npm run build:tsx-components && npm run build:cjs && npm run build:es",
+    "build:cjs": "tsc tsx/index.ts --outDir lib --module commonjs --jsx react --declaration",
+    "build:es": "tsc tsx/index.ts --outDir es --module esnext --jsx react --declaration --skipLibCheck",
+    "build:tsx-components": "node ./src/build-tsx-components.js",
+    "clean": "rimraf tmp tsx lib es",
     "lint": "eslint src/.",
     "test": "npm run lint"
   },
@@ -36,7 +37,8 @@
     "mkdirp": "^0.5.1",
     "react": "^16.9.0",
     "react-dom": "^16.9.0",
-    "rimraf": "^2.6.2"
+    "rimraf": "^2.6.2",
+    "typescript": "^3.7.5"
   },
   "peerDependencies": {
     "react": "^16.9.0"

--- a/packages/ffe-icons-react/src/build-tsx-components.js
+++ b/packages/ffe-icons-react/src/build-tsx-components.js
@@ -4,7 +4,7 @@ const fs = require('fs');
 const path = require('path');
 const mkdirp = require('mkdirp');
 
-mkdirp.sync('./jsx');
+mkdirp.sync('./tsx');
 
 const createSvgMap = () => {
     const map = {};
@@ -33,7 +33,7 @@ const createSvgMap = () => {
  *
  * Should this proplem (sic!) pop up more often, another solution should be sought
  * */
-const toJsx = svgString => {
+const toTsx = svgString => {
     const $ = cheerio.load(svgString, {
         xmlMode: true,
     });
@@ -49,15 +49,22 @@ const toJsx = svgString => {
 };
 
 /**
- * Creates a new React component and a corresponding .jsx file for each icon
+ * Creates a new React component and a corresponding .tsx file for each icon
  * */
-const createStandaloneJSX = (icons, iconName) => `
-import React from 'react';
+const createStandaloneTSX = (icons, iconName) => `
+import * as React from 'react';
 import { bool, string } from 'prop-types';
 
-const svg = ${toJsx(icons[iconName])};
+const svg = ${toTsx(icons[iconName])};
 
-const Icon = ({
+interface IconProps {
+    desc?: string;
+    focusable? : boolean;
+    title?: string;
+    iconName?: string;
+}
+
+const Icon: React.FC<IconProps> = ({
     desc,
     focusable = false,
     title,
@@ -90,8 +97,8 @@ export default Icon;
 const icons = createSvgMap();
 Object.keys(icons).forEach(iconName =>
     fs.writeFileSync(
-        `./jsx/${iconName}.js`,
-        createStandaloneJSX(icons, iconName),
+        `./tsx/${iconName}.tsx`,
+        createStandaloneTSX(icons, iconName),
     ),
 );
 
@@ -107,4 +114,4 @@ const indexFileString = Object.keys(icons)
     )
     .join('\n');
 
-fs.writeFileSync('./jsx/index.js', indexFileString);
+fs.writeFileSync('./tsx/index.ts', indexFileString);


### PR DESCRIPTION
## Problem 1: ffe-core problematic .ts-files 
I recently merged a change to `ffe-core` which implemented generation of typescript declarations for constants defined in `.less`-files. This meant that `.ts`-files were published (including `.js` and `.d.ts` files), which in turn lead to confusion for the typescript compiler and lots of error messages.

### solution
The solution was to only publish `.js` and `d.ts` files, so this PR deletes the `.ts` files after they are used for type declarations.



## Problem 2: generate typescript declaration files for all Icons in  ffe-icons-react
@henrikhermansen suggested that we also add typescript types all the `Icon` components in `ffe-icons-react`.

### solution
My suggested solution is to replace `babel` with `tsc` in order to use that to generate declaration files from the `.tsx` files generated from the build-script. This could have unintented consequenses as the final transpiled code will be a bit different, but the behaviour should be the same. Another solution I thought about would be to just generate the `.d.ts` files directly with a template and keep the old `babel` setup, but I thought that could lead to problems down the line should the component change.