### PR TITLE
docs: ignore __esModule when importing all icons

### DIFF
--- a/styleguide-content/komponenter/ikoner.md
+++ b/styleguide-content/komponenter/ikoner.md
@@ -10,12 +10,14 @@ const allIcons = require('../../packages/ffe-icons-react/lib');
 
 <Grid>
     <GridRow>
-        {Object.entries(allIcons).map(([name, Icon]) => (
-            <GridCol key={name} sm="6" md="4" lg="3" center={true}>
-                <Icon className="sb1ds-icon" />
-                <p>{name}</p>
-            </GridCol>
-        ))}
+        {Object.entries(allIcons)
+            .filter(([name]) => !name.startsWith('__'))
+            .map(([name, Icon]) => (
+                <GridCol key={name} sm="6" md="4" lg="3" center={true}>
+                    <Icon className="sb1ds-icon" />
+                    <p>{name}</p>
+                </GridCol>
+            ))}
     </GridRow>
 </Grid>;
 ```


### PR DESCRIPTION
After generating types for all icons in the package `ffe-icons-react`, I encountered an odd issue in the styleguide where the icons page would no longer display the icons.

The problem was that tsc outputs `exports.__esModule = true;` as well as the other exports. This is not a problem for normal use, but the styleguide imports everything, and would try to render the value "true".

The fix is to filter out imports starting with `__`.