### PR TITLE
chore: Added NPM release action [WIP]

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,92 @@
+name: Release to NPM
+
+on:
+    watch:
+        types: [started]
+
+jobs:
+    release_to_npm:
+        name: Release to NPM
+        runs-on: ubuntu-latest
+        if: github.actor == 'steffenz' && github.ref == 'refs/heads/develop'
+        steps:
+            - name: Configure NPM
+              run: |
+                  echo $'\n//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}' >> .npmrc
+                  npm whoami
+
+            - name: 'GIT: Checkout develop branch'
+              uses: actions/checkout@v2
+              with:
+                  fetch-depth: '0'
+
+            - name: 'GIT: Fetch master branch'
+              run: git fetch origin master:master
+
+            - name: 'GIT: Compare branches'
+              id: compare
+              run: echo "##[set-output name=commits_ahead;]$(git rev-list --count master..develop)"
+
+            - name: 'GIT: Merge develop into master'
+              id: merge
+              if: steps.compare.outputs.commits_ahead > 0
+              run: |
+                  git config user.email "designsystem@sparebank1.no"
+                  git config user.name "sb1-designsystem"
+                  git checkout master
+                  git merge --no-edit develop
+                  git push origin master
+                  echo "::set-output name=should_publish::true"
+
+            - name: 'NPM: Install'
+              id: install
+              run: 'npm install'
+
+            - name: 'NPM: Build'
+              id: build
+              run: 'npm build'
+
+            - name: Changed command
+              id: changed
+              uses: sparebank1/designsystem-gh-actions/publish-to-npm@feature/output-support
+              with:
+                  action: 'lerna-changed'
+
+            - name: Publish
+              id: publish
+              if: steps.changed.outputs.has_changes == 'true'
+              uses: sparebank1/designsystem-gh-actions/publish-to-npm@feature/output-support
+              with:
+                  action: 'lerna-publish'
+
+            - name: Post Error
+              id: error
+              if: steps.publish.outputs.publish_failed == 'true'
+              uses: sparebank1/designsystem-gh-actions/publish-to-npm@feature/output-support
+              env:
+                  SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+                  SLACK_CHANNEL_ID: 'CRD325L14'
+              with:
+                  action: 'slack-error'
+                  error_message: 'This is an error message UPDATE'
+                  error_details: ${{ steps.publish.outputs.publish_error_log }}
+
+            - name: Post Success
+              id: success
+              if: steps.publish.outputs.publish_failed == 'false'
+              uses: sparebank1/designsystem-gh-actions/publish-to-npm@feature/output-support
+              env:
+                  SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+                  SLACK_CHANNEL_ID: 'CRD325L14'
+              with:
+                  action: 'slack-success'
+                  success_message: 'Awesome hamburgers'
+                  changed_packages: ${{ steps.changed.outputs.changed_packages }}
+            - name: Merge back
+              if: steps.changed.outputs.has_changes == 'true' #merge back even if publish failed.
+              run: |
+                  git checkout develop
+                  git pull
+                  git merge -X theirs --no-edit master
+                  git push origin develop
+                  git push --tags


### PR DESCRIPTION
Added GitHub action for publishing to NPM. This need to run from the develop branch, and during test/development it can only be triggered by me.  
This is a work in progress. 

~~Remember to add ```NPM_TOKEN``` and ```SLACK_BOT_TOKEN``` as secrets.~~:heavy_check_mark: 