### PR TITLE
Allow light mode even though OS uses dark mode

### DIFF
--- a/src/assets/darkmode-switch.css
+++ b/src/assets/darkmode-switch.css
@@ -61,10 +61,6 @@
     transform: translateX(-100%);
 }
 
-.darkmode-button__switch--input-disabled {
-    cursor: not-allowed !important;
-}
-
 html.transition,
 html.transition *,
 html.transition *::before,

--- a/src/assets/darkmode-switch.js
+++ b/src/assets/darkmode-switch.js
@@ -1,41 +1,15 @@
 /*eslint no-var:0,no-param-reassign:0,no-use-before-define:["error",{"functions":false}] */
 (function() {
-    var userControls = initUserControls();
+    return main();
 
-    document.addEventListener('DOMContentLoaded', userControls.restoreDarkMode);
-
-    if (getDarkModeEnabledByOS()) {
-        // TODO not sure this is a good idea
-        userControls.disableUserInput();
-        turnOnDarkMode();
-    }
-
-    listenToOsDarkModeChanges();
-
-    function listenToOsDarkModeChanges() {
-        var mediaQueryList = window.matchMedia('(prefers-color-scheme: dark)');
-
-        if (mediaQueryList.addListener) {
-            mediaQueryList.addListener(onOsDarkModeSelected);
-        } else {
-            mediaQueryList.addEventListener('change', onOsDarkModeSelected);
-        }
-
-        function onOsDarkModeSelected() {
-            if (getDarkModeEnabledByOS()) {
-                userControls.disableUserInput();
-                turnOnDarkMode();
-            } else {
-                userControls.allowUserInput();
-                turnOffDarkMode();
-            }
-        }
-    }
-
-    function initUserControls() {
-        var label = document.querySelector('.darkmode-button__label');
+    function main() {
         var button = document.querySelector('.darkmode-button');
         var checkbox = document.querySelector('.darkmode-button__switch');
+
+        checkbox.checked = getInitialDarkModeChoice();
+        if (checkbox.checked) {
+            turnOnDarkMode();
+        }
 
         button.addEventListener('click', function(event) {
             if (!isDarkModeSupported()) {
@@ -67,32 +41,34 @@
             } else {
                 turnOffDarkMode();
             }
-            setDarkModeCookie(checked);
+            storeDarkModeChoice(checked);
         });
+    }
 
-        return {
-            restoreDarkMode: function() {
-                if (getDarkModeCookieValue()) {
-                    if (checkbox.checked) {
-                        turnOnDarkMode();
-                    } else {
-                        checkbox.click();
-                    }
-                }
-            },
-            disableUserInput: function() {
-                checkbox.checked = true;
-                checkbox.disabled = true;
-                label.classList.add('darkmode-button__switch--input-disabled');
-            },
-            allowUserInput: function() {
-                label.classList.remove(
-                    'darkmode-button__switch--input-disabled',
-                );
-                checkbox.checked = false;
-                checkbox.disabled = false;
-            },
-        };
+    function getInitialDarkModeChoice() {
+        if (getStoredDarkModeChoice() === null) {
+            storeDarkModeChoice(
+                window.matchMedia('(prefers-color-scheme: dark)').matches,
+            );
+        }
+
+        return getStoredDarkModeChoice();
+    }
+
+    function storeDarkModeChoice(choice) {
+        localStorage.setItem('wantsDarkmode', choice);
+    }
+
+    function getStoredDarkModeChoice() {
+        switch (localStorage.getItem('wantsDarkmode')) {
+            case 'true':
+                return true;
+            case 'false':
+                return false;
+            default:
+                // not set
+                return null;
+        }
     }
 
     function turnOnDarkMode() {
@@ -146,22 +122,6 @@
                 // never mind
             }
         }
-    }
-
-    function getDarkModeEnabledByOS() {
-        return window.matchMedia('(prefers-color-scheme: dark)').matches;
-    }
-
-    function setDarkModeCookie(darkmodeEnabled) {
-        var date = new Date();
-        date.setTime(date.getTime() + 24 * 60 * 60 * 1000);
-        document.cookie = `sb1design-darkmode=${
-            darkmodeEnabled ? 'true' : 'false'
-        }; expires=${date.toGMTString()}; path=/`;
-    }
-
-    function getDarkModeCookieValue() {
-        return document.cookie.indexOf('sb1design-darkmode=true') !== -1;
     }
 
     function animateCssTransition() {


### PR DESCRIPTION
Turning off dark mode preview was disabled if dark mode was enabled on
operating system level. With this changed the toggle button will not
be disabled when dark mode is turned on.

<!-- 
Thanks for opening a pull request! 🎉

If your changes include some kind of UI element, please attach a screenshot of 
how it looks.

Before submitting a pull request, please have a look through the CONTRIBUTING.md
document. TL;DR:

- Follow the conventional commit standard
- Write full, explanatory commit messages
- Follow our code standards
- Write tests where applicable
- Be courteous and respect our code of conduct
-->
