### PR TITLE
Extend SVG attributes for icons in TypeScript Interface

### DIFF
--- a/packages/ffe-icons-react/src/build-tsx-components.js
+++ b/packages/ffe-icons-react/src/build-tsx-components.js
@@ -59,19 +59,17 @@ const svg = ${toTsx(icons[iconName])};
 
 interface IconProps extends React.SVGAttributes<SVGElement> {
     desc?: string;
-    focusable? : boolean;
     title?: string;
     iconName?: string;
 }
 
 const Icon: React.FC<IconProps> = ({
     desc,
-    focusable = false,
     title,
     iconName,
     ...rest
     }) => (
-        <svg focusable={String(focusable)} {...rest} {...svg.props}>
+        <svg {...svg.props} {...rest}>
             {title &&
                 <title>{title}</title>
             }

--- a/packages/ffe-icons-react/src/build-tsx-components.js
+++ b/packages/ffe-icons-react/src/build-tsx-components.js
@@ -53,13 +53,15 @@ const toTsx = svgString => {
  * */
 const createStandaloneTSX = (icons, iconName) => `
 import * as React from 'react';
-import { bool, string } from 'prop-types';
+import { string, bool } from 'prop-types';
+import * as PropTypes from 'prop-types';
 
 const svg = ${toTsx(icons[iconName])};
 
-interface IconProps extends React.SVGAttributes<SVGElement> {
+interface IconProps extends Omit<React.SVGAttributes<SVGElement>, 'focusable'> {
     desc?: string;
     title?: string;
+    focusable?: boolean | string;
     iconName?: string;
 }
 
@@ -82,8 +84,11 @@ const Icon: React.FC<IconProps> = ({
 
 Icon.propTypes = {
     desc: string,
-    focusable: bool,
     title: string,
+    focusable: PropTypes.oneOfType([
+        PropTypes.bool,
+        PropTypes.oneOf(["true", "false", "auto", "undefined"]),
+    ]),
     iconName: string,
 };
 

--- a/packages/ffe-icons-react/src/build-tsx-components.js
+++ b/packages/ffe-icons-react/src/build-tsx-components.js
@@ -57,7 +57,7 @@ import { bool, string } from 'prop-types';
 
 const svg = ${toTsx(icons[iconName])};
 
-interface IconProps {
+interface IconProps extends React.SVGAttributes<SVGElement> {
     desc?: string;
     focusable? : boolean;
     title?: string;


### PR DESCRIPTION
## Issue description
When using icons with TypeScript, attributes not defined in the IconProps triggers an error.
Allowed SVG attributes should be supported as props to these elements. 
Related issue: https://github.com/SpareBank1/designsystem/issues/860 

## Solution
The short and simple solution here is extending React.SVGAttributes and spread them in with the other props defined. ~~Please do note however that overriding props set in the embedded SVG icon itself will simply be ignored (for example ViewBox). If this ends up being an problem it should be reported in as a separate issue, as it is unrelated to adding type support.~~ Overriding SVG props is now supported. 

