### PR TITLE
fix(ffe-form-react): updated type for input

### DIFF
--- a/packages/ffe-form-react/src/index.d.ts
+++ b/packages/ffe-form-react/src/index.d.ts
@@ -29,7 +29,10 @@ export interface BaseFieldMessageProps
 }
 
 export interface InputProps
-    extends React.InputHTMLAttributes<HTMLInputElement> {
+    extends React.DetailedHTMLProps<
+        React.InputHTMLAttributes<HTMLInputElement>,
+        HTMLInputElement
+    > {
     className?: string;
     inline?: boolean;
     textLike?: boolean;


### PR DESCRIPTION
Input now extends React.DetailedHTMLProps to make it compatible with external libraries.

We have started to use react-hook-form and somehow the old definition was not enough for this component, the ref-definition in the React.InputHTMLAttributes<HTMLInputElement> did not accecpt ref={register()} (register from react-hook-form).