### PR TITLE
Greenkeeper/default/eslint plugin import 2.20.1

### DIFF
--- a/linting/eslint-config-ffe-base/package.json
+++ b/linting/eslint-config-ffe-base/package.json
@@ -20,7 +20,7 @@
   "devDependencies": {
     "eslint": "^5.9.0",
     "eslint-find-rules": "^3.1.1",
-    "eslint-plugin-import": "^2.0.1"
+    "eslint-plugin-import": "^2.20.1"
   },
   "peerDependencies": {
     "eslint": ">=2",

--- a/linting/eslint-config-ffe-base/package.json
+++ b/linting/eslint-config-ffe-base/package.json
@@ -24,7 +24,7 @@
   },
   "peerDependencies": {
     "eslint": ">=2",
-    "eslint-plugin-import": ">=1.10"
+    "eslint-plugin-import": ">=2.20.1"
   },
   "publishConfig": {
     "access": "public"

--- a/linting/eslint-config-ffe/package.json
+++ b/linting/eslint-config-ffe/package.json
@@ -21,7 +21,7 @@
   },
   "devDependencies": {
     "eslint": "^5.9.0",
-    "eslint-plugin-import": "^2.0.1",
+    "eslint-plugin-import": "^2.20.1",
     "eslint-plugin-jsx-a11y": "^6.0.3",
     "eslint-plugin-react": "^7.0.0",
     "eslint-plugin-react-hooks": "^2.0.1"


### PR DESCRIPTION
This update doesn't seem to break anything, and I've merged in the latest changes from develop. 