### PR TITLE
fix(ffe-buttons): fix :visited-styles on anchors with button styles

### DIFF
--- a/packages/ffe-buttons/less/base-button.less
+++ b/packages/ffe-buttons/less/base-button.less
@@ -292,8 +292,33 @@
     &:hover,
     &:visited {
         background-color: @ffe-white;
-        border-color: @ffe-blue-azure;
         color: @ffe-blue-azure;
+
+        &.ffe-button--dark {
+            background-color: transparent;
+            color: @ffe-white;
+            .native & {
+                @media (prefers-color-scheme: dark) {
+                    background-color: transparent;
+                    color: @ffe-white;
+                }
+            }
+        }
+    }
+
+    &:visited {
+        .native & {
+            @media (prefers-color-scheme: dark) {
+                color: @ffe-blue-azure-darkmode;
+                background-color: @ffe-grey-charcoal-darkmode;
+            }
+        }
+    }
+
+    &:active,
+    &:focus,
+    &:hover {
+        border-color: @ffe-blue-azure;
         .native & {
             @media (prefers-color-scheme: dark) {
                 color: lighten(@ffe-blue-azure-darkmode, 10%);
@@ -304,13 +329,9 @@
 
         &.ffe-button--dark {
             border-color: @ffe-blue-focus;
-            background-color: transparent;
-            color: @ffe-white;
             .native & {
                 @media (prefers-color-scheme: dark) {
                     border-color: @ffe-blue-focus;
-                    background-color: transparent;
-                    color: @ffe-white;
                 }
             }
         }


### PR DESCRIPTION
This PR fixes the :visited-style on anchors with button styles.

The following screenshots shows the affected buttons where all buttons are anchors. The first of each button type is a link I have visited, while the second I have not visited.

Before these changes:
![image](https://user-images.githubusercontent.com/435037/76852296-45235200-684b-11ea-81d8-99356bba9a61.png)

![image](https://user-images.githubusercontent.com/435037/76852326-52d8d780-684b-11ea-8d2b-a0006ca80783.png)

With these changes:
![image](https://user-images.githubusercontent.com/435037/76852178-10af9600-684b-11ea-87d2-a864a0a6e3bd.png)

![image](https://user-images.githubusercontent.com/435037/76852362-6edc7900-684b-11ea-8f0f-2f898ae6ee11.png)
