### PR TITLE
fix(ffe-tables-react): dont mutate passed columns

### DIFF
--- a/packages/ffe-tables-react/src/Table/Table.js
+++ b/packages/ffe-tables-react/src/Table/Table.js
@@ -32,12 +32,19 @@ class Table extends Component {
             return null;
         }
 
+        const renderColumns = [...columns];
+
         if (this.props.expandedContentMapper) {
-            columns.push({ key: 'expandIcon', header: '', alignRight: true });
+            renderColumns.push({
+                key: 'expandIcon',
+                header: '',
+                alignRight: true,
+            });
         }
+
         return (
             <TableHeaders
-                columns={columns}
+                columns={renderColumns}
                 headerRender={headerRender}
                 dataWindow={this.getData()}
             />
@@ -77,13 +84,20 @@ class Table extends Component {
             return null;
         }
 
+        const renderColumns = [...columns];
+
         if (expandedContentMapper) {
+            renderColumns.push({
+                key: 'expandIcon',
+                header: '',
+                alignRight: true,
+            });
             return data.map((row, index) => {
                 const key = row.id || row.id === 0 ? row.id.toString() : index;
                 const expandedContent = expandedContentMapper(row);
                 const rowProps = {
                     cells: row,
-                    columns,
+                    columns: renderColumns,
                     sort,
                     rowRender,
                     rowIndex: index,


### PR DESCRIPTION
Previously the component was mutating the passed `columns`
prop if an `expandedContentMapper` was being used. This is
not a good pattern to use in React and the component no longer
does this.

Fixes #883

<!-- 
Thanks for opening a pull request! 🎉

If your changes include some kind of UI element, please attach a screenshot of 
how it looks.

Before submitting a pull request, please have a look through the CONTRIBUTING.md
document. TL;DR:

- Follow the conventional commit standard
- Write full, explanatory commit messages
- Follow our code standards
- Write tests where applicable
- Be courteous and respect our code of conduct
-->
