### PR TITLE
fix(ffe-account-selector-react): optimize performance of suggestion list

### DIFF
--- a/packages/ffe-account-selector-react/package.json
+++ b/packages/ffe-account-selector-react/package.json
@@ -41,7 +41,8 @@
     "classnames": "^2.2.5",
     "prop-types": "^15.6.0",
     "react-auto-bind": "^0.4.2",
-    "react-custom-scrollbars": "^4.2.1"
+    "react-custom-scrollbars": "^4.2.1",
+    "react-window": "^1.8.5"
   },
   "devDependencies": {
     "enzyme": "^3.7.0",

--- a/packages/ffe-account-selector-react/src/components/account-selector/AccountSelector.spec.js
+++ b/packages/ffe-account-selector-react/src/components/account-selector/AccountSelector.spec.js
@@ -1,9 +1,12 @@
 import React from 'react';
-import { mount } from 'enzyme';
+import { mount, configure } from 'enzyme';
 
 import AccountSelector from './AccountSelector';
 import Input from '../../subcomponents/input-field';
 import { SuggestionItem } from '../../subcomponents/suggestion';
+
+import Adapter from 'enzyme-adapter-react-16';
+configure({ adapter: new Adapter() });
 
 const accounts = [
     {

--- a/packages/ffe-account-selector-react/src/components/base-selector/BaseSelector.spec.js
+++ b/packages/ffe-account-selector-react/src/components/base-selector/BaseSelector.spec.js
@@ -1,10 +1,13 @@
 import React from 'react';
-import { mount } from 'enzyme';
+import { mount, configure } from 'enzyme';
 
 import BaseSelector from './BaseSelector';
 import { SuggestionItem } from '../../subcomponents/suggestion';
 import Input from '../../subcomponents/input-field';
 import { KeyCodes } from '../../util/types';
+
+import Adapter from 'enzyme-adapter-react-16';
+configure({ adapter: new Adapter() });
 
 function suggestions() {
     return [{ header: '1' }, { header: '2' }, { header: '3' }];

--- a/packages/ffe-account-selector-react/src/subcomponents/input-field/InputField.spec.js
+++ b/packages/ffe-account-selector-react/src/subcomponents/input-field/InputField.spec.js
@@ -1,7 +1,10 @@
 import React from 'react';
-import { mount } from 'enzyme';
+import { mount, configure } from 'enzyme';
 
 import InputField from './InputField';
+
+import Adapter from 'enzyme-adapter-react-16';
+configure({ adapter: new Adapter() });
 
 function renderInputField(value = 'value', readOnly = false) {
     return mount(

--- a/packages/ffe-account-selector-react/src/subcomponents/suggestion/SuggestionItem.js
+++ b/packages/ffe-account-selector-react/src/subcomponents/suggestion/SuggestionItem.js
@@ -1,6 +1,6 @@
-import React, { Component } from 'react';
-import { object, bool, func, string } from 'prop-types';
 import classNames from 'classnames';
+import { bool, func, object, string } from 'prop-types';
+import React, { Component } from 'react';
 
 class SuggestionItem extends Component {
     render() {
@@ -11,6 +11,7 @@ class SuggestionItem extends Component {
             render,
             onSelect,
             refHighlightedSuggestion,
+            style,
         } = this.props;
         return (
             <li
@@ -30,6 +31,7 @@ class SuggestionItem extends Component {
                     'ffe-account-suggestion--highlighted': isHighlighted,
                 })}
                 tabIndex={-1}
+                style={style}
             >
                 {render(item)}
             </li>
@@ -44,6 +46,7 @@ SuggestionItem.propTypes = {
     render: func.isRequired,
     onSelect: func.isRequired,
     refHighlightedSuggestion: func.isRequired,
+    style: object,
 };
 
 export default SuggestionItem;

--- a/packages/ffe-account-selector-react/src/subcomponents/suggestion/SuggestionItem.spec.js
+++ b/packages/ffe-account-selector-react/src/subcomponents/suggestion/SuggestionItem.spec.js
@@ -1,7 +1,10 @@
 import React from 'react';
-import { mount } from 'enzyme';
+import { mount, configure } from 'enzyme';
 
 import SuggestionItem from './SuggestionItem';
+
+import Adapter from 'enzyme-adapter-react-16';
+configure({ adapter: new Adapter() });
 
 function item() {
     return { header: 'header' };

--- a/packages/ffe-account-selector-react/src/subcomponents/suggestion/SuggestionList.spec.js
+++ b/packages/ffe-account-selector-react/src/subcomponents/suggestion/SuggestionList.spec.js
@@ -1,10 +1,13 @@
 import React from 'react';
-import { shallow, mount } from 'enzyme';
+import { shallow, mount, configure } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
 
 import Spinner from '@sb1/ffe-spinner-react';
 
 import SuggestionList from './SuggestionList';
 import SuggestionListContainer from './SuggestionListContainer';
+
+configure({ adapter: new Adapter() });
 
 function suggestions() {
     return [{ header: '1' }, { header: '2' }];
@@ -39,22 +42,38 @@ function propsSuggestionListContainer() {
     };
 }
 
+function mountSuggestionList(props) {
+    return mount(<SuggestionList {...propsSuggestionList()} {...props} />);
+}
+
 function shallowSuggestionList(props) {
     return shallow(<SuggestionList {...propsSuggestionList()} {...props} />);
 }
 
 function mountSuggestionListContainer(props = propsSuggestionListContainer()) {
-    return mount(<SuggestionListContainer {...props} />);
+    const ref = React.createRef();
+    return mount(<SuggestionListContainer ref={ref} {...props} />);
 }
 
 describe('<SuggestionList />', () => {
     it('highlighted <Suggestion> set to highlightedIndex', () => {
-        const wrapper = shallowSuggestionList();
-        const ul = wrapper.find('ul');
+        // const wrapper = shallowSuggestionList();
+        // const ul = wrapper.find('ul');
+        //
+        // expect(ul.children().length).toBe(2);
+        // expect(ul.childAt(0).props().isHighlighted).toBe(false);
+        // expect(ul.childAt(1).props().isHighlighted).toBe(true);
 
-        expect(ul.children().length).toBe(2);
-        expect(ul.childAt(0).props().isHighlighted).toBe(false);
-        expect(ul.childAt(1).props().isHighlighted).toBe(true);
+        const wrapper = mountSuggestionList();
+        const suggestionList = wrapper.find('[role="listbox"]');
+        const firstRow = suggestionList.childAt(0);
+        const secondRow = suggestionList.childAt(1);
+
+        expect(suggestionList.children().length).toBe(2);
+        expect(firstRow.children().length).toBe(1);
+        expect(secondRow.children().length).toBe(1);
+        expect(firstRow.childAt(0).props().isHighlighted).toBe(false);
+        expect(secondRow.childAt(0).props().isHighlighted).toBe(true);
         expect(wrapper.find(Spinner).length === 0).toBe(true);
     });
 

--- a/packages/ffe-account-selector-react/src/subcomponents/suggestion/SuggestionListContainer.js
+++ b/packages/ffe-account-selector-react/src/subcomponents/suggestion/SuggestionListContainer.js
@@ -7,6 +7,8 @@ import { Scrollbars } from 'react-custom-scrollbars';
 import SuggestionList from './SuggestionList';
 
 class SuggestionListContainer extends React.Component {
+    listRef = React.createRef();
+
     constructor(props) {
         super(props);
         this.refHighlightedSuggestion = this.refHighlightedSuggestion.bind(
@@ -43,6 +45,12 @@ class SuggestionListContainer extends React.Component {
         );
     }
 
+    handleScroll = ({ target }) => {
+        const { scrollTop } = target;
+
+        this.listRef.current.scrollTo(scrollTop);
+    };
+
     render() {
         const { heightMax, autoHeight } = this.props;
         return (
@@ -58,8 +66,11 @@ class SuggestionListContainer extends React.Component {
                             this.scrollbars = scrollbars;
                         }
                     }}
+                    onScroll={this.handleScroll}
                 >
                     <SuggestionList
+                        height={heightMax}
+                        refList={this.listRef}
                         refHighlightedSuggestion={this.refHighlightedSuggestion}
                         {...this.props}
                     />


### PR DESCRIPTION
using react-window

Based on: https://github.com/SpareBank1/designsystem/pull/568

Rebased and fixed sizing and markup issues, uses "ul" and "li" instead of divs, tests are running fine again. Bumped react-window to latest version.

We need this component to support large amount of data, if merging it with current AccountSelector is not an option maybe can we fork a AccountSelectorHighCapacity?

TODOS:
There are some hardcoded height variables that could be synced with less

![AccountSelector-oneMatch-crop](https://user-images.githubusercontent.com/37411268/79959683-b5457900-8484-11ea-83c7-2fc60015f7c4.png)
![account-selector-no-match-crop](https://user-images.githubusercontent.com/37411268/79959696-b8406980-8484-11ea-859d-1b06059efae4.png)



