### PR TITLE
feat(ffe-account-selector-react): Optimize performance of suggestion list, highCapacity prop

### DIFF
--- a/packages/ffe-account-selector-react/package.json
+++ b/packages/ffe-account-selector-react/package.json
@@ -41,7 +41,8 @@
     "classnames": "^2.2.5",
     "prop-types": "^15.6.0",
     "react-auto-bind": "^0.4.2",
-    "react-custom-scrollbars": "^4.2.1"
+    "react-custom-scrollbars": "^4.2.1",
+    "react-window": "^1.8.5"
   },
   "devDependencies": {
     "enzyme": "^3.7.0",

--- a/packages/ffe-account-selector-react/src/components/account-selector-multi/AccountSelectorMulti.js
+++ b/packages/ffe-account-selector-react/src/components/account-selector-multi/AccountSelectorMulti.js
@@ -1,4 +1,3 @@
-/* TODO: Needs an aria-role, but I'm not sure which is correct */
 /* eslint jsx-a11y/no-static-element-interactions:0 */
 import React from 'react';
 import { func, string, arrayOf, bool } from 'prop-types';
@@ -141,7 +140,13 @@ class AccountSelectorMulti extends React.Component {
     }
 
     render() {
-        const { noMatches, onAccountSelected, locale, value } = this.props;
+        const {
+            noMatches,
+            onAccountSelected,
+            locale,
+            value,
+            highCapacity,
+        } = this.props;
         return (
             <div className="ffe-account-selector" onKeyDown={this.onKeyDown}>
                 <BaseSelector
@@ -167,6 +172,7 @@ class AccountSelectorMulti extends React.Component {
                     }}
                     {...this.props}
                     onBlur={e => this.onBlur(e)}
+                    highCapacity={highCapacity}
                 />
                 {this.state.suggestionListHeight > 0 &&
                     this.renderSuggestionDetails(
@@ -217,6 +223,11 @@ AccountSelectorMulti.propTypes = {
     selectedAccounts: arrayOf(Account),
     showSelectAllOption: bool,
     value: string,
+    /*
+     * For situations where AccountSelector might be populated with hundreds of accounts
+     * uses react-window for performance optimization, default false
+     * */
+    highCapacity: bool,
 };
 
 export default AccountSelectorMulti;

--- a/packages/ffe-account-selector-react/src/components/account-selector/AccountSelector.js
+++ b/packages/ffe-account-selector-react/src/components/account-selector/AccountSelector.js
@@ -76,6 +76,7 @@ class AccountSelector extends Component {
             locale,
             selectedAccount,
             showBalance,
+            highCapacity,
         } = this.props;
         return (
             <div
@@ -97,6 +98,7 @@ class AccountSelector extends Component {
                     onSelect={this.onAccountSelect}
                     onChange={this.onInputChange}
                     locale={locale}
+                    highCapacity={highCapacity}
                 />
                 {selectedAccount && (
                     <AccountDetails
@@ -140,6 +142,11 @@ AccountSelector.propTypes = {
      * where the textual input and keyboard can be distracting.
      */
     readOnly: bool,
+    /*
+     * For situations where AccountSelector might be populated with hundreds of accounts
+     * uses react-window for performance optimization, default false
+     * */
+    highCapacity: bool,
 };
 
 export default AccountSelector;

--- a/packages/ffe-account-selector-react/src/components/base-selector/BaseSelector.js
+++ b/packages/ffe-account-selector-react/src/components/base-selector/BaseSelector.js
@@ -4,6 +4,8 @@ import autoBind from 'react-auto-bind';
 
 import Input from '../../subcomponents/input-field';
 import { SuggestionListContainer } from '../../subcomponents/suggestion';
+import { SuggestionListContainer as SuggestionListContainerHighCapacity } from '../../subcomponents/suggestion-high-capacity';
+
 import { KeyCodes, Locale } from '../../util/types';
 
 class BaseSelector extends Component {
@@ -199,6 +201,7 @@ class BaseSelector extends Component {
             onSuggestionSelect,
             readOnly,
             locale,
+            highCapacity,
         } = this.props;
         const {
             showSuggestions,
@@ -228,8 +231,21 @@ class BaseSelector extends Component {
                     readOnly={readOnly}
                     locale={locale}
                 />
-                {showSuggestions && (
+                {showSuggestions && !highCapacity && (
                     <SuggestionListContainer
+                        {...this.props}
+                        ref={suggestionList => {
+                            this.suggestionList = suggestionList;
+                        }}
+                        highlightedIndex={highlightedSuggestionIndex}
+                        suggestions={suggestions}
+                        heightMax={suggestionsHeightMax}
+                        onSelect={onSuggestionSelect}
+                        id={suggestionListId}
+                    />
+                )}
+                {showSuggestions && highCapacity && (
+                    <SuggestionListContainerHighCapacity
                         {...this.props}
                         ref={suggestionList => {
                             this.suggestionList = suggestionList;
@@ -270,6 +286,7 @@ BaseSelector.propTypes = {
     id: string,
     name: string,
     readOnly: bool,
+    highCapacity: bool,
 };
 
 BaseSelector.defaultProps = {
@@ -283,6 +300,7 @@ BaseSelector.defaultProps = {
     placeholder: '',
     value: '',
     shouldShowSuggestionsOnFocus: true,
+    highCapacity: false,
 };
 
 export default BaseSelector;

--- a/packages/ffe-account-selector-react/src/components/base-selector/BaseSelector.spec.js
+++ b/packages/ffe-account-selector-react/src/components/base-selector/BaseSelector.spec.js
@@ -2,7 +2,12 @@ import React from 'react';
 import { mount } from 'enzyme';
 
 import BaseSelector from './BaseSelector';
-import { SuggestionItem } from '../../subcomponents/suggestion';
+import {
+    SuggestionItem,
+    SuggestionListContainer,
+} from '../../subcomponents/suggestion';
+import { SuggestionListContainer as SuggestionListContainerHighCapacity } from '../../subcomponents/suggestion-high-capacity';
+
 import Input from '../../subcomponents/input-field';
 import { KeyCodes } from '../../util/types';
 
@@ -389,5 +394,35 @@ describe('<BaseSelector> focus', () => {
         component.onFocus();
 
         expect(showHideSuggestionsSpy).toHaveBeenCalledWith(false, onFocus);
+    });
+});
+
+describe('<BaseSelector> highCapacity', () => {
+    it('should display default component when highCapacity=false', () => {
+        const component = mountBaseSelector({
+            shouldShowSuggestionsOnFocus: true,
+            suggestions: suggestions(),
+            highCapacity: false,
+        });
+        const input = component.find(Input);
+        input.simulate('focus');
+
+        const suggestionListContainer = component.find(SuggestionListContainer);
+        expect(suggestionListContainer.length === 1).toBe(true);
+    });
+
+    it('should display high capacity component when highCapacity=true', () => {
+        const component = mountBaseSelector({
+            shouldShowSuggestionsOnFocus: true,
+            suggestions: suggestions(),
+            highCapacity: true,
+        });
+        const input = component.find(Input);
+        input.simulate('focus');
+
+        const suggestionListContainer = component.find(
+            SuggestionListContainerHighCapacity,
+        );
+        expect(suggestionListContainer.length === 1).toBe(true);
     });
 });

--- a/packages/ffe-account-selector-react/src/subcomponents/suggestion-high-capacity/SuggestionItem.js
+++ b/packages/ffe-account-selector-react/src/subcomponents/suggestion-high-capacity/SuggestionItem.js
@@ -1,0 +1,52 @@
+import classNames from 'classnames';
+import { bool, func, object, string } from 'prop-types';
+import React, { Component } from 'react';
+
+class SuggestionItem extends Component {
+    render() {
+        const {
+            item,
+            id,
+            isHighlighted,
+            render,
+            onSelect,
+            refHighlightedSuggestion,
+            style,
+        } = this.props;
+        return (
+            <li
+                ref={itemRef => {
+                    if (itemRef && isHighlighted) {
+                        refHighlightedSuggestion(itemRef);
+                    }
+                }}
+                role="option"
+                aria-selected={isHighlighted}
+                id={id}
+                onMouseDown={e => {
+                    e.preventDefault();
+                    onSelect(item);
+                }}
+                className={classNames('ffe-account-suggestion', {
+                    'ffe-account-suggestion--highlighted': isHighlighted,
+                })}
+                tabIndex={-1}
+                style={style}
+            >
+                {render(item)}
+            </li>
+        );
+    }
+}
+
+SuggestionItem.propTypes = {
+    item: object.isRequired,
+    id: string.isRequired,
+    isHighlighted: bool.isRequired,
+    render: func.isRequired,
+    onSelect: func.isRequired,
+    refHighlightedSuggestion: func.isRequired,
+    style: object,
+};
+
+export default SuggestionItem;

--- a/packages/ffe-account-selector-react/src/subcomponents/suggestion-high-capacity/SuggestionItem.spec.js
+++ b/packages/ffe-account-selector-react/src/subcomponents/suggestion-high-capacity/SuggestionItem.spec.js
@@ -1,0 +1,71 @@
+import React from 'react';
+import { mount } from 'enzyme';
+
+import SuggestionItem from './SuggestionItem';
+
+function item() {
+    return { header: 'header' };
+}
+
+function renderSuggestionItem(
+    isHighlighted = true,
+    refHighlightedSuggestion = () => {},
+    onSelect = () => {},
+) {
+    return mount(
+        <SuggestionItem
+            onSelect={onSelect}
+            item={item()}
+            id="suggestion-option-0"
+            isHighlighted={isHighlighted}
+            refHighlightedSuggestion={refHighlightedSuggestion}
+            render={({ header }) => <h1>{header}</h1>}
+        />,
+    );
+}
+
+describe('<SuggestionItem />', () => {
+    it('item is rendered', () => {
+        const wrapper = renderSuggestionItem();
+        const li = wrapper.find('li');
+
+        expect(li.prop('id') === 'suggestion-option-0').toBe(true);
+        expect(li.childAt(0).html()).toBe('<h1>header</h1>');
+    });
+
+    it('isHighlighted', () => {
+        const refHighlightedSuggestionSpy = jest.fn();
+        const wrapper = renderSuggestionItem(true, refHighlightedSuggestionSpy);
+
+        expect(
+            wrapper.children().hasClass('ffe-account-suggestion--highlighted'),
+        ).toBe(true);
+        expect(wrapper.children().hasClass('ffe-account-suggestion')).toBe(
+            true,
+        );
+        expect(refHighlightedSuggestionSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('not Highlighted', () => {
+        const refHighlightedSuggestionSpy = jest.fn();
+        const wrapper = renderSuggestionItem(
+            false,
+            refHighlightedSuggestionSpy,
+        );
+
+        expect(
+            wrapper.children().hasClass('ffe-account-suggestion--highlighted'),
+        ).toBe(false);
+        expect(wrapper.children().hasClass('ffe-account-suggestion')).toBe(
+            true,
+        );
+        expect(refHighlightedSuggestionSpy).not.toHaveBeenCalled();
+    });
+
+    it('onSelect called', () => {
+        const onSelectSpy = jest.fn();
+        const wrapper = renderSuggestionItem(true, () => {}, onSelectSpy);
+        wrapper.simulate('mousedown');
+        expect(onSelectSpy).toHaveBeenCalledWith(item());
+    });
+});

--- a/packages/ffe-account-selector-react/src/subcomponents/suggestion-high-capacity/SuggestionList.js
+++ b/packages/ffe-account-selector-react/src/subcomponents/suggestion-high-capacity/SuggestionList.js
@@ -1,0 +1,117 @@
+import Spinner from '@sb1/ffe-spinner-react';
+import {
+    arrayOf,
+    bool,
+    func,
+    number,
+    object,
+    shape,
+    string,
+    array,
+} from 'prop-types';
+import React, { forwardRef } from 'react';
+import { FixedSizeList as List } from 'react-window';
+
+import SuggestionItem from './SuggestionItem';
+
+const Row = props => {
+    const {
+        style,
+        index,
+        data: { forwardProps, suggestions, renderSuggestion, highlightedIndex },
+    } = props;
+
+    return (
+        <SuggestionItem
+            {...forwardProps}
+            item={suggestions[index]}
+            id={`suggestion-item-${index}`}
+            isHighlighted={index === highlightedIndex}
+            render={renderSuggestion}
+            style={style}
+        />
+    );
+};
+
+Row.propTypes = {
+    style: object,
+    index: number,
+    data: shape({
+        forwardProps: object,
+        suggestions: array,
+        renderSuggestion: func,
+        highlightedIndex: number,
+    }),
+};
+
+export default function SuggestionList(props) {
+    const {
+        suggestions,
+        highlightedIndex,
+        renderSuggestion,
+        renderNoMatches,
+        id,
+        isLoading,
+        height,
+        itemSize,
+    } = props;
+    return isLoading ? (
+        <Spinner center={true} large={true} />
+    ) : suggestions.length > 0 ? (
+        <List
+            height={
+                suggestions.length * itemSize < height
+                    ? suggestions.length * itemSize
+                    : height
+            }
+            innerElementType={forwardRef((forwardProps, ref) => (
+                <ul
+                    ref={ref}
+                    id={id}
+                    className={'ffe-base-selector__suggestion-container-list'}
+                    role="listbox"
+                    {...forwardProps}
+                />
+            ))}
+            itemCount={suggestions.length}
+            itemSize={itemSize}
+            itemData={{
+                forwardProps: props,
+                renderSuggestion,
+                highlightedIndex,
+                suggestions,
+            }}
+            ref={props.refList}
+            style={{ overflow: false }}
+        >
+            {Row}
+        </List>
+    ) : (
+        <ul
+            className="ffe-base-selector__suggestion-container-list"
+            role="listbox"
+            id={id}
+        >
+            <li>{renderNoMatches()}</li>
+        </ul>
+    );
+}
+
+SuggestionList.propTypes = {
+    suggestions: arrayOf(object).isRequired,
+    highlightedIndex: number.isRequired,
+    renderSuggestion: func.isRequired,
+    renderNoMatches: func,
+    id: string.isRequired,
+    isLoading: bool,
+    refList: object,
+    height: number,
+    itemSize: number,
+};
+
+SuggestionList.defaultProps = {
+    renderNoMatches: () => {},
+    isLoading: false,
+    height: 300,
+    itemSize: 55,
+};

--- a/packages/ffe-account-selector-react/src/subcomponents/suggestion-high-capacity/SuggestionList.spec.js
+++ b/packages/ffe-account-selector-react/src/subcomponents/suggestion-high-capacity/SuggestionList.spec.js
@@ -1,0 +1,124 @@
+import React from 'react';
+import { shallow, mount } from 'enzyme';
+
+import Spinner from '@sb1/ffe-spinner-react';
+
+import SuggestionList from './SuggestionList';
+import SuggestionListContainer from './SuggestionListContainer';
+
+function suggestions() {
+    return [{ header: '1' }, { header: '2' }];
+}
+
+function renderSuggestion(suggestion) {
+    return <h1>{suggestion.header}</h1>;
+}
+
+function renderNoSuggestion() {
+    return <h2>No Match found</h2>;
+}
+
+function propsSuggestionList(_suggestions = suggestions()) {
+    return {
+        suggestions: _suggestions,
+        onSelect: () => {},
+        highlightedIndex: 1,
+        renderSuggestion,
+        renderNoSuggestion,
+        refHighlightedSuggestion: () => {},
+        onKeyDown: () => {},
+        id: 'id',
+    };
+}
+
+function propsSuggestionListContainer() {
+    return {
+        ...propsSuggestionList(),
+        highlightedIndex: 2,
+        autoHeight: false,
+    };
+}
+
+function mountSuggestionList(props) {
+    return mount(<SuggestionList {...propsSuggestionList()} {...props} />);
+}
+
+function shallowSuggestionList(props) {
+    return shallow(<SuggestionList {...propsSuggestionList()} {...props} />);
+}
+
+function mountSuggestionListContainer(props = propsSuggestionListContainer()) {
+    const ref = React.createRef();
+    return mount(<SuggestionListContainer ref={ref} {...props} />);
+}
+
+describe('<SuggestionList />', () => {
+    it('highlighted <Suggestion> set to highlightedIndex', () => {
+        const wrapper = mountSuggestionList();
+        const suggestionList = wrapper.find('[role="listbox"]');
+        const firstRow = suggestionList.childAt(0);
+        const secondRow = suggestionList.childAt(1);
+
+        expect(suggestionList.children().length).toBe(2);
+        expect(firstRow.children().length).toBe(1);
+        expect(secondRow.children().length).toBe(1);
+        expect(firstRow.childAt(0).props().isHighlighted).toBe(false);
+        expect(secondRow.childAt(0).props().isHighlighted).toBe(true);
+        expect(wrapper.find(Spinner).length === 0).toBe(true);
+    });
+
+    it('should renderNoSuggestions when suggestions is empty', () => {
+        const renderNoMatchesSpy = jest.fn();
+        const wrapper = shallowSuggestionList({
+            ...propsSuggestionList(),
+            suggestions: [],
+            renderNoMatches: renderNoMatchesSpy,
+        });
+        const ul = wrapper.find('ul');
+        expect(ul.children().length).toBe(1);
+        expect(renderNoMatchesSpy).toHaveBeenCalled();
+        expect(wrapper.find(Spinner).length === 0).toBe(true);
+    });
+
+    it('should render spinner', () => {
+        const wrapper = shallowSuggestionList({ isLoading: true });
+        expect(wrapper.find(Spinner).length === 1).toBe(true);
+    });
+});
+
+describe('<SuggestionListContainer />', () => {
+    it('should set scrollPos to start', () => {
+        const component = mountSuggestionListContainer().instance();
+        const scrollSpy = jest.spyOn(component.scrollbars, 'scrollTop');
+
+        component.setScrollPosStart();
+        expect(scrollSpy).toHaveBeenCalledWith(0);
+    });
+
+    it('should set scrollPos to end', () => {
+        const component = mountSuggestionListContainer().instance();
+        component.scrollbars.getScrollHeight = jest.fn().mockReturnValue(300);
+        const scrollSpy = jest.spyOn(component.scrollbars, 'scrollTop');
+
+        component.setScrollPosEnd();
+        expect(scrollSpy).toHaveBeenCalledWith(300);
+    });
+
+    it('should set scrollPos to next', () => {
+        const component = mountSuggestionListContainer().instance();
+        component.refHighlightedSuggestion({ clientHeight: 50 });
+        const scrollSpy = jest.spyOn(component.scrollbars, 'scrollTop');
+
+        component.setScrollPosNext();
+        expect(scrollSpy).toHaveBeenCalledWith(100);
+    });
+
+    it('should set scrollPos to previous', () => {
+        const component = mountSuggestionListContainer().instance();
+        component.refHighlightedSuggestion({ clientHeight: 50 });
+        const scrollSpy = jest.spyOn(component.scrollbars, 'scrollTop');
+
+        component.setScrollPosPrevious();
+        expect(scrollSpy).toHaveBeenCalledWith(50);
+    });
+});

--- a/packages/ffe-account-selector-react/src/subcomponents/suggestion-high-capacity/SuggestionListContainer.js
+++ b/packages/ffe-account-selector-react/src/subcomponents/suggestion-high-capacity/SuggestionListContainer.js
@@ -6,6 +6,8 @@ import { Scrollbars } from 'react-custom-scrollbars';
 import SuggestionList from './SuggestionList';
 
 class SuggestionListContainer extends React.Component {
+    listRef = React.createRef();
+
     constructor(props) {
         super(props);
         this.refHighlightedSuggestion = this.refHighlightedSuggestion.bind(
@@ -42,6 +44,12 @@ class SuggestionListContainer extends React.Component {
         );
     }
 
+    handleScroll = ({ target }) => {
+        const { scrollTop } = target;
+
+        this.listRef.current.scrollTo(scrollTop);
+    };
+
     render() {
         const { heightMax, autoHeight } = this.props;
         return (
@@ -57,8 +65,11 @@ class SuggestionListContainer extends React.Component {
                             this.scrollbars = scrollbars;
                         }
                     }}
+                    onScroll={this.handleScroll}
                 >
                     <SuggestionList
+                        height={heightMax}
+                        refList={this.listRef}
                         refHighlightedSuggestion={this.refHighlightedSuggestion}
                         {...this.props}
                     />

--- a/packages/ffe-account-selector-react/src/subcomponents/suggestion-high-capacity/SuggestionListStatusBar.js
+++ b/packages/ffe-account-selector-react/src/subcomponents/suggestion-high-capacity/SuggestionListStatusBar.js
@@ -1,0 +1,46 @@
+import React from 'react';
+import { func, string, object } from 'prop-types';
+
+import { KeyCodes } from '../../util/types';
+
+const StatusBar = ({
+    onDone,
+    renderSelectionStatus,
+    labelDoneButton,
+    style,
+}) => {
+    const onKeyDown = evt => {
+        if (
+            (evt.which === KeyCodes.TAB && !evt.shiftKey) ||
+            evt.which === KeyCodes.ENTER
+        ) {
+            onDone();
+        }
+    };
+
+    return (
+        <div className="ffe-account-selector__dropdown-statusbar" style={style}>
+            <div className="ffe-account-selector__selection-status">
+                {renderSelectionStatus()}
+            </div>
+            <button
+                type="button"
+                className="ffe-button ffe-button--primary ffe-account-selector__statusbar-button"
+                tabIndex="0"
+                onMouseDown={onDone}
+                onKeyDown={onKeyDown}
+            >
+                {labelDoneButton}
+            </button>
+        </div>
+    );
+};
+
+StatusBar.propTypes = {
+    onDone: func.isRequired,
+    renderSelectionStatus: func.isRequired,
+    labelDoneButton: string.isRequired,
+    style: object.isRequired,
+};
+
+export default StatusBar;

--- a/packages/ffe-account-selector-react/src/subcomponents/suggestion-high-capacity/index.js
+++ b/packages/ffe-account-selector-react/src/subcomponents/suggestion-high-capacity/index.js
@@ -1,0 +1,4 @@
+export { default as SuggestionItem } from './SuggestionItem';
+export { default as SuggestionList } from './SuggestionList';
+export { default as SuggestionListContainer } from './SuggestionListContainer';
+export { default as SuggestionListStatusBar } from './SuggestionListStatusBar';


### PR DESCRIPTION
using react-window

Based on: #568

Uses a highCapacity prop to determine suggestion rendering. By default uses the "old" rendering.
highCapacity=true for react-window based.
Rebased and fixed sizing and markup issues, uses "ul" and "li" instead of divs, tests are running fine again. Bumped react-window to latest version.