### PR TITLE
Skrivefeil i header til kontekstmeldinger

### DIFF
--- a/packages/ffe-context-message-react/src/ContextErrorMessage.md
+++ b/packages/ffe-context-message-react/src/ContextErrorMessage.md
@@ -13,7 +13,7 @@ const { UtropstegnIkon } = require('@sb1/ffe-icons-react');
 ```
 
 ```js
-<ContextErrorMessage heading="Opps...">
+<ContextErrorMessage header="Opps...">
     Dette gikk ikke som forventet i det hele tatt!
 </ContextErrorMessage>
 ```

--- a/packages/ffe-context-message-react/src/ContextInfoMessage.md
+++ b/packages/ffe-context-message-react/src/ContextInfoMessage.md
@@ -13,7 +13,7 @@ const { InfoIkon } = require('@sb1/ffe-icons-react');
 ```
 
 ```js
-<ContextInfoMessage heading="Til info">
+<ContextInfoMessage header="Til info">
     Nå har det kommet noe nytt og spennende fra SpareBank 1!
 </ContextInfoMessage>
 ```

--- a/packages/ffe-context-message-react/src/ContextSuccessMessage.md
+++ b/packages/ffe-context-message-react/src/ContextSuccessMessage.md
@@ -11,7 +11,7 @@ const { HakeIkon } = require('@sb1/ffe-icons-react');
 ```
 
 ```js
-<ContextSuccessMessage heading="Hurra!">
+<ContextSuccessMessage header="Hurra!">
     Betalingen ble registrert!
 </ContextSuccessMessage>
 ```

--- a/packages/ffe-context-message-react/src/ContextTipMessage.md
+++ b/packages/ffe-context-message-react/src/ContextTipMessage.md
@@ -13,7 +13,7 @@ const { LyspareIkon } = require('@sb1/ffe-icons-react');
 ```
 
 ```js
-<ContextTipMessage heading="Tips">
+<ContextTipMessage header="Tips">
     Visste du at du kan få en skattefordel ved sparing i IPS?
 </ContextTipMessage>
 ```


### PR DESCRIPTION
Fikser skrivefeil i dokumentasjon for kontekstmeldinger, beskrevet i #893 
Ser dette fornuftig ut? Skriver ikke så mye her, for issuet var så bra beskrevet fra før av :smile: 