### PR TITLE
feat(ffe-system-message-react): stop using deprecated lifecycle methods

### DIFF
--- a/packages/ffe-buttons-react/package.json
+++ b/packages/ffe-buttons-react/package.json
@@ -43,7 +43,8 @@
     "eslint": "^5.9.0",
     "jest": "^23.4.2",
     "react": "^16.9.0",
-    "react-dom": "^16.9.0"
+    "react-dom": "^16.9.0",
+    "react-collapse": "^4.0.3"
   },
   "peerDependencies": {
     "@sb1/ffe-buttons": "^8.1.0",

--- a/packages/ffe-system-message-react/package.json
+++ b/packages/ffe-system-message-react/package.json
@@ -29,9 +29,7 @@
   "dependencies": {
     "@sb1/ffe-grid-react": "^10.1.1",
     "classnames": "^2.2.5",
-    "prop-types": "^15.6.0",
-    "react-collapse": "^4.0.3",
-    "react-motion": "^0.5.2"
+    "prop-types": "^15.6.0"
   },
   "devDependencies": {
     "@sb1/ffe-icons-react": "^7.2.9",

--- a/packages/ffe-system-message-react/src/SystemMessage.js
+++ b/packages/ffe-system-message-react/src/SystemMessage.js
@@ -1,21 +1,35 @@
 import React, { Component } from 'react';
-import { func, string, node, oneOf } from 'prop-types';
-import { UnmountClosed as Collapse } from 'react-collapse';
+import { func, string, number, node, oneOf } from 'prop-types';
 import classNames from 'classnames';
 import KryssIkon from '@sb1/ffe-icons-react/lib/kryss-ikon';
 
 class SystemMessage extends Component {
-    state = {
-        dismissed: false,
-    };
+    constructor() {
+        super();
+        this.close = this.close.bind(this);
+        this.state = {
+            closed: false,
+        };
+    }
 
-    onClose = () => {
-        this.setState({ dismissed: true });
-        this.props.onClose();
-    };
+    close(event) {
+        const { animationLengthMs, onClose } = this.props;
+        const self = this._self;
+        self.style.height = `${self.offsetHeight}px`;
+        setTimeout(() => {
+            self.style.height = 0;
+        }, 0);
+        setTimeout(() => {
+            this.setState({ closed: true }, () => {
+                onClose(event);
+            });
+        }, animationLengthMs);
+        return false;
+    }
 
     render() {
         const {
+            animationLengthMs,
             children,
             className,
             icon,
@@ -23,43 +37,49 @@ class SystemMessage extends Component {
             modifier,
         } = this.props;
 
+        if (this.state.closed) {
+            return null;
+        }
+
         return (
-            <Collapse isOpened={!this.state.dismissed}>
-                <div
-                    className={classNames(
-                        'ffe-system-message-wrapper',
-                        `ffe-system-message-wrapper--${modifier}`,
-                        className,
-                    )}
-                >
-                    <div className="ffe-system-message">
-                        <span className="ffe-system-message__icon">
-                            {icon}
-                        </span>
-                        <p className="ffe-system-message__content">
-                            {children}
-                        </p>
-                        <button
-                            aria-label={locale === 'en' ? 'Close' : 'Lukk'}
-                            className="ffe-system-message__close"
-                            onClick={this.onClose}
-                            type="button"
-                        >
-                            <KryssIkon />
-                        </button>
-                    </div>
+            <div
+                className={classNames(
+                    'ffe-system-message-wrapper',
+                    `ffe-system-message-wrapper--${modifier}`,
+                    className,
+                )}
+                ref={_self => {
+                    this._self = _self;
+                }}
+                style={{
+                    transition: `height ${animationLengthMs / 1000}s`,
+                }}
+            >
+                <div className="ffe-system-message">
+                    <span className="ffe-system-message__icon">{icon}</span>
+                    <p className="ffe-system-message__content">{children}</p>
+                    <button
+                        aria-label={locale === 'en' ? 'Close' : 'Lukk'}
+                        className="ffe-system-message__close"
+                        onClick={this.close}
+                        type="button"
+                    >
+                        <KryssIkon />
+                    </button>
                 </div>
-            </Collapse>
+            </div>
         );
     }
 }
 
 SystemMessage.defaultProps = {
+    animationLengthMs: 300,
     locale: 'nb',
     onClose: f => f,
 };
 
 SystemMessage.propTypes = {
+    animationLengthMs: number,
     /** The content of the system message */
     children: node.isRequired,
     /** Additional classes added to the surrounding div */

--- a/packages/ffe-system-message-react/src/SystemMessage.spec.js
+++ b/packages/ffe-system-message-react/src/SystemMessage.spec.js
@@ -54,21 +54,35 @@ describe('<SystemMessage />', () => {
                 .hasClass('ffe-system-message-wrapper--success'),
         ).toBe(true);
     });
-    it('collapses when close button is clicked', () => {
-        const wrapper = getInfoWrapper();
-        expect(wrapper.find('UnmountClosed').prop('isOpened')).toBe(true);
-
+    it('collapses when close button is clicked', done => {
+        const wrapper = getInfoWrapper({
+            animationLengthMs: 10,
+        });
+        expect(wrapper.find('.ffe-system-message-wrapper').exists()).toBe(true);
         wrapper.find('button').simulate('click');
 
-        expect(wrapper.find('UnmountClosed').prop('isOpened')).toBe(false);
+        setTimeout(() => {
+            wrapper.update();
+            expect(wrapper.find('.ffe-system-message-wrapper').exists()).toBe(
+                false,
+            );
+            done();
+        }, 20);
     });
-    it('calls onClose prop when close button is clicked', () => {
-        const onClose = jest.fn();
-        const wrapper = getInfoWrapper({ onClose });
-
+    it('calls onClose prop when close button is clicked', done => {
+        const onClickSpy = jest.fn();
+        const wrapper = getInfoWrapper({
+            animationLengthMs: 10,
+            onClose: onClickSpy,
+        });
+        expect(wrapper.find('.ffe-system-message-wrapper').exists()).toBe(true);
         wrapper.find('button').simulate('click');
 
-        expect(onClose).toHaveBeenCalledTimes(1);
+        setTimeout(() => {
+            wrapper.update();
+            expect(onClickSpy).toHaveBeenCalledTimes(1);
+            done();
+        }, 20);
     });
     it('renders a Norwegian aria label on the close button by default', () => {
         const wrapper = getInfoWrapper();

--- a/packages/ffe-system-message-react/src/index.d.ts
+++ b/packages/ffe-system-message-react/src/index.d.ts
@@ -1,6 +1,7 @@
 import * as React from 'react';
 
 export interface SystemMessageProps {
+    animationLengthMs?: number;
     children: React.ReactNode;
     className?: string;
     icon?: React.ReactNode;


### PR DESCRIPTION
Do the collapse animation the same way as context-message, instead of using react-collapse/react-motion, which use deprecated lifecycle methods (componentWillReceiveProps)

<!-- 
Thanks for opening a pull request! 🎉

If your changes include some kind of UI element, please attach a screenshot of 
how it looks.

Before submitting a pull request, please have a look through the CONTRIBUTING.md
document. TL;DR:

- Follow the conventional commit standard
- Write full, explanatory commit messages
- Follow our code standards
- Write tests where applicable
- Be courteous and respect our code of conduct
-->
