### PR TITLE
fix(ffe-accordion-react): renamed title tag

### DIFF
--- a/packages/ffe-accordion-react/src/Accordion.md
+++ b/packages/ffe-accordion-react/src/Accordion.md
@@ -2,9 +2,13 @@
 const { WhiteAccordion, AccordionItem } = require('.');
 
 <WhiteAccordion>
-    <AccordionItem title="Tittel">Skjult innhold</AccordionItem>
-    <AccordionItem title="Enda en tittel">Mer skjult innhold</AccordionItem>
-    <AccordionItem title="En siste tittel">Enda mer innhold</AccordionItem>
+    <AccordionItem accordionTitle="Tittel">Skjult innhold</AccordionItem>
+    <AccordionItem accordionTitle="Enda en tittel">
+        Mer skjult innhold
+    </AccordionItem>
+    <AccordionItem accordionTitle="En siste tittel">
+        Enda mer innhold
+    </AccordionItem>
 </WhiteAccordion>;
 ```
 
@@ -17,7 +21,9 @@ const { WhiteAccordion, AccordionItem } = require('.');
     <AccordionItem defaultOpen={true} title="Åpen!">
         Her er info du kan se med EN gang!
     </AccordionItem>
-    <AccordionItem title="Lukket">Skjult innhold</AccordionItem>
-    <AccordionItem title="Denne er også lukket">Enda mer innhold</AccordionItem>
+    <AccordionItem accordionTitle="Lukket">Skjult innhold</AccordionItem>
+    <AccordionItem accordionTitle="Denne er også lukket">
+        Enda mer innhold
+    </AccordionItem>
 </WhiteAccordion>;
 ```

--- a/packages/ffe-accordion-react/src/AccordionItem.js
+++ b/packages/ffe-accordion-react/src/AccordionItem.js
@@ -45,7 +45,7 @@ class AccordionItem extends Component {
             className,
             children,
             index,
-            title,
+            accordionTitle,
             uuid,
             id,
         } = this.props;
@@ -75,7 +75,7 @@ class AccordionItem extends Component {
                 >
                     <span className="ffe-accordion-item__toggler-content">
                         <span className="ffe-accordion-item__title">
-                            {title}
+                            {accordionTitle}
                         </span>
                         <ChevronIkon className="ffe-accordion-item__icon" />
                     </span>
@@ -117,7 +117,7 @@ AccordionItem.propTypes = {
     /** Callback that fires whenever the accordion item is opened or closed */
     onToggleOpen: func,
     /** The title */
-    title: node,
+    accordionTitle: node,
     /** A unique ID, usually provided by the wrapping <Accordion /> element */
     uuid: string,
     /** An optional ID for the element, will be auto-generated if not provided */

--- a/packages/ffe-accordion-react/src/index.d.ts
+++ b/packages/ffe-accordion-react/src/index.d.ts
@@ -15,7 +15,7 @@ export interface AccordionItemProps extends React.HTMLProps<HTMLLIElement> {
     open?: boolean;
     defaultOpen?: boolean;
     onToggleOpen?: Function;
-    title?: React.ReactNode;
+    accordionTitle?: React.ReactNode;
     uuid?: string;
     id?: string;
 }


### PR DESCRIPTION
Her endrer jeg navn på title til accordionTitle for å unngå at vi bruker en eksisterende tag/prop. TypeScript er ikke så fornøyd når vi overrider, samtidig som det kan skape litt forvirring over hva ting gjør. Det skal imidlertid nevnes at øvrige props ikke sendes ned til li-elementet, så man har ikke noen mulighet til å sette title tagen nå heller (men er det et problem?) 

<!-- 
Thanks for opening a pull request! 🎉

If your changes include some kind of UI element, please attach a screenshot of 
how it looks.

Before submitting a pull request, please have a look through the CONTRIBUTING.md
document. TL;DR:

- Follow the conventional commit standard
- Write full, explanatory commit messages
- Follow our code standards
- Write tests where applicable
- Be courteous and respect our code of conduct
-->
