### PR TITLE
fix(ffe-buttons-react): fix InlineExpandButton types

### DIFF
--- a/packages/ffe-buttons-react/src/InlineExpandButton.js
+++ b/packages/ffe-buttons-react/src/InlineExpandButton.js
@@ -10,6 +10,7 @@ const InlineExpandButton = props => {
     return (
         <InlineButton
             buttonType="expand"
+            type="button"
             rightIcon={
                 <ChevronIkon
                     style={{

--- a/packages/ffe-buttons-react/src/index.d.ts
+++ b/packages/ffe-buttons-react/src/index.d.ts
@@ -42,7 +42,7 @@ export interface ExpandButtonProps extends MinimalBaseButtonProps {
     onClick: (e: React.MouseEvent | undefined) => void;
 }
 
-export interface InlineExpandButtonProps {
+export interface InlineExpandButtonProps extends MinimalBaseButtonProps {
     children?: React.ReactNode;
     innerRef?: React.Ref<HTMLElement>;
     isExpanded: boolean;


### PR DESCRIPTION
Det er ikke mulig å sette `type="button"` på `InlineExpandButton`, så den ender opp med å få default `type="submit"`. Når den brukes i et `form` vil dermed Enter-tasten på tastaturet fyre av denne knappen. For å unngå det trenger man å kunne sette `type` selv :ok_hand: 
![image](https://user-images.githubusercontent.com/3830142/88792561-b3820480-d19b-11ea-821f-ab7f483b0306.png)
