### PR TITLE
fix(eslint-config-ffe): temporarily disable role props check

### DIFF
--- a/linting/eslint-config-ffe/rules/jsx-a11y.js
+++ b/linting/eslint-config-ffe/rules/jsx-a11y.js
@@ -67,7 +67,7 @@ module.exports = {
 
         // Enforce that elements with explicit or implicit roles defined contain only aria-* properties supported by that role.
         // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/role-supports-aria-props.md
-        'jsx-a11y/role-supports-aria-props': 2,
+        'jsx-a11y/role-supports-aria-props': 1,
 
         // Enforce tabIndex value is not greater than zero.
         // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/tabindex-no-positive.md


### PR DESCRIPTION
The linting rule `jsx-a11y/role-supports-aria-props` caused several ci builds to break because of a linting error related to ffe-forms-react. See issue #912 for details.

To keep business going this rule is temporarily set to severity warn.