### PR TITLE
fix(ffe-form-react): remove checkbox props

### DIFF
--- a/packages/ffe-form-react/src/Checkbox.js
+++ b/packages/ffe-form-react/src/Checkbox.js
@@ -1,20 +1,10 @@
 import React, { Fragment } from 'react';
-import { bool, node, string, func, oneOfType, shape, object } from 'prop-types';
+import { bool, node, string, func, oneOfType } from 'prop-types';
 import { v4 as hash } from 'uuid';
 import classNames from 'classnames';
 
-export default function Checkbox(props) {
-    const {
-        children,
-        hiddenLabel,
-        inline,
-        invalid,
-        innerRef,
-        label,
-        noMargins,
-        dark,
-        ...rest
-    } = props;
+const Checkbox = React.forwardRef((props, ref) => {
+    const { children, hiddenLabel, inline, noMargins, dark, ...rest } = props;
 
     const id = props.id || `checkbox-${hash()}`;
     const labelProps = {
@@ -31,33 +21,25 @@ export default function Checkbox(props) {
     return (
         <Fragment>
             <input
+                ref={ref}
                 className={classNames('ffe-hidden-checkbox', {
                     'ffe-hidden-checkbox--dark': dark,
                 })}
                 id={id}
                 type="checkbox"
-                aria-invalid={String(invalid)}
-                ref={innerRef}
                 {...rest}
             />
             {typeof children === 'function' ? (
                 children(labelProps)
             ) : (
                 // eslint-disable-next-line jsx-a11y/label-has-for
-                <label {...labelProps}>
-                    {!hiddenLabel && (label || children)}
-                </label>
+                <label {...labelProps}>{!hiddenLabel && children}</label>
             )}
         </Fragment>
     );
-}
+});
 
 Checkbox.propTypes = {
-    /**
-     * @deprecated
-     * Use `children` instead
-     */
-    label: string,
     /** Removes vertical margins from the checkbox */
     noMargins: bool,
     /** If you plan to render the checkbox without a visible label */
@@ -65,13 +47,6 @@ Checkbox.propTypes = {
     /** Override the automatically generated ID */
     id: string,
     inline: bool,
-    /**
-     * @deprecated
-     * Use `aria-invalid` directly instead
-     */
-    invalid: bool,
-    /** Ref-setting function, or ref created by useRef, passed to the input element */
-    innerRef: oneOfType([func, shape({ current: object })]),
     /** The label for the checkbox */
     children: oneOfType([node, func]),
     /** Dark variant */
@@ -80,6 +55,7 @@ Checkbox.propTypes = {
 
 Checkbox.defaultProps = {
     inline: true,
-    invalid: false,
     dark: false,
 };
+
+export default Checkbox;

--- a/packages/ffe-form-react/src/Checkbox.spec.js
+++ b/packages/ffe-form-react/src/Checkbox.spec.js
@@ -73,24 +73,10 @@ describe('<Checkbox />', () => {
         expect(wrapper.find('.ffe-checkbox--inline').exists()).toBe(true);
     });
 
-    it('should support invalid', () => {
-        const wrapper = getWrapper({ invalid: false });
+    it('should support aria-invalid', () => {
+        const wrapper = getWrapper({ 'aria-invalid': 'false' });
 
         expect(wrapper.find('input').prop('aria-invalid')).toBe('false');
-
-        wrapper.setProps({ invalid: true });
-
-        expect(wrapper.find('input').prop('aria-invalid')).toBe('true');
-    });
-
-    it('setting "aria-invalid" should override "invalid"', () => {
-        const wrapper = getWrapper({ invalid: true, 'aria-invalid': 'false' });
-
-        expect(wrapper.find('input').prop('aria-invalid')).toBe('false');
-
-        wrapper.setProps({ invalid: false, 'aria-invalid': 'true' });
-
-        expect(wrapper.find('input').prop('aria-invalid')).toBe('true');
     });
 
     it('should set arbitrary props (rest) on input', () => {

--- a/packages/ffe-form-react/src/index.d.ts
+++ b/packages/ffe-form-react/src/index.d.ts
@@ -2,21 +2,10 @@ import * as React from 'react';
 
 export interface CheckboxProps
     extends React.InputHTMLAttributes<HTMLInputElement> {
-    /**
-     * @deprecated
-     * Use `children` instead
-     */
-    label?: string;
     noMargins?: boolean;
     hiddenLabel?: boolean;
     id?: string;
     inline?: boolean;
-    innerRef?: React.Ref<HTMLInputElement>;
-    /**
-     * @deprecated
-     * Use `aria-invalid` directly instead
-     */
-    invalid?: boolean;
     children?: React.ReactNode;
     dark?: boolean;
 }


### PR DESCRIPTION
BREAKING CHANGE:

Instead of having an `innerRef` prop, use the more modern
approach with `React.forwardRef`. This means that instead
of using the `innerRef` prop, refs should be passed as
they would to any other React element.

```diff
- <Checkbox innerRef={ref} />
+ <Checkbox ref={ref} />
```

While we're doing breaking changes anyway, removed
support from the two deprecated props `label` and
`valid`. Use children and `aria-invalid` instead.

```diff
- <Checkbox invalid={true} label="To arr is pirate" />
+ <Checkbox aria-invalid={true}>To arr is pirate</Checkbox>
```

<!-- 
Thanks for opening a pull request! 🎉

If your changes include some kind of UI element, please attach a screenshot of 
how it looks.

Before submitting a pull request, please have a look through the CONTRIBUTING.md
document. TL;DR:

- Follow the conventional commit standard
- Write full, explanatory commit messages
- Follow our code standards
- Write tests where applicable
- Be courteous and respect our code of conduct
-->
