### PR TITLE
fix(ffe-context-message): add padding to compact context message

### DIFF
--- a/packages/ffe-context-message/less/ffe-context-message.less
+++ b/packages/ffe-context-message/less/ffe-context-message.less
@@ -156,7 +156,8 @@
     &--compact {
         .ffe-context-message-content {
             flex-direction: row;
-            padding: @ffe-spacing-xs @ffe-spacing-sm;
+            padding: @ffe-spacing-xs @ffe-spacing-xl @ffe-spacing-xs
+                @ffe-spacing-sm;
         }
 
         .ffe-context-message-content__icon {


### PR DESCRIPTION
Legger til padding i kompakte kontekstmeldinger, for å unngå at lukkeknappen flyter over innholdet.

Fixes #916 