### PR TITLE
fix(ffe-chart-donut-react): accessible text color in chart name

### DIFF
--- a/packages/ffe-chart-donut-react/src/ffe-chart-donut.less
+++ b/packages/ffe-chart-donut-react/src/ffe-chart-donut.less
@@ -36,7 +36,7 @@
     }
 
     &__name {
-        color: #808285;
+        color: @ffe-grey-charcoal;
         text-align: center;
     }
 


### PR DESCRIPTION
Byttet ut tekstfarge på `.ffe-chart-donut--name` fra `#808285` til nærmeste tilsvarende av [våre farger](https://design.sparebank1.no/visuell-identitet.html#visuell-identitet_farger), `@ffe-grey-charcoal`. Dette øker contrast ratio fra 3.85:1 til 5.65:1, jmf [WebAIM](https://webaim.org/resources/contrastchecker/?fcolor=676767&bcolor=FFFFFF).

Fixes #493 