### PR TITLE
fix(ffe-form-react): add aria-describedby to radio block description

### DIFF
--- a/packages/ffe-form-react/src/RadioBlock.js
+++ b/packages/ffe-form-react/src/RadioBlock.js
@@ -39,6 +39,9 @@ class RadioBlock extends Component {
                     type="radio"
                     name={name}
                     value={value}
+                    aria-describedby={
+                        children ? `${this.id}-described` : undefined
+                    }
                     {...inputProps}
                 />
                 <div className="ffe-radio-block__content">
@@ -56,6 +59,7 @@ class RadioBlock extends Component {
                             className={classNames('ffe-radio-block__wrapper', {
                                 'ffe-radio-block__wrapper--empty': !children,
                             })}
+                            id={`${this.id}-described`}
                         >
                             {children}
                         </div>


### PR DESCRIPTION
## Beskrivelse

Legger til `aria-describedby` på RadioBlocker som har children/beskrivelsesfelt (`.ffe-radio-block__wrapper`).

## Motivasjon og kontekst

Dette sørger for at skjermlesere leser opp beskrivelsen når RadioBlockens input blir valgt.

Fixes #499 

## Testing

Testet i ChromeVox.