### PR TITLE
fix(ffe-datepicker-react): added calendar lookup debounce

### DIFF
--- a/packages/ffe-datepicker-react/package.json
+++ b/packages/ffe-datepicker-react/package.json
@@ -31,6 +31,7 @@
     "@sb1/ffe-datepicker": "^6.0.11",
     "@sb1/ffe-icons-react": "^7.2.13",
     "classnames": "^2.2.5",
+    "lodash.debounce": "^4.0.8",
     "prop-types": "^15.6.0",
     "uuid": "^8.0.0"
   },

--- a/packages/ffe-datepicker-react/src/datepicker/Datepicker.js
+++ b/packages/ffe-datepicker-react/src/datepicker/Datepicker.js
@@ -9,6 +9,7 @@ import SimpleDate from '../datelogic/simpledate';
 import dateErrorTypes from '../datelogic/error-types';
 import i18n from '../i18n/i18n';
 import { validateDate } from '../util/dateUtil';
+import { debounce } from 'lodash';
 
 export default class Datepicker extends Component {
     constructor(props) {
@@ -22,6 +23,7 @@ export default class Datepicker extends Component {
             minDate: props.minDate,
             maxDate: props.maxDate,
             lastValidDate: '',
+            calendarActiveDate: '',
         };
 
         this.datepickerId = uuid();
@@ -43,6 +45,12 @@ export default class Datepicker extends Component {
         this.onError = this.onError.bind(this);
     }
 
+    debounceCalendar = debounce(value => {
+        if (value !== this.state.lastValidDate && validateDate(value)) {
+            this.setState({ calendarActiveDate: value, lastValidDate: value });
+        }
+    }, 250);
+
     componentWillUnmount() {
         this.removeGlobalEventListeners();
     }
@@ -58,6 +66,8 @@ export default class Datepicker extends Component {
                 this.validateDateIntervals,
             );
         }
+
+        this.debounceCalendar(this.props.value);
     }
 
     onInputFocus() {
@@ -301,13 +311,7 @@ export default class Datepicker extends Component {
             value,
             fullWidth,
         } = this.props;
-        const {
-            focusOnCalendarOpen,
-            minDate,
-            maxDate,
-            lastValidDate,
-        } = this.state;
-        const latestValue = validateDate(value) ? value : lastValidDate;
+        const { focusOnCalendarOpen, minDate, maxDate } = this.state;
 
         if (this.state.ariaInvalid && !inputProps['aria-describedby']) {
             inputProps[
@@ -373,7 +377,7 @@ export default class Datepicker extends Component {
                             maxDate={maxDate}
                             minDate={minDate}
                             onDatePicked={this.datePickedHandler}
-                            selectedDate={latestValue}
+                            selectedDate={this.state.calendarActiveDate}
                             onBlurHandler={this.blurHandler}
                             focusOnOpen={focusOnCalendarOpen}
                             ref={c => {

--- a/packages/ffe-datepicker-react/src/datepicker/Datepicker.js
+++ b/packages/ffe-datepicker-react/src/datepicker/Datepicker.js
@@ -23,7 +23,7 @@ export default class Datepicker extends Component {
             minDate: props.minDate,
             maxDate: props.maxDate,
             lastValidDate: '',
-            calendarActiveDate: '',
+            calendarActiveDate: validateDate(props.value) ? props.value : '',
         };
 
         this.datepickerId = uuid();
@@ -252,6 +252,7 @@ export default class Datepicker extends Component {
             {
                 openOnFocus: false,
                 displayDatePicker: false,
+                calendarActiveDate: date,
             },
             () => this.dateInputRef.focus(),
         );


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse
Denne forsøker å løse #678 ved å legge inn 250ms pause før den "slår opp" datoen i kalenderfeltet. Jeg har gått en del runder med meg selv og funnet ut at dette er "minste motstands vei". Som alltid frister det jo å gjøre større omskrivinger, men ikke sikker på om det er så lurt akkurat nå. Kan jo diskuteres hva den skal godta av datoer o.l (det har jeg ikke rørt ved).

Har valgt å bruke lodash sin debounce funksjon for å slippe å finne opp hjulet på nytt. 

Er på ingen måte sikker på at dette er beste måten å fikse det på, så kom gjerne med tilbakemeldinger. Test også gjerne selv for å se om det føles naturlig ut. Vurderte å ha debounce timeouten som en prop som defaulter til 250, men holdt ann litt. Hva tenker dere om det? 

<!-- Detaljert beskrivelse av endringene dine. Skjermskudd er lov. -->

## Motivasjon og kontekst
I og med at dette er kommet inn som et issue er det jo et mål i seg selv å få fikset feilen, men det er klart at dette nok bidrar til en litt mindre distraherende brukeropplevelse.

<!-- Hvorfor trengs denne endringen, og hva løser den? -->

## Testing
Har ikke gjort noe mer spesielt enn å teste lokalt. 
<!-- Hvordan har du har testet endringene dine? Ta gjerne med systeminfo o.l -->

<!--

Helt til slutt, har du ..

.. lest retningslinjene våre for bidrag?
.. tatt en siste sjekk for kode og skrivefeil, debug informasjon o.l?
.. kjørt og eventuelt oppdatert testene?
.. kommentert og dokumentert det som trengs?
.. knyttet denne opp til relaterte issues?

-->
