### PR TITLE
Develop a11y accordion

### DIFF
--- a/packages/ffe-accordion-react/src/Accordion.js
+++ b/packages/ffe-accordion-react/src/Accordion.js
@@ -6,7 +6,6 @@ import classNames from 'classnames';
 class Accordion extends Component {
     constructor() {
         super();
-
         this.id = uuid();
     }
 
@@ -14,7 +13,7 @@ class Accordion extends Component {
         const { children, isBlue, className, ...rest } = this.props;
 
         return (
-            <ul
+            <div
                 {...rest}
                 aria-multiselectable="true"
                 className={classNames(
@@ -26,10 +25,10 @@ class Accordion extends Component {
                 )}
                 role="tablist"
             >
-                {React.Children.map(children, ele =>
-                    React.cloneElement(ele, { uuid: this.id }),
+                {React.Children.map(children, (ele, index) =>
+                    React.cloneElement(ele, { uuid: this.id, index }),
                 )}
-            </ul>
+            </div>
         );
     }
 }

--- a/packages/ffe-accordion-react/src/Accordion.spec.js
+++ b/packages/ffe-accordion-react/src/Accordion.spec.js
@@ -11,9 +11,9 @@ const getWrapper = props =>
     );
 
 describe('<Accordion />', () => {
-    it('renders an unorderered list', () => {
+    it('renders a tablist', () => {
         const wrapper = getWrapper();
-        expect(wrapper.is('ul')).toBe(true);
+        expect(wrapper.find('[role="tablist"]').exists()).toBe(true);
     });
     it('provides the same uuid property to each child', () => {
         const wrapper = getWrapper();

--- a/packages/ffe-accordion-react/src/AccordionItem.js
+++ b/packages/ffe-accordion-react/src/AccordionItem.js
@@ -53,7 +53,7 @@ class AccordionItem extends Component {
         const open = this.getOpen();
 
         return (
-            <li
+            <div
                 className={classNames(
                     {
                         'ffe-accordion-item': true,
@@ -94,7 +94,7 @@ class AccordionItem extends Component {
                         {children}
                     </div>
                 </Collapse>
-            </li>
+            </div>
         );
     }
 }

--- a/packages/ffe-accordion-react/src/BlueAccordion.spec.js
+++ b/packages/ffe-accordion-react/src/BlueAccordion.spec.js
@@ -13,8 +13,8 @@ const getWrapper = () =>
 describe('<Accordion />', () => {
     it('adds modifier class to block element', () => {
         const wrapper = getWrapper();
-        expect(
-            wrapper.find('ul.ffe-accordion.ffe-accordion--blue').length,
-        ).toBe(1);
+        expect(wrapper.find('.ffe-accordion.ffe-accordion--blue').length).toBe(
+            1,
+        );
     });
 });


### PR DESCRIPTION
Fikser noen accessibillity issues

## Beskrivelse

Siger ikke att den blir perfekt nå men dette er feil som automatiserte verktøy tar.

*  Dette er ikke lov. `role="tablist"`  gjør ju så att det ikke lenger er en `<ul/>`  og da er det heller ikke log med `<li/>`
```
<ul role="tablist">
    <li />
</ul>

```

*  Vi ente op med att alla ids ble lik fordi index var `undefined`. 
