### PR TITLE
fix(ffe-accordion-react): remove aria hidden from tabs

### DIFF
--- a/packages/ffe-accordion-react/src/AccordionItem.js
+++ b/packages/ffe-accordion-react/src/AccordionItem.js
@@ -88,7 +88,6 @@ class AccordionItem extends Component {
                         className="ffe-accordion-item__content"
                         role="tabpanel"
                         id={`panel-${uuid}-${index}`}
-                        aria-hidden={!open}
                         aria-labelledby={`tab-${uuid}-${index}`}
                     >
                         {children}


### PR DESCRIPTION
**aria-hidden elements do not contain focusable elements**

https://dequeuniversity.com/rules/axe/3.5/aria-hidden-focus?application=axeAP

Det er vell nesten alltid man ønsker linker og lignende ting i accordion tabsen? Allternativ kunde vell bruke wrappa alt i en div på slenge på en display: none;

```
<div role="tab" aria-hidden="true">
     <div style="display: none;">{children}</div>
</div>

```
Vilket foretrekker dere?


Synes dere denne burde vare breaking? Hvis vi går før slik det er nå