### PR TITLE
fix(ffe-tables): ensure caption is more visible in dark mode

### DIFF
--- a/packages/ffe-tables/less/table.less
+++ b/packages/ffe-tables/less/table.less
@@ -123,7 +123,7 @@
     }
 
     &__caption {
-        &:extend(.ffe-h4);
+        &:extend(.ffe-h4 all);
     }
 
     &__head {


### PR DESCRIPTION
## Beskrivelse

La inn en endring der overskriften på tabellen synes når brukeren benytter seg av dark mode. Har brukt samme farge som til overskrift på kolonnene i tabellen. 

## Motivasjon og kontekst

Selvom det er frivillig å ha på dark mode, tenker jeg dette er viktig for en god brukeropplevelse.

## Testing

Har testet det lokalt. 

