### PR TITLE
fix(ffe-core): add dark mode styling to ffe-body-paragraph

### DIFF
--- a/packages/ffe-core/less/typography.less
+++ b/packages/ffe-core/less/typography.less
@@ -257,6 +257,12 @@
     margin-bottom: 1em;
     margin-top: 0;
     line-height: 24px;
+    color: @ffe-black;
+    .native & {
+        @media (prefers-color-scheme: dark) {
+            color: @ffe-grey-cloud-darkmode;
+        }
+    }
 
     &--text-center {
         text-align: center;


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse
Denne PRen legger til dark mode styling for <Paragraph>-komponenten (ffe-body-paragraph), siden det har manglet:
![Image from iOS (4)](https://user-images.githubusercontent.com/8818089/91159564-83f5e780-e6c8-11ea-8ab1-b098b9f725a8.jpg)

## Motivasjon og kontekst
Fikser dark mode for paragrafer

## Testing
Sjekket at korrekt styling blir brukt på dark mode (ved hjelp av devtools)

<!-- Hvordan har du har testet endringene dine? Ta gjerne med systeminfo o.l -->

<!--

Helt til slutt, har du ..

.. lest retningslinjene våre for bidrag?
.. tatt en siste sjekk for kode og skrivefeil, debug informasjon o.l?
.. kjørt og eventuelt oppdatert testene?
.. kommentert og dokumentert det som trengs?
.. knyttet denne opp til relaterte issues?

-->
