### PR TITLE
fix(ffe-buttons-react): to property when usin react router can be object

### DIFF
--- a/packages/ffe-buttons-react/src/index.d.ts
+++ b/packages/ffe-buttons-react/src/index.d.ts
@@ -1,10 +1,19 @@
 import * as React from 'react';
 
+type To =
+    | string
+    | {
+          pathname: string;
+          search?: string;
+          hash?: string;
+          state?: { [key: string]: any };
+      };
+
 export interface MinimalBaseButtonProps extends React.HTMLProps<HTMLElement> {
     className?: string;
     element?: HTMLElement | string | React.ElementType;
     innerRef?: React.Ref<HTMLElement>;
-    to?: string; //used in order to make buttons work with react-router functionality in typescript-files.
+    to?: To; //used in order to make buttons work with react-router functionality in typescript-files.
 }
 
 export interface BaseButtonProps extends MinimalBaseButtonProps {


### PR DESCRIPTION
Når man bruker react router så kan to også vare et object. 

Fikk ikke low o bruke Record eller unknown så ble any tillslut men har vell inget og si i praktiken. Er det gammel ts verson?