### PR TITLE
fix(ffe-account-selector-react): ts-interface locale should not be list

### DIFF
--- a/packages/ffe-account-selector-react/src/index.d.ts
+++ b/packages/ffe-account-selector-react/src/index.d.ts
@@ -11,7 +11,7 @@ export interface AccountSelectorProps {
     accounts?: Array<Account>;
     className?: string;
     id: string;
-    locale: Array<string>;
+    locale: string;
     noMatches?: string;
     onAccountSelected: (account: Account) => void;
     onChange: (value: string) => void;


### PR DESCRIPTION
I følge prop-types til komponenten så skall locale ikke vare en liste