### PR TITLE
fix(ffe-form): add darkmode styling to ffe-checkbox

### DIFF
--- a/packages/ffe-form/less/checkbox.less
+++ b/packages/ffe-form/less/checkbox.less
@@ -27,7 +27,11 @@
     text-align: left;
     padding-left: @ffe-spacing-lg;
     -webkit-tap-highlight-color: fade(@ffe-blue-focus, 15%);
-
+    .native & {
+        @media (prefers-color-scheme: dark) {
+            color: @ffe-grey-cloud-darkmode;
+        }
+    }
     &--no-margin {
         margin-top: 0;
         margin-bottom: 0;


### PR DESCRIPTION
Manglet darkmode styling på checkbox

## Beskrivelse

Fikk beskjed av utvikler om at det manglet darkmode på checkbox.

## Motivasjon og kontekst
Legger til darkmode på checkbox, så folk kan se hva de klikker på i dark mode.

## Testing
Har testet det med å kjøre designsystemet å toggle darkmode i dokumentasjonen.


Helt til slutt, har du ..

.. lest retningslinjene våre for bidrag?
.. tatt en siste sjekk for kode og skrivefeil, debug informasjon o.l?
.. kjørt og eventuelt oppdatert testene?
.. kommentert og dokumentert det som trengs?
.. knyttet denne opp til relaterte issues?

-->
