### PR TITLE
fix(ffe-lists): darkode styling missing for checklist

### DIFF
--- a/packages/ffe-lists/less/regular-lists.less
+++ b/packages/ffe-lists/less/regular-lists.less
@@ -126,6 +126,14 @@
 @ffe-blue-royal-fill: @ffe-blue-royal-escape;
 @ffe-red-fill: @ffe-red-escape;
 
+.ffe-check-list__item {
+    .native & {
+        @media (prefers-color-scheme: dark) {
+            color: @ffe-grey-cloud-darkmode;
+        }
+    }
+}
+
 .ffe-check-list {
     > .ffe-check-list__item {
         &::before {


### PR DESCRIPTION
Darkmode styling saknas for checklist item. Det ser greit ut i dokuemntasjonen men det er pga av att man blir lurt av dette i styles.less. 

```
   li,
    p:not(.ffe-lead-paragraph) {
        color: @ffe-grey-cloud-darkmode;
    }

```

Dette er ju style for biblioteket og den burde nok haft en klasse men vet ikke helt overallt den kan tenkes vare brukt.