### PR TITLE
fix(ffe-tables): darkode styling missing for table cell

### DIFF
--- a/packages/ffe-tables/less/table.less
+++ b/packages/ffe-tables/less/table.less
@@ -218,6 +218,12 @@
             text-align: right;
         }
 
+        .native & {
+            @media (prefers-color-scheme: dark) {
+                color: @ffe-grey-cloud-darkmode;
+            }
+        }
+
         @media (min-width: @breakpoint-md) {
             display: block;
             max-width: none;


### PR DESCRIPTION
styling for inneholl i table cell mangler

Det ser bra ut i designsystemet men stylingen kommer med inherit herifra i styles.less
```
.sb1ds-section,
.sb1ds-section-static {
    .native & {
        @media (prefers-color-scheme: dark) {
            color: @ffe-grey-cloud-darkmode;
```

Vet ikke hvor vanlig det er med disse tabllerna på native men koster lite og støtta det iaf. Tror vi har det noe sted men er osikker?