### PR TITLE
fix(ffe-datepicker): fix date input error styling on aria-invalid="true"

### DIFF
--- a/packages/ffe-datepicker/less/dateinput.less
+++ b/packages/ffe-datepicker/less/dateinput.less
@@ -21,6 +21,16 @@
         &::-ms-clear {
             display: none;
         }
+
+        &[aria-invalid='true'] {
+            border-color: @ffe-orange-fire;
+            border-style: solid;
+            .native & {
+                @media (prefers-color-scheme: dark) {
+                    border-color: @ffe-red-darkmode;
+                }
+            }
+        }
     }
 
     &__icon {


### PR DESCRIPTION
## Beskrivelse

Som kan sees i seksjonen om `aria-invalid="true"` på https://design.sparebank1.no/styleguidist/index.html#!/Datepicker så er aria-invalid-stylinga borte. Dette PRet legger på error-styling.

## Motivasjon og kontekst

Hvorfor? Fordi den var borte :cry: 

## Testing

Kjørte `npm start` og så at komponenten hadde fått riktig styling.