### PR TITLE
fix(ffe-cards-react): cardbase need to be able to be a button or anchor

### DIFF
--- a/packages/ffe-cards-react/src/index.d.ts
+++ b/packages/ffe-cards-react/src/index.d.ts
@@ -1,7 +1,9 @@
 import * as React from 'react';
 
 export interface ComponentBaseProps
-    extends React.HtmlHTMLAttributes<HTMLElement> {
+    extends React.HtmlHTMLAttributes<
+        HTMLElement | HTMLButtonElement | HTMLAnchorElement
+    > {
     className?: string;
     element?: HTMLElement | string | React.ElementType;
     children?: React.ReactNode;


### PR DESCRIPTION
Kunde ikke ha 
```
element="button"
type="submit" 
```
for typescript


Byrde vi ha fjernet HTMLElement? Gir vell ikke mening og ha ett kort som ikke er lenke eller button da den har hover styling og allt. What do you think?