### PR TITLE
feat(ffe-form-react): add role="alert" to ErrorFieldMessage

### DIFF
--- a/packages/ffe-form-react/src/ErrorFieldMessage.js
+++ b/packages/ffe-form-react/src/ErrorFieldMessage.js
@@ -2,7 +2,7 @@ import React from 'react';
 import BaseFieldMessage from './BaseFieldMessage';
 
 const ErrorFieldMessage = props => {
-    return <BaseFieldMessage {...props} type="error" />;
+    return <BaseFieldMessage {...props} type="error" role="alert" />;
 };
 
 export default ErrorFieldMessage;


### PR DESCRIPTION
## Beskrivelse

Bruker samme fremgangsmåte som i eksempel #2 på MDN sin side [Using the alert role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_alert_role#Example_2_Dynamically_adding_an_element_with_the_alert_role)

## Motivasjon og kontekst

Dette gjør at skjermleserbrukere ser skjemafeilmeldinger med én gang de oppstår, på samme måte som en "seende" bruker ser de med én gang.

## Testing

Fyrte opp designsystemet på lokal maskin og testet med Talkback på Android og Orca på Firefox.