### PR TITLE
feat(ffe-message-box-react): add role="alert" to ErrorMessage

### DIFF
--- a/packages/ffe-message-box-react/src/ErrorMessage.js
+++ b/packages/ffe-message-box-react/src/ErrorMessage.js
@@ -8,7 +8,8 @@ import BaseMessage from './BaseMessage';
 const ErrorMessage = props => (
     <BaseMessage
         type="error"
-        icon={<UtropstegnIkon />}
+        icon={<UtropstegnIkon aria-hidden="true" />}
+        role="alert"
         {...props}
     />
 );


### PR DESCRIPTION
## Beskrivelse

Bruker samme fremgangsmåte som i eksempel #2 på MDN sin side [Using the alert role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_alert_role#Example_2_Dynamically_adding_an_element_with_the_alert_role)

## Motivasjon og kontekst

Dette gjør at skjermleserbrukere ser skjemafeilmeldinger med én gang de oppstår, på samme måte som en "seende" bruker ser de med én gang.

## Testing

Fyrte opp designsystemet på lokal maskin og testet med Talkback på Android og Orca på Firefox.