### PR TITLE
feat(ffe-context-message-react): add role="alert" to error message

### DIFF
--- a/packages/ffe-context-message-react/src/ContextErrorMessage.js
+++ b/packages/ffe-context-message-react/src/ContextErrorMessage.js
@@ -2,7 +2,7 @@ import React from 'react';
 import ContextMessage from './ContextMessage';
 
 const ContextErrorMessage = props => (
-    <ContextMessage messageType="error" {...props} />
+    <ContextMessage messageType="error" role="alert" {...props} />
 );
 
 export default ContextErrorMessage;

--- a/packages/ffe-context-message-react/src/ContextMessage.js
+++ b/packages/ffe-context-message-react/src/ContextMessage.js
@@ -82,7 +82,6 @@ export default class ContextMessage extends Component {
 
         return (
             <div
-                {...rest}
                 aria-describedby={contentElementId}
                 aria-labelledby={header && headerElementId}
                 className={classNames(
@@ -98,6 +97,7 @@ export default class ContextMessage extends Component {
                     ...style,
                     transition: `height ${animationLengthMs / 1000}s`,
                 }}
+                {...rest}
             >
                 <div className="ffe-context-message-content">
                     {icon && this.renderIcon()}


### PR DESCRIPTION
## Beskrivelse

Bruker samme fremgangsmåte som i eksempel #2 på MDN sin side [Using the alert role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_alert_role#Example_2_Dynamically_adding_an_element_with_the_alert_role)

## Motivasjon og kontekst

Dette gjør at skjermleserbrukere ser skjemafeilmeldinger med én gang de oppstår, på samme måte som en "seende" bruker ser de med én gang.

## Testing

Fyrte opp designsystemet på lokal maskin og testet med Talkback på Android og Orca på Firefox.