### PR TITLE
feat(ffe-system-message-react): add role="alert" to error message

### DIFF
--- a/packages/ffe-system-message-react/src/SystemErrorMessage.js
+++ b/packages/ffe-system-message-react/src/SystemErrorMessage.js
@@ -7,7 +7,8 @@ export default function SystemErrorMessage(props) {
     return (
         <SystemMessage
             modifier="error"
-            icon={<UtropstegnIkon />}
+            icon={<UtropstegnIkon aria-hidden="true" />}
+            role="alert"
             {...props}
         />
     );

--- a/packages/ffe-system-message-react/src/SystemMessage.js
+++ b/packages/ffe-system-message-react/src/SystemMessage.js
@@ -35,6 +35,7 @@ class SystemMessage extends Component {
             icon,
             locale,
             modifier,
+            ...rest
         } = this.props;
 
         if (this.state.closed) {
@@ -54,6 +55,7 @@ class SystemMessage extends Component {
                 style={{
                     transition: `height ${animationLengthMs / 1000}s`,
                 }}
+                {...rest}
             >
                 <div className="ffe-system-message">
                     <span className="ffe-system-message__icon">{icon}</span>
@@ -64,7 +66,7 @@ class SystemMessage extends Component {
                         onClick={this.close}
                         type="button"
                     >
-                        <KryssIkon />
+                        <KryssIkon aria-hidden="true" />
                     </button>
                 </div>
             </div>


### PR DESCRIPTION
## Beskrivelse

Bruker samme fremgangsmåte som i eksempel #2 på MDN sin side [Using the alert role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_alert_role#Example_2_Dynamically_adding_an_element_with_the_alert_role)

## Motivasjon og kontekst

Dette gjør at skjermleserbrukere ser skjemafeilmeldinger med én gang de oppstår, på samme måte som en "seende" bruker ser de med én gang.

## Testing

Fyrte opp designsystemet på lokal maskin og testet med Talkback på Android og Orca på Firefox.