### PR TITLE
fix(ffe-message-box-react): fix MessageBox Typescript types

### DIFF
--- a/packages/ffe-message-box-react/src/index.d.ts
+++ b/packages/ffe-message-box-react/src/index.d.ts
@@ -1,6 +1,7 @@
 import * as React from 'react';
 
-export interface MessageBoxProps {
+export interface MessageBoxProps
+    extends Omit<React.HTMLAttributes<HTMLDivElement>, 'title'> {
     children?: React.ReactNode;
     className?: string;
     /**


### PR DESCRIPTION
Omitting the title from HTMLDivElement because `MessageBoxProps` overrides it.
