### PR TITLE
Develop fix input group

### DIFF
--- a/packages/ffe-form-react/src/InputGroup.js
+++ b/packages/ffe-form-react/src/InputGroup.js
@@ -54,6 +54,8 @@ const InputGroup = ({
         (typeof fieldMessage === 'string' ||
             fieldMessage.type === ErrorFieldMessage);
 
+    const hasMessage = !!fieldMessage;
+
     const ariaDescribedBy =
         `${fieldMessageId || ''} ${descriptionId || ''}`.trim() || undefined;
 
@@ -73,7 +75,7 @@ const InputGroup = ({
             className={classNames(
                 'ffe-input-group',
                 { 'ffe-input-group--no-extra-margin': !extraMargin },
-                { 'ffe-input-group--error': isInvalid },
+                { 'ffe-input-group--message': hasMessage },
                 className,
             )}
             {...rest}

--- a/packages/ffe-form-react/src/InputGroup.spec.js
+++ b/packages/ffe-form-react/src/InputGroup.spec.js
@@ -17,7 +17,7 @@ describe('<InputGroup>', () => {
         expect(wrapper.exists()).toBe(true);
         expect(wrapper.is('div')).toBe(true);
         expect(wrapper.hasClass('ffe-input-group')).toBe(true);
-        expect(wrapper.hasClass('ffe-input-group--error')).toBe(false);
+        expect(wrapper.hasClass('ffe-input-group--message')).toBe(false);
     });
 
     it('renders the given child', () => {
@@ -64,7 +64,7 @@ describe('<InputGroup>', () => {
         expect(errorFieldMessage.prop('children')).toBe('such error');
 
         const input = wrapper.find(Input);
-        expect(wrapper.hasClass('ffe-input-group--error')).toBe(true);
+        expect(wrapper.hasClass('ffe-input-group--message')).toBe(true);
         expect(input.prop('aria-invalid')).toBe('true');
         expect(input.prop('aria-describedby')).toBe(
             errorFieldMessage.prop('id'),
@@ -97,7 +97,7 @@ describe('<InputGroup>', () => {
         expect(errorFieldMessage.prop('children')).toBe('Some error');
 
         const input = wrapper.find(Input);
-        expect(wrapper.hasClass('ffe-input-group--error')).toBe(true);
+        expect(wrapper.hasClass('ffe-input-group--message')).toBe(true);
         expect(input.prop('aria-invalid')).toBe('true');
         expect(input.prop('aria-describedby')).toBe(
             errorFieldMessage.prop('id'),
@@ -131,7 +131,7 @@ describe('<InputGroup>', () => {
         const successFieldMessage = wrapper.find('SuccessFieldMessage');
         expect(successFieldMessage.exists()).toBe(true);
         expect(successFieldMessage.prop('children')).toBe('Some success');
-        expect(wrapper.hasClass('ffe-input-group--error')).toBe(false);
+        expect(wrapper.hasClass('ffe-input-group--message')).toBe(true);
         const input = wrapper.find(Input);
         expect(input.prop('aria-invalid')).toBe('false');
         expect(input.prop('aria-describedby')).toBe(

--- a/packages/ffe-form/less/input-group.less
+++ b/packages/ffe-form/less/input-group.less
@@ -41,7 +41,7 @@
         margin-bottom: @ffe-spacing-lg;
     }
 
-    &--error {
+    &--message {
         > *:nth-last-child(1) {
             margin-bottom: 0;
         }


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

Sliter med att vi ikke bruker en ErrorFieldMessage direkt uten custom komponent.  

```
const FormError = ({ name }) => (
    <Field
        name={ name }
        subscription={ { submitFailed: true, error: true } }
    >
        {
            ({ meta: { submitFailed, error } }) => submitFailed && error ?
                <ErrorFieldMessage>{ error }</ErrorFieldMessage> : <div />
        }
    </Field>
);

```

Dette `fieldMessage.type === ErrorFieldMessage`vill aldrig bli sant før oss og medfører att ikke klassen som ger riktiga marginer `ffe-input-group--error` blir satt på og det vill då se slik ut. 

![image](https://user-images.githubusercontent.com/2248579/95452657-e0a41d80-0969-11eb-85d8-f68a502759c1.png)

Eftersom fielMessage nødvendigvis ikke er en feil har jag også kallat klassen message.

