### PR TITLE
fix(ffe-context-message-react): optout var for alert for error message

### DIFF
--- a/packages/ffe-context-message-react/src/ContextErrorMessage.js
+++ b/packages/ffe-context-message-react/src/ContextErrorMessage.js
@@ -1,8 +1,66 @@
 import React from 'react';
+import {
+    number,
+    node,
+    string,
+    bool,
+    element,
+    oneOf,
+    func,
+    object,
+} from 'prop-types';
+import acceptedLocales from './locale/accepted-locales';
 import ContextMessage from './ContextMessage';
 
-const ContextErrorMessage = props => (
-    <ContextMessage messageType="error" role="alert" {...props} />
-);
+const ContextErrorMessage = props => {
+    const { alert, ...rest } = props;
+
+    return (
+        <ContextMessage
+            messageType="error"
+            role={alert ? 'alert' : false}
+            {...rest}
+        />
+    );
+};
+
+ContextErrorMessage.propTypes = {
+    animationLengthMs: number,
+    /** The content shown in the context box */
+    children: node.isRequired,
+    /** Classes are added in addition to the relevant context message classes */
+    className: string,
+    /** Renders a more compact version of the context message */
+    compact: bool,
+    /** ID for the children container */
+    contentElementId: string,
+    header: string,
+    /** ID for the header container */
+    headerElementId: string,
+    icon: element,
+    /** Decides the language of the aria-label for the close icon */
+    locale: oneOf(acceptedLocales),
+    /** Provided by the wrapper component */
+    messageType: oneOf(['info', 'tip', 'success', 'error']).isRequired,
+    /** Callback for when the context message has been closed (after the animation) */
+    onClose: func,
+    showCloseButton: bool,
+    /** Styles applied to the outermost element. `height` will be overridden */
+    style: object,
+    /** When false, role is not set to alert, avoids message from being read up immediately after page load. Default value is true. */
+    alert: bool,
+};
+
+ContextErrorMessage.defaultProps = {
+    animationLengthMs: 300,
+    compact: false,
+    contentElementId: 'contentElementId',
+    headerElementId: 'headerElementId',
+    locale: 'nb',
+    onClose: () => {},
+    showCloseButton: false,
+    style: {},
+    alert: true,
+};
 
 export default ContextErrorMessage;

--- a/packages/ffe-context-message-react/src/ContextErrorMessage.md
+++ b/packages/ffe-context-message-react/src/ContextErrorMessage.md
@@ -1,3 +1,5 @@
+Vær oppmerksom på at alle feilmeldinger automatisk får role="alert", dette gjør at en skjermleser automatisk vil lese opp innholdet i meldingen med en gang meldingen vises. Dersom meldingen er tilstede ved initiell sidelasting leses meldingen opp like etter sidetittel. Dette kan slås av, se eksempelet under.
+
 ```js
 <ContextErrorMessage>
     Dette gikk ikke som forventet i det hele tatt!
@@ -28,4 +30,8 @@ const { UtropstegnIkon } = require('@sb1/ffe-icons-react');
 <ContextErrorMessage showCloseButton={true}>
     Jeg kan også lukkes
 </ContextErrorMessage>
+```
+
+```js
+<ContextErrorMessage alert={false}>Slår av alert.</ContextErrorMessage>
 ```

--- a/packages/ffe-context-message-react/src/index.d.ts
+++ b/packages/ffe-context-message-react/src/index.d.ts
@@ -16,6 +16,10 @@ export interface ContextMessageProps
     style?: React.CSSProperties;
 }
 
+export interface ContextErrorMessageProps extends ContextMessageProps {
+    alert?: boolean;
+}
+
 declare class ContextInfoMessage extends React.Component<
     ContextMessageProps,
     any
@@ -29,6 +33,6 @@ declare class ContextSuccessMessage extends React.Component<
     any
 > {}
 declare class ContextErrorMessage extends React.Component<
-    ContextMessageProps,
+    ContextErrorMessageProps,
     any
 > {}


### PR DESCRIPTION
Last release added alert role for all context error messages. This release adds an opt-out parameter no alert.

Løser issue 949 for ContextErrorMessage.