### PR TITLE
fix(ffe-message-box-react): opt-out param for alert for error message

### DIFF
--- a/packages/ffe-message-box-react/src/ErrorMessage.js
+++ b/packages/ffe-message-box-react/src/ErrorMessage.js
@@ -1,18 +1,26 @@
 import React from 'react';
-import { node, string } from 'prop-types';
+import { node, string, bool } from 'prop-types';
 
 import UtropstegnIkon from '@sb1/ffe-icons-react/lib/utropstegn-ikon';
 
 import BaseMessage from './BaseMessage';
 
-const ErrorMessage = props => (
-    <BaseMessage
-        type="error"
-        icon={<UtropstegnIkon aria-hidden="true" />}
-        role="alert"
-        {...props}
-    />
-);
+const ErrorMessage = props => {
+    const { alert, ...rest } = props;
+
+    return (
+        <BaseMessage
+            type="error"
+            icon={<UtropstegnIkon aria-hidden="true" />}
+            role={alert ? 'alert' : false}
+            {...rest}
+        />
+    );
+};
+
+ErrorMessage.defaultProps = {
+    alert: true,
+};
 
 ErrorMessage.propTypes = {
     /** The content of the message box */
@@ -28,6 +36,8 @@ ErrorMessage.propTypes = {
     icon: node,
     /** An optional title for the message */
     title: node,
+    /** When false, role is not set to alert, avoids message from being read up immediately after page load. Default value is true. */
+    alert: bool,
 };
 
 export default ErrorMessage;

--- a/packages/ffe-message-box-react/src/ErrorMessage.md
+++ b/packages/ffe-message-box-react/src/ErrorMessage.md
@@ -1,10 +1,26 @@
 `ErrorMessage` skal brukes når noe har gått feil. Eksempler kan være valideringsfeil, eller hvis noe ikke gikk som
 forventet.
 
+Vær oppmerksom på at alle feilmeldinger automatisk får role="alert", dette gjør at en skjermleser automatisk vil lese opp innholdet i meldingen med en gang meldingen vises. Dersom meldingen er tilstede ved initiell sidelasting leses meldingen opp like etter sidetittel. Dette kan slås av, se eksempelet under.
+
 ```js
 const { ErrorMessage } = require('.');
 
 <ErrorMessage title="Fikk ikke kalkulert pris">
+    <p className="ffe-body-paragraph">
+        Det ser ut til at vi har litt problemer med priskalkuleringstjenestene
+        våre akkurat nå. Hvis problemet vedvarer, kan du ta kontakt med
+        kundesupport, så hjelper vi deg.
+    </p>
+</ErrorMessage>;
+```
+
+Slå av alert:
+
+```js
+const { ErrorMessage } = require('.');
+
+<ErrorMessage title="Fikk ikke kalkulert pris" alert={false}>
     <p className="ffe-body-paragraph">
         Det ser ut til at vi har litt problemer med priskalkuleringstjenestene
         våre akkurat nå. Hvis problemet vedvarer, kan du ta kontakt med

--- a/packages/ffe-message-box-react/src/index.d.ts
+++ b/packages/ffe-message-box-react/src/index.d.ts
@@ -13,6 +13,10 @@ export interface MessageBoxProps
     title?: React.ReactNode;
 }
 
+export interface ErrorMessageBoxProps extends MessageBoxProps {
+    alert?: boolean;
+}
+
 export interface InfoMessageListItemProps {
     children: string;
     href?: string;
@@ -23,7 +27,7 @@ export interface InfoMessageListProps {
 }
 
 declare class SuccessMessage extends React.Component<MessageBoxProps, any> {}
-declare class ErrorMessage extends React.Component<MessageBoxProps, any> {}
+declare class ErrorMessage extends React.Component<ErrorMessageBoxProps, any> {}
 declare class InfoMessage extends React.Component<MessageBoxProps, any> {}
 declare class TipsMessage extends React.Component<MessageBoxProps, any> {}
 declare class InfoMessageList extends React.Component<


### PR DESCRIPTION
Last release added alert role for all error messages. This release adds an opt-out parameter no alert.

Denne PR-en løser issue 949 for ErrorMessageBox.