### PR TITLE
fix(ffe-system-message-react): optout param for alert for error message

### DIFF
--- a/packages/ffe-system-message-react/src/SystemErrorMessage.js
+++ b/packages/ffe-system-message-react/src/SystemErrorMessage.js
@@ -1,15 +1,46 @@
 import React from 'react';
+import { func, string, number, node, oneOf, bool } from 'prop-types';
 import UtropstegnIkon from '@sb1/ffe-icons-react/lib/utropstegn-ikon';
 
 import SystemMessage from './SystemMessage';
 
 export default function SystemErrorMessage(props) {
+    const { alert, ...rest } = props;
+
     return (
         <SystemMessage
             modifier="error"
             icon={<UtropstegnIkon aria-hidden="true" />}
-            role="alert"
-            {...props}
+            role={alert ? 'alert' : false}
+            {...rest}
         />
     );
 }
+
+SystemErrorMessage.defaultProps = {
+    animationLengthMs: 300,
+    locale: 'nb',
+    onClose: f => f,
+    alert: true,
+};
+
+SystemErrorMessage.propTypes = {
+    animationLengthMs: number,
+    /** The content of the system message */
+    children: node.isRequired,
+    /** Additional classes added to the surrounding div */
+    className: string,
+    /** Override the default icon - use with caution! */
+    icon: node.isRequired,
+    /** 'nb', 'nn', or 'en' */
+    locale: oneOf(['en', 'nb', 'nn']),
+    /**
+     * The type of system message. Used internally only-
+     * @ignore
+     **/
+    modifier: oneOf(['error', 'info', 'success', 'news']),
+    /** Callback for when the system message has been closed (after animation ends) */
+    onClose: func,
+    /** When false, role is not set to alert, avoids message from being read up immediately after page load. Default value is true. */
+    alert: bool,
+};

--- a/packages/ffe-system-message-react/src/SystemErrorMessage.md
+++ b/packages/ffe-system-message-react/src/SystemErrorMessage.md
@@ -1,5 +1,15 @@
+Vær oppmerksom på at alle feilmeldinger automatisk får role="alert", dette gjør at en skjermleser automatisk vil lese opp innholdet i meldingen med en gang meldingen vises. Dersom meldingen er tilstede ved initiell sidelasting leses meldingen opp like etter sidetittel. Dette kan slås av, se eksempelet under.
+
 ```js
 <SystemErrorMessage>
+    Noen av systemene våre er dessverre utilgjengelige akkurat nå.
+</SystemErrorMessage>
+```
+
+Slår av alert:
+
+```js
+<SystemErrorMessage alert={false}>
     Noen av systemene våre er dessverre utilgjengelige akkurat nå.
 </SystemErrorMessage>
 ```

--- a/packages/ffe-system-message-react/src/index.d.ts
+++ b/packages/ffe-system-message-react/src/index.d.ts
@@ -9,8 +9,12 @@ export interface SystemMessageProps {
     onClose?: (e: React.MouseEvent | undefined) => void;
 }
 
+export interface SystemErrorMessageProps extends SystemMessageProps {
+    alert?: boolean;
+}
+
 declare class SystemErrorMessage extends React.Component<
-    SystemMessageProps,
+    SystemErrorMessageProps,
     any
 > {}
 declare class SystemInfoMessage extends React.Component<


### PR DESCRIPTION
Last release added alert role for all error messages. This release adds an opt-out parameter no alert.

Løser issue 949 for SystemErrorMessage.