### PR TITLE
fix(ffe-form): dropdown arrow bug

### DIFF
--- a/packages/ffe-form/less/dropdown.less
+++ b/packages/ffe-form/less/dropdown.less
@@ -19,6 +19,7 @@
 }
 
 .ffe-dropdown {
+    appearance: none;
     background-color: @ffe-white;
     background-size: 18px 18px;
     background-repeat: no-repeat;


### PR DESCRIPTION
Vi får den pilen i firefox på våra sidor. 
![broken-dropdown](https://user-images.githubusercontent.com/2248579/96995902-3b737280-152f-11eb-91a9-2d0999f7e51a.png)

I designsystemet så får komponenten dette iaf så dær ser den fin ut i FF(even om screenshot nedan her er fra chrome)
![image](https://user-images.githubusercontent.com/2248579/96996014-6eb60180-152f-11eb-8d81-6bac32bbcbe6.png)

