### PR TITLE
Anpasse gh-action release til vintertid

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ on:
         # Central European Time (CET): '0 5-20/5 * * *'
         # Central European Summer Time (CEST): '0 4-19/5 * * *'
         #
-        - cron: '0 4-19/5 * * *'
+        - cron: '0 5-20/5 * * *'
 
 jobs:
     release_to_npm:


### PR DESCRIPTION
Cron-jobben som trigger den gitub-action som publiserer til npm må manuell stilles til vintertid.