### PR TITLE
feat(ffe-core): darkmode color palette & darkmode form label color tweak

### DIFF
--- a/packages/ffe-core/less/colors.less
+++ b/packages/ffe-core/less/colors.less
@@ -57,6 +57,6 @@
 @ffe-grey-charcoal-darkmode: #1c1c1c; // Emphasized surfaces
 @ffe-grey-darkmode: #292929; // Interactive surfaces
 @ffe-grey-silver-darkmode: #858585; // Borders and accents
-@ffe-grey-cloud-darkmode: #adadad; // Default font color on default background
+@ffe-grey-cloud-darkmode: #cccccc; // Default font color on default background and form labels
 @ffe-blue-azure-darkmode: #0a91ff; // Primary interaction and icon color
 @ffe-red-darkmode: #ff2424; // Tweaked ffe-red for better contrast

--- a/packages/ffe-form/less/form-label.less
+++ b/packages/ffe-form/less/form-label.less
@@ -22,7 +22,7 @@
     color: @ffe-blue-royal;
     .native & {
         @media (prefers-color-scheme: dark) {
-            color: @ffe-grey-silver-darkmode;
+            color: @ffe-grey-cloud-darkmode;
         }
     }
 

--- a/styleguide-content/visuell-identitet/farger.md
+++ b/styleguide-content/visuell-identitet/farger.md
@@ -172,7 +172,7 @@
         </li>
         <li class="sb1ds-color-palette__item sb1ds-color-palette__item--ffe-grey-cloud-darkmode">
             <div>Skygrå</div>
-            <div>#ADADAD<br/>@ffe-grey-cloud-darkmode</div>
+            <div>#CCCCCC<br/>@ffe-grey-cloud-darkmode</div>
         </li>
         <li class="sb1ds-color-palette__item sb1ds-color-palette__item--ffe-white-darkmode">
             <div>Hvit</div>
@@ -683,7 +683,7 @@
                 <rect x="284.106" width="129.11" height="116.13" fill="#1C1C1C"/>
                 <rect x="417.219" width="57.59" height="116.13" fill="#292929"/>
                 <rect x="478.808" width="35.74" height="116.13" fill="#858585"/>
-                <rect x="518.543" width="36.73" height="116.13" fill="#ADADAD"/>
+                <rect x="518.543" width="36.73" height="116.13" fill="#CCCCCC"/>
                 <rect x="559.772" y="0.5" width="23.81" height="115.13" fill="white" stroke="#CCCCCC"/>
                 <rect x="588.079" width="5.93" height="116.13" fill="#0A91FF"/>
                 <rect x="598.013" width="1.98676" height="116.13" fill="#FF2424"/>
@@ -799,7 +799,7 @@
             </td>
             <td class="ffe-table__cell">
                 <ul class="sb1ds-color-usage__list">
-                    <li>#ADADAD</li>
+                    <li>#CCCCCC</li>
                     <li>@ffe-grey-cloud-darkmode</li>
                 </ul>
             </td>


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse

<!-- Detaljert beskrivelse av endringene dine. Skjermskudd er lov. -->

Endringer etter diskusjon i GD/IXD-forum 04.11.2020:

* Endret til lysere farge for @ffe-grey-cloud-darkmode i fargepaletten for darkmode for bedre kontrast
![image](https://user-images.githubusercontent.com/1208362/98116755-03621d00-1ea9-11eb-82ff-d97ed12883a4.png)

* Endret form labels i darkmode til å bruke oppdatert @ffe-grey-cloud-darkmode
![image](https://user-images.githubusercontent.com/1208362/98116952-589e2e80-1ea9-11eb-8652-d70770e69432.png)


<!-- Hvorfor trengs denne endringen, og hva løser den? -->

<!-- Hvordan har du har testet endringene dine? Ta gjerne med systeminfo o.l -->

<!--

Helt til slutt, har du ..

.. lest retningslinjene våre for bidrag?
.. tatt en siste sjekk for kode og skrivefeil, debug informasjon o.l?
.. kjørt og eventuelt oppdatert testene?
.. kommentert og dokumentert det som trengs?
.. knyttet denne opp til relaterte issues?

-->
