### PR TITLE
fix(ffe-form): autoprefixer does not work with apprence: none

### DIFF
--- a/packages/ffe-form/less/dropdown.less
+++ b/packages/ffe-form/less/dropdown.less
@@ -19,6 +19,10 @@
 }
 
 .ffe-dropdown {
+    /* stylelint-disable */
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    /* stylelint-enable */
     appearance: none;
     background-color: @ffe-white;
     background-size: 18px 18px;


### PR DESCRIPTION
Vi sliter med disse pilerne på firefox

![image](https://user-images.githubusercontent.com/2248579/98346266-01699c80-2016-11eb-9413-ee52a8330e51.png)

Jag la tidligare på `apperence: none;` og det funker fint i bygget her. 

generert css:
![image](https://user-images.githubusercontent.com/2248579/98346444-4392de00-2016-11eb-89b5-82d41dffd6a9.png)

Problemet hos oss er av vi importerar less filen og bruker postcss sin autoprefixer og det kan se ut som dom ikke støttar `appearance`. 
[gammel issue fra 2013](https://github.com/postcss/autoprefixer/issues/43)

Slik blir det til slut:
![apperence](https://user-images.githubusercontent.com/2248579/98346323-147c6c80-2016-11eb-8a15-4b07a752fc91.png)

Jag tror derfor vi burde gjøre dette slik. Enige?