### PR TITLE
fix(ffe-accordion-react): hidden after animation is done

### DIFF
--- a/packages/ffe-accordion-react/src/Accordion.spec.js
+++ b/packages/ffe-accordion-react/src/Accordion.spec.js
@@ -3,14 +3,6 @@ import AccordionItem from './AccordionItem';
 import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
 
-const renderAccordion = props =>
-    render(
-        <Accordion {...props}>
-            <AccordionItem heading="heading1">content1</AccordionItem>
-            <AccordionItem heading="heading2">content2</AccordionItem>
-        </Accordion>,
-    );
-
 describe('<Accordion />', () => {
     it('should render headings', () => {
         render(
@@ -61,7 +53,12 @@ describe('<Accordion />', () => {
     });
 
     it('should expand sections', () => {
-        renderAccordion({ headingLevel: 3 });
+        render(
+            <Accordion headingLevel={3}>
+                <AccordionItem heading="heading1">content1</AccordionItem>
+                <AccordionItem heading="heading2">content2</AccordionItem>
+            </Accordion>,
+        );
 
         const firstButton = screen.getByRole('button', { name: /heading1/i });
         const secondButton = screen.getByRole('button', { name: /heading2/i });

--- a/packages/ffe-accordion-react/src/AccordionItem.js
+++ b/packages/ffe-accordion-react/src/AccordionItem.js
@@ -14,6 +14,7 @@ const AccordionItem = ({
     ...accordionProps
 }) => {
     const [isExpanded, setIsExpanded] = useState(defaultOpen);
+    const [isAnimating, setIsAnimating] = useState(false);
     const buttonId = useRef(uuid());
     const contentId = useRef(uuid());
 
@@ -40,6 +41,7 @@ const AccordionItem = ({
                         'ffe-accordion__heading-button--open': isExpanded,
                     })}
                     onClick={() => {
+                        setIsAnimating(true);
                         setIsExpanded(prevState => {
                             onToggleOpen(!prevState);
                             return !prevState;
@@ -54,16 +56,16 @@ const AccordionItem = ({
                     </span>
                 </button>,
             )}
-            <div
+            <Collapse
+                isOpen={isExpanded}
+                onRest={() => setIsAnimating(false)}
                 id={contentId.current}
                 aria-labelledby={buttonId.current}
-                hidden={!isExpanded}
+                hidden={!isExpanded && !isAnimating}
                 role="region"
             >
-                <Collapse isOpen={isExpanded}>
-                    <div className="ffe-accordion-body">{children}</div>
-                </Collapse>
-            </div>
+                <div className="ffe-accordion-body">{children}</div>
+            </Collapse>
         </div>
     );
 };

--- a/packages/ffe-accordion-react/src/index.d.ts
+++ b/packages/ffe-accordion-react/src/index.d.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 export interface AccordionItemProps extends React.HTMLProps<HTMLDivElement> {
-    heading: string | HTMLElement;
+    heading: string | React.ReactElement;
     defaultOpen?: boolean;
     onToggleOpen?: (isOpen: boolean) => void;
 }


### PR DESCRIPTION
Hvis man slenger på `hidden` før tidlig blir det ikke noen animasjon når den lukkes. Denne pr venter på animasjonen og legger efter det på hidden.  