### PR TITLE
fix in multiple packages:  Change font size and line height to rem

### DIFF
--- a/packages/ffe-account-selector-react/less/account-suggestion.less
+++ b/packages/ffe-account-selector-react/less/account-suggestion.less
@@ -47,14 +47,14 @@
 
     &__name {
         line-height: 1;
-        font-size: 15px;
+        font-size: 0.9375rem;
         display: block;
         padding-bottom: @ffe-spacing-2xs;
     }
 
     &__details {
         color: @ffe-grey-charcoal;
-        font-size: 12px;
+        font-size: 0.75rem;
         .ffe-clearfix;
 
         .native & {

--- a/packages/ffe-account-selector-react/less/ffe-account-selector.less
+++ b/packages/ffe-account-selector-react/less/ffe-account-selector.less
@@ -7,7 +7,7 @@
     display: block;
 
     &__details {
-        font-size: 14px;
+        font-size: 0.875rem;
         padding: @ffe-spacing-xs @ffe-spacing-2xs;
         color: @ffe-black;
 
@@ -49,8 +49,8 @@
 
     &__statusbar-button {
         padding: 0 @ffe-spacing-md;
-        font-size: 14px;
-        line-height: 34px;
+        font-size: 0.875rem;
+        line-height: 2.125rem;
         background: @ffe-blue-azure;
     }
 

--- a/packages/ffe-cards/less/ffe-link-card.less
+++ b/packages/ffe-cards/less/ffe-link-card.less
@@ -71,7 +71,7 @@
         text-transform: uppercase;
         padding: 0;
         width: 75%;
-        font-size: 14px;
+        font-size: 0.875rem;
         text-align: center;
         position: relative;
         top: -10px;
@@ -129,14 +129,14 @@
 
     &--large > &__sub-heading {
         color: @ffe-blue-royal;
-        line-height: 1.3;
+        line-height: 1.3rem;
     }
 
     &--large > &__details {
         color: @ffe-blue-royal;
         font-family: 'MuseoSansRounded-700', arial, sans-serif;
-        font-size: 20px;
-        line-height: 2.2;
+        font-size: 1.25rem;
+        line-height: 2.2rem;
         .native & {
             @media (prefers-color-scheme: dark) {
                 color: @ffe-white-darkmode;
@@ -226,7 +226,7 @@
             left: 0;
             right: 0;
             padding: 3px;
-            font-size: 16px;
+            font-size: 1rem;
         }
 
         &--medium > &__icon,
@@ -240,7 +240,7 @@
         &--medium > &__heading,
         &--large > &__heading {
             font-family: 'MuseoSansRounded-500', arial, sans-serif;
-            font-size: 20px;
+            font-size: 1.25rem;
             margin-bottom: 20px;
             margin-top: 0;
             max-width: 100%;
@@ -248,15 +248,15 @@
 
         &--medium > &__sub-heading,
         &--large > &__sub-heading {
-            font-size: 18px;
+            font-size: 1.125rem;
         }
 
         &--medium > &__details,
         &--large > &__details {
             color: @ffe-blue-royal;
             font-family: 'MuseoSansRounded-700', arial, sans-serif;
-            font-size: 24px;
-            line-height: 110px;
+            font-size: 1.5rem;
+            line-height: 6.875rem;
             position: absolute;
             bottom: 0;
             right: 0;

--- a/packages/ffe-cards/less/ffe-product-card.less
+++ b/packages/ffe-cards/less/ffe-product-card.less
@@ -108,7 +108,7 @@
     text-transform: uppercase;
     padding: 0;
     max-width: 75%;
-    font-size: 14px;
+    font-size: 0.875rem;
     text-align: center;
     position: relative;
     top: -10px;
@@ -133,7 +133,7 @@
 
     .ffe-product-card__heading {
         font-family: 'MuseoSansRounded-500', arial, sans-serif;
-        font-size: 20px;
+        font-size: 1.25rem;
         max-width: 100%;
         margin-top: 17px;
     }

--- a/packages/ffe-core/less/ffe-normalize.less
+++ b/packages/ffe-core/less/ffe-normalize.less
@@ -1,6 +1,7 @@
 /* GAB: Use border-box: http://www.paulirish.com/2012/box-sizing-border-box-ftw/ */
 html {
     box-sizing: border-box;
+    font-size: 16px; /* Default font-size, sets rem value */
 }
 
 *,

--- a/packages/ffe-core/less/font-sizes.less
+++ b/packages/ffe-core/less/font-sizes.less
@@ -1,7 +1,3 @@
-/* Font-size Default */
-html {
-    font-size: 16px;
-}
 /* stylelint-disable */
 .ffe-fontsize(@minWidth, @rules) {
     @media (min-width: @minWidth) {

--- a/packages/ffe-core/less/font-sizes.less
+++ b/packages/ffe-core/less/font-sizes.less
@@ -1,3 +1,7 @@
+/* Font-size Default */
+html {
+    font-size: 16px;
+}
 /* stylelint-disable */
 .ffe-fontsize(@minWidth, @rules) {
     @media (min-width: @minWidth) {
@@ -7,81 +11,81 @@
 /* stylelint-enable */
 
 .ffe-fontsize-body-text() {
-    font-size: 16px;
+    font-size: 1rem;
 }
 
 .ffe-fontsize-small-text() {
-    font-size: 14px;
+    font-size: 0.875rem;
 }
 
 .ffe-fontsize-micro-text() {
-    font-size: 12px;
+    font-size: 0.75rem;
 }
 
 .ffe-fontsize-lead-paragraph() {
-    font-size: 18px;
+    font-size: 1.125rem;
 
-    .ffe-fontsize(@breakpoint-sm, {font-size: 24px;});
+    .ffe-fontsize(@breakpoint-sm, {font-size: 1.5rem;});
 }
 
 .ffe-fontsize-sub-lead-paragraph() {
-    font-size: 16px;
+    font-size: 1rem;
 
-    .ffe-fontsize(@breakpoint-sm, {font-size: 18px;});
+    .ffe-fontsize(@breakpoint-sm, {font-size: 1.125rem;});
 }
 
 .ffe-fontsize-h1() {
-    font-size: 28px;
+    font-size: 1.75rem;
 
-    .ffe-fontsize(@breakpoint-sm, {font-size: 46px;});
+    .ffe-fontsize(@breakpoint-sm, {font-size: 2.875rem;});
 }
 
 .ffe-fontsize-h2() {
-    font-size: 24px;
+    font-size: 1.5rem;
 
-    .ffe-fontsize(@breakpoint-sm, {font-size: 36px;});
+    .ffe-fontsize(@breakpoint-sm, {font-size: 2.25rem;});
 }
 
 .ffe-fontsize-h3() {
-    font-size: 20px;
+    font-size: 1.25rem;
 
-    .ffe-fontsize(@breakpoint-sm, {font-size: 28px;});
+    .ffe-fontsize(@breakpoint-sm, {font-size: 1.75rem;});
 }
 
 .ffe-fontsize-h4() {
-    font-size: 18px;
+    font-size: 1.125rem;
 
-    .ffe-fontsize(@breakpoint-sm, {font-size: 22px;});
+    .ffe-fontsize(@breakpoint-sm, {font-size: 1.375rem;});
 }
 
 .ffe-fontsize-h5() {
-    font-size: 16px;
+    font-size: 1rem;
 
-    .ffe-fontsize(@breakpoint-sm, {font-size: 18px;});
+    .ffe-fontsize(@breakpoint-sm, {font-size: 1.125rem;});
 }
 
 .ffe-fontsize-h6() {
-    font-size: 15px;
+    font-size: 0.9375rem;
 
-    .ffe-fontsize(@breakpoint-sm, {font-size: 16px;});
+    .ffe-fontsize(@breakpoint-sm, {font-size: 1rem;});
 }
 
 .ffe-fontsize-form-input() {
-    font-size: 16px;
+    font-size: 1rem;
 }
 
 .ffe-fontsize-form-dropdown() {
-    font-size: 16px;
+    font-size: 1rem;
 }
 
 .ffe-fontsize-button() {
-    font-size: 16px;
+    font-size: 1rem;
 }
 
 .ffe-fontsize-button-transparent() {
-    font-size: 16px;
+    font-size: 1rem;
 }
 
 .ffe-fontsize-button-condensed() {
-    font-size: 14px;
+    font-size: 0.875rem;
 }

--- a/packages/ffe-core/less/typography.less
+++ b/packages/ffe-core/less/typography.less
@@ -140,32 +140,32 @@
 // Styleguide ffe-core.typography.link-text
 
 .ffe-h1 {
-    line-height: 36px;
+    line-height: 2.25rem;
     .ffe-fontsize-h1;
 }
 
 .ffe-h2 {
-    line-height: 28px;
+    line-height: 1.75rem;
     .ffe-fontsize-h2;
 }
 
 .ffe-h3 {
-    line-height: 24px;
+    line-height: 1.5rem;
     .ffe-fontsize-h3;
 }
 
 .ffe-h4 {
-    line-height: 24px;
+    line-height: 1.5rem;
     .ffe-fontsize-h4;
 }
 
 .ffe-h5 {
-    line-height: 20px;
+    line-height: 1.25rem;
     .ffe-fontsize-h5;
 }
 
 .ffe-h6 {
-    line-height: 20px;
+    line-height: 1.25rem;
     .ffe-fontsize-h6;
 }
 
@@ -173,7 +173,7 @@
     color: @ffe-grey-charcoal;
     font-family: 'MuseoSans-500', arial, sans-serif;
     font-weight: normal;
-    line-height: 20px;
+    line-height: 1.25rem;
     .ffe-fontsize-small-text;
     &--dark {
         color: @ffe-white;
@@ -184,7 +184,7 @@
     color: @ffe-grey-charcoal;
     font-family: 'MuseoSans-500', arial, sans-serif;
     font-weight: normal;
-    line-height: 20px;
+    line-height: 1.25rem;
     .ffe-fontsize-micro-text;
 }
 
@@ -244,7 +244,7 @@
 .ffe-body-text {
     color: @ffe-black;
     font-family: 'MuseoSans-500', arial, sans-serif;
-    line-height: 24px;
+    line-height: 1.5rem;
     .ffe-fontsize-body-text;
     .native & {
         @media (prefers-color-scheme: dark) {
@@ -256,7 +256,7 @@
 .ffe-body-paragraph {
     margin-bottom: 1em;
     margin-top: 0;
-    line-height: 24px;
+    line-height: 1.5rem;
     color: @ffe-black;
     .native & {
         @media (prefers-color-scheme: dark) {
@@ -281,7 +281,7 @@
 
 .ffe-lead-paragraph {
     color: @ffe-blue-royal;
-    line-height: 28px;
+    line-height: 1.75rem;
     .ffe-fontsize-lead-paragraph;
     .native & {
         @media (prefers-color-scheme: dark) {
@@ -292,7 +292,7 @@
 
 .ffe-sub-lead-paragraph {
     color: @ffe-black;
-    line-height: 24px;
+    line-height: 1.5rem;
     .ffe-fontsize-sub-lead-paragraph;
     .native & {
         @media (prefers-color-scheme: dark) {
@@ -383,27 +383,27 @@
 
 @media (min-width: @breakpoint-sm) {
     .ffe-h1 {
-        line-height: 56px;
+        line-height: 3.5rem;
     }
 
     .ffe-h2 {
-        line-height: 44px;
+        line-height: 2.75rem;
     }
 
     .ffe-h3 {
-        line-height: 36px;
+        line-height: 2.25rem;
     }
 
     .ffe-h4 {
-        line-height: 28px;
+        line-height: 1.75rem;
     }
 
     .ffe-h5 {
-        line-height: 24px;
+        line-height: 1.5rem;
     }
 
     .ffe-h6 {
-        line-height: 20px;
+        line-height: 1.25rem;
     }
 
     .ffe-h1,
@@ -420,24 +420,24 @@
     }
 
     .ffe-lead-paragraph {
-        line-height: 32px;
+        line-height: 2rem;
     }
 
     .ffe-sub-lead-paragraph {
-        line-height: 28px;
+        line-height: 1.75rem;
     }
 
     .ffe-body-text,
     .ffe-body-paragraph {
-        line-height: 24px;
+        line-height: 1.5rem;
     }
 
     .ffe-small-text {
-        line-height: 20px;
+        line-height: 1.25rem;
     }
 
     .ffe-micro-text {
-        line-height: 20px;
+        line-height: 1.25rem;
     }
 }
 

--- a/packages/ffe-datepicker/less/calendar.less
+++ b/packages/ffe-datepicker/less/calendar.less
@@ -139,14 +139,14 @@
     &__date {
         &:extend(.ffe-small-text);
 
-        font-size: 16px;
+        font-size: 1rem;
         background-color: @ffe-white;
         width: 35px;
         height: 35px;
         color: @ffe-black;
         border-radius: 4px;
         display: inline-block;
-        line-height: 35px;
+        line-height: 2.1875rem;
         border: 2px solid transparent;
         cursor: pointer;
         .native & {

--- a/packages/ffe-file-upload/less/file-upload.less
+++ b/packages/ffe-file-upload/less/file-upload.less
@@ -45,7 +45,7 @@
 
     &__file-items-section {
         margin-top: @ffe-spacing-sm;
-        line-height: 35px;
+        line-height: 2.1875rem;
         grid-row: 4;
 
         @media (min-width: @breakpoint-md) {
@@ -160,7 +160,7 @@
         border: solid 2px @ffe-grey-silver;
         border-radius: 4px;
         box-shadow: 0 1px 2px 1px rgba(0, 0, 0, 0.05);
-        line-height: 24px;
+        line-height: 1.5rem;
         outline: none;
         overflow: hidden;
         padding: @ffe-spacing-xs @ffe-spacing-sm;
@@ -247,10 +247,10 @@
         margin-left: auto;
         background-color: transparent;
         border: none;
-        line-height: 18px;
+        line-height: 1.125rem;
         position: relative;
         color: @ffe-blue-azure;
-        font-size: 14px;
+        font-size: 0.875rem;
         grid-column: 3;
         grid-row: 1;
         .native & {

--- a/packages/ffe-header/examples/examples.less
+++ b/packages/ffe-header/examples/examples.less
@@ -11,9 +11,9 @@ body {
     padding: 0 20px;
     color: @ffe-grey-silver;
     font-family: 'MuseoSans-500', arial, sans-serif;
-    font-size: 16px;
-    line-height: 26px;
+    font-size: 1rem;
+    line-height: 1.625rem;
     @media (min-width: @breakpoint-md) {
-        line-height: 24px;
+        line-height: 1.5rem;
     }
 }

--- a/packages/ffe-header/less/ffe-header.less
+++ b/packages/ffe-header/less/ffe-header.less
@@ -308,12 +308,12 @@
     &__notification-bubble {
         font-family: 'MuseoSansRounded-700', arial, sans-serif;
         font-weight: normal;
-        font-size: 12px;
+        font-size: 0.75rem;
         display: inline-block;
         min-width: 19px;
         height: 19px;
         padding: 0 @ffe-spacing-2xs;
-        line-height: 20px;
+        line-height: 1.25rem;
         background: @ffe-green-shamrock;
         color: @ffe-white;
         border-radius: 10px;
@@ -332,7 +332,7 @@
             a {
                 display: inline-block;
                 height: 60px;
-                line-height: 60px;
+                line-height: 3.75rem;
             }
         }
 

--- a/packages/ffe-system-message/less/ffe-system-message.less
+++ b/packages/ffe-system-message/less/ffe-system-message.less
@@ -116,11 +116,11 @@
     &__content {
         margin: 0;
         padding: 0;
-        font-size: 14px;
+        font-size: 0.875rem;
         flex: 1 1 auto;
 
         @media (min-width: 600px) {
-            font-size: 16px;
+            font-size: 1rem;
         }
     }
 

--- a/packages/ffe-tables/less/table.less
+++ b/packages/ffe-tables/less/table.less
@@ -198,7 +198,7 @@
     }
 
     &--condensed {
-        font-size: 14px;
+        font-size: 0.875rem;
 
         .ffe-table__heading,
         .ffe-table__cell {

--- a/packages/ffe-tabs/less/tab-button.less
+++ b/packages/ffe-tabs/less/tab-button.less
@@ -18,7 +18,7 @@
     cursor: pointer;
     display: block;
     font-family: 'MuseoSansRounded-500', arial, sans-serif;
-    font-size: 16px;
+    font-size: 1rem;
     outline: none;
     overflow: hidden;
     padding: @ffe-spacing-xs @ffe-spacing-lg @ffe-spacing-xs;
@@ -87,7 +87,7 @@
     }
 
     &--condensed {
-        font-size: 14px;
+        font-size: 0.875rem;
         padding-bottom: @ffe-spacing-2xs;
         padding-top: @ffe-spacing-2xs;
     }

--- a/packages/ffe-tabs/less/tab.less
+++ b/packages/ffe-tabs/less/tab.less
@@ -16,7 +16,7 @@
     cursor: pointer;
     display: block;
     font-family: 'MuseoSansRounded-500', arial, sans-serif;
-    font-size: 16px;
+    font-size: 1rem;
     outline: none;
     overflow: hidden;
     padding: @ffe-spacing-xs @ffe-spacing-lg @ffe-spacing-xs;
@@ -63,7 +63,7 @@
     }
 
     &--condensed {
-        font-size: 14px;
+        font-size: 0.875rem;
         padding-bottom: @ffe-spacing-2xs;
         padding-top: @ffe-spacing-2xs;
     }

--- a/src/styles/components/sidebar.less
+++ b/src/styles/components/sidebar.less
@@ -70,8 +70,8 @@
         position: absolute;
         top: 10px;
         right: 10px;
-        font-size: 29px;
-        line-height: 29px;
+        font-size: 1.8125rem;
+        line-height: 1.8125rem;
         cursor: pointer;
         color: @ffe-blue-royal;
 

--- a/src/styles/examples/motion.less
+++ b/src/styles/examples/motion.less
@@ -86,8 +86,8 @@
         display: block;
         position: absolute;
         text-align: center;
-        line-height: 50px;
-        font-size: 40px;
+        line-height: 3.125rem;
+        font-size: 2.5rem;
         top: 50%;
         left: 50%;
         transform: translate(-50%, -50%) rotate(-90deg);


### PR DESCRIPTION
## Beskrivelse
Denne fiksen setter en default font-size på html elementet, og endrer alle andre font-size og line-height verdier i designsystemet til rem. Det skal ikke være noen visuelle endringer. 

## Motivasjon og kontekst
Noen brukere hadde problemer med å forstørre teksten på iOS.
Vi ønsker at brukere skal selv kunne forstørre innholdet så mye de selv ønsker.

## Testing
Kjørte npm start, og sammenlignet localhost versjonen (med endringene) med live versjonen design.sparebank1.no
Så ingen visuelle endringer på komponentene. 

