### PR TITLE
fix(ffe-context-message-react): replace header tag

### DIFF
--- a/packages/ffe-context-message-react/src/ContextMessage.js
+++ b/packages/ffe-context-message-react/src/ContextMessage.js
@@ -66,8 +66,9 @@ export default class ContextMessage extends Component {
             compact,
             contentElementId,
             className,
-            header,
+            headerText,
             headerElementId,
+            headerElement,
             icon,
             locale,
             messageType,
@@ -83,7 +84,7 @@ export default class ContextMessage extends Component {
         return (
             <div
                 aria-describedby={contentElementId}
-                aria-labelledby={header && headerElementId}
+                aria-labelledby={headerText && headerElementId}
                 className={classNames(
                     'ffe-context-message',
                     `ffe-context-message--${messageType}`,
@@ -102,14 +103,16 @@ export default class ContextMessage extends Component {
                 <div className="ffe-context-message-content">
                     {icon && this.renderIcon()}
                     <div>
-                        {header && (
-                            <header
-                                className="ffe-context-message-content__header"
-                                id={headerElementId}
-                            >
-                                {header}
-                            </header>
-                        )}
+                        {headerText &&
+                            React.createElement(
+                                headerElement,
+                                {
+                                    id: headerElementId,
+                                    className:
+                                        'ffe-context-message-content__header',
+                                },
+                                headerText,
+                            )}
                         <div className="ffe-body-text" id={contentElementId}>
                             {children}
                         </div>
@@ -119,7 +122,7 @@ export default class ContextMessage extends Component {
                     <button
                         aria-label={`${
                             texts[locale].FFE_CONTEXT_MESSAGE_CLOSE
-                        } ${header || ''}`}
+                        } ${headerText || ''}`}
                         className="ffe-context-message-content__close-button"
                         onClick={this.close}
                         type="button"
@@ -145,9 +148,11 @@ ContextMessage.propTypes = {
     compact: bool,
     /** ID for the children container */
     contentElementId: string,
-    header: string,
+    headerText: string,
     /** ID for the header container */
     headerElementId: string,
+    /* HTML element for the header */
+    headerElement: string,
     icon: element,
     /** Decides the language of the aria-label for the close icon */
     locale: oneOf(acceptedLocales),
@@ -165,6 +170,7 @@ ContextMessage.defaultProps = {
     compact: false,
     contentElementId: 'contentElementId',
     headerElementId: 'headerElementId',
+    headerElement: 'div',
     locale: 'nb',
     onClose: () => {},
     showCloseButton: false,

--- a/packages/ffe-context-message-react/src/ContextMessage.spec.js
+++ b/packages/ffe-context-message-react/src/ContextMessage.spec.js
@@ -31,20 +31,31 @@ describe('<ContextMessage />', () => {
     });
 
     it('renders with provided header', () => {
-        const header = 'header';
         const wrapper = getMountedWrapper({
-            header,
+            headerText: 'header text',
         });
-        const headerComponent = wrapper.find('header');
+        const headerComponent = wrapper.find(
+            '.ffe-context-message-content__header',
+        );
         expect(headerComponent.exists()).toBe(true);
-        expect(headerComponent.text()).toBe(header);
+        expect(headerComponent.text()).toBe('header text');
+        expect(headerComponent.type()).toBe('div');
+    });
+
+    it('renders with provided header as given tag', () => {
+        const wrapper = getMountedWrapper({
+            headerText: 'header text',
+            headerElement: 'h5',
+        });
+        const headerComponent = wrapper.find(
+            '.ffe-context-message-content__header',
+        );
+        expect(headerComponent.type()).toBe('h5');
     });
 
     it('renders without header', () => {
         const wrapper = getMountedWrapper();
-        const header = wrapper
-            .find('.ffe-context-message-content')
-            .find('header');
+        const header = wrapper.find('.ffe-context-message-content__header');
         expect(header.exists()).toBe(false);
     });
 

--- a/packages/ffe-context-message-react/src/index.d.ts
+++ b/packages/ffe-context-message-react/src/index.d.ts
@@ -7,8 +7,9 @@ export interface ContextMessageProps
     className?: string;
     compact?: boolean;
     contentElementId?: string;
-    header?: string;
+    headerText?: string;
     headerElementId?: string;
+    headerElement?: string;
     icon?: React.ReactNode;
     locale?: 'nb' | 'nn' | 'en';
     onClose?: (event: React.MouseEvent) => void;


### PR DESCRIPTION
## Beskrivelse
Denne fiksen legger til en ny prop som heter headerHTMLElement, som lar deg bestemme hvilket html-element 
tittelen i context-message skal være.  Hvis ingenting er satt, vil den generere en div. Klassen og id er som før, så det skal ikke være noen visuelle endringer. 
 
Tidligere ble det alltid generert en <header> tag, men dette er ikke semantisk riktig i denne konteksten. Siden denne komponenten kan brukes ulike steder i hierarkiet, så ga det ikke mening å hardkode ett heading nivå, da dette også fort kunne bli feil. 

## Motivasjon og kontekst
Riktig HTML-syntaks og struktur er viktig for Universell Utforming, da det kan påvirke hvilken rekkefølge skjermlesere leser innholdet. Det er ikke semantisk riktig å bruke headere, inne i en div på måten det har blitt hittil. 

## Testing
Kjørt npm start og sjekket endringen opp mot localhost, ved å inspekte koden etter å ha gjort endringer i "kode demoen" 
(view code, delen der man kan endre kode). La til den nye propertyen, og testet at html elementet endret seg og defaultet til div. 
