### PR TITLE
fix(ffe-account-selector-react): fix typo in .d.ts file

### DIFF
--- a/packages/ffe-account-selector-react/src/index.d.ts
+++ b/packages/ffe-account-selector-react/src/index.d.ts
@@ -18,7 +18,7 @@ export interface AccountSelectorProps {
     selectedAccount?: Account;
     showBalance?: boolean;
     value: string;
-    readonly?: boolean;
+    readOnly?: boolean;
     highCapacity?: boolean;
 }
 
@@ -70,7 +70,7 @@ export interface BaseSelectorProps {
     suggestionsHeightMax?: number;
     id?: string;
     name?: string;
-    readonly?: boolean;
+    readOnly?: boolean;
     highCapacity?: boolean;
 }
 


### PR DESCRIPTION
# Fiks skrivefeil i TS-interface for ffe-account-selector-react

## Beskrivelse

Endringen retter `readonly` til `readOnly` i `AccountSelectorProps` og `BaseSelectorProps`.

## Motivasjon og kontekst

Feilen fører i dag til at TypeScript-kode ikke kompilerer, jeg må bruke `// @ts-ignore` for å komme forbi.

## Testing

Jeg har kjørt `npm test`, men ikke gjort noe videre testing.  Tar imot tilbakemeldinger om noe mer må gjøres. Jeg kjenner ikke kodebasen, men følger opp diskusjon fra `#support-team-frontend` på Slack.