### PR TITLE
Setter korrekt type på onError-propsen til Datepicker

### DIFF
--- a/packages/ffe-datepicker-react/src/datepicker/Datepicker.js
+++ b/packages/ffe-datepicker-react/src/datepicker/Datepicker.js
@@ -426,6 +426,6 @@ Datepicker.propTypes = {
     onChange: func.isRequired,
     onError: func,
     value: string.isRequired,
-    keepDisplayStateOnError: bool.isRequired,
+    keepDisplayStateOnError: bool,
     fullWidth: bool,
 };

--- a/packages/ffe-datepicker-react/src/index.d.ts
+++ b/packages/ffe-datepicker-react/src/index.d.ts
@@ -24,7 +24,7 @@ export interface DatepickerProps {
     onChange: (value: string) => void;
     onError?: (type: DatePickerErrorType, errorText: string) => void;
     value: string;
-    keepDisplayStateOnError: boolean;
+    keepDisplayStateOnError?: boolean;
     fullWidth?: boolean;
 }
 

--- a/packages/ffe-datepicker-react/src/index.d.ts
+++ b/packages/ffe-datepicker-react/src/index.d.ts
@@ -4,6 +4,12 @@ export type InputProps = React.InputHTMLAttributes<HTMLInputElement>;
 
 type AriaInvalid = boolean | 'false' | 'true' | 'grammar' | 'spelling';
 
+export type DatePickerErrorType =
+    | 'INVALID_DATE_FORMAT'
+    | 'INVALID_DATE'
+    | 'MAX_DATE'
+    | 'MIN_DATE';
+
 export interface DatepickerProps {
     'aria-invalid'?: AriaInvalid;
     ariaInvalid?: AriaInvalid;
@@ -16,7 +22,7 @@ export interface DatepickerProps {
     maxDate?: string;
     minDate?: string;
     onChange: (value: string) => void;
-    onError?: (event: React.SyntheticEvent<HTMLInputElement, Event>) => void;
+    onError?: (type: DatePickerErrorType, errorText: string) => void;
     value: string;
     keepDisplayStateOnError: boolean;
     fullWidth?: boolean;


### PR DESCRIPTION
## Beskrivelse

Closing #973 
Setter også propen `keepDisplayStateOnError` til optional da den er satt opp med default-verdi. 
