### PR TITLE
fix(ffe-core): some variables where ignored due to comments

### DIFF
--- a/packages/ffe-core/bin/build.js
+++ b/packages/ffe-core/bin/build.js
@@ -24,7 +24,10 @@ FILES_WITH_VARIABLES.forEach(filename => {
         .map(line => line.trim())
         .filter(line => line.startsWith('@') && !line.startsWith('@import'))
         .map(line => line.split(': '))
-        .filter(([, value]) => !value.includes('@'))
+        .filter(([, value]) => {
+            const [valueBeforeComment] = value.split(/\/\//);
+            return !valueBeforeComment.includes('@');
+        })
         .map(([key, value]) => [key.replace('@ffe-', ''), value])
         .map(([key, value]) => [key.replace('@', ''), value])
         .reduce(


### PR DESCRIPTION
Noen variabler feks 

```
// Beige
@ffe-sand: #f8f5eb; // @ffe-sand + @ffe-sand-25
```

Ble ikke med som js variable pga av att kommentaren inneholder `@`. Den filtreringen er vell for og filtrera vell variabler som er definert med andra variabler. 