### PR TITLE
feat(ffe-context-message-react): remove heading and content id

### DIFF
--- a/packages/ffe-context-message-react/package.json
+++ b/packages/ffe-context-message-react/package.json
@@ -35,7 +35,8 @@
   "dependencies": {
     "@sb1/ffe-icons-react": "^7.2.16",
     "classnames": "^2.2.5",
-    "prop-types": "^15.6.0"
+    "prop-types": "^15.6.0",
+    "uuid": "^8.0.0"
   },
   "devDependencies": {
     "enzyme": "^3.7.0",

--- a/packages/ffe-context-message-react/src/ContextErrorMessage.js
+++ b/packages/ffe-context-message-react/src/ContextErrorMessage.js
@@ -54,8 +54,6 @@ ContextErrorMessage.propTypes = {
 ContextErrorMessage.defaultProps = {
     animationLengthMs: 300,
     compact: false,
-    contentElementId: 'contentElementId',
-    headerElementId: 'headerElementId',
     locale: 'nb',
     onClose: () => {},
     showCloseButton: false,

--- a/packages/ffe-context-message-react/src/ContextMessage.spec.js
+++ b/packages/ffe-context-message-react/src/ContextMessage.spec.js
@@ -149,10 +149,7 @@ describe('<ContextMessage />', () => {
     });
 
     it('does not have aria-labelledby when header was not specified', () => {
-        const wrapper = getMountedWrapper({
-            headerElementId: 'header-element-id',
-        });
-
+        const wrapper = getMountedWrapper();
         const message = wrapper.find('.ffe-context-message');
         expect(message.prop('aria-labelledby')).toBe(undefined);
     });


### PR DESCRIPTION
Synes ikke man skall behøve tenkte på og sende med headingElementId og contentElementId. Vad om man feks har en Info og en Error på siden og glømmer og sende med id. Da vill man få flere elementer med samme id. Vet ikke om det er riktig måte og bruke komponenten på men men? 


