### PR TITLE
feat(ffe-accordion-react): Add isOpen as new prop on items resolves #984

### DIFF
--- a/packages/ffe-accordion-react/src/Accordion.md
+++ b/packages/ffe-accordion-react/src/Accordion.md
@@ -25,3 +25,51 @@ const { Accordion, AccordionItem } = require('.');
     </AccordionItem>
 </Accordion>;
 ```
+
+Alle `<AccordionItem />`-komponenter har innebygget funksjonalitet for å styre åpning og lukking. Men om ønskelig kan du også overstyre dette. Et
+bruksområde kan være å lage en komponent som kun kan ha 1. element åpent om gangen.
+
+Bruker man `isOpen`-propen vil intern-logikk som styrer åpning og lukking være skrudd av.
+
+```js
+const { useState } = require('react');
+const { Accordion, AccordionItem } = require('.');
+
+const ManagedAccordion = () => {
+    const [openElementId, setOpenElementId] = useState(0);
+
+    const createOnToggleOpenHandler = id => isOpen => {
+        if (isOpen) {
+            setOpenElementId(id);
+        }
+    };
+
+    return (
+        <Accordion headingLevel={3}>
+            <AccordionItem
+                isOpen={openElementId === 0}
+                onToggleOpen={createOnToggleOpenHandler(0)}
+                heading="Starter åpen"
+            >
+                Element med ID=0
+            </AccordionItem>
+            <AccordionItem
+                isOpen={openElementId === 1}
+                onToggleOpen={createOnToggleOpenHandler(1)}
+                heading="Starter lukket"
+            >
+                Element med ID=1
+            </AccordionItem>
+            <AccordionItem
+                isOpen={openElementId === 2}
+                onToggleOpen={createOnToggleOpenHandler(2)}
+                heading="Starter også lukket"
+            >
+                Element med ID=2
+            </AccordionItem>
+        </Accordion>
+    );
+};
+
+<ManagedAccordion />;
+```

--- a/packages/ffe-accordion-react/src/AccordionItem.js
+++ b/packages/ffe-accordion-react/src/AccordionItem.js
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { bool, func, node, string } from 'prop-types';
 import { v4 as uuid } from 'uuid';
 import { ChevronIkon } from '@sb1/ffe-icons-react';
@@ -9,6 +9,7 @@ const AccordionItem = ({
     children,
     heading,
     defaultOpen,
+    isOpen,
     className,
     onToggleOpen = Function.prototype,
     ...accordionProps
@@ -17,6 +18,21 @@ const AccordionItem = ({
     const [isAnimating, setIsAnimating] = useState(false);
     const buttonId = useRef(uuid());
     const contentId = useRef(uuid());
+
+    useEffect(() => {
+        if (isOpen != null) {
+            setIsAnimating(true);
+            setIsExpanded(isOpen);
+        }
+    }, [isOpen]);
+
+    const handleOnClick = () => {
+        onToggleOpen(!isExpanded);
+        if (isOpen == null) {
+            setIsAnimating(true);
+            setIsExpanded(!isExpanded);
+        }
+    };
 
     const {
         headingLevel,
@@ -40,13 +56,7 @@ const AccordionItem = ({
                     className={classNames('ffe-accordion__heading-button', {
                         'ffe-accordion__heading-button--open': isExpanded,
                     })}
-                    onClick={() => {
-                        setIsAnimating(true);
-                        setIsExpanded(prevState => {
-                            onToggleOpen(!prevState);
-                            return !prevState;
-                        });
-                    }}
+                    onClick={handleOnClick}
                     onFocus={onFocus}
                     onBlur={onBlur}
                 >
@@ -77,6 +87,8 @@ AccordionItem.propTypes = {
     children: node.isRequired,
     /** Should it be open by default */
     defaultOpen: bool,
+    /** Is the item open or collapsed? Used for overriding default behaviour */
+    isOpen: bool,
     /** Class assigned the container */
     className: string,
     /** Callback when the item is open/closed */

--- a/packages/ffe-accordion-react/src/index.d.ts
+++ b/packages/ffe-accordion-react/src/index.d.ts
@@ -3,6 +3,7 @@ import * as React from 'react';
 export interface AccordionItemProps extends React.HTMLProps<HTMLDivElement> {
     heading: string | React.ReactElement;
     defaultOpen?: boolean;
+    isOpen?: boolean;
     onToggleOpen?: (isOpen: boolean) => void;
 }
 


### PR DESCRIPTION
## Beskrivelse

Denne pullrequesten legger til en nå optional-prop på `AccordionItem` som heter `isOpen`.
Om man sender inn denne propen vil den overstyre intern-oppførsel for å åpne/lukke en AccordionItem, og hele komponenten forventer at man tar ansvaret for om den er åpen eller lukket. Dette er veldig likt oppførsel på interne komponentet som f.eks. `value` på `<Input />`

Se gjerne issue #984

## Motivasjon og kontekst

Se #984

Men vi trenger å kunne overstyre om et `AccordionItem` er åpen eller lukkes. Dette var mulig i eldre versjoner av denne pakken men forsvant i en omskriving. Vi har laget en komponent som gjør at kun 1. AccordionItem er åpen om gangen, likt med eksempelet jeg la inn.

## Testing

Kjørter den opp lokalt og testet at Accordion oppførte seg som før. La også til et nytt eksempel med `ManagedAccordion` som viser hvordan man kan lage en komponent som styrer oppførselen (og lager en accordion hvor kun 1. element kan være åpent om gangen).

resolves #984
