### PR TITLE
Revert less-oppgraderingen

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
         "jest": "^23.4.2",
         "kss": "^3.0.0-beta.23",
         "lerna": "^3.0.1",
-        "less": "4.0.0",
+        "less": "^3.13.1",
         "less-loader": "^5.0.0",
         "less-plugin-autoprefix": "^2.0.0",
         "less-plugin-clean-css": "^1.5.1",

--- a/packages/ffe-header/package.json
+++ b/packages/ffe-header/package.json
@@ -22,7 +22,7 @@
     "@sb1/ffe-buttons": "^10.0.0",
     "@sb1/ffe-core": "^17.0.0",
     "@sb1/ffe-webfonts": "^2.1.0",
-    "less": "^4.0.0",
+    "less": "^3.13.1",
     "less-plugin-autoprefix": "^2.0.0",
     "mkdirp": "^1.0.0",
     "stylelint": "^10.0.0"

--- a/packages/ffe-searchable-dropdown-react/package.json
+++ b/packages/ffe-searchable-dropdown-react/package.json
@@ -42,7 +42,7 @@
   "devDependencies": {
     "eslint": "^7.6.0",
     "jest": "^26.3.0",
-    "less": "^4.0.0",
+    "less": "^3.13.1",
     "npm-check": "^5.9.2",
     "react": "^16.9.0",
     "react-dom": "^16.9.0"


### PR DESCRIPTION
Oppgraderingen til less 4 ødela design.sparebank1.no. Denne PR ruller tilbake denne oppgraderingen. 