### PR TITLE
docs: fjerne footer og oppdatere referanser fra sketch til figma

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ designsystemet til å passe dine behov.
 
 ### Kom i gang
 
-Ta kontakt med faglederne (heidi.stolen@sparebank1.no eller siri.corneliussen@sparebank1.no), så hjelper de deg med tilgang til Verktøykassa til Sketch.
+Ta kontakt med faglederne (heidi.stolen@sparebank1.no eller siri.corneliussen@sparebank1.no), så hjelper de deg med tilgang til Verktøykassa til Figma.
 
 Verktøykassa blir oppdatert av faglederene ved endringer eller når nye ting legges til. Endringene annonseres enn så
 lenge via interne kanaler - spør fagleder, så blir du pekt i riktig retning for å få med deg disse beskjedene :+1:
@@ -32,7 +32,6 @@ Resten av denne READMEen hjelper deg med å komme i gang med utvikling på selve
 
 Klon ned repoet, og kjør `npm install`. Dette vil installere alle dependencies for alle pakker, så du kan begynne
 kjøre opp alt lokalt. Når denne kommandoen er ferdig, kan du kjøre følgende kommandoer fra rotpakken:
-
 
 ```bash
 npm start              # Starter en lokal server på localhost:6060
@@ -59,5 +58,5 @@ bidrag. Ta en titt på [CONTRIBUTING.md](CONTRIBUTING.md) for hvordan du går fr
 
 ## Licenses
 
-* Source code is licensed under MIT
-* The MuseoSans fonts are licensed separately. See LICENSE-fonts.md.
+-   Source code is licensed under MIT
+-   The MuseoSans fonts are licensed separately. See LICENSE-fonts.md.

--- a/src/templates/frontpage.hbs
+++ b/src/templates/frontpage.hbs
@@ -123,58 +123,6 @@
         </div>
     </main>
 
-    <footer class="sb1ds-footer">
-        <div class="ffe-grid">
-            <div class="ffe-grid__row">
-                <div class="ffe-grid__col ffe-grid__col--md-4 ffe-grid__col--md-offset-2 ffe-grid__col--sm-12">
-                    <div class="sb1ds-footer__link">
-                        <div>
-                            <div class="sb1ds-footer__logo">
-                                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 494 447">
-                                    <g fill="none" fill-rule="evenodd">
-                                        <path fill="#FFAE00" d="M247 447L0 160 107 15 247 0l140 15 107 145z" />
-                                        <path fill="#EC6C00" d="M247 447L0 160h494z" />
-                                        <path fill="#FFAE00" d="M247 447L100 160h294z" />
-                                        <path fill="#FFEFB4" d="M247 0L100 160h294z" />
-                                        <path fill="#FFAE00" d="M107 15L52 88 0 160h101zM387 15l55 73 52 72H393z" />
-                                        <path fill="#FED305" d="M107 15l-7 145L247 0zM387 15l7 145L247 0z" />
-                                    </g>
-                                </svg>
-                            </div>
-                        </div>
-                        <div class="sb1ds-footer__link-text">
-                            <h3 class="ffe-h5">
-                                <a class="ffe-link-text ffe-link-text--no-underline"
-                                    href="kom-i-gang.html#kom-i-gang_for-designere">Sketch UI Kit</a>
-                            </h3>
-                            <p class="ffe-body-text">Last ned den nyeste Sketch-malen for designere.</p>
-                        </div>
-                    </div>
-                </div>
-                <div class="ffe-grid__col ffe-grid__col--md-4 ffe-grid__col--sm-12">
-                    <div class="sb1ds-footer__link">
-                        <div>
-                            <div class="sb1ds-footer__logo">
-                                <svg xmlns="http://www.w3.org/2000/svg" style="isolation:isolate" viewBox="0 0 42 41"
-                                    class="sb1ds-footer__github-logo">
-                                    <path fill="#000000" fill-rule="evenodd"
-                                        d="M20.998.5C9.676.5.494 9.681.494 21.007c0 9.059 5.875 16.745 14.024 19.458 1.025.187 1.399-.446 1.399-.99 0-.487-.017-1.776-.027-3.487-5.704 1.239-6.908-2.749-6.908-2.749-.932-2.369-2.277-3-2.277-3-1.862-1.271.141-1.246.141-1.246 2.058.145 3.141 2.114 3.141 2.114 1.829 3.133 4.8 2.228 5.968 1.703.186-1.325.716-2.228 1.302-2.741-4.553-.518-9.341-2.277-9.341-10.135 0-2.239.799-4.068 2.111-5.502-.211-.519-.915-2.604.202-5.427 0 0 1.72-.552 5.638 2.101 1.635-.455 3.39-.681 5.134-.69 1.742.009 3.495.235 5.133.69 3.915-2.653 5.634-2.101 5.634-2.101 1.119 2.823.415 4.908.205 5.427 1.314 1.434 2.107 3.263 2.107 5.502 0 7.878-4.795 9.612-9.362 10.119.735.633 1.391 1.884 1.391 3.798 0 2.74-.025 4.952-.025 5.624 0 .549.37 1.188 1.41.987 8.142-2.717 14.012-10.398 14.012-19.455 0-2.88-.593-5.62-1.665-8.107C36.699 5.606 29.445.5 20.998.5" />
-                                </svg>
-                            </div>
-                        </div>
-                        <div class="sb1ds-footer__link-text">
-                            <h3 class="ffe-h5">
-                                <a class="ffe-link-text ffe-link-text--no-underline"
-                                    href="https://github.com/SpareBank1/designsystem">GitHub</a>
-                            </h3>
-                            <p class="ffe-body-text">Utforsk kildekoden og fremdriften i vårt GitHub-repository.</p>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </footer>
-
     <script src="/assets/sds.js"></script>
     <script src="/assets/darkmode-switch.js"></script>
 </body>

--- a/styleguide-content/kom-i-gang/for-designere.md
+++ b/styleguide-content/kom-i-gang/for-designere.md
@@ -1,3 +1,3 @@
-* Bli kjent med [merkevaren](stil-og-tone.html) og vår [visuelle identitet](visuell-identitet.html) for å lære FFEs design patterns og prinsipper.
-* Gå igjennom [komponentseksjonen](styleguidist/index.html) for å gjøre deg kjent med de eksisterende komponentene du kan implementere i designet ditt.
-* Vi vedlikeholder en verktøykasse med gjenbrukbare elementer i Sketch.
+-   Bli kjent med [merkevaren](stil-og-tone.html) og vår [visuelle identitet](visuell-identitet.html) for å lære FFEs design patterns og prinsipper.
+-   Gå igjennom [komponentseksjonen](styleguidist/index.html) for å gjøre deg kjent med de eksisterende komponentene du kan implementere i designet ditt.
+-   Vi vedlikeholder en verktøykasse med gjenbrukbare elementer i Figma.


### PR DESCRIPTION
## Beskrivelse
PR fjerner footeren fra forsiden, og endrer referanser til sketch verktøykassen til figma. 

## Motivasjon og kontekst
Vi bruker ikke sketch lenger. Footeren ble fjernet etter diskusjon med designerne og resten av frontend teamet.
Dette var litt fordi vi ikke nevner det noen andre steder, og det er en kjappere løsning nå som vi jobber med å flytte dokumentasjonen over til Gatsby.

## Testing
Ikke testet, da jeg ikke får kjørt opp forsiden. Det er også bare formuleringsendringer. 
