### PR TITLE
docs: remove duplicate wave link

### DIFF
--- a/styleguide-content/universell-utforming/verktoy.md
+++ b/styleguide-content/universell-utforming/verktoy.md
@@ -1,11 +1,10 @@
 Browser-plugins, validering og andre automatiske verktøy kan gi verdifull informasjon underveis i utviklingen.
 
 -   [Axe](https://www.deque.com/axe/)
--   [Wave](https://wave.webaim.org/)
+-   [WAVE Accessibility Evaluation Tool](https://wave.webaim.org/)
 -   [Accessibility insights](https://accessibilityinsights.io/)
 -   [Colour Contrast Check](https://snook.ca/technical/colour_contrast/colour.html#fg=33FF33,bg=333333)
 -   [Funkify](https://www.funkify.org/)
 -   [W3C Markup Validation](https://validator.w3.org/)
 -   [WAI valideringsverktøy](https://www.w3.org/WAI/ER/tools/)
 -   [Kontrastsjekk](https://webaim.org/resources/contrastchecker/)
--   [WAVE Accessibility Evaluation Tool](https://wave.webaim.org/)


### PR DESCRIPTION


## Beskrivelse
Det var to lenker til wave verktøyet. Fjernet en av de. 

## Motivasjon og kontekst
Viktig verktøy, men trenger ikke å bli nevnt to ganger

## Testing
Ikke testet, er bare fjerning av en linje. 
