### PR TITLE
Fix datpicker dependencies

### DIFF
--- a/packages/ffe-datepicker-react/src/input/Input.js
+++ b/packages/ffe-datepicker-react/src/input/Input.js
@@ -9,7 +9,10 @@ export default class Input extends Component {
     }
 
     inputClassNames(extraClassNames) {
-        return classNames('ffe-dateinput__field', extraClassNames);
+        return classNames(
+            'ffe-input-field ffe-dateinput__field',
+            extraClassNames,
+        );
     }
 
     render() {

--- a/packages/ffe-datepicker/less/dateinput.less
+++ b/packages/ffe-datepicker/less/dateinput.less
@@ -1,5 +1,3 @@
-@import (reference) '../node_modules/@sb1/ffe-form/less/input-field';
-
 .ffe-dateinput {
     position: relative;
     display: inline-block;
@@ -18,8 +16,6 @@
     }
 
     &__field {
-        .ffe-input-field();
-
         min-width: 160px;
         &::-ms-clear {
             display: none;


### PR DESCRIPTION
Fix av `import` i `dateinput.less` fila

## Beskrivelse

@import (reference) '../node_modules/@sb1/ffe-form/less/input-field' skapte problemer når ffe-datepicker ble brukt andre steder. Dette siden node_modules ikke nødvendigvis bor på den pathen som var forventet. Stylingen som ble hentet fra `ffe-input-field` ble ikke modifisert på noe vis så fant det like greit å bruke klassen direkte i `Input.js`

## Motivasjon og kontekst

Fikse en bug som oppsto når pakken ble importert fra andre

## Testing

Har testet at input feltet oppfører seg likt som før endringen
