### PR TITLE
fix(ffe-datepicker-react): chrashes without language

### DIFF
--- a/packages/ffe-datepicker-react/src/index.d.ts
+++ b/packages/ffe-datepicker-react/src/index.d.ts
@@ -18,7 +18,7 @@ export interface DatepickerProps {
     onValidationComplete?: Function;
     inputProps?: InputProps;
     label?: string;
-    language?: string;
+    language?: 'nb' | 'en' | 'nn';
     maxDate?: string;
     minDate?: string;
     onChange: (value: string) => void;

--- a/packages/ffe-datepicker-react/src/input/Input.js
+++ b/packages/ffe-datepicker-react/src/input/Input.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { bool, func, oneOfType, string, shape } from 'prop-types';
+import { bool, func, oneOfType, string, shape, oneOf } from 'prop-types';
 import classNames from 'classnames';
 import i18n from '../i18n/i18n';
 
@@ -20,7 +20,7 @@ export default class Input extends Component {
             onChange,
             onKeyDown,
             value,
-            language,
+            language = 'nb',
         } = this.props;
 
         return (
@@ -53,5 +53,5 @@ Input.propTypes = {
     onKeyDown: func,
     value: string.isRequired,
     fullWidth: bool,
-    language: string,
+    language: oneOf(['nb', 'nn', 'en']),
 };


### PR DESCRIPTION
Denne krasher hvis man ikke sender med språk. Språk har tidligare vart frivillig. Kan ju gjøres required men da blir det vell enda en breaking change. Vad er ønsklig?


Denne linjer tryner
```
                aria-placeholder={i18n[language].DATE_FORMAT}
```