### PR TITLE
Oppgradere til less 4, ny forsøk

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
         "jest": "^23.4.2",
         "kss": "^3.0.0-beta.23",
         "lerna": "^3.0.1",
-        "less": "^3.13.1",
+        "less": "^4.1.1",
         "less-loader": "^5.0.0",
         "less-plugin-autoprefix": "^2.0.0",
         "less-plugin-clean-css": "^1.5.1",

--- a/packages/ffe-grid/less/ffe-grid.less
+++ b/packages/ffe-grid/less/ffe-grid.less
@@ -121,8 +121,8 @@
 // Mixins
 .create-column(@size, @total, @current: 0) when (@current <= @total) {
     .ffe-grid__col--@{size}-@{current} {
-        flex-basis: (@current * 100%) / @total;
-        max-width: (@current * 100%) / @total;
+        flex-basis: ((@current * 100%) / @total);
+        max-width: ((@current * 100%) / @total);
 
         & when (@current = 0) {
             display: none;
@@ -133,7 +133,7 @@
     }
 
     .ffe-grid__col--@{size}-offset-@{current} {
-        margin-left: (@current * 100%) / @total;
+        margin-left: ((@current * 100%) / @total);
     }
 
     .create-column(@size, @total, @current + 1);
@@ -173,8 +173,8 @@
     width: 100%;
 
     @media (min-width: @breakpoint-lg) {
-        margin-left: @ffe-grid-gutter-lg / 2 * -1;
-        margin-right: @ffe-grid-gutter-lg / 2 * -1;
+        margin-left: (@ffe-grid-gutter-lg / 2 * -1);
+        margin-right: (@ffe-grid-gutter-lg / 2 * -1);
     }
 
     &--bg-blue-ice {

--- a/packages/ffe-header/package.json
+++ b/packages/ffe-header/package.json
@@ -22,7 +22,7 @@
     "@sb1/ffe-buttons": "^10.0.0",
     "@sb1/ffe-core": "^17.0.0",
     "@sb1/ffe-webfonts": "^2.1.0",
-    "less": "^3.13.1",
+    "less": "^4.1.1",
     "less-plugin-autoprefix": "^2.0.0",
     "mkdirp": "^1.0.0",
     "stylelint": "^10.0.0"

--- a/packages/ffe-searchable-dropdown-react/package.json
+++ b/packages/ffe-searchable-dropdown-react/package.json
@@ -42,7 +42,6 @@
   "devDependencies": {
     "eslint": "^7.6.0",
     "jest": "^26.3.0",
-    "less": "^3.13.1",
     "npm-check": "^5.9.2",
     "react": "^16.9.0",
     "react-dom": "^16.9.0"


### PR DESCRIPTION
Denne PR oppgraderer til less 4 -- både den less-kompilator og less-syntaksen i ett tilfelle der det var behov (6ab32ad10d35936555c6d23d7a694a0a252c26ed).

Pga. nye [defaults i less rundt `math`](http://lesscss.org/usage/#less-options-math) må man nå ha parentes rundt divisjoner, som vi da ikke hadde i _ffe-grid_. 

Jeg testet det gjennom å transpilere `packages/ffe-all.less` med less v3 og v4, og kjøre en diff på resultatene.

Relatert til #987 og #988