### PR TITLE
Rydde i hoisted dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
         "less-plugin-clean-css": "^1.5.1",
         "marked": "^1.1.1",
         "mini-css-extract-plugin": "^0.6.0",
-        "mkdirp": "^0.5.1",
+        "mkdirp": "^1.0.0",
         "npm-run-all": "^4.1.2",
         "postcss-loader": "^2.1.6",
         "prettier": "^1.15.2",

--- a/packages/ffe-checkbox-react/package.json
+++ b/packages/ffe-checkbox-react/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "classnames": "^2.2.5",
     "prop-types": "^15.6.0",
-    "uuid": "^7.0.0"
+    "uuid": "^8.0.0"
   },
   "devDependencies": {
     "enzyme": "^3.7.0",

--- a/packages/ffe-radio-button-react/package.json
+++ b/packages/ffe-radio-button-react/package.json
@@ -24,7 +24,7 @@
     "@sb1/ffe-form-react": "^7.2.2",
     "classnames": "^2.2.5",
     "prop-types": "^15.6.0",
-    "uuid": "^7.0.0"
+    "uuid": "^8.0.0"
   },
   "devDependencies": {
     "jest": "^24.0.0",

--- a/packages/ffe-sb1-logos/package.json
+++ b/packages/ffe-sb1-logos/package.json
@@ -20,6 +20,6 @@
     "access": "public"
   },
   "devDependencies": {
-    "handlebars": "^4.0.12"
+    "handlebars": "^4.7.0"
   }
 }

--- a/packages/ffe-searchable-dropdown-react/package.json
+++ b/packages/ffe-searchable-dropdown-react/package.json
@@ -40,8 +40,8 @@
     "react-proptype-conditional-require": "^1.0.4"
   },
   "devDependencies": {
-    "eslint": "^7.6.0",
-    "jest": "^26.3.0",
+    "eslint": "^5.9.0",
+    "jest": "^26.0.0",
     "npm-check": "^5.9.2",
     "react": "^16.9.0",
     "react-dom": "^16.9.0"


### PR DESCRIPTION
Lerna "hoister"  avhengigheter, dvs. hvis to eller flere pakke avhenger til en ekstern npm-pakke i samme versjon så installerer lerna denne avhengigheten slik at den kan gjenbrukes. Denne PR-en tilpasser noe versjonsnummer og gjør da at disse pakkene kan "hoistet".