### PR TITLE
fix(ffe-form-react): onclick on tooltip should be optional

### DIFF
--- a/packages/ffe-form-react/src/index.d.ts
+++ b/packages/ffe-form-react/src/index.d.ts
@@ -70,7 +70,7 @@ export interface TooltipProps extends React.HTMLAttributes<HTMLSpanElement> {
     children?: React.ReactNode;
     className?: string;
     isOpen?: boolean;
-    onClick: (e: React.MouseEvent | undefined) => void;
+    onClick?: (e: React.MouseEvent | undefined) => void;
     tabIndex?: number;
     dark?: boolean;
 }


### PR DESCRIPTION
Denne er ikke påkrevd i komponenten.

```
onToggle(evt) {
    this.setState(prevState => ({ isOpen: !prevState.isOpen }));
    if (this.props.onClick) {
        this.props.onClick(evt);
    }
}
```
PropTypes:
```
  /** Optional listener for clicks on the tooltip button. Is passed the event object. */
    onClick: func,
```