### PR TITLE
fix(ffe-datepicker-react): fix type on button

### DIFF
--- a/packages/ffe-datepicker-react/src/button/Button.js
+++ b/packages/ffe-datepicker-react/src/button/Button.js
@@ -17,6 +17,7 @@ export default class Button extends Component {
                 onClick={onClick}
                 className="ffe-datepicker__button"
                 aria-label={buttonLabel}
+                type="button"
             >
                 <KalenderIkon className="ffe-datepicker__icon" />
             </button>

--- a/packages/ffe-datepicker-react/src/calendar/ClickableDate.js
+++ b/packages/ffe-datepicker-react/src/calendar/ClickableDate.js
@@ -86,7 +86,7 @@ ClickableDate.propTypes = {
         isToday: bool,
     }).isRequired,
     month: string.isRequired,
-    year: string.isRequired,
+    year: number.isRequired,
     headers: string.isRequired,
     onClick: func.isRequired,
     language: string.isRequired,


### PR DESCRIPTION
Fikse slik at kalenderknappen ikke blir tolket som form-submit, og fjerne støy i konsollet

## Beskrivelse

Lagt til type="button" på kalender knappen til datepicker siden `<form>` tolker button uten `type="button"` som form submit knapp
Lagt til toString på år-parametre siden ClickableDate forventer at dette parametre er en streng og ikke nummer, dette skapte litt støy i konsollet

## Testing

Testet lokalt og lokalt på pm-betaling
