### PR TITLE
fix(ffe-collapse-react): fix ts

### DIFF
--- a/packages/ffe-collapse-react/src/index.d.ts
+++ b/packages/ffe-collapse-react/src/index.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-interface CollapseProps extends React.HTMLProps<HTMLDivElement> {
+export interface CollapseProps extends React.HTMLProps<HTMLDivElement> {
     isOpen: boolean;
     onRest?: () => void;
 }


### PR DESCRIPTION
Nå ær den helt lik index.d.ts i Accordion
```
ERROR in src/features/min-pensjon/aksept-norsk-pensjon/AkseptText.tsx:32:18
TS2604: JSX element type 'Collapse' does not have any construct or call signatures.
    30 |                     {txt('AkseptText.expandButton')}
    31 |                 </InlineExpandButton>
  > 32 |                 <Collapse id={collapseId.current} isOpen={isExpanded}>
       |                  ^^^^^^^^
    33 |                     <Paragraph>{txt('AkseptText.part2')}</Paragraph>
    34 |                     <Paragraph>
    35 |                         <LesOmPersonOpplysningerLink />

```