### PR TITLE
fix(ffe-form-react): Add role="status" to expanded content in Tooltip

### DIFF
--- a/packages/ffe-form-react/src/Tooltip.js
+++ b/packages/ffe-form-react/src/Tooltip.js
@@ -70,6 +70,7 @@ class Tooltip extends React.Component {
                                 { 'ffe-small-text--dark': dark },
                                 className,
                             )}
+                            role="status"
                         >
                             {children}
                         </div>


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse
Når brukeren trykker på knappen i tooltip, og informasjonen dukker opp, så vil skjermleser automatisk lese opp teksten

<!-- Detaljert beskrivelse av endringene dine. Skjermskudd er lov. -->

## Motivasjon og kontekst
Ved å legge det til i designsystemet, slipper folk rundt på teamene og legge til dette selv hver gang de tar i bruk Tooltip

<!-- Hvorfor trengs denne endringen, og hva løser den? -->

## Testing

<!-- Hvordan har du har testet endringene dine? Ta gjerne med systeminfo o.l -->
Har ikke fått testet på akkurat denne branchen. Vet ikke helt hvordan jeg skal få testet selv når jeg ikke har skjermleser på maskina mi. Men har testet i pm-betaling når vi har tatt i bruk role="status", og det har funket fint der. Dersom noen av dere har mulighet til å teste med skjermleser hadde det vært supert.

<!--

Helt til slutt, har du ..

.. lest retningslinjene våre for bidrag?
.. tatt en siste sjekk for kode og skrivefeil, debug informasjon o.l?
.. kjørt og eventuelt oppdatert testene?
.. kommentert og dokumentert det som trengs?
.. knyttet denne opp til relaterte issues?

-->
