### PR TITLE
fix(ffe-webfonts): fjerner fonter som ikke skal brukes

### DIFF
--- a/packages/ffe-webfonts/sb1-fonts-inline.less
+++ b/packages/ffe-webfonts/sb1-fonts-inline.less
@@ -1,66 +1,10 @@
 @fonts-url: './fonts';
 
 @font-face {
-    font-family: 'SpareBank1-black';
-    font-display: fallback;
-    src: data-uri('@{fonts-url}/SpareBank1-Black-Web.woff2') format('woff2'),
-        data-uri('@{fonts-url}/SpareBank1-Black-Web.woff') format('woff');
-}
-
-@font-face {
-    font-family: 'SpareBank1-black-italic';
-    font-display: fallback;
-    src: data-uri('@{fonts-url}/SpareBank1-BlackIt-Web.woff2') format('woff2'),
-        data-uri('@{fonts-url}/SpareBank1-BlackIt-Web.woff') format('woff');
-}
-
-@font-face {
-    font-family: 'SpareBank1-bold';
-    font-display: fallback;
-    src: data-uri('@{fonts-url}/SpareBank1-Bold-Web.woff2') format('woff2'),
-        data-uri('@{fonts-url}/SpareBank1-Bold-Web.woff') format('woff');
-}
-
-@font-face {
-    font-family: 'SpareBank1-bold-italic';
-    font-display: fallback;
-    src: data-uri('@{fonts-url}/SpareBank1-BoldIt-Web.woff2') format('woff2'),
-        data-uri('@{fonts-url}/SpareBank1-BoldIt-Web.woff') format('woff');
-}
-
-@font-face {
-    font-family: 'SpareBank1-italic';
-    font-display: fallback;
-    src: data-uri('@{fonts-url}/SpareBank1-It-Web.woff2') format('woff2'),
-        data-uri('@{fonts-url}/SpareBank1-It-Web.woff') format('woff');
-}
-
-@font-face {
-    font-family: 'SpareBank1-light';
-    font-display: fallback;
-    src: data-uri('@{fonts-url}/SpareBank1-Light-Web.woff2') format('woff2'),
-        data-uri('@{fonts-url}/SpareBank1-Light-Web.woff') format('woff');
-}
-
-@font-face {
-    font-family: 'SpareBank1-light-italic';
-    font-display: fallback;
-    src: data-uri('@{fonts-url}/SpareBank1-LightIt-Web.woff2') format('woff2'),
-        data-uri('@{fonts-url}/SpareBank1-LightIt-Web.woff') format('woff');
-}
-
-@font-face {
     font-family: 'SpareBank1-medium';
     font-display: fallback;
     src: data-uri('@{fonts-url}/SpareBank1-Medium-Web.woff2') format('woff2'),
         data-uri('@{fonts-url}/SpareBank1-Medium-Web.woff') format('woff');
-}
-
-@font-face {
-    font-family: 'SpareBank1-medium-italic';
-    font-display: fallback;
-    src: data-uri('@{fonts-url}/SpareBank1-MediumIt-Web.woff2') format('woff2'),
-        data-uri('@{fonts-url}/SpareBank1-MediumIt-Web.woff') format('woff');
 }
 
 @font-face {
@@ -71,26 +15,9 @@
 }
 
 @font-face {
-    font-family: 'SpareBank1-title-light';
-    font-display: fallback;
-    src: data-uri('@{fonts-url}/SpareBank1-Title-Light-Web.woff2')
-            format('woff2'),
-        data-uri('@{fonts-url}/SpareBank1-Title-Light-Web.woff') format('woff');
-}
-
-@font-face {
     font-family: 'SpareBank1-title-medium';
     font-display: fallback;
     src: data-uri('@{fonts-url}/SpareBank1-Title-Medium-Web.woff2')
             format('woff2'),
         data-uri('@{fonts-url}/SpareBank1-Title-Medium-Web.woff') format('woff');
-}
-
-@font-face {
-    font-family: 'SpareBank1-title-regular';
-    font-display: fallback;
-    src: data-uri('@{fonts-url}/SpareBank1-Title-Regular-Web.woff2')
-            format('woff2'),
-        data-uri('@{fonts-url}/SpareBank1-Title-Regular-Web.woff')
-            format('woff');
 }

--- a/packages/ffe-webfonts/sb1-fonts.less
+++ b/packages/ffe-webfonts/sb1-fonts.less
@@ -1,66 +1,10 @@
 @fonts-url: './fonts';
 
 @font-face {
-    font-family: 'SpareBank1-black';
-    font-display: fallback;
-    src: url('@{fonts-url}/SpareBank1-Black-Web.woff2') format('woff2'),
-        url('@{fonts-url}/SpareBank1-Black-Web.woff') format('woff');
-}
-
-@font-face {
-    font-family: 'SpareBank1-black-italic';
-    font-display: fallback;
-    src: url('@{fonts-url}/SpareBank1-BlackIt-Web.woff2') format('woff2'),
-        url('@{fonts-url}/SpareBank1-BlackIt-Web.woff') format('woff');
-}
-
-@font-face {
-    font-family: 'SpareBank1-bold';
-    font-display: fallback;
-    src: url('@{fonts-url}/SpareBank1-Bold-Web.woff2') format('woff2'),
-        url('@{fonts-url}/SpareBank1-Bold-Web.woff') format('woff');
-}
-
-@font-face {
-    font-family: 'SpareBank1-bold-italic';
-    font-display: fallback;
-    src: url('@{fonts-url}/SpareBank1-BoldIt-Web.woff2') format('woff2'),
-        url('@{fonts-url}/SpareBank1-BoldIt-Web.woff') format('woff');
-}
-
-@font-face {
-    font-family: 'SpareBank1-italic';
-    font-display: fallback;
-    src: url('@{fonts-url}/SpareBank1-It-Web.woff2') format('woff2'),
-        url('@{fonts-url}/SpareBank1-It-Web.woff') format('woff');
-}
-
-@font-face {
-    font-family: 'SpareBank1-light';
-    font-display: fallback;
-    src: url('@{fonts-url}/SpareBank1-Light-Web.woff2') format('woff2'),
-        url('@{fonts-url}/SpareBank1-Light-Web.woff') format('woff');
-}
-
-@font-face {
-    font-family: 'SpareBank1-light-italic';
-    font-display: fallback;
-    src: url('@{fonts-url}/SpareBank1-LightIt-Web.woff2') format('woff2'),
-        url('@{fonts-url}/SpareBank1-LightIt-Web.woff') format('woff');
-}
-
-@font-face {
     font-family: 'SpareBank1-medium';
     font-display: fallback;
     src: url('@{fonts-url}/SpareBank1-Medium-Web.woff2') format('woff2'),
         url('@{fonts-url}/SpareBank1-Medium-Web.woff') format('woff');
-}
-
-@font-face {
-    font-family: 'SpareBank1-medium-italic';
-    font-display: fallback;
-    src: url('@{fonts-url}/SpareBank1-MediumIt-Web.woff2') format('woff2'),
-        url('@{fonts-url}/SpareBank1-MediumIt-Web.woff') format('woff');
 }
 
 @font-face {
@@ -71,22 +15,8 @@
 }
 
 @font-face {
-    font-family: 'SpareBank1-title-light';
-    font-display: fallback;
-    src: url('@{fonts-url}/SpareBank1-Title-Light-Web.woff2') format('woff2'),
-        url('@{fonts-url}/SpareBank1-Title-Light-Web.woff') format('woff');
-}
-
-@font-face {
     font-family: 'SpareBank1-title-medium';
     font-display: fallback;
     src: url('@{fonts-url}/SpareBank1-Title-Medium-Web.woff2') format('woff2'),
         url('@{fonts-url}/SpareBank1-Title-Medium-Web.woff') format('woff');
-}
-
-@font-face {
-    font-family: 'SpareBank1-title-regular';
-    font-display: fallback;
-    src: url('@{fonts-url}/SpareBank1-Title-Regular-Web.woff2') format('woff2'),
-        url('@{fonts-url}/SpareBank1-Title-Regular-Web.woff') format('woff');
 }


### PR DESCRIPTION
BREAKING: fjerner fonter som ikke skal brukes på web for å redusere filstørrelse og lastetid

<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse

Fjerner fonter som ikke skal brukes i appene våre

## Motivasjon og kontekst

Inkludering av alle fonter fører til unødvendig stor filstørrelse og dermed lengre lastetider
