### PR TITLE
fix(ffe-form-react): Only use role="status" when tooltip is expanded

### DIFF
--- a/packages/ffe-form-react/src/Tooltip.js
+++ b/packages/ffe-form-react/src/Tooltip.js
@@ -70,7 +70,7 @@ class Tooltip extends React.Component {
                                 { 'ffe-small-text--dark': dark },
                                 className,
                             )}
-                            role="status"
+                            role={isOpen ? 'status' : 'none'}
                         >
                             {children}
                         </div>


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

Ettersom innholdet som collapses skjules med en `visability: hidden` for å få til animering, så leses det opp av skjermleser med `role="status"` selv om det ikke er expanded. Vurderte å bruke `aria-labelledby` og `aria-hidden`, men da leses innholdet opp når man navigerer seg til knappen, ikke teksten knyttet til knappen, og det er vel ikke ønskelig.

<!-- Hvordan har du har testet endringene dine? Ta gjerne med systeminfo o.l -->
Har testet med skjermleser på android emulator
<!--

Helt til slutt, har du ..

.. lest retningslinjene våre for bidrag?
.. tatt en siste sjekk for kode og skrivefeil, debug informasjon o.l?
.. kjørt og eventuelt oppdatert testene?
.. kommentert og dokumentert det som trengs?
.. knyttet denne opp til relaterte issues?

-->
