### PR TITLE
Være mer fleksibel med peerDependencies

### DIFF
--- a/packages/ffe-accordion-react/package.json
+++ b/packages/ffe-accordion-react/package.json
@@ -43,8 +43,8 @@
     "react-dom": "^16.9.0"
   },
   "peerDependencies": {
-    "@sb1/ffe-accordion": "^5.0.3",
-    "react": "^16.9.0"
+    "@sb1/ffe-accordion": "*",
+    "react": ">=16.9.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ffe-accordion/package.json
+++ b/packages/ffe-accordion/package.json
@@ -22,7 +22,7 @@
     "@sb1/ffe-core": "^17.1.1"
   },
   "peerDependencies": {
-    "@sb1/ffe-core": "^15.2.0"
+    "@sb1/ffe-core": "*"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ffe-account-selector-react/package.json
+++ b/packages/ffe-account-selector-react/package.json
@@ -53,9 +53,9 @@
     "react-dom": "^16.9.0"
   },
   "peerDependencies": {
-    "@sb1/ffe-form": ">=11.0.1",
-    "@sb1/ffe-spinner": "^3.0.0",
-    "react": "^16.9.0"
+    "@sb1/ffe-form": "*",
+    "@sb1/ffe-spinner": "*",
+    "react": ">=16.9.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ffe-buttons-react/package.json
+++ b/packages/ffe-buttons-react/package.json
@@ -47,8 +47,8 @@
     "react-dom": "^16.9.0"
   },
   "peerDependencies": {
-    "@sb1/ffe-buttons": "^8.1.0",
-    "react": "^16.9.0"
+    "@sb1/ffe-buttons": "*",
+    "react": ">=16.9.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ffe-buttons/package.json
+++ b/packages/ffe-buttons/package.json
@@ -19,7 +19,7 @@
     "stylelint": "^13.0.0"
   },
   "peerDependencies": {
-    "@sb1/ffe-core": "^15.2.0"
+    "@sb1/ffe-core": "*"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ffe-cards-react/package.json
+++ b/packages/ffe-cards-react/package.json
@@ -42,8 +42,8 @@
     "react-dom": "^16.9.0"
   },
   "peerDependencies": {
-    "@sb1/ffe-cards": "^7.0.0",
-    "react": "^16.9.0"
+    "@sb1/ffe-cards": "*",
+    "react": ">=16.9.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ffe-cards/package.json
+++ b/packages/ffe-cards/package.json
@@ -17,7 +17,7 @@
     "@sb1/ffe-core": "^17.1.1"
   },
   "peerDependencies": {
-    "@sb1/ffe-core": "^15.2.0"
+    "@sb1/ffe-core": "*"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ffe-chart-donut-react/package.json
+++ b/packages/ffe-chart-donut-react/package.json
@@ -43,7 +43,7 @@
     "react-dom": "^16.9.0"
   },
   "peerDependencies": {
-    "react": "^16.9.0"
+    "react": ">=16.9.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ffe-collapse-react/package.json
+++ b/packages/ffe-collapse-react/package.json
@@ -1,53 +1,53 @@
 {
-    "name": "@sb1/ffe-collapse-react",
-    "version": "1.1.5",
-    "description": "React component for expand/collapse",
-    "keywords": [
-        "ffe"
-    ],
-    "license": "MIT",
-    "author": "SpareBank 1",
-    "files": [
-        "lib",
-        "es",
-        "less",
-        "types"
-    ],
-    "main": "lib/index.js",
-    "module": "es/index.js",
-    "types": "types/index.d.ts",
-    "sideEffects": false,
-    "repository": {
-        "type": "git",
-        "url": "ssh://git@github.com:SpareBank1/designsystem.git"
-    },
-    "scripts": {
-        "build": "npm run build:cjs && npm run build:es && npm run build:types",
-        "build:cjs": "babel -d lib/. --root-mode=upward  --env-name=cjs --ignore=*.spec.js src/.",
-        "build:es": "babel -d es/. --root-mode=upward --env-name=es --ignore=*.spec.js src/.",
-        "build:types": "copyfiles -f src/index.d.ts types/",
-        "lint": "eslint src/.",
-        "test": "jest",
-        "test:watch": "jest --watch"
-    },
-    "jest": {
-        "setupTestFrameworkScriptFile": "../../test-setup.js"
-    },
-    "dependencies": {
-        "classnames": "^2.2.5"
-    },
-    "devDependencies": {
-        "eslint": "^5.9.0",
-        "jest": "^26.0.0",
-        "prop-types": "^15.6.0",
-        "react": "^16.9.0",
-        "react-dom": "^16.9.0"
-    },
-    "peerDependencies": {
-        "@sb1/ffe-core": "^14.0.0",
-        "react": "^16.9.0"
-    },
-    "publishConfig": {
-        "access": "public"
-    }
+  "name": "@sb1/ffe-collapse-react",
+  "version": "1.1.5",
+  "description": "React component for expand/collapse",
+  "keywords": [
+    "ffe"
+  ],
+  "license": "MIT",
+  "author": "SpareBank 1",
+  "files": [
+    "lib",
+    "es",
+    "less",
+    "types"
+  ],
+  "main": "lib/index.js",
+  "module": "es/index.js",
+  "types": "types/index.d.ts",
+  "sideEffects": false,
+  "repository": {
+    "type": "git",
+    "url": "ssh://git@github.com:SpareBank1/designsystem.git"
+  },
+  "scripts": {
+    "build": "npm run build:cjs && npm run build:es && npm run build:types",
+    "build:cjs": "babel -d lib/. --root-mode=upward  --env-name=cjs --ignore=*.spec.js src/.",
+    "build:es": "babel -d es/. --root-mode=upward --env-name=es --ignore=*.spec.js src/.",
+    "build:types": "copyfiles -f src/index.d.ts types/",
+    "lint": "eslint src/.",
+    "test": "jest",
+    "test:watch": "jest --watch"
+  },
+  "jest": {
+    "setupTestFrameworkScriptFile": "../../test-setup.js"
+  },
+  "dependencies": {
+    "classnames": "^2.2.5"
+  },
+  "devDependencies": {
+    "eslint": "^5.9.0",
+    "jest": "^26.0.0",
+    "prop-types": "^15.6.0",
+    "react": "^16.9.0",
+    "react-dom": "^16.9.0"
+  },
+  "peerDependencies": {
+    "@sb1/ffe-core": "*",
+    "react": ">=16.9.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/packages/ffe-context-message-react/package.json
+++ b/packages/ffe-context-message-react/package.json
@@ -46,8 +46,8 @@
     "react-dom": "^16.9.0"
   },
   "peerDependencies": {
-    "@sb1/ffe-context-message": "^3.0.0",
-    "react": "^16.9.0"
+    "@sb1/ffe-context-message": "*",
+    "react": ">=16.9.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ffe-context-message/package.json
+++ b/packages/ffe-context-message/package.json
@@ -22,7 +22,7 @@
     "@sb1/ffe-core": "^17.1.1"
   },
   "peerDependencies": {
-    "@sb1/ffe-core": "^15.2.0"
+    "@sb1/ffe-core": "*"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ffe-core-react/package.json
+++ b/packages/ffe-core-react/package.json
@@ -46,8 +46,8 @@
     "react-test-renderer": "^16.2.0"
   },
   "peerDependencies": {
-    "@sb1/ffe-core": "^15.2.0",
-    "react": "^16.9.0"
+    "@sb1/ffe-core": "*",
+    "react": ">=16.9.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ffe-datepicker-react/package.json
+++ b/packages/ffe-datepicker-react/package.json
@@ -44,9 +44,9 @@
     "react-dom": "^16.9.0"
   },
   "peerDependencies": {
-    "@sb1/ffe-datepicker": "^5.0.0",
-    "@sb1/ffe-form": ">=11.0.1",
-    "react": "^16.9.0"
+    "@sb1/ffe-datepicker": "*",
+    "@sb1/ffe-form": "*",
+    "react": ">=16.9.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ffe-datepicker/package.json
+++ b/packages/ffe-datepicker/package.json
@@ -18,8 +18,8 @@
     "@sb1/ffe-form": "^15.0.3"
   },
   "peerDependencies": {
-    "@sb1/ffe-core": "^15.2.0",
-    "@sb1/ffe-form": ">=11.0.1"
+    "@sb1/ffe-core": "*",
+    "@sb1/ffe-form": "*"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ffe-decorators-react/package.json
+++ b/packages/ffe-decorators-react/package.json
@@ -41,7 +41,7 @@
     "sinon": "^7.2.3"
   },
   "peerDependencies": {
-    "react": "^16.9.0"
+    "react": ">=16.9.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ffe-details-list-react/package.json
+++ b/packages/ffe-details-list-react/package.json
@@ -39,9 +39,9 @@
     "react-dom": "^16.9.0"
   },
   "peerDependencies": {
-    "@sb1/ffe-grid": "^10.1.2",
-    "@sb1/ffe-grid-react": "^9.0.1",
-    "react": "^16.9.0"
+    "@sb1/ffe-grid": "*",
+    "@sb1/ffe-grid-react": "*",
+    "react": ">=16.9.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ffe-details-list/package.json
+++ b/packages/ffe-details-list/package.json
@@ -18,7 +18,7 @@
     "stylelint": "^13.0.0"
   },
   "peerDependencies": {
-    "@sb1/ffe-core": "^15.2.0"
+    "@sb1/ffe-core": "*"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ffe-dropdown-react/package.json
+++ b/packages/ffe-dropdown-react/package.json
@@ -40,8 +40,8 @@
     "react-dom": "^16.9.0"
   },
   "peerDependencies": {
-    "@sb1/ffe-form": ">=11.0.1",
-    "react": "^16.9.0"
+    "@sb1/ffe-form": "*",
+    "react": ">=16.9.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ffe-file-upload-react/package.json
+++ b/packages/ffe-file-upload-react/package.json
@@ -40,9 +40,9 @@
     "react-dom": "^16.9.0"
   },
   "peerDependencies": {
-    "@sb1/ffe-core": "^15.2.0",
-    "@sb1/ffe-form": ">=11.0.1",
-    "react": "^16.9.0"
+    "@sb1/ffe-core": "*",
+    "@sb1/ffe-form": "*",
+    "react": ">=16.9.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ffe-file-upload/package.json
+++ b/packages/ffe-file-upload/package.json
@@ -17,8 +17,8 @@
     "@sb1/ffe-core": "^17.1.1"
   },
   "peerDependencies": {
-    "@sb1/ffe-core": "^15.0.0",
-    "@sb1/ffe-form": "^11.0.2"
+    "@sb1/ffe-core": "*",
+    "@sb1/ffe-form": "*"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ffe-form-react/package.json
+++ b/packages/ffe-form-react/package.json
@@ -47,9 +47,9 @@
     "sinon": "^7.2.3"
   },
   "peerDependencies": {
-    "@sb1/ffe-core": "^15.2.0",
-    "@sb1/ffe-form": "^11.0.1",
-    "react": "^16.9.0"
+    "@sb1/ffe-core": "*",
+    "@sb1/ffe-form": "*",
+    "react": ">=16.9.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ffe-grid-react/package.json
+++ b/packages/ffe-grid-react/package.json
@@ -39,8 +39,8 @@
     "react-dom": "^16.9.0"
   },
   "peerDependencies": {
-    "@sb1/ffe-grid": "^10.1.2",
-    "react": "^16.9.0"
+    "@sb1/ffe-grid": "*",
+    "react": ">=16.9.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ffe-grid/package.json
+++ b/packages/ffe-grid/package.json
@@ -23,7 +23,7 @@
     "stylelint": "^13.0.0"
   },
   "peerDependencies": {
-    "@sb1/ffe-core": "^15.2.0"
+    "@sb1/ffe-core": "*"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ffe-header/package.json
+++ b/packages/ffe-header/package.json
@@ -28,8 +28,8 @@
     "stylelint": "^13.0.0"
   },
   "peerDependencies": {
-    "@sb1/ffe-buttons": "^8.1.0",
-    "@sb1/ffe-core": "^15.2.0"
+    "@sb1/ffe-buttons": "*",
+    "@sb1/ffe-core": "*"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ffe-icons-react/package.json
+++ b/packages/ffe-icons-react/package.json
@@ -41,7 +41,7 @@
     "typescript": "^3.7.5"
   },
   "peerDependencies": {
-    "react": "^16.9.0"
+    "react": ">=16.9.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ffe-lists-react/package.json
+++ b/packages/ffe-lists-react/package.json
@@ -41,8 +41,8 @@
     "react-dom": "^16.9.0"
   },
   "peerDependencies": {
-    "@sb1/ffe-lists": "^7.0.0",
-    "react": "^16.9.0"
+    "@sb1/ffe-lists": "*",
+    "react": ">=16.9.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ffe-lists/package.json
+++ b/packages/ffe-lists/package.json
@@ -20,7 +20,7 @@
     "@sb1/ffe-core": "^17.1.1"
   },
   "peerDependencies": {
-    "@sb1/ffe-core": "^15.2.0"
+    "@sb1/ffe-core": "*"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ffe-message-box-react/package.json
+++ b/packages/ffe-message-box-react/package.json
@@ -43,8 +43,8 @@
     "react-dom": "^16.9.0"
   },
   "peerDependencies": {
-    "@sb1/ffe-message-box": "^6.0.0",
-    "react": "^16.9.0"
+    "@sb1/ffe-message-box": "*",
+    "react": ">=16.9.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ffe-message-box/package.json
+++ b/packages/ffe-message-box/package.json
@@ -17,7 +17,7 @@
     "stylelint": "^13.0.0"
   },
   "peerDependencies": {
-    "@sb1/ffe-core": "^15.2.0"
+    "@sb1/ffe-core": "*"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ffe-searchable-dropdown-react/package.json
+++ b/packages/ffe-searchable-dropdown-react/package.json
@@ -47,7 +47,7 @@
     "react-dom": "^16.9.0"
   },
   "peerDependencies": {
-    "react": "^16.9.0"
+    "react": ">=16.9.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ffe-spinner-react/package.json
+++ b/packages/ffe-spinner-react/package.json
@@ -39,8 +39,8 @@
     "react-dom": "^16.9.0"
   },
   "peerDependencies": {
-    "@sb1/ffe-spinner": "^3.0.0",
-    "react": "^16.9.0"
+    "@sb1/ffe-spinner": "*",
+    "react": ">=16.9.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ffe-spinner/package.json
+++ b/packages/ffe-spinner/package.json
@@ -20,7 +20,7 @@
     "@sb1/ffe-core": "^17.1.1"
   },
   "peerDependencies": {
-    "@sb1/ffe-core": "^15.2.0"
+    "@sb1/ffe-core": "*"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ffe-system-message-react/package.json
+++ b/packages/ffe-system-message-react/package.json
@@ -40,9 +40,9 @@
     "react-dom": "^16.9.0"
   },
   "peerDependencies": {
-    "@sb1/ffe-icons-react": "^5.0.0 || ^6.0.0",
-    "@sb1/ffe-system-message": "^3.0.0",
-    "react": "^16.9.0"
+    "@sb1/ffe-icons-react": "*",
+    "@sb1/ffe-system-message": "*",
+    "react": ">=16.9.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ffe-system-message/package.json
+++ b/packages/ffe-system-message/package.json
@@ -19,7 +19,7 @@
     "@sb1/ffe-core": "^17.1.1"
   },
   "peerDependencies": {
-    "@sb1/ffe-core": "^15.2.0"
+    "@sb1/ffe-core": "*"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ffe-tables-react/package.json
+++ b/packages/ffe-tables-react/package.json
@@ -46,8 +46,8 @@
     "sinon": "^7.2.3"
   },
   "peerDependencies": {
-    "@sb1/ffe-tables": "^9.0.0",
-    "react": "^16.9.0"
+    "@sb1/ffe-tables": "*",
+    "react": ">=16.9.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ffe-tables/package.json
+++ b/packages/ffe-tables/package.json
@@ -19,7 +19,7 @@
     "stylelint": "^13.0.0"
   },
   "peerDependencies": {
-    "@sb1/ffe-core": "^15.2.0"
+    "@sb1/ffe-core": "*"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ffe-tabs-react/package.json
+++ b/packages/ffe-tabs-react/package.json
@@ -40,9 +40,9 @@
     "react-dom": "^16.9.0"
   },
   "peerDependencies": {
-    "@sb1/ffe-core": "^15.2.0",
-    "@sb1/ffe-tabs": "^6.1.0",
-    "react": "^16.9.0"
+    "@sb1/ffe-core": "*",
+    "@sb1/ffe-tabs": "*",
+    "react": ">=16.9.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ffe-tabs/package.json
+++ b/packages/ffe-tabs/package.json
@@ -18,7 +18,7 @@
     "@sb1/ffe-core": "^17.1.1"
   },
   "peerDependencies": {
-    "@sb1/ffe-core": "^15.2.0"
+    "@sb1/ffe-core": "*"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Siste major release av npm til versjon 7 har endret hvordan npm håndterer peer dependencies. Om versjonen av ønsket peer dependency og tilsvarende dependency i konsumenten ikke matcher så avbryter `npm install` med en feilmelding.

For å redusere vedlikehold av designsystem er nå alle interne peer dependencies satt til wildcard'en `*`. Dvs. hvilken som helst versjon oppfyller ønsken -- selv om den versjonen ikke er teknisk kompatibel.

Resolves #415 