### PR TITLE
fix(ffe-datepicker-react): import lodash.debounce instead of lodash

### DIFF
--- a/packages/ffe-datepicker-react/src/datepicker/Datepicker.js
+++ b/packages/ffe-datepicker-react/src/datepicker/Datepicker.js
@@ -10,7 +10,7 @@ import SimpleDate from '../datelogic/simpledate';
 import dateErrorTypes from '../datelogic/error-types';
 import i18n from '../i18n/i18n';
 import { validateDate } from '../util/dateUtil';
-import { debounce } from 'lodash';
+import debounce from 'lodash.debounce';
 
 export default class Datepicker extends Component {
     constructor(props) {


### PR DESCRIPTION
## Beskrivelse

Pakken ffe-datepicker-react brukerdebounce fra lodash, men importerer i dag fra hoved-pakken `lodash` fremfor å importere fra pakken `lodash.debounce`. Jeg har endret importen til å matche avhengigheten som faktisk står i package.json.

## Motivasjon og kontekst

Vi går gjennom bundle size på appene våre, og ser at hele lodash på 500kB blir dratt inn i bundle. Vi mistenker at denne pakken kan være årsaken. 