### PR TITLE
Bytter ut Museo med SpareBank 1

### DIFF
--- a/packages/ffe-buttons/less/base-button.less
+++ b/packages/ffe-buttons/less/base-button.less
@@ -59,7 +59,7 @@
     color: @ffe-white;
     cursor: pointer;
     display: flex;
-    font-family: 'MuseoSansRounded-500', arial, sans-serif;
+    font-family: 'SpareBank1-regular', arial, sans-serif;
     justify-content: center;
     line-height: 24px;
     overflow: hidden;

--- a/packages/ffe-buttons/less/inline-base-button.less
+++ b/packages/ffe-buttons/less/inline-base-button.less
@@ -18,7 +18,7 @@
     border-radius: 6px;
     cursor: pointer;
     display: inline-flex;
-    font-family: 'MuseoSansRounded-500', arial, sans-serif;
+    font-family: 'SpareBank1-regular', arial, sans-serif;
     margin: 0 -4px; // Hack to allow box-shadow to float outside content on focus
     overflow: hidden;
     padding: 0 @ffe-spacing-2xs;

--- a/packages/ffe-cards/less/ffe-link-card.less
+++ b/packages/ffe-cards/less/ffe-link-card.less
@@ -134,7 +134,7 @@
 
     &--large > &__details {
         color: @ffe-blue-royal;
-        font-family: 'MuseoSansRounded-700', arial, sans-serif;
+        font-family: 'SpareBank1-medium', arial, sans-serif;
         font-size: 1.25rem;
         line-height: 2.2rem;
         .native & {
@@ -239,7 +239,7 @@
 
         &--medium > &__heading,
         &--large > &__heading {
-            font-family: 'MuseoSansRounded-500', arial, sans-serif;
+            font-family: 'SpareBank1-regular', arial, sans-serif;
             font-size: 1.25rem;
             margin-bottom: 20px;
             margin-top: 0;
@@ -254,7 +254,7 @@
         &--medium > &__details,
         &--large > &__details {
             color: @ffe-blue-royal;
-            font-family: 'MuseoSansRounded-700', arial, sans-serif;
+            font-family: 'SpareBank1-medium', arial, sans-serif;
             font-size: 1.5rem;
             line-height: 6.875rem;
             position: absolute;

--- a/packages/ffe-cards/less/ffe-product-card.less
+++ b/packages/ffe-cards/less/ffe-product-card.less
@@ -132,7 +132,7 @@
     }
 
     .ffe-product-card__heading {
-        font-family: 'MuseoSansRounded-500', arial, sans-serif;
+        font-family: 'SpareBank1-regular', arial, sans-serif;
         font-size: 1.25rem;
         max-width: 100%;
         margin-top: 17px;

--- a/packages/ffe-core/less/typography.less
+++ b/packages/ffe-core/less/typography.less
@@ -171,7 +171,7 @@
 
 .ffe-small-text {
     color: @ffe-grey-charcoal;
-    font-family: 'MuseoSans-500', arial, sans-serif;
+    font-family: 'SpareBank1-regular', arial, sans-serif;
     font-weight: normal;
     line-height: 1.25rem;
     .ffe-fontsize-small-text();
@@ -182,7 +182,7 @@
 
 .ffe-micro-text {
     color: @ffe-grey-charcoal;
-    font-family: 'MuseoSans-500', arial, sans-serif;
+    font-family: 'SpareBank1-regular', arial, sans-serif;
     font-weight: normal;
     line-height: 1.25rem;
     .ffe-fontsize-micro-text();
@@ -195,7 +195,7 @@
 .ffe-h5,
 .ffe-h6 {
     color: @ffe-blue-royal;
-    font-family: 'MuseoSansRounded-700', arial, sans-serif;
+    font-family: 'SpareBank1-title-medium', arial, sans-serif;
     font-weight: normal;
     margin-bottom: 10px;
     margin-top: 0;
@@ -243,7 +243,7 @@
 
 .ffe-body-text {
     color: @ffe-black;
-    font-family: 'MuseoSans-500', arial, sans-serif;
+    font-family: 'SpareBank1-regular', arial, sans-serif;
     line-height: 1.5rem;
     .ffe-fontsize-body-text();
     .native & {
@@ -275,7 +275,7 @@
 
 .ffe-lead-paragraph,
 .ffe-sub-lead-paragraph {
-    font-family: 'MuseoSans-500', arial, sans-serif;
+    font-family: 'SpareBank1-regular', arial, sans-serif;
     margin-top: 0;
 }
 
@@ -357,7 +357,7 @@
 }
 
 .ffe-strong-text {
-    font-family: 'MuseoSansRounded-700', arial, sans-serif;
+    font-family: 'SpareBank1-medium', arial, sans-serif;
     font-weight: normal;
 }
 

--- a/packages/ffe-core/less/typography.less
+++ b/packages/ffe-core/less/typography.less
@@ -171,7 +171,7 @@
 
 .ffe-small-text {
     color: @ffe-grey-charcoal;
-    font-family: 'MuseoSans-500', arial, sans-serif;
+    font-family: 'SpareBank1-regular', arial, sans-serif;
     font-weight: normal;
     line-height: 1.25rem;
     .ffe-fontsize-small-text();
@@ -182,7 +182,7 @@
 
 .ffe-micro-text {
     color: @ffe-grey-charcoal;
-    font-family: 'MuseoSans-500', arial, sans-serif;
+    font-family: 'SpareBank1-regular', arial, sans-serif;
     font-weight: normal;
     line-height: 1.25rem;
     .ffe-fontsize-micro-text();
@@ -195,7 +195,6 @@
 .ffe-h5,
 .ffe-h6 {
     color: @ffe-blue-royal;
-    font-family: 'MuseoSansRounded-700', arial, sans-serif;
     font-weight: normal;
     margin-bottom: 10px;
     margin-top: 0;
@@ -241,9 +240,21 @@
     }
 }
 
+.ffe-h1,
+.ffe-h2 {
+    font-family: 'SpareBank1-title-medium', arial, sans-serif;
+}
+
+.ffe-h3,
+.ffe-h4,
+.ffe-h5,
+.ffe-h6 {
+    font-family: 'SpareBank1-medium', arial, sans-serif;
+}
+
 .ffe-body-text {
     color: @ffe-black;
-    font-family: 'MuseoSans-500', arial, sans-serif;
+    font-family: 'SpareBank1-regular', arial, sans-serif;
     line-height: 1.5rem;
     .ffe-fontsize-body-text();
     .native & {
@@ -275,7 +286,7 @@
 
 .ffe-lead-paragraph,
 .ffe-sub-lead-paragraph {
-    font-family: 'MuseoSans-500', arial, sans-serif;
+    font-family: 'SpareBank1-regular', arial, sans-serif;
     margin-top: 0;
 }
 
@@ -357,7 +368,7 @@
 }
 
 .ffe-strong-text {
-    font-family: 'MuseoSansRounded-700', arial, sans-serif;
+    font-family: 'SpareBank1-medium', arial, sans-serif;
     font-weight: normal;
 }
 

--- a/packages/ffe-form/less/dropdown.less
+++ b/packages/ffe-form/less/dropdown.less
@@ -39,7 +39,7 @@
         }
     }
 
-    font-family: MuseoSans-500, arial, sans-serif;
+    font-family: 'SpareBank1-regular', arial, sans-serif;
     height: 45px;
     padding: 0 @ffe-spacing-lg 0 @ffe-spacing-sm;
     line-height: 20px;

--- a/packages/ffe-form/less/form-label.less
+++ b/packages/ffe-form/less/form-label.less
@@ -12,7 +12,7 @@
     padding: @ffe-spacing-xs 0 @ffe-spacing-2xs;
     display: inline-block;
     position: relative;
-    font-family: MuseoSans-500, arial, sans-serif;
+    font-family: 'SpareBank1-regular', arial, sans-serif;
     .ffe-fontsize-h6();
 
     font-weight: 500;

--- a/packages/ffe-form/less/input-field.less
+++ b/packages/ffe-form/less/input-field.less
@@ -16,7 +16,7 @@
     display: block;
     height: 45px;
     padding: 0 @ffe-spacing-sm;
-    font-family: MuseoSans-500, arial, sans-serif;
+    font-family: 'SpareBank1-regular', arial, sans-serif;
     color: @ffe-black;
     border-radius: 4px;
     border: 2px solid @ffe-grey-silver;

--- a/packages/ffe-form/less/radio-switch.less
+++ b/packages/ffe-form/less/radio-switch.less
@@ -23,7 +23,7 @@
     min-width: 100px;
     text-align: left;
     color: @ffe-blue-azure;
-    font-family: 'MuseoSansRounded-700', arial, sans-serif;
+    font-family: 'SpareBank1-medium', arial, sans-serif;
     cursor: pointer;
     transition: all @ffe-transition-duration @ffe-ease;
     box-shadow: 0 1px 2px 1px rgba(0, 0, 0, 0.05);

--- a/packages/ffe-form/less/textarea.less
+++ b/packages/ffe-form/less/textarea.less
@@ -12,7 +12,7 @@
     display: block;
     width: 100%;
     padding: @ffe-spacing-sm;
-    font-family: MuseoSans-500, arial, sans-serif;
+    font-family: 'SpareBank1-regular', arial, sans-serif;
     border-radius: 4px;
     border: 2px solid @ffe-grey-silver;
     transition: all @ffe-transition-duration @ffe-ease;

--- a/packages/ffe-header/examples/examples.less
+++ b/packages/ffe-header/examples/examples.less
@@ -10,7 +10,7 @@ body {
     margin: 0;
     padding: 0 20px;
     color: @ffe-grey-silver;
-    font-family: 'MuseoSans-500', arial, sans-serif;
+    font-family: 'SpareBank1-regular', arial, sans-serif;
     font-size: 1rem;
     line-height: 1.625rem;
     @media (min-width: @breakpoint-md) {

--- a/packages/ffe-header/less/ffe-header.less
+++ b/packages/ffe-header/less/ffe-header.less
@@ -306,7 +306,7 @@
     }
 
     &__notification-bubble {
-        font-family: 'MuseoSansRounded-700', arial, sans-serif;
+        font-family: 'SpareBank1-medium', arial, sans-serif;
         font-weight: normal;
         font-size: 0.75rem;
         display: inline-block;

--- a/packages/ffe-message-box/less/ffe-message-box.less
+++ b/packages/ffe-message-box/less/ffe-message-box.less
@@ -180,7 +180,7 @@
 
         &:hover,
         &:focus {
-            font-family: 'MuseoSansRounded-700', arial, sans-serif;
+            font-family: 'SpareBank1-medium', arial, sans-serif;
         }
     }
 }

--- a/packages/ffe-tabs/less/tab-button.less
+++ b/packages/ffe-tabs/less/tab-button.less
@@ -17,7 +17,7 @@
     color: @ffe-grey-charcoal;
     cursor: pointer;
     display: block;
-    font-family: 'MuseoSansRounded-500', arial, sans-serif;
+    font-family: 'SpareBank1-regular', arial, sans-serif;
     font-size: 1rem;
     outline: none;
     overflow: hidden;

--- a/packages/ffe-tabs/less/tab.less
+++ b/packages/ffe-tabs/less/tab.less
@@ -15,7 +15,7 @@
     color: @ffe-grey-charcoal;
     cursor: pointer;
     display: block;
-    font-family: 'MuseoSansRounded-500', arial, sans-serif;
+    font-family: 'SpareBank1-regular', arial, sans-serif;
     font-size: 1rem;
     outline: none;
     overflow: hidden;

--- a/packages/ffe-webfonts/README.md
+++ b/packages/ffe-webfonts/README.md
@@ -10,47 +10,47 @@ npm install @sb1/ffe-webfonts
 
 There are two ways to use `ffe-webfonts`:
 
-1. Copy the font files from `node_modules/@sb1/ffe-webfonts/fonts/` and use `fonts.less`
-2. Use `fonts.css` where the fonts are base64 encoded inline
+1. Copy the font files from `node_modules/@sb1/ffe-webfonts/fonts/` and use `sb1-fonts.less`
+2. Use `sb1-fonts.css`, where the fonts are base64 encoded inline
 
-**You also need to include the webfonts license.** It is included as a comment in both `fonts.css` and `fonts.less`.
-It should survive minification, but make sure your build tools don't strip those comments out.
-
-Approach 1 is propably what you want for performance reasons.
+Approach 1 is probably what you want for performance reasons.
 
 ### Using Less
 
-Copy the font files from `node_modules/@sb1/ffe-webfonts/fonts/` to a folder that will be shipped with your app. You can use
-npm-scripts, (if you use Webpack) [copy-webpack-plugin](https://github.com/webpack-contrib/copy-webpack-plugin), or what
-ever you see fit to get the files to where they need to be.
+Copy the font files from `node_modules/@sb1/ffe-webfonts/fonts/` to a folder that will be shipped with your app. You can use npm-scripts, (if you use Webpack) [copy-webpack-plugin](https://github.com/webpack-contrib/copy-webpack-plugin), or whatever you see fit to get the files to where they need to be.
 
-Import `node_modules/@sb1/ffe-webfonts/fonts.less` in your app:
+Import `node_modules/@sb1/ffe-webfonts/sb1-fonts.less` in your app:
 
 ```less
-@import 'npm://@sb1/ffe-webfonts/fonts.less';                      // with less-plugin
-@import '~@sb1/ffe-webfonts/fonts.less';                           // with webpack and less-loader
-@import '../path/to/node_modules/@sb1/ffe-webfonts/fonts.less';    // by path
+@import 'npm://@sb1/ffe-webfonts/sb1-fonts.less'; // with less-plugin
+@import '~@sb1/ffe-webfonts/sb1-fonts.less'; // with webpack and less-loader
+@import '../path/to/node_modules/@sb1/ffe-webfonts/sb1-fonts.less'; // by path
 ```
 
-You need to provide a constant named `@fonts-url` after the `@import` with a URL path to the fonts folder so the browser
-knows where to download the font files.
+You need to provide a constant named `@fonts-url` after the `@import` with a URL path to the fonts folder so the browser knows where to download the font files.
 
 ```less
-@import '~@sb1/ffe-webfonts/fonts.less';
+@import '~@sb1/ffe-webfonts/sb1-fonts.less';
 @fonts-url: '/privat/forsikring/fonts';
 ```
 
 ### CSS with inline fonts
 
 ```css
-@import url('~@sb1/ffe-webfonts/fonts.css');
+@import url('~@sb1/ffe-webfonts/sb1-fonts.css');
 ```
 
 ```less
-@import (inline) '~@sb1/ffe-webfonts/fonts.css';
+@import (inline) '~@sb1/ffe-webfonts/sb1-fonts.css';
 ```
+
+## Deprecated fonts
+
+In addition to the SpareBank 1 fonts, this package currently still contains the previously used MuseoSans fonts. These are deprecated and will be removed at a later date.
+
+MuseoSans is distributed through `fonts.less`, `fonts.css` and `fonts-inline.less`. Any use of these files should be replaced with `sb1-fonts.less`, `sb1-fonts.css` and `sb1-fonts-inline.less`.
 
 # Licenses
 
-* Source code is licensed under MIT
-* The MuseoSans fonts are licensed separately. See LICENSE-fonts.md.
+-   Source code is licensed under MIT
+-   The MuseoSans fonts are licensed separately. See LICENSE-fonts.md.

--- a/src/styles/examples/typography.less
+++ b/src/styles/examples/typography.less
@@ -44,7 +44,7 @@
         }
 
         &--h3 {
-            font-family: 'SpareBank1-title-medium';
+            font-family: 'SpareBank1-medium';
             font-size: 28px;
 
             .sb1ds-typography-hierarchy--mobile & {
@@ -53,7 +53,7 @@
         }
 
         &--h4 {
-            font-family: 'SpareBank1-title-medium';
+            font-family: 'SpareBank1-medium';
             font-size: 22px;
 
             .sb1ds-typography-hierarchy--mobile & {
@@ -62,7 +62,7 @@
         }
 
         &--h5 {
-            font-family: 'SpareBank1-title-medium';
+            font-family: 'SpareBank1-medium';
             font-size: 18px;
 
             .sb1ds-typography-hierarchy--mobile & {
@@ -71,7 +71,7 @@
         }
 
         &--h6 {
-            font-family: 'SpareBank1-title-medium';
+            font-family: 'SpareBank1-medium';
             font-size: 16px;
 
             .sb1ds-typography-hierarchy--mobile & {

--- a/styleguide-content/visuell-identitet/typografi.md
+++ b/styleguide-content/visuell-identitet/typografi.md
@@ -16,22 +16,22 @@ Vi har ulike regler for skriftstørrelser på mobil og desktop. Her er en oversi
 
 <dl class="sb1ds-typography-hierarchy sb1ds-typography-hierarchy--desktop">
     <dt class="sb1ds-typography-hierarchy__description">Overskrift 1</dt>
-    <dd class="sb1ds-typography-hierarchy__element"><span class="ffe-h1 sb1ds-typography-hierarchy__example sb1ds-typography-hierarchy__example--h1">SpareBank 1 Title</span></dd>
+    <dd class="sb1ds-typography-hierarchy__element"><span class="ffe-h1 sb1ds-typography-hierarchy__example sb1ds-typography-hierarchy__example--h1">SpareBank 1 Title Medium</span></dd>
     <dd class="sb1ds-typography-hierarchy__font-size">46 px</dd>
     <dt class="sb1ds-typography-hierarchy__description">Overskrift 2</dt>
-    <dd class="sb1ds-typography-hierarchy__element"><span class="ffe-h2 sb1ds-typography-hierarchy__example sb1ds-typography-hierarchy__example--h2">SpareBank 1 Title</span></dd>
+    <dd class="sb1ds-typography-hierarchy__element"><span class="ffe-h2 sb1ds-typography-hierarchy__example sb1ds-typography-hierarchy__example--h2">SpareBank 1 Title Medium</span></dd>
     <dd class="sb1ds-typography-hierarchy__font-size">36 px</dd>
     <dt class="sb1ds-typography-hierarchy__description">Overskrift 3</dt>
-    <dd class="sb1ds-typography-hierarchy__element"><span class="ffe-h3 sb1ds-typography-hierarchy__example sb1ds-typography-hierarchy__example--h3">SpareBank 1 Title</span></dd>
+    <dd class="sb1ds-typography-hierarchy__element"><span class="ffe-h3 sb1ds-typography-hierarchy__example sb1ds-typography-hierarchy__example--h3">SpareBank 1 Medium</span></dd>
     <dd class="sb1ds-typography-hierarchy__font-size">28 px</dd>
     <dt class="sb1ds-typography-hierarchy__description">Overskrift 4</dt>
-    <dd class="sb1ds-typography-hierarchy__element"><span class="ffe-h4 sb1ds-typography-hierarchy__example sb1ds-typography-hierarchy__example--h4">SpareBank 1 Title</span></dd>
+    <dd class="sb1ds-typography-hierarchy__element"><span class="ffe-h4 sb1ds-typography-hierarchy__example sb1ds-typography-hierarchy__example--h4">SpareBank 1 Medium</span></dd>
     <dd class="sb1ds-typography-hierarchy__font-size">22 px</dd>
     <dt class="sb1ds-typography-hierarchy__description">Overskrift 5</dt>
-    <dd class="sb1ds-typography-hierarchy__element"><span class="ffe-h5 sb1ds-typography-hierarchy__example sb1ds-typography-hierarchy__example--h5">SpareBank 1 Title</span></dd>
+    <dd class="sb1ds-typography-hierarchy__element"><span class="ffe-h5 sb1ds-typography-hierarchy__example sb1ds-typography-hierarchy__example--h5">SpareBank 1 Medium</span></dd>
     <dd class="sb1ds-typography-hierarchy__font-size">18 px</dd>
     <dt class="sb1ds-typography-hierarchy__description">Overskrift 6</dt>
-    <dd class="sb1ds-typography-hierarchy__element"><span class="ffe-h6 sb1ds-typography-hierarchy__example sb1ds-typography-hierarchy__example--h6">SpareBank 1 Title</span></dd>
+    <dd class="sb1ds-typography-hierarchy__element"><span class="ffe-h6 sb1ds-typography-hierarchy__example sb1ds-typography-hierarchy__example--h6">SpareBank 1 Medium</span></dd>
     <dd class="sb1ds-typography-hierarchy__font-size">16 px</dd>
     <dt class="sb1ds-typography-hierarchy__description">Lead</dt>
     <dd class="sb1ds-typography-hierarchy__element"><span class="ffe-lead-paragraph sb1ds-typography-hierarchy__example sb1ds-typography-hierarchy__example--lead-paragraph">SpareBank 1 Regular</span></dd>
@@ -57,22 +57,22 @@ Vi har ulike regler for skriftstørrelser på mobil og desktop. Her er en oversi
 
 <dl class="sb1ds-typography-hierarchy sb1ds-typography-hierarchy--mobile">
     <dt class="sb1ds-typography-hierarchy__description">Overskrift 1</dt>
-    <dd class="sb1ds-typography-hierarchy__element"><span class="ffe-h1 sb1ds-typography-hierarchy__example sb1ds-typography-hierarchy__example--h1">SpareBank 1 Title</span></dd>
+    <dd class="sb1ds-typography-hierarchy__element"><span class="ffe-h1 sb1ds-typography-hierarchy__example sb1ds-typography-hierarchy__example--h1">SpareBank 1 Title Medium</span></dd>
     <dd class="sb1ds-typography-hierarchy__font-size">28 px</dd>
     <dt class="sb1ds-typography-hierarchy__description">Overskrift 2</dt>
-    <dd class="sb1ds-typography-hierarchy__element"><span class="ffe-h2 sb1ds-typography-hierarchy__example sb1ds-typography-hierarchy__example--h2">SpareBank 1 Title</span></dd>
+    <dd class="sb1ds-typography-hierarchy__element"><span class="ffe-h2 sb1ds-typography-hierarchy__example sb1ds-typography-hierarchy__example--h2">SpareBank 1 Title Medium</span></dd>
     <dd class="sb1ds-typography-hierarchy__font-size">24 px</dd>
     <dt class="sb1ds-typography-hierarchy__description">Overskrift 3</dt>
-    <dd class="sb1ds-typography-hierarchy__element"><span class="ffe-h3 sb1ds-typography-hierarchy__example sb1ds-typography-hierarchy__example--h3">SpareBank 1 Title</span></dd>
+    <dd class="sb1ds-typography-hierarchy__element"><span class="ffe-h3 sb1ds-typography-hierarchy__example sb1ds-typography-hierarchy__example--h3">SpareBank 1 Medium</span></dd>
     <dd class="sb1ds-typography-hierarchy__font-size">20 px</dd>
     <dt class="sb1ds-typography-hierarchy__description">Overskrift 4</dt>
-    <dd class="sb1ds-typography-hierarchy__element"><span class="ffe-h4 sb1ds-typography-hierarchy__example sb1ds-typography-hierarchy__example--h4">SpareBank 1 Title</span></dd>
+    <dd class="sb1ds-typography-hierarchy__element"><span class="ffe-h4 sb1ds-typography-hierarchy__example sb1ds-typography-hierarchy__example--h4">SpareBank 1 Medium</span></dd>
     <dd class="sb1ds-typography-hierarchy__font-size">18 px</dd>
     <dt class="sb1ds-typography-hierarchy__description">Overskrift 5</dt>
-    <dd class="sb1ds-typography-hierarchy__element"><span class="ffe-h5 sb1ds-typography-hierarchy__example sb1ds-typography-hierarchy__example--h5">SpareBank 1 Title</span></dd>
+    <dd class="sb1ds-typography-hierarchy__element"><span class="ffe-h5 sb1ds-typography-hierarchy__example sb1ds-typography-hierarchy__example--h5">SpareBank 1 Medium</span></dd>
     <dd class="sb1ds-typography-hierarchy__font-size">17 px</dd>
     <dt class="sb1ds-typography-hierarchy__description">Overskrift 6</dt>
-    <dd class="sb1ds-typography-hierarchy__element"><span class="ffe-h6 sb1ds-typography-hierarchy__example sb1ds-typography-hierarchy__example--h6">SpareBank 1 Title</span></dd>
+    <dd class="sb1ds-typography-hierarchy__element"><span class="ffe-h6 sb1ds-typography-hierarchy__example sb1ds-typography-hierarchy__example--h6">SpareBank 1 Medium</span></dd>
     <dd class="sb1ds-typography-hierarchy__font-size">16 px</dd>
     <dt class="sb1ds-typography-hierarchy__description">Lead</dt>
     <dd class="sb1ds-typography-hierarchy__element"><span class="ffe-lead-paragraph sb1ds-typography-hierarchy__example sb1ds-typography-hierarchy__example--lead-paragraph">SpareBank 1 Regular</span></dd>

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -68,7 +68,7 @@ module.exports = {
             codeBackground: '#F8F5EB',
         },
         fontFamily: {
-            base: ['MuseoSans-500', 'arial', 'sans-serif'],
+            base: ['SpareBank1-regular', 'arial', 'sans-serif'],
         },
     },
     pagePerSection: true,


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse

Erstatter alle instanser av Museo Sans med den nye SpareBank 1-fonten. 
`MuseoSans-500` erstattes med `SpareBank1-regular`.
`MuseoSans-700` erstattes med `SpareBank1-medium`, bortsett fra i headinger, som har sin egen font - `SpareBank1-title-medium`.

Endringen påvirker all tekst, men her er noen stikkprøver:

**Skjemaelementer**

![Screenshot 2021-03-12 at 11 19 16](https://user-images.githubusercontent.com/463847/110927073-767f1280-8325-11eb-834b-d023baf9e082.png)
![Screenshot 2021-03-12 at 11 20 09](https://user-images.githubusercontent.com/463847/110927077-7717a900-8325-11eb-890b-00dac8e27434.png)
![Screenshot 2021-03-12 at 11 22 14](https://user-images.githubusercontent.com/463847/110927080-77b03f80-8325-11eb-9d59-95866098a0ec.png)

**Kontekstmeldinger**

![Screenshot 2021-03-12 at 11 22 51](https://user-images.githubusercontent.com/463847/110927082-7848d600-8325-11eb-9215-0e5a5db20578.png)

**Kort**

![Screenshot 2021-03-12 at 11 23 39](https://user-images.githubusercontent.com/463847/110927084-7848d600-8325-11eb-8148-b1b70f4538e8.png)

**Nedtrekksliste**

![Screenshot 2021-03-12 at 11 25 44](https://user-images.githubusercontent.com/463847/110927289-be9e3500-8325-11eb-889f-49c2872cb5d1.png)


## Motivasjon og kontekst

SpareBank 1-fonten er del av den nye visuelle profilen som rulles ut i disse dager.

## Testing

Fontene er testet ut ved å kjøre designsystemet lokalt. I tillegg har de vært testet i bruk på andre SpareBank 1-sider ved hjelp av en browser extension som legger til egendefinert css.

Regresjonstesting kan med fordel gjøres i hver enkelt applikasjon.