### PR TITLE
Darkmode fargepalett

### DIFF
--- a/packages/ffe-core/less/colors.less
+++ b/packages/ffe-core/less/colors.less
@@ -119,3 +119,13 @@
 @ffe-farge-varmgraa: #9b9797;
 @ffe-farge-lysvarmgraa: #d7d2cb;
 @ffe-farge-hvit: #fff;
+
+// Dark mode
+@ffe-farge-darkmode-svart: #000000; // Default background color
+@ffe-farge-darkmode-hvit: #ffffff; // Emphasized text
+@ffe-farge-darkmode-koksgraa: #1c1c1c; // Emphasized surfaces
+@ffe-farge-darkmode-moerkgraa: #292929; // Interactive surfaces
+@ffe-farge-darkmode-graa: #858585; // Borders and accents
+@ffe-farge-darkmode-lysgraa: #cccccc; // Default font color on default background and form labels
+@ffe-farge-darkmode-vann: #0a91ff; // Primary interaction and icon color
+@ffe-farge-darkmode-baer: #ff2424; // Tweaked ffe-red for better contrast

--- a/src/styles/examples/color.less
+++ b/src/styles/examples/color.less
@@ -261,6 +261,44 @@
         &--hvit {
             background-color: @ffe-farge-hvit;
         }
+
+        &--darkmode-svart {
+            background-color: @ffe-farge-darkmode-svart;
+            color: @ffe-farge-hvit;
+        }
+
+        &--darkmode-hvit {
+            background-color: @ffe-farge-darkmode-hvit;
+        }
+
+        &--darkmode-koksgraa {
+            background-color: @ffe-farge-darkmode-koksgraa;
+            color: @ffe-farge-hvit;
+        }
+
+        &--darkmode-graa {
+            background-color: @ffe-farge-darkmode-graa;
+            color: @ffe-farge-hvit;
+        }
+
+        &--darkmode-moerkgraa {
+            background-color: @ffe-farge-darkmode-moerkgraa;
+            color: @ffe-farge-hvit;
+        }
+
+        &--darkmode-lysgraa {
+            background-color: @ffe-farge-darkmode-lysgraa;
+        }
+
+        &--darkmode-vann {
+            background-color: @ffe-farge-darkmode-vann;
+            color: @ffe-farge-hvit;
+        }
+
+        &--darkmode-baer {
+            background-color: @ffe-farge-darkmode-baer;
+            color: @ffe-farge-hvit;
+        }
     }
 
     &__color-properties {

--- a/src/styles/examples/color.less
+++ b/src/styles/examples/color.less
@@ -127,26 +127,32 @@
 
         &--villblomst {
             background-color: @ffe-farge-villblomst;
+            color: @ffe-farge-svart;
         }
 
         &--villblomst-70 {
             background-color: @ffe-farge-villblomst-70;
+            color: @ffe-farge-svart;
         }
 
         &--villblomst-30 {
             background-color: @ffe-farge-villblomst-30;
+            color: @ffe-farge-svart;
         }
 
         &--nordlys {
             background-color: @ffe-farge-nordlys;
+            color: @ffe-farge-svart;
         }
 
         &--nordlys-70 {
             background-color: @ffe-farge-nordlys-70;
+            color: @ffe-farge-svart;
         }
 
         &--nordlys-30 {
             background-color: @ffe-farge-nordlys-30;
+            color: @ffe-farge-svart;
         }
 
         &--lyng {
@@ -161,6 +167,7 @@
 
         &--lyng-30 {
             background-color: @ffe-farge-lyng-30;
+            color: @ffe-farge-svart;
         }
 
         &--baer {
@@ -175,6 +182,7 @@
 
         &--baer-30 {
             background-color: @ffe-farge-baer-30;
+            color: @ffe-farge-svart;
         }
 
         &--skog {
@@ -189,30 +197,37 @@
 
         &--skog-30 {
             background-color: @ffe-farge-skog-30;
+            color: @ffe-farge-svart;
         }
 
         &--multe {
             background-color: @ffe-farge-multe;
+            color: @ffe-farge-svart;
         }
 
         &--multe-70 {
             background-color: @ffe-farge-multe-70;
+            color: @ffe-farge-svart;
         }
 
         &--multe-30 {
             background-color: @ffe-farge-multe-30;
+            color: @ffe-farge-svart;
         }
 
         &--sol {
             background-color: @ffe-farge-sol;
+            color: @ffe-farge-svart;
         }
 
         &--sol-70 {
             background-color: @ffe-farge-sol-70;
+            color: @ffe-farge-svart;
         }
 
         &--sol-30 {
             background-color: @ffe-farge-sol-30;
+            color: @ffe-farge-svart;
         }
 
         &--natt {
@@ -242,6 +257,7 @@
 
         &--lysgraa {
             background-color: @ffe-farge-lysgraa;
+            color: @ffe-farge-svart;
         }
 
         &--moerkvarmgraa {
@@ -256,10 +272,52 @@
 
         &--lysvarmgraa {
             background-color: @ffe-farge-lysvarmgraa;
+            color: @ffe-farge-svart;
         }
 
         &--hvit {
             background-color: @ffe-farge-hvit;
+            color: @ffe-farge-svart;
+        }
+
+        &--black-darkmode {
+            background-color: @ffe-black-darkmode;
+            color: @ffe-farge-hvit;
+        }
+
+        &--white-darkmode {
+            background-color: @ffe-white-darkmode;
+            color: @ffe-farge-svart;
+        }
+
+        &--grey-charcoal-darkmode {
+            background-color: @ffe-grey-charcoal-darkmode;
+            color: @ffe-farge-hvit;
+        }
+
+        &--grey-darkmode {
+            background-color: @ffe-grey-darkmode;
+            color: @ffe-farge-hvit;
+        }
+
+        &--grey-silver-darkmode {
+            background-color: @ffe-grey-silver-darkmode;
+            color: @ffe-farge-hvit;
+        }
+
+        &--grey-cloud-darkmode {
+            background-color: @ffe-grey-cloud-darkmode;
+            color: @ffe-farge-svart;
+        }
+
+        &--blue-azure-darkmode {
+            background-color: @ffe-blue-azure-darkmode;
+            color: @ffe-farge-hvit;
+        }
+
+        &--red-darkmode {
+            background-color: @ffe-red-darkmode;
+            color: @ffe-farge-hvit;
         }
     }
 

--- a/styleguide-content/visuell-identitet/farger.md
+++ b/styleguide-content/visuell-identitet/farger.md
@@ -511,3 +511,114 @@ Her er en oversikt over gråtoner, svart og andre nøytrale farger vi har behov 
         </div>
     </li>
 </ul>
+
+### Dark mode
+
+Oversikt over farger som brukes når dark mode er aktivert.
+
+<ul class="sb1ds-color-palette sb1ds-color-palette--darkmode">
+    <li class="sb1ds-color-palette__item">
+        <div class="sb1ds-color-palette__color sb1ds-color-palette__color--black-darkmode">
+            <h4 class="sb1ds-color-palette__color-name">Black</h4>
+            <dl class="sb1ds-color-palette__color-properties">
+                <dt>LESS:</dt>
+                <dd>@ffe-black-darkmode</dd>
+                <dt>HEX:</dt>
+                <dd>#000000</dd>
+                <dt>RGB:</dt>
+                <dd>0, 0, 0</dd>
+            </dl>
+        </div>
+    </li>
+    <li class="sb1ds-color-palette__item">
+        <div class="sb1ds-color-palette__color sb1ds-color-palette__color--grey-charcoal-darkmode">
+            <h4 class="sb1ds-color-palette__color-name">Grey Charcoal</h4>
+            <dl class="sb1ds-color-palette__color-properties">
+                <dt>LESS:</dt>
+                <dd>@ffe-grey-charcoal-darkmode</dd>
+                <dt>HEX:</dt>
+                <dd>#1c1c1c</dd>
+                <dt>RGB:</dt>
+                <dd>28, 28, 28</dd>
+            </dl>
+        </div>
+    </li>
+    <li class="sb1ds-color-palette__item">
+        <div class="sb1ds-color-palette__color sb1ds-color-palette__color--grey-darkmode">
+            <h4 class="sb1ds-color-palette__color-name">Grey</h4>
+            <dl class="sb1ds-color-palette__color-properties">
+                <dt>LESS:</dt>
+                <dd>@ffe-grey-darkmode</dd>
+                <dt>HEX:</dt>
+                <dd>#292929</dd>
+                <dt>RGB:</dt>
+                <dd>41, 41, 41</dd>
+            </dl>
+        </div>
+    </li>
+    <li class="sb1ds-color-palette__item">
+        <div class="sb1ds-color-palette__color sb1ds-color-palette__color--grey-silver-darkmode">
+            <h4 class="sb1ds-color-palette__color-name">Grey Silver</h4>
+            <dl class="sb1ds-color-palette__color-properties">
+                <dt>LESS:</dt>
+                <dd>@ffe-grey-silver-darkmode</dd>
+                <dt>HEX:</dt>
+                <dd>#858585</dd>
+                <dt>RGB:</dt>
+                <dd>133, 133, 133</dd>
+            </dl>
+        </div>
+    </li>
+    <li class="sb1ds-color-palette__item">
+        <div class="sb1ds-color-palette__color sb1ds-color-palette__color--grey-cloud-darkmode">
+            <h4 class="sb1ds-color-palette__color-name">Grey Cloud</h4>
+            <dl class="sb1ds-color-palette__color-properties">
+                <dt>LESS:</dt>
+                <dd>@ffe-grey-cloud-darkmode</dd>
+                <dt>HEX:</dt>
+                <dd>#cccccc</dd>
+                <dt>RGB:</dt>
+                <dd>204, 204, 204</dd>
+            </dl>
+        </div>
+    </li>
+    <li class="sb1ds-color-palette__item">
+        <div class="sb1ds-color-palette__color sb1ds-color-palette__color--blue-azure-darkmode">
+            <h4 class="sb1ds-color-palette__color-name">Blue Azure</h4>
+            <dl class="sb1ds-color-palette__color-properties">
+                <dt>LESS:</dt>
+                <dd>@ffe-blue-azure-darkmode</dd>
+                <dt>HEX:</dt>
+                <dd>#0a91ff</dd>
+                <dt>RGB:</dt>
+                <dd>10, 145, 255</dd>
+            </dl>
+        </div>
+    </li>
+    <li class="sb1ds-color-palette__item">
+        <div class="sb1ds-color-palette__color sb1ds-color-palette__color--red-darkmode">
+            <h4 class="sb1ds-color-palette__color-name">Red</h4>
+            <dl class="sb1ds-color-palette__color-properties">
+                <dt>LESS:</dt>
+                <dd>@ffe-red-darkmode</dd>
+                <dt>HEX:</dt>
+                <dd>#ff2424</dd>
+                <dt>RGB:</dt>
+                <dd>255, 36, 36</dd>
+            </dl>
+        </div>
+    </li>
+    <li class="sb1ds-color-palette__item">
+        <div class="sb1ds-color-palette__color sb1ds-color-palette__color--white-darkmode">
+            <h4 class="sb1ds-color-palette__color-name">White</h4>
+            <dl class="sb1ds-color-palette__color-properties">
+                <dt>LESS:</dt>
+                <dd>@ffe-white-darkmode</dd>
+                <dt>HEX:</dt>
+                <dd>#ffffff</dd>
+                <dt>RGB:</dt>
+                <dd>255, 255, 255</dd>
+            </dl>
+        </div>
+    </li>
+</ul>

--- a/styleguide-content/visuell-identitet/farger.md
+++ b/styleguide-content/visuell-identitet/farger.md
@@ -511,3 +511,114 @@ Her er en oversikt over gråtoner, svart og andre nøytrale farger vi har behov 
         </div>
     </li>
 </ul>
+
+### Dark mode
+
+Oversikt over farger som brukes når dark mode er aktivert.
+
+<ul class="sb1ds-color-palette sb1ds-color-palette--darkmode">
+    <li class="sb1ds-color-palette__item">
+        <div class="sb1ds-color-palette__color sb1ds-color-palette__color--darkmode-svart">
+            <h4 class="sb1ds-color-palette__color-name">Svart</h4>
+            <dl class="sb1ds-color-palette__color-properties">
+                <dt>LESS:</dt>
+                <dd>@ffe-farge-darkmode-svart</dd>
+                <dt>HEX:</dt>
+                <dd>#000000</dd>
+                <dt>RGB:</dt>
+                <dd>0, 0, 0</dd>
+            </dl>
+        </div>
+    </li>
+    <li class="sb1ds-color-palette__item">
+        <div class="sb1ds-color-palette__color sb1ds-color-palette__color--darkmode-koksgraa">
+            <h4 class="sb1ds-color-palette__color-name">Koksgrå</h4>
+            <dl class="sb1ds-color-palette__color-properties">
+                <dt>LESS:</dt>
+                <dd>@ffe-farge-darkmode-koksgraa</dd>
+                <dt>HEX:</dt>
+                <dd>#1c1c1c</dd>
+                <dt>RGB:</dt>
+                <dd>28, 28, 28</dd>
+            </dl>
+        </div>
+    </li>
+    <li class="sb1ds-color-palette__item">
+        <div class="sb1ds-color-palette__color sb1ds-color-palette__color--darkmode-moerkgraa">
+            <h4 class="sb1ds-color-palette__color-name">Mørk grå</h4>
+            <dl class="sb1ds-color-palette__color-properties">
+                <dt>LESS:</dt>
+                <dd>@ffe-farge-darkmode-moerkgraa</dd>
+                <dt>HEX:</dt>
+                <dd>#292929</dd>
+                <dt>RGB:</dt>
+                <dd>41, 41, 41</dd>
+            </dl>
+        </div>
+    </li>
+    <li class="sb1ds-color-palette__item">
+        <div class="sb1ds-color-palette__color sb1ds-color-palette__color--darkmode-graa">
+            <h4 class="sb1ds-color-palette__color-name">Grå</h4>
+            <dl class="sb1ds-color-palette__color-properties">
+                <dt>LESS:</dt>
+                <dd>@ffe-farge-darkmode-graa</dd>
+                <dt>HEX:</dt>
+                <dd>#858585</dd>
+                <dt>RGB:</dt>
+                <dd>133, 133, 133</dd>
+            </dl>
+        </div>
+    </li>
+    <li class="sb1ds-color-palette__item">
+        <div class="sb1ds-color-palette__color sb1ds-color-palette__color--darkmode-lysgraa">
+            <h4 class="sb1ds-color-palette__color-name">Lys grå</h4>
+            <dl class="sb1ds-color-palette__color-properties">
+                <dt>LESS:</dt>
+                <dd>@ffe-farge-darkmode-lysgraa</dd>
+                <dt>HEX:</dt>
+                <dd>#cccccc</dd>
+                <dt>RGB:</dt>
+                <dd>204, 204, 204</dd>
+            </dl>
+        </div>
+    </li>
+    <li class="sb1ds-color-palette__item">
+        <div class="sb1ds-color-palette__color sb1ds-color-palette__color--darkmode-vann">
+            <h4 class="sb1ds-color-palette__color-name">Vann</h4>
+            <dl class="sb1ds-color-palette__color-properties">
+                <dt>LESS:</dt>
+                <dd>@ffe-farge-darkmode-vann</dd>
+                <dt>HEX:</dt>
+                <dd>#0a91ff</dd>
+                <dt>RGB:</dt>
+                <dd>10, 145, 255</dd>
+            </dl>
+        </div>
+    </li>
+    <li class="sb1ds-color-palette__item">
+        <div class="sb1ds-color-palette__color sb1ds-color-palette__color--darkmode-baer">
+            <h4 class="sb1ds-color-palette__color-name">Bær</h4>
+            <dl class="sb1ds-color-palette__color-properties">
+                <dt>LESS:</dt>
+                <dd>@ffe-farge-darkmode-baer</dd>
+                <dt>HEX:</dt>
+                <dd>#ff2424</dd>
+                <dt>RGB:</dt>
+                <dd>255, 36, 36</dd>
+            </dl>
+        </div>
+    </li>
+    <li class="sb1ds-color-palette__item">
+        <div class="sb1ds-color-palette__color sb1ds-color-palette__color--darkmode-hvit">
+            <h4 class="sb1ds-color-palette__color-name">Hvit</h4>
+            <dl class="sb1ds-color-palette__color-properties">
+                <dt>LESS:</dt>
+                <dd>@ffe-farge-darkmode-hvit</dd>
+                <dt>HEX:</dt>
+                <dd>#ffffff</dd>
+                <dt>RGB:</dt>
+                <dd>255, 255, 255</dd>
+            </dl>
+        </div>
+    </li>
+</ul>


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse

Legger til dokumentasjon av fargepalett for dark mode, ~~med nye navn~~.
**Edit:** Bruker samme palett som vi hittil har brukt, i påvente av en oppdatert palett for darkmode.

Screenshot fra dokumentasjonen:

![Screenshot 2021-03-24 at 12 20 30](https://user-images.githubusercontent.com/463847/112304579-f13d1b80-8c9d-11eb-92d3-ac78bf12a16c.png)

## Motivasjon og kontekst

Dark mode ble ikke med i den nylige endringen av fargepaletten, men brukes fortsatt aktivt.

## Testing

Variablene og dokumentasjonen er testet lokalt.

<!--

Helt til slutt, har du ..

.. lest retningslinjene våre for bidrag?
.. tatt en siste sjekk for kode og skrivefeil, debug informasjon o.l?
.. kjørt og eventuelt oppdatert testene?
.. kommentert og dokumentert det som trengs?
.. knyttet denne opp til relaterte issues?

-->
