### PR TITLE
fix(ffe-searchable-dropdown-react): fixes isse in talkback

### DIFF
--- a/packages/ffe-searchable-dropdown-react/less/searchable-dropdown.less
+++ b/packages/ffe-searchable-dropdown-react/less/searchable-dropdown.less
@@ -7,6 +7,11 @@
     }
 
     &__list {
+        ul {
+            margin: 0;
+            padding: 0;
+            list-style: none;
+        }
         background: @ffe-white;
         position: absolute;
         width: 100%;

--- a/packages/ffe-searchable-dropdown-react/src/ListItemContainer.js
+++ b/packages/ffe-searchable-dropdown-react/src/ListItemContainer.js
@@ -1,20 +1,9 @@
 import React from 'react';
-import { func, object, bool, arrayOf, string } from 'prop-types';
+import { func, object, bool } from 'prop-types';
 
-const ListItemContainer = ({
-    getItemProps,
-    item,
-    isHighlighted,
-    dropdownAttributes,
-    children,
-}) => {
-    const [titleAttribute] = dropdownAttributes;
-    const itemProps = getItemProps({
-        item: item[titleAttribute],
-        key: item[titleAttribute],
-    });
+const ListItemContainer = ({ item, isHighlighted, children, ...itemProps }) => {
     return (
-        <div
+        <li
             {...itemProps}
             className="ffe-searchable-dropdown__list-item-container"
         >
@@ -22,15 +11,13 @@ const ListItemContainer = ({
                 item,
                 isHighlighted,
             })}
-        </div>
+        </li>
     );
 };
 
 ListItemContainer.propTypes = {
-    getItemProps: func.isRequired,
     item: object.isRequired,
     isHighlighted: bool.isRequired,
-    dropdownAttributes: arrayOf(string).isRequired,
     children: func.isRequired,
 };
 

--- a/packages/ffe-searchable-dropdown-react/src/findSelectedItem.js
+++ b/packages/ffe-searchable-dropdown-react/src/findSelectedItem.js
@@ -1,4 +1,0 @@
-export default (value, dropdownList, dropdownAttributes) => {
-    const [searchAttribute] = dropdownAttributes;
-    return dropdownList.find(item => item[searchAttribute] === value) || null;
-};

--- a/packages/ffe-searchable-dropdown-react/src/index.d.ts
+++ b/packages/ffe-searchable-dropdown-react/src/index.d.ts
@@ -17,7 +17,7 @@ export interface SearchableDropdownProps<T> {
     dropdownList: T[];
     dropdownAttributes: (keyof T)[];
     searchAttributes: (keyof T)[];
-    inputProps?: React.InputHTMLAttributes<HTMLInputElement>;
+    inputProps?: React.HTMLProps<HTMLInputElement>;
     initialValue?: T;
     maxRenderedDropdownElements?: number;
     onChange?: (dropdownListItem: T) => any;


### PR DESCRIPTION
Screen reader issues på device

## Beskrivelse

Team betalning oppdager att denne ikke funker på device(skjermleser) vilket jag bekreftar. Jag var tvungen att fjerne att den opnes på focus før att få det att funke. Fant ikke noen vei run det. Det er manuellt openMenu og closeMenu i blur og focus som ødelegger her. 

I vart fall er dom endaste som vil merka en forskjell brukare som bruker tastatur og tabbar seg in i feltet, men og andra sidan har vi ju en pil expandera listan man lett kan trykke på.  

**edit**: Det ser ut som vi kan beholde att den opnes på focus. Problemet ser ut att vare når den får en defaultverdi.

Jag tog også i bruk hooksen før mer kontrol over markupen. 

**edit2**: Ser ut som også defaultverdier løst seg denne snutten så nu tror jag vi har samme funksjionalitet som før men att det virker på talkback med defaultverdier. Vi har forsatt muligens ett problem med Voiceover. 

```
onFocus={e => {
   e.preventDefault();
   onFocus(e);
   if (!selectedItem) {
      openMenu();
   }
}}
```
## Testing

Jag har testat selv på emulator og Talkback men skulle sett pris på hvis noen fler sjekkade ut branchen og gjorde detsamma. Nås på http://10.0.2.4:6060/#!/SearchableDropdown hvis du bruker emulator.
