### PR TITLE
fix(ffe-account-selector-react): Remove role="listbox" to make dropdo…

### DIFF
--- a/packages/ffe-account-selector-react/src/subcomponents/suggestion-high-capacity/SuggestionList.js
+++ b/packages/ffe-account-selector-react/src/subcomponents/suggestion-high-capacity/SuggestionList.js
@@ -69,7 +69,6 @@ export default function SuggestionList(props) {
                     ref={ref}
                     id={id}
                     className={'ffe-base-selector__suggestion-container-list'}
-                    role="listbox"
                     {...forwardProps}
                 />
             ))}
@@ -87,11 +86,7 @@ export default function SuggestionList(props) {
             {Row}
         </List>
     ) : (
-        <ul
-            className="ffe-base-selector__suggestion-container-list"
-            role="listbox"
-            id={id}
-        >
+        <ul className="ffe-base-selector__suggestion-container-list" id={id}>
             <li>{renderNoMatches()}</li>
         </ul>
     );

--- a/packages/ffe-account-selector-react/src/subcomponents/suggestion-high-capacity/SuggestionList.spec.js
+++ b/packages/ffe-account-selector-react/src/subcomponents/suggestion-high-capacity/SuggestionList.spec.js
@@ -55,7 +55,6 @@ function mountSuggestionListContainer(props = propsSuggestionListContainer()) {
 describe('<SuggestionList />', () => {
     it('highlighted <Suggestion> set to highlightedIndex', () => {
         const wrapper = mountSuggestionList();
-        const suggestionList = wrapper.find('[role="listbox"]');
         const firstRow = suggestionList.childAt(0);
         const secondRow = suggestionList.childAt(1);
 

--- a/packages/ffe-account-selector-react/src/subcomponents/suggestion/SuggestionList.js
+++ b/packages/ffe-account-selector-react/src/subcomponents/suggestion/SuggestionList.js
@@ -16,11 +16,7 @@ export default function SuggestionList(props) {
     return isLoading ? (
         <Spinner center={true} large={true} />
     ) : (
-        <ul
-            className="ffe-base-selector__suggestion-container-list"
-            role="listbox"
-            id={id}
-        >
+        <ul className="ffe-base-selector__suggestion-container-list" id={id}>
             {suggestions.length > 0 ? (
                 suggestions.map((item, index) => (
                     <SuggestionItem


### PR DESCRIPTION
…wn accessible for VoiceOver

<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse

`AccountSelector` fungerer ikke med skjermleser på iPhone og mac, men fungerer på android. I pm-betaling har vi tidligere hatt problem med at skjermleser kun leser "listeboks" og går videre forbi elementene i listeboksen. Det hjalp for oss å fjerne `role="listbox"` som jeg har gjort her, men får ikke testa på mac eller iPhone lokalt i designsystemet, får bare testet på android-emulatoren. Har noen av dere mulighet til å sjekke det? Har sjekket at det fungerer som før på android. Eneste forskjellen er at skjermleser ikke leser opp "listeboks" før en navigeres til første element i dropdownen. :blush: Dersom ingen har mulighet til å teste på en ios device, så lurer jeg på om vi kan gå ut med dette uten å teste siden det er en så liten endring?

## Motivasjon og kontekst

<!-- Hvorfor trengs denne endringen, og hva løser den? -->

## Testing

<!-- Hvordan har du har testet endringene dine? Ta gjerne med systeminfo o.l -->

<!--

Helt til slutt, har du ..

.. lest retningslinjene våre for bidrag?
.. tatt en siste sjekk for kode og skrivefeil, debug informasjon o.l?
.. kjørt og eventuelt oppdatert testene?
.. kommentert og dokumentert det som trengs?
.. knyttet denne opp til relaterte issues?

-->
