### PR TITLE
perf(ffe-accordion-react): dont render collapsed content when closed

### DIFF
--- a/packages/ffe-accordion-react/src/AccordionItem.js
+++ b/packages/ffe-accordion-react/src/AccordionItem.js
@@ -43,6 +43,8 @@ const AccordionItem = ({
         ...rest
     } = accordionProps;
 
+    const collapseHidden = !isExpanded && !isAnimating;
+
     return (
         <div
             className={classNames(className, 'ffe-accordion-item', {
@@ -78,10 +80,12 @@ const AccordionItem = ({
                 onRest={() => setIsAnimating(false)}
                 id={contentId.current}
                 aria-labelledby={buttonId.current}
-                hidden={!isExpanded && !isAnimating}
+                hidden={collapseHidden}
                 role="region"
             >
-                <div className="ffe-accordion-body">{children}</div>
+                {!collapseHidden && (
+                    <div className="ffe-accordion-body">{children}</div>
+                )}
             </Collapse>
         </div>
     );


### PR DESCRIPTION
## Beskrivelse

En forbedrelse av ytelse. 

## Motivasjon og kontekst

Vi trenger ikke rendre elementer som ikke er i bruk. `hidden` skjuler ju ting for skjermleser så det ju vara i orden att ikke rendra inneholdet i ett element som er `hidden`.

## Testing

Testat lokalt. Accordion oppfører seg som vanligt. 

