### PR TITLE
revert(ffe-form-react): remove described by

### DIFF
--- a/packages/ffe-form-react/src/InputGroup.js
+++ b/packages/ffe-form-react/src/InputGroup.js
@@ -21,9 +21,6 @@ const InputGroup = ({
 }) => {
     const [id] = useState(inputId ? inputId : `input-${uuid()}`);
     const descriptionId = description ? `${id}-description` : undefined;
-    const fieldMessageId = fieldMessage
-        ? (fieldMessage.props && fieldMessage.props.id) || `${id}-fieldmessage`
-        : undefined;
 
     if (React.Children.count(children) > 1) {
         throw new Error(
@@ -56,8 +53,7 @@ const InputGroup = ({
 
     const hasMessage = !!fieldMessage;
 
-    const ariaDescribedBy =
-        `${fieldMessageId || ''} ${descriptionId || ''}`.trim() || undefined;
+    const ariaDescribedBy = `${descriptionId || ''}`.trim() || null;
 
     const extraProps = {
         id,
@@ -109,14 +105,11 @@ const InputGroup = ({
             {modifiedChildren}
 
             {typeof fieldMessage === 'string' && (
-                <ErrorFieldMessage element="p" id={fieldMessageId}>
+                <ErrorFieldMessage element="p">
                     {fieldMessage}
                 </ErrorFieldMessage>
             )}
-            {React.isValidElement(fieldMessage) &&
-                React.cloneElement(fieldMessage, {
-                    id: fieldMessageId,
-                })}
+            {React.isValidElement(fieldMessage) && fieldMessage}
         </div>
     );
 };

--- a/packages/ffe-form-react/src/InputGroup.spec.js
+++ b/packages/ffe-form-react/src/InputGroup.spec.js
@@ -57,7 +57,7 @@ describe('<InputGroup>', () => {
         expect(wrapper.find('Tooltip').prop('children')).toBe('custom tooltip');
     });
 
-    it('renders an ErrorFieldMessage and sets aria-invalid and aria-describedby if a string is passed as fieldMessage', () => {
+    it('renders an ErrorFieldMessage and sets aria-invalid', () => {
         const wrapper = getWrapper({ fieldMessage: 'such error' });
 
         const errorFieldMessage = wrapper.find('ErrorFieldMessage');
@@ -66,9 +66,6 @@ describe('<InputGroup>', () => {
         const input = wrapper.find(Input);
         expect(wrapper.hasClass('ffe-input-group--message')).toBe(true);
         expect(input.prop('aria-invalid')).toBe('true');
-        expect(input.prop('aria-describedby')).toBe(
-            errorFieldMessage.prop('id'),
-        );
     });
 
     it('renders a Label component if passed a label prop', () => {
@@ -86,7 +83,7 @@ describe('<InputGroup>', () => {
         expect(wrapper.find('Tooltip').prop('children')).toBe('Tooltip text');
     });
 
-    it('renders a ErrorFieldMessage and sets aria-invalid and aria-describedby if passed as fieldMessage prop', () => {
+    it('renders a ErrorFieldMessage and sets aria-invalid if passed as fieldMessage prop', () => {
         const wrapper = getWrapper({
             fieldMessage: <ErrorFieldMessage>Some error</ErrorFieldMessage>,
         });
@@ -99,9 +96,6 @@ describe('<InputGroup>', () => {
         const input = wrapper.find(Input);
         expect(wrapper.hasClass('ffe-input-group--message')).toBe(true);
         expect(input.prop('aria-invalid')).toBe('true');
-        expect(input.prop('aria-describedby')).toBe(
-            errorFieldMessage.prop('id'),
-        );
     });
 
     it('connects an ErrorFieldMessage that specifies its own id to the correct input field', () => {
@@ -116,12 +110,9 @@ describe('<InputGroup>', () => {
 
         const errorFieldMessageId = errorFieldMessage.prop('id');
         expect(errorFieldMessageId).toBe('best-id');
-        expect(wrapper.find(Input).prop('aria-describedby')).toBe(
-            errorFieldMessageId,
-        );
     });
 
-    it('renders a SuccessFieldMessage and sets aria-describedby but not not aria-invalid if passed as fieldMessage prop', () => {
+    it('renders a SuccessFieldMessage and not aria-invalid if passed as fieldMessage prop', () => {
         const wrapper = getWrapper({
             fieldMessage: (
                 <SuccessFieldMessage>Some success</SuccessFieldMessage>
@@ -134,9 +125,6 @@ describe('<InputGroup>', () => {
         expect(wrapper.hasClass('ffe-input-group--message')).toBe(true);
         const input = wrapper.find(Input);
         expect(input.prop('aria-invalid')).toBe('false');
-        expect(input.prop('aria-describedby')).toBe(
-            successFieldMessage.prop('id'),
-        );
     });
 
     it('throws error when receiving multiple children', () => {
@@ -212,42 +200,26 @@ describe('<InputGroup>', () => {
         );
     });
 
-    it('sets aria-describedby with two ids when both fieldMessage and description are defined', () => {
+    it('sets aria-describedby when description is defined', () => {
         const wrapper = getWrapper({
             description: 'description',
-            fieldMessage: 'field message',
         });
-        const fieldMessageId = wrapper.find('ErrorFieldMessage').prop('id');
         const descriptionId = wrapper.find('.ffe-small-text').prop('id');
         expect(wrapper.find(Input).prop('aria-describedby')).toBe(
-            `${fieldMessageId} ${descriptionId}`,
+            descriptionId,
         );
     });
 
-    it('does not set aria-describedby when neither fieldMessage or description is defined', () => {
+    it('does not set aria-describedby when description is not defined', () => {
         const wrapper = getWrapper();
-        expect(wrapper.find(Input).prop('aria-describedby')).toBe(undefined);
-    });
-
-    it('adds aria-describedby when adding fieldMessage on second render', () => {
-        const wrapper = getWrapper();
-        expect(wrapper.find(Input).prop('aria-describedby')).toBe(undefined);
-        wrapper.setProps({ fieldMessage: 'field message' });
-        expect(wrapper.find(Input).prop('aria-describedby')).not.toBe(
-            undefined,
-        );
-        expect(wrapper.find(Input).prop('aria-describedby')).toBe(
-            wrapper.find('ErrorFieldMessage').prop('id'),
-        );
+        expect(wrapper.find(Input).prop('aria-describedby')).toBeNull();
     });
 
     it('adds aria-describedby when adding description on second render', () => {
         const wrapper = getWrapper();
-        expect(wrapper.find(Input).prop('aria-describedby')).toBe(undefined);
+        expect(wrapper.find(Input).prop('aria-describedby')).toBeNull();
         wrapper.setProps({ description: 'description' });
-        expect(wrapper.find(Input).prop('aria-describedby')).not.toBe(
-            undefined,
-        );
+        expect(wrapper.find(Input).prop('aria-describedby')).not.toBe(null);
         expect(wrapper.find(Input).prop('aria-describedby')).toBe(
             wrapper.find('.ffe-small-text').prop('id'),
         );


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse

aria-described på fieldmessage skaper problemer før oss. Slik ser vår fieldMessage ut og oppfyller vell kraven til proptypes som er node eller string. Vi vill da enda op her med en tom dom div som aria-described peker på.  

```
import React from 'react';
import { Field } from 'react-final-form';

import { ErrorFieldMessage } from '@sb1/ffe-form-react';

const FormError: React.FC<{ name: string }> = ({ name }) => (
    <Field name={name} subscription={{ submitFailed: true, error: true }}>
        {({ meta: { submitFailed, error } }) =>
            submitFailed && error ? <ErrorFieldMessage>{error}</ErrorFieldMessage> : <div />
        }
    </Field>
);

export default FormError;
```

Vad gjør vi med dette. Vi har otroligt mange skjemaen og bruker denne komponeten overallt. Vad har vi før alternativer på denne?
