### PR TITLE
fix(ffe-searchable-dropdown-react): better screen reader support

### DIFF
--- a/packages/ffe-searchable-dropdown-react/less/searchable-dropdown.less
+++ b/packages/ffe-searchable-dropdown-react/less/searchable-dropdown.less
@@ -7,6 +7,7 @@
     }
 
     &__list {
+        display: none;
         background: @ffe-white;
         position: absolute;
         width: 100%;
@@ -22,6 +23,7 @@
         }
 
         &--open {
+            display: block;
             height: auto;
             border: 1px solid @ffe-grey-silver;
             .native & {
@@ -117,6 +119,10 @@
         display: flex;
         justify-content: center;
         align-items: center;
+
+        &--hidden {
+            display: none;
+        }
 
         &:hover {
             border: 2px solid @ffe-blue-azure;

--- a/packages/ffe-searchable-dropdown-react/package.json
+++ b/packages/ffe-searchable-dropdown-react/package.json
@@ -33,11 +33,10 @@
     "@sb1/ffe-form": "^16.0.1",
     "@sb1/ffe-icons-react": "^7.2.18",
     "classnames": "^2.2.5",
-    "downshift": "^6.0.3",
+    "compute-scroll-into-view": "^1.0.17",
     "lodash.isequal": "^4.5.0",
     "prop-types": "^15.6.0",
-    "react-custom-scrollbars": "^4.2.1",
-    "react-proptype-conditional-require": "^1.0.4"
+    "react-custom-scrollbars": "^4.2.1"
   },
   "devDependencies": {
     "eslint": "^5.9.0",

--- a/packages/ffe-searchable-dropdown-react/src/ListItemContainer.js
+++ b/packages/ffe-searchable-dropdown-react/src/ListItemContainer.js
@@ -1,21 +1,25 @@
-import React from 'react';
-import { func, object, bool, arrayOf, string } from 'prop-types';
+import React, { useRef } from 'react';
+import { any, bool, func, object, oneOfType, shape } from 'prop-types';
+import { v4 as uuid } from 'uuid';
 
 const ListItemContainer = ({
-    getItemProps,
     item,
     isHighlighted,
-    dropdownAttributes,
     children,
+    forwardedRef,
+    onMouseEnter,
+    onClick,
 }) => {
-    const [titleAttribute] = dropdownAttributes;
-    const itemProps = getItemProps({
-        item: item[titleAttribute],
-        key: item[titleAttribute],
-    });
+    const id = useRef(`ìtem-${uuid()}`);
     return (
+        // eslint-disable-next-line jsx-a11y/interactive-supports-focus
         <div
-            {...itemProps}
+            id={id.current}
+            role="option"
+            onMouseEnter={onMouseEnter}
+            aria-selected={isHighlighted}
+            ref={forwardedRef}
+            onClick={onClick}
             className="ffe-searchable-dropdown__list-item-container"
         >
             {children({
@@ -27,11 +31,14 @@ const ListItemContainer = ({
 };
 
 ListItemContainer.propTypes = {
-    getItemProps: func.isRequired,
     item: object.isRequired,
     isHighlighted: bool.isRequired,
-    dropdownAttributes: arrayOf(string).isRequired,
     children: func.isRequired,
+    forwardedRef: oneOfType([func, shape({ current: any })]),
+    onMouseEnter: func,
+    onClick: func,
 };
 
-export default ListItemContainer;
+export default React.forwardRef((props, ref) => {
+    return <ListItemContainer {...props} forwardedRef={ref} />;
+});

--- a/packages/ffe-searchable-dropdown-react/src/SearchableDropdown.js
+++ b/packages/ffe-searchable-dropdown-react/src/SearchableDropdown.js
@@ -1,33 +1,52 @@
-import React, { useMemo, useRef } from 'react';
+import React, {
+    createRef,
+    useLayoutEffect,
+    useMemo,
+    useReducer,
+    useRef,
+    useState,
+    useEffect,
+} from 'react';
 import {
-    string,
     arrayOf,
-    shape,
-    number,
-    func,
     bool,
+    func,
+    number,
     object,
     oneOf,
     oneOfType,
+    shape,
+    string,
 } from 'prop-types';
 import classNames from 'classnames';
-import Downshift from 'downshift';
 import { Scrollbars } from 'react-custom-scrollbars';
 import isEqual from 'lodash.isequal';
-
-import { KryssIkon, ChevronIkon } from '@sb1/ffe-icons-react';
+import { ChevronIkon, KryssIkon } from '@sb1/ffe-icons-react';
 import { Paragraph } from '@sb1/ffe-core-react';
 
-import filterDropdownList from './filterDropdownList';
 import ListItemContainer from './ListItemContainer';
 import ListItemBody from './ListItemBody';
 import {
-    locales,
     getButtonLabelClear,
     getButtonLabelClose,
     getButtonLabelOpen,
+    getNotMatchText,
+    locales,
 } from './translations';
-import findSelectedItem from './findSelectedItem';
+import { v4 as uuid } from 'uuid';
+import { createReducer, stateChangeTypes } from './reducer';
+import { getListToRender } from './getListToRender';
+import { scrollIntoView } from './scrollIntoView';
+import {
+    getNewHighlightedIndexUp,
+    getNewHighlightedIndexDown,
+} from './getNewHighlightedIndex';
+import { useSetAllyMessageItemSelection } from './a11y';
+
+const ARROW_UP = 'ArrowUp';
+const ARROW_DOWN = 'ArrowDown';
+const ESCAPE = 'Escape';
+const ENTER = 'Enter';
 
 const SearchableDropdown = ({
     id,
@@ -46,186 +65,325 @@ const SearchableDropdown = ({
     locale,
     'aria-invalid': ariaInvalid,
 }) => {
-    const inputEl = useRef(null);
-
     const initialSelectedItem = useMemo(
         () => dropdownList.find(item => isEqual(initialValue, item)),
         [dropdownList, initialValue],
     );
 
+    const [state, dispatch] = useReducer(
+        createReducer({
+            dropdownList,
+            searchAttributes,
+            maxRenderedDropdownElements,
+            noMatchDropdownList: noMatch.dropdownList,
+        }),
+        {
+            isExpanded: false,
+            prevResultCount: 0,
+            prevSelectedItem: initialSelectedItem,
+            selectedItem: initialSelectedItem,
+            highlightedIndex: -1,
+            inputValue: initialSelectedItem
+                ? initialSelectedItem[dropdownAttributes[0]]
+                : '',
+        },
+        initialState => {
+            return {
+                ...initialState,
+                ...getListToRender({
+                    inputValue: initialState.inputValue,
+                    searchAttributes,
+                    maxRenderedDropdownElements,
+                    dropdownList,
+                }),
+            };
+        },
+    );
+    const isInitialMountRef = useRef(true);
+    const [refs, setRefs] = useState([]);
+    const inputRef = useRef();
+    const toggleButtonRef = useRef();
+    const containerRef = useRef();
+
     const ListItemBodyElement = CustomListItemBody || ListItemBody;
+    const listBoxRef = useRef(uuid());
+    const notMatchMessageId = useRef(uuid());
+    const shouldFocusToggleButton = useRef(false);
+    const shouldFocusInput = useRef(false);
+
+    const handleInputClick = () => {
+        dispatch({ type: stateChangeTypes.InputClick });
+    };
+
+    useSetAllyMessageItemSelection({
+        searchAttributes,
+        selectedItem: state.selectedItem,
+        prevSelectedItem: state.prevSelectedItem,
+        isInitialMount: isInitialMountRef.current,
+        isExpanded: state.isExpanded,
+        resultCount: state.listToRender.length,
+        prevResultCount: state.prevResultCount,
+    });
+
+    useLayoutEffect(() => {
+        setRefs(prevRefs =>
+            Array(state.listToRender.length)
+                .fill(null)
+                .map((_, i) => prevRefs[i] || createRef()),
+        );
+    }, [state.listToRender.length]);
+
+    useLayoutEffect(() => {
+        if (shouldFocusToggleButton.current) {
+            toggleButtonRef.current.focus();
+            shouldFocusToggleButton.current = false;
+        } else if (shouldFocusInput.current) {
+            inputRef.current.focus();
+            shouldFocusInput.current = false;
+        }
+    });
+
+    useEffect(() => {
+        isInitialMountRef.current = false;
+    }, []);
+
+    const handleContainerFocus = e => {
+        if (!containerRef.current.contains(e.target)) {
+            dispatch({
+                type: stateChangeTypes.FocusMovedOutSide,
+            });
+        }
+    };
+
+    useEffect(() => {
+        document.addEventListener('mousedown', handleContainerFocus);
+        document.addEventListener('focusin', handleContainerFocus);
+        return () => {
+            document.removeEventListener('mousedown', handleContainerFocus);
+            document.removeEventListener('focusin', handleContainerFocus);
+        };
+    }, []);
+
+    const handleKeyDown = event => {
+        if (event.key === ENTER && state.highlightedIndex >= 0) {
+            dispatch({
+                type: stateChangeTypes.InputKeyDownEnter,
+                payload: {
+                    selectedItem: state.listToRender[state.highlightedIndex],
+                },
+            });
+            onChange(state.listToRender[state.highlightedIndex]);
+            return;
+        } else if (event.key === ESCAPE) {
+            dispatch({ type: stateChangeTypes.InputKeyDownEscape });
+            return;
+        }
+
+        if (event.key === ARROW_UP) {
+            event.preventDefault();
+            const newHighlightedIndex = getNewHighlightedIndexUp(
+                state.highlightedIndex,
+                state.listToRender.length,
+            );
+            dispatch({
+                type: stateChangeTypes.InputKeyDownArrowUp,
+                payload: { highlightedIndex: newHighlightedIndex },
+            });
+            scrollIntoView(
+                refs[newHighlightedIndex].current,
+                listBoxRef.current,
+            );
+            return;
+        }
+        if (event.key === ARROW_DOWN) {
+            event.preventDefault();
+            const newHighlightedIndex = getNewHighlightedIndexDown(
+                state.highlightedIndex,
+                state.listToRender.length,
+            );
+            dispatch({
+                type: stateChangeTypes.InputKeyDownArrowDown,
+                payload: { highlightedIndex: newHighlightedIndex },
+            });
+            scrollIntoView(
+                refs[newHighlightedIndex].current,
+                listBoxRef.current,
+            );
+            return;
+        }
+    };
 
     return (
-        <Downshift
-            inputId={id}
-            labelId={labelId}
-            initialSelectedItem={
-                initialSelectedItem
-                    ? initialSelectedItem[dropdownAttributes[0]]
-                    : null
-            }
-            onChange={value =>
-                onChange(
-                    findSelectedItem(value, dropdownList, dropdownAttributes),
-                )
-            }
+        <div // eslint-disable-line jsx-a11y/no-static-element-interactions
+            onKeyDown={handleKeyDown}
+            className={classNames(className, 'ffe-searchable-dropdown', {
+                'ffe-searchable-dropdown--dark': dark,
+            })}
+            ref={containerRef}
         >
-            {({
-                getInputProps,
-                getItemProps,
-                getMenuProps,
-                isOpen,
-                inputValue,
-                highlightedIndex,
-                selectedItem,
-                openMenu,
-                closeMenu,
-                clearSelection,
-            }) => {
-                const trimmedInput = inputValue.trim();
-
-                const shouldFilter =
-                    trimmedInput.length > 0 && trimmedInput !== selectedItem;
-                const dropdownListFiltered = shouldFilter
-                    ? filterDropdownList(
-                          dropdownList,
-                          searchAttributes,
-                          trimmedInput,
-                      ).slice(0, maxRenderedDropdownElements)
-                    : dropdownList.slice(0, maxRenderedDropdownElements);
-
-                const listToRender = dropdownListFiltered.length
-                    ? dropdownListFiltered
-                    : noMatch.dropdownList || [];
-
-                const {
-                    onFocus = Function.prototype,
-                    onBlur = Function.prototype,
-                    onClick = Function.prototype,
-                    ...restInputProps
-                } = inputProps;
-
-                return (
-                    <div
-                        className={classNames(
-                            className,
-                            'ffe-searchable-dropdown',
-                            {
-                                'ffe-searchable-dropdown--dark': dark,
-                            },
-                        )}
-                    >
-                        <input
-                            ref={inputEl}
-                            {...getInputProps({
-                                className: classNames('ffe-input-field', {
-                                    'ffe-input-field--dark': dark,
-                                }),
-                                onFocus: (...args) => {
-                                    openMenu();
-                                    onFocus(...args);
-                                },
-                                onBlur: (...args) => {
-                                    closeMenu();
-                                    onBlur(...args);
-                                },
-                                onClick: (...args) => {
-                                    openMenu();
-                                    onClick(...args);
-                                },
-                                ...restInputProps,
-                            })}
-                            aria-invalid={
-                                typeof ariaInvalid === 'string'
-                                    ? ariaInvalid
-                                    : String(!!ariaInvalid)
-                            }
-                        />
-                        {selectedItem ? (
-                            <button
-                                type="button"
-                                aria-label={getButtonLabelClear(locale)}
-                                className="ffe-searchable-dropdown__button ffe-searchable-dropdown__button--cross"
-                                onClick={clearSelection}
-                            >
-                                <KryssIkon />
-                            </button>
-                        ) : (
-                            <button
-                                type="button"
-                                aria-label={
-                                    isOpen
-                                        ? getButtonLabelClose(locale)
-                                        : getButtonLabelOpen(locale)
-                                }
-                                className={classNames(
-                                    'ffe-searchable-dropdown__button ffe-searchable-dropdown__button--arrow',
-                                    {
-                                        'ffe-searchable-dropdown__button--flip': isOpen,
-                                    },
-                                )}
-                                onClick={isOpen ? closeMenu : openMenu}
-                            >
-                                <ChevronIkon />
-                            </button>
-                        )}
-                        <div
-                            className={classNames(
-                                'ffe-searchable-dropdown__list',
-                                {
-                                    'ffe-searchable-dropdown__list--open': isOpen,
-                                },
+            <div>
+                <input
+                    {...inputProps}
+                    ref={inputRef}
+                    id={id}
+                    aria-labelledby={labelId}
+                    className={classNames('ffe-input-field', {
+                        'ffe-input-field--dark': dark,
+                    })}
+                    onClick={handleInputClick}
+                    onChange={e => {
+                        if (inputProps.onChange) {
+                            inputProps.onChange(e);
+                        }
+                        dispatch({
+                            type: stateChangeTypes.InputChange,
+                            payload: { inputValue: e.target.value },
+                        });
+                    }}
+                    aria-describedby={
+                        [
+                            inputProps['aria-describedby'],
+                            state.noMatch && notMatchMessageId.current,
+                        ]
+                            .filter(Boolean)
+                            .join(' ') || null
+                    }
+                    value={state.inputValue}
+                    type="text"
+                    role="combobox"
+                    autoComplete="off"
+                    aria-controls={listBoxRef.current}
+                    aria-expanded={
+                        state.isExpanded && !!state.listToRender.length
+                    }
+                    aria-autocomplete="list"
+                    aria-haspopup="listbox"
+                    aria-activedescendant={
+                        state.highlightedIndex >= 0
+                            ? refs[
+                                  state.highlightedIndex
+                              ]?.current.getAttribute('id')
+                            : null
+                    }
+                    aria-invalid={
+                        typeof ariaInvalid === 'string'
+                            ? ariaInvalid
+                            : String(!!ariaInvalid)
+                    }
+                />
+                <button
+                    type="button"
+                    aria-label={getButtonLabelClear(locale)}
+                    className={classNames(
+                        'ffe-searchable-dropdown__button ffe-searchable-dropdown__button--cross',
+                        {
+                            'ffe-searchable-dropdown__button--hidden': !state.selectedItem,
+                        },
+                    )}
+                    onClick={() => {
+                        dispatch({ type: stateChangeTypes.ClearButtonPressed });
+                        onChange(null);
+                        shouldFocusToggleButton.current = true;
+                    }}
+                >
+                    <KryssIkon />
+                </button>
+                <button
+                    type="button"
+                    ref={toggleButtonRef}
+                    aria-label={
+                        state.isExpanded
+                            ? getButtonLabelClose(locale)
+                            : getButtonLabelOpen(locale)
+                    }
+                    className={classNames(
+                        'ffe-searchable-dropdown__button ffe-searchable-dropdown__button--arrow',
+                        {
+                            'ffe-searchable-dropdown__button--flip':
+                                state.isExpanded,
+                        },
+                        {
+                            'ffe-searchable-dropdown__button--hidden': !!state.selectedItem,
+                        },
+                    )}
+                    onClick={() =>
+                        dispatch({ type: stateChangeTypes.ToggleButtonPressed })
+                    }
+                >
+                    <ChevronIkon />
+                </button>
+            </div>
+            <div
+                className={classNames('ffe-searchable-dropdown__list', {
+                    'ffe-searchable-dropdown__list--open': state.isExpanded,
+                })}
+            >
+                <Scrollbars autoHeight={true} autoHeightMax={300}>
+                    {state.noMatch && (
+                        <>
+                            {noMatch.text ? (
+                                <div className="ffe-searchable-dropdown__no-match">
+                                    <Paragraph id={notMatchMessageId.current}>
+                                        {noMatch.text}
+                                    </Paragraph>
+                                </div>
+                            ) : (
+                                <Paragraph
+                                    id={notMatchMessageId.current}
+                                    className="ffe-screenreader-only"
+                                >
+                                    {getNotMatchText()}
+                                </Paragraph>
                             )}
-                        >
-                            <Scrollbars
-                                {...getMenuProps()}
-                                autoHeight={true}
-                                autoHeightMax={300}
-                            >
-                                {!dropdownListFiltered.length &&
-                                    noMatch.text &&
-                                    isOpen && (
-                                        <div className="ffe-searchable-dropdown__no-match">
-                                            <Paragraph>
-                                                {noMatch.text}
-                                            </Paragraph>
-                                        </div>
-                                    )}
-                                {isOpen &&
-                                    listToRender.map((item, index) => {
-                                        return (
-                                            <ListItemContainer
-                                                key={
-                                                    item[dropdownAttributes[0]]
-                                                }
-                                                dropdownAttributes={
-                                                    dropdownAttributes
-                                                }
-                                                getItemProps={getItemProps}
-                                                isHighlighted={
-                                                    index === highlightedIndex
-                                                }
-                                                item={item}
-                                            >
-                                                {props => {
-                                                    return (
-                                                        <ListItemBodyElement
-                                                            {...props}
-                                                            dropdownAttributes={
-                                                                dropdownAttributes
-                                                            }
-                                                        />
-                                                    );
-                                                }}
-                                            </ListItemContainer>
-                                        );
-                                    })}
-                            </Scrollbars>
-                        </div>
+                        </>
+                    )}
+                    <div id={listBoxRef.current} role="listbox">
+                        {state.isExpanded &&
+                            state.listToRender.map((item, index) => {
+                                return (
+                                    <ListItemContainer
+                                        key={item[dropdownAttributes[0]]}
+                                        ref={refs[index]}
+                                        isHighlighted={
+                                            state.highlightedIndex === index
+                                        }
+                                        onMouseEnter={e => {
+                                            dispatch({
+                                                type:
+                                                    stateChangeTypes.ItemOnMouseEnter,
+                                                payload: {
+                                                    highlightedIndex: index,
+                                                },
+                                            });
+                                        }}
+                                        onClick={() => {
+                                            onChange(item);
+                                            dispatch({
+                                                type:
+                                                    stateChangeTypes.ItemOnClick,
+                                                payload: { selectedItem: item },
+                                            });
+                                            shouldFocusInput.current = true;
+                                        }}
+                                        item={item}
+                                    >
+                                        {props => {
+                                            return (
+                                                <ListItemBodyElement
+                                                    {...props}
+                                                    dropdownAttributes={
+                                                        dropdownAttributes
+                                                    }
+                                                />
+                                            );
+                                        }}
+                                    </ListItemContainer>
+                                );
+                            })}
                     </div>
-                );
-            }}
-        </Downshift>
+                </Scrollbars>
+            </div>
+        </div>
     );
 };
 

--- a/packages/ffe-searchable-dropdown-react/src/SearchableDropdown.spec.js
+++ b/packages/ffe-searchable-dropdown-react/src/SearchableDropdown.spec.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, fireEvent } from '@testing-library/react';
+import { render, fireEvent, screen } from '@testing-library/react';
 
 import SearchableDropdown from './SearchableDropdown';
 
@@ -23,12 +23,10 @@ describe('SearchableDropdown', () => {
     ];
 
     it('should show filtered result', () => {
-        const placeholder = 'placeholder';
-        const { queryByText, getByPlaceholderText, getByText } = render(
+        render(
             <SearchableDropdown
                 id="id"
                 labelId="labelId"
-                inputProps={{ placeholder }}
                 dropdownAttributes={['organizationName', 'organizationNumber']}
                 dropdownList={companies}
                 searchAttributes={['organizationName', 'organizationNumber']}
@@ -36,35 +34,33 @@ describe('SearchableDropdown', () => {
             />,
         );
 
-        const input = getByPlaceholderText(placeholder);
+        const input = screen.getByRole('combobox');
 
         fireEvent.change(input, { target: { value: 'Be' } });
 
-        expect(getByText('Bedriften')).toBeInTheDocument();
-        expect(getByText('912602370')).toBeInTheDocument();
-        expect(queryByText('Sønn & co')).toBeNull();
-        expect(queryByText('812602372')).toBeNull();
-        expect(getByText('Beslag skytter')).toBeInTheDocument();
-        expect(getByText('812602552')).toBeInTheDocument();
+        expect(screen.getByText('Bedriften')).toBeInTheDocument();
+        expect(screen.getByText('912602370')).toBeInTheDocument();
+        expect(screen.queryByText('Sønn & co')).toBeNull();
+        expect(screen.queryByText('812602372')).toBeNull();
+        expect(screen.getByText('Beslag skytter')).toBeInTheDocument();
+        expect(screen.getByText('812602552')).toBeInTheDocument();
 
         fireEvent.change(input, { target: { value: '8126023' } });
 
-        expect(queryByText('Bedriften')).toBeNull();
-        expect(queryByText('912602370')).toBeNull();
-        expect(getByText('Sønn & co')).toBeInTheDocument();
-        expect(getByText('812602372')).toBeInTheDocument();
-        expect(queryByText('Beslag skytter')).toBeNull();
-        expect(queryByText('812602552')).toBeNull();
+        expect(screen.queryByText('Bedriften')).toBeNull();
+        expect(screen.queryByText('912602370')).toBeNull();
+        expect(screen.getByText('Sønn & co')).toBeInTheDocument();
+        expect(screen.getByText('812602372')).toBeInTheDocument();
+        expect(screen.queryByText('Beslag skytter')).toBeNull();
+        expect(screen.queryByText('812602552')).toBeNull();
     });
 
     it('should select clicked element', () => {
-        const placeholder = 'placeholder';
         const onChange = jest.fn();
-        const { getByPlaceholderText, getByText } = render(
+        render(
             <SearchableDropdown
                 id="id"
                 labelId="labelId"
-                inputProps={{ placeholder }}
                 dropdownAttributes={['organizationName', 'organizationNumber']}
                 dropdownList={companies}
                 onChange={onChange}
@@ -73,11 +69,11 @@ describe('SearchableDropdown', () => {
             />,
         );
 
-        const input = getByPlaceholderText(placeholder);
+        const input = screen.getByRole('combobox');
 
         fireEvent.change(input, { target: { value: 'Be' } });
 
-        fireEvent.click(getByText('Bedriften'), { button: 1 });
+        fireEvent.click(screen.getByText('Bedriften'), { button: 1 });
 
         expect(onChange).toHaveBeenCalledTimes(1);
         expect(onChange).toHaveBeenCalledWith(companies[0]);
@@ -85,13 +81,11 @@ describe('SearchableDropdown', () => {
     });
 
     it('should be possible to select item with keyboard', () => {
-        const placeholder = 'placeholder';
         const onChange = jest.fn();
-        const { getByPlaceholderText } = render(
+        render(
             <SearchableDropdown
                 id="id"
                 labelId="labelId"
-                inputProps={{ placeholder }}
                 dropdownAttributes={['organizationName', 'organizationNumber']}
                 dropdownList={companies}
                 onChange={onChange}
@@ -100,8 +94,8 @@ describe('SearchableDropdown', () => {
             />,
         );
 
-        const input = getByPlaceholderText(placeholder);
-        fireEvent.focus(input);
+        const input = screen.getByRole('combobox');
+        fireEvent.click(input);
 
         fireEvent.keyDown(input, { key: 'ArrowDown' });
         fireEvent.keyDown(input, { key: 'ArrowDown' });
@@ -127,12 +121,10 @@ describe('SearchableDropdown', () => {
         ];
         const noMatchText = 'No result';
 
-        const placeholder = 'placeholder';
-        const { getByPlaceholderText, getByText, queryByText } = render(
+        render(
             <SearchableDropdown
                 id="id"
                 labelId="labelId"
-                inputProps={{ placeholder }}
                 dropdownAttributes={['organizationName', 'organizationNumber']}
                 dropdownList={companies}
                 noMatch={{
@@ -144,36 +136,33 @@ describe('SearchableDropdown', () => {
             />,
         );
 
-        const input = getByPlaceholderText(placeholder);
-        fireEvent.focus(input);
-
+        const input = screen.getByRole('combobox');
+        fireEvent.click(input);
         fireEvent.change(input, {
             target: { value: 'some thing without a match' },
         });
 
-        expect(getByText(noMatchText)).toBeInTheDocument();
-        expect(getByText('Rør og sånt')).toBeInTheDocument();
-        expect(getByText('812602399')).toBeInTheDocument();
-        expect(getByText('Kaffekoppen')).toBeInTheDocument();
-        expect(getByText('812602222')).toBeInTheDocument();
+        expect(screen.getByText(noMatchText)).toBeInTheDocument();
+        expect(screen.getByText('Rør og sånt')).toBeInTheDocument();
+        expect(screen.getByText('812602399')).toBeInTheDocument();
+        expect(screen.getByText('Kaffekoppen')).toBeInTheDocument();
+        expect(screen.getByText('812602222')).toBeInTheDocument();
 
         fireEvent.change(input, { target: { value: '' } });
 
-        expect(queryByText(noMatchText)).toBeNull();
-        expect(queryByText('Rør og sånt')).toBeNull();
-        expect(queryByText('812602399')).toBeNull();
-        expect(queryByText('Kaffekoppen')).toBeNull();
-        expect(queryByText('812602222')).toBeNull();
+        expect(screen.queryByText(noMatchText)).toBeNull();
+        expect(screen.queryByText('Rør og sånt')).toBeNull();
+        expect(screen.queryByText('812602399')).toBeNull();
+        expect(screen.queryByText('Kaffekoppen')).toBeNull();
+        expect(screen.queryByText('812602222')).toBeNull();
     });
 
     it('should have clear button', () => {
-        const placeholder = 'placeholder';
         const onChange = jest.fn();
-        const { getByPlaceholderText, getByText, getByLabelText } = render(
+        render(
             <SearchableDropdown
                 id="id"
                 labelId="labelId"
-                inputProps={{ placeholder }}
                 dropdownAttributes={['organizationName', 'organizationNumber']}
                 dropdownList={companies}
                 onChange={onChange}
@@ -182,16 +171,18 @@ describe('SearchableDropdown', () => {
             />,
         );
 
-        const input = getByPlaceholderText(placeholder);
+        const input = screen.getByRole('combobox');
         fireEvent.change(input, { target: { value: 'Be' } });
 
-        fireEvent.click(getByText('Bedriften'), { button: 1 });
+        fireEvent.click(screen.getByText('Bedriften'), { button: 1 });
 
         expect(onChange).toHaveBeenCalledTimes(1);
         expect(onChange).toHaveBeenLastCalledWith(companies[0]);
         expect(input.value).toEqual('Bedriften');
 
-        const clearButton = getByLabelText('fjern valgt');
+        const clearButton = screen.getByRole('button', {
+            name: /fjern valgt/i,
+        });
 
         fireEvent.click(clearButton, { button: 1 });
 
@@ -215,13 +206,11 @@ describe('SearchableDropdown', () => {
         };
         /* eslint-enable react/prop-types */
 
-        const placeholder = 'placeholder';
         const onChange = jest.fn();
-        const { getByPlaceholderText, getByText, getByTestId } = render(
+        render(
             <SearchableDropdown
                 id="id"
                 labelId="labelId"
-                inputProps={{ placeholder }}
                 dropdownAttributes={['organizationName', 'organizationNumber']}
                 dropdownList={companies}
                 onChange={onChange}
@@ -231,40 +220,46 @@ describe('SearchableDropdown', () => {
             />,
         );
 
-        const input = getByPlaceholderText(placeholder);
-        fireEvent.focus(input);
+        const input = screen.getByRole('combobox');
+        fireEvent.click(input);
 
         fireEvent.keyDown(input, { key: 'ArrowDown' });
 
-        const listItemBody0 = getByTestId(companies[0].organizationNumber);
+        const listItemBody0 = screen.getByTestId(
+            companies[0].organizationNumber,
+        );
         expect(listItemBody0).toBeInTheDocument();
         expect(listItemBody0.getAttribute('data-is-higlighted')).toEqual(
             'true',
         );
-        expect(getByText('Bedriften,912602370,5')).toBeInTheDocument();
+        expect(screen.getByText('Bedriften,912602370,5')).toBeInTheDocument();
 
-        const listItemBody1 = getByTestId(companies[1].organizationNumber);
+        const listItemBody1 = screen.getByTestId(
+            companies[1].organizationNumber,
+        );
         expect(listItemBody1).toBeInTheDocument();
         expect(listItemBody1.getAttribute('data-is-higlighted')).toEqual(
             'false',
         );
-        expect(getByText('Sønn & co,812602372,3')).toBeInTheDocument();
+        expect(screen.getByText('Sønn & co,812602372,3')).toBeInTheDocument();
 
-        const listItemBody2 = getByTestId(companies[2].organizationNumber);
+        const listItemBody2 = screen.getByTestId(
+            companies[2].organizationNumber,
+        );
         expect(listItemBody2).toBeInTheDocument();
         expect(listItemBody2.getAttribute('data-is-higlighted')).toEqual(
             'false',
         );
-        expect(getByText('Beslag skytter,812602552,1')).toBeInTheDocument();
+        expect(
+            screen.getByText('Beslag skytter,812602552,1'),
+        ).toBeInTheDocument();
     });
 
     it('should use initialValue', () => {
-        const placeholder = 'placeholder';
-        const { getByPlaceholderText } = render(
+        render(
             <SearchableDropdown
                 id="id"
                 labelId="labelId"
-                inputProps={{ placeholder }}
                 dropdownAttributes={['organizationName', 'organizationNumber']}
                 dropdownList={companies}
                 initialValue={companies[1]}
@@ -273,17 +268,15 @@ describe('SearchableDropdown', () => {
             />,
         );
 
-        const input = getByPlaceholderText(placeholder);
+        const input = screen.getByRole('combobox');
         expect(input.value).toEqual('Sønn & co');
     });
 
     it('should open and close', function() {
-        const placeholder = 'placeholder';
-        const { getByLabelText, getByText, queryByText } = render(
+        render(
             <SearchableDropdown
                 id="id"
                 labelId="labelId"
-                inputProps={{ placeholder }}
                 dropdownAttributes={['organizationName', 'organizationNumber']}
                 dropdownList={companies}
                 searchAttributes={['organizationName', 'organizationNumber']}
@@ -291,34 +284,38 @@ describe('SearchableDropdown', () => {
             />,
         );
 
-        const openButton = getByLabelText('åpne meny');
+        const openButton = screen.getByRole('button', {
+            name: /åpne alternativer/i,
+        });
+
         fireEvent.click(openButton, { button: 1 });
 
-        expect(getByText('Bedriften')).toBeInTheDocument();
-        expect(getByText('912602370')).toBeInTheDocument();
-        expect(getByText('Sønn & co')).toBeInTheDocument();
-        expect(getByText('812602372')).toBeInTheDocument();
-        expect(getByText('Beslag skytter')).toBeInTheDocument();
-        expect(getByText('812602552')).toBeInTheDocument();
+        expect(screen.getByText('Bedriften')).toBeInTheDocument();
+        expect(screen.getByText('912602370')).toBeInTheDocument();
+        expect(screen.getByText('Sønn & co')).toBeInTheDocument();
+        expect(screen.getByText('812602372')).toBeInTheDocument();
+        expect(screen.getByText('Beslag skytter')).toBeInTheDocument();
+        expect(screen.getByText('812602552')).toBeInTheDocument();
 
-        const closeButton = getByLabelText('lukk meny');
+        const closeButton = screen.getByRole('button', {
+            name: /lukk alternativer/i,
+        });
+
         fireEvent.click(closeButton, { button: 1 });
 
-        expect(queryByText('Bedriften')).toBeNull();
-        expect(queryByText('912602370')).toBeNull();
-        expect(queryByText('Sønn & co')).toBeNull();
-        expect(queryByText('812602372')).toBeNull();
-        expect(queryByText('Beslag skytter')).toBeNull();
-        expect(queryByText('812602552')).toBeNull();
+        expect(screen.queryByText('Bedriften')).toBeNull();
+        expect(screen.queryByText('912602370')).toBeNull();
+        expect(screen.queryByText('Sønn & co')).toBeNull();
+        expect(screen.queryByText('812602372')).toBeNull();
+        expect(screen.queryByText('Beslag skytter')).toBeNull();
+        expect(screen.queryByText('812602552')).toBeNull();
     });
 
     it('should filter only when value is changed', () => {
-        const placeholder = 'placeholder';
-        const { getByText, queryByText, getByPlaceholderText } = render(
+        render(
             <SearchableDropdown
                 id="id"
                 labelId="labelId"
-                inputProps={{ placeholder }}
                 dropdownAttributes={['organizationName', 'organizationNumber']}
                 dropdownList={companies}
                 searchAttributes={['organizationName', 'organizationNumber']}
@@ -326,33 +323,71 @@ describe('SearchableDropdown', () => {
             />,
         );
 
-        const input = getByPlaceholderText(placeholder);
+        const input = screen.getByRole('combobox');
 
-        fireEvent.focus(input);
+        fireEvent.click(input);
 
-        expect(getByText('Bedriften')).toBeInTheDocument();
-        expect(getByText('912602370')).toBeInTheDocument();
-        expect(getByText('Sønn & co')).toBeInTheDocument();
-        expect(getByText('812602372')).toBeInTheDocument();
-        expect(getByText('Beslag skytter')).toBeInTheDocument();
-        expect(getByText('812602552')).toBeInTheDocument();
+        expect(screen.getByText('Bedriften')).toBeInTheDocument();
+        expect(screen.getByText('912602370')).toBeInTheDocument();
+        expect(screen.getByText('Sønn & co')).toBeInTheDocument();
+        expect(screen.getByText('812602372')).toBeInTheDocument();
+        expect(screen.getByText('Beslag skytter')).toBeInTheDocument();
+        expect(screen.getByText('812602552')).toBeInTheDocument();
 
         fireEvent.change(input, { target: { value: 'Sønn' } });
 
-        expect(queryByText('Bedriften')).toBeNull();
-        expect(queryByText('912602370')).toBeNull();
-        expect(getByText('Sønn & co')).toBeInTheDocument();
-        expect(getByText('812602372')).toBeInTheDocument();
-        expect(queryByText('Beslag skytter')).toBeNull();
-        expect(queryByText('812602552')).toBeNull();
+        expect(screen.queryByText('Bedriften')).toBeNull();
+        expect(screen.queryByText('912602370')).toBeNull();
+        expect(screen.getByText('Sønn & co')).toBeInTheDocument();
+        expect(screen.getByText('812602372')).toBeInTheDocument();
+        expect(screen.queryByText('Beslag skytter')).toBeNull();
+        expect(screen.queryByText('812602552')).toBeNull();
 
         fireEvent.change(input, { target: { value: '' } });
 
-        expect(getByText('Bedriften')).toBeInTheDocument();
-        expect(getByText('912602370')).toBeInTheDocument();
-        expect(getByText('Sønn & co')).toBeInTheDocument();
-        expect(getByText('812602372')).toBeInTheDocument();
-        expect(getByText('Beslag skytter')).toBeInTheDocument();
-        expect(getByText('812602552')).toBeInTheDocument();
+        expect(screen.getByText('Bedriften')).toBeInTheDocument();
+        expect(screen.getByText('912602370')).toBeInTheDocument();
+        expect(screen.getByText('Sønn & co')).toBeInTheDocument();
+        expect(screen.getByText('812602372')).toBeInTheDocument();
+        expect(screen.getByText('Beslag skytter')).toBeInTheDocument();
+        expect(screen.getByText('812602552')).toBeInTheDocument();
+    });
+
+    it('should be a wai-aria 1.0 combobox', () => {
+        render(
+            <SearchableDropdown
+                id="id"
+                labelId="labelId"
+                dropdownAttributes={['organizationName', 'organizationNumber']}
+                dropdownList={companies}
+                searchAttributes={['organizationName', 'organizationNumber']}
+                locale="nb"
+            />,
+        );
+
+        const input = screen.getByRole('combobox');
+
+        fireEvent.click(input);
+        fireEvent.keyDown(input, { key: 'ArrowDown' });
+        fireEvent.keyDown(input, { key: 'ArrowDown' });
+
+        const listBox = screen.getByRole('listbox');
+        const options = screen.getAllByRole('option');
+
+        expect(input.getAttribute('aria-autocomplete')).toEqual('list');
+        expect(input.getAttribute('autocomplete')).toEqual('off');
+        expect(input.getAttribute('aria-activedescendant')).toEqual(
+            options[1].getAttribute('id'),
+        );
+        expect(input.getAttribute('aria-controls')).toEqual(
+            listBox.getAttribute('id'),
+        );
+        expect(input.getAttribute('aria-haspopup')).toEqual('listbox');
+
+        options.forEach((option, index) =>
+            expect(option.getAttribute('aria-selected')).toEqual(
+                index === 1 ? 'true' : 'false',
+            ),
+        );
     });
 });

--- a/packages/ffe-searchable-dropdown-react/src/a11y.js
+++ b/packages/ffe-searchable-dropdown-react/src/a11y.js
@@ -1,0 +1,150 @@
+import { useEffect } from 'react';
+import {
+    getItemClearedA11yStatus,
+    getItemSelectedA11yStatus,
+    getNoResultA11yStatus,
+    getResultCountChangedA11yStatus,
+} from './translations';
+
+const debounce = (fn, time) => {
+    let timeoutId;
+
+    function cancel() {
+        if (timeoutId) {
+            clearTimeout(timeoutId);
+        }
+    }
+
+    function wrapper(...args) {
+        cancel();
+        timeoutId = setTimeout(() => {
+            timeoutId = null;
+            fn(...args);
+        }, time);
+    }
+
+    wrapper.cancel = cancel;
+
+    return wrapper;
+};
+
+const getStatusDiv = () => {
+    const id = 'a11y-status-message';
+    let statusDiv = window.document.getElementById(id);
+    if (statusDiv) {
+        return statusDiv;
+    }
+
+    statusDiv = window.document.createElement('div');
+    statusDiv.setAttribute('id', id);
+    statusDiv.setAttribute('role', 'status');
+    statusDiv.setAttribute('aria-live', 'polite');
+    statusDiv.setAttribute('aria-relevant', 'additions text');
+    Object.assign(statusDiv.style, {
+        border: '0',
+        clip: 'rect(0 0 0 0)',
+        height: '1px',
+        margin: '-1px',
+        overflow: 'hidden',
+        padding: '0',
+        position: 'absolute',
+        width: '1px',
+    });
+    window.document.body.appendChild(statusDiv);
+    return statusDiv;
+};
+
+const cleanupStatus = debounce(() => {
+    getStatusDiv().textContent = '';
+}, 500);
+
+const setStatus = status => {
+    const div = getStatusDiv();
+    if (!status) {
+        return;
+    }
+
+    div.textContent = status;
+    cleanupStatus();
+};
+
+const updateA11yStatus = debounce(getA11yMessage => {
+    setStatus(getA11yMessage());
+}, 200);
+
+const getItemSelectedMessage = ({ selectedItem, searchAttributes, locale }) => {
+    if (!selectedItem) {
+        return getItemClearedA11yStatus(locale);
+    }
+    return getItemSelectedA11yStatus(locale, selectedItem[searchAttributes[0]]);
+};
+
+const getStateChangeMessage = ({
+    isExpanded,
+    resultCount,
+    previousResultCount,
+    locale,
+}) => {
+    if (!isExpanded) {
+        return '';
+    }
+
+    if (!resultCount) {
+        return getNoResultA11yStatus(locale);
+    }
+
+    if (resultCount !== previousResultCount) {
+        return getResultCountChangedA11yStatus(locale, resultCount);
+    }
+
+    return '';
+};
+
+export const useSetAllyMessageItemSelection = ({
+    isInitialMount,
+    selectedItem,
+    prevSelectedItem,
+    searchAttributes,
+    locale,
+    resultCount,
+    previousResultCount,
+    isExpanded,
+}) => {
+    useEffect(() => {
+        if (isInitialMount) {
+            return;
+        }
+
+        if (
+            selectedItem?.[searchAttributes[0]] !==
+            prevSelectedItem?.[searchAttributes[0]]
+        ) {
+            updateA11yStatus(() => {
+                return getItemSelectedMessage({
+                    selectedItem,
+                    searchAttributes,
+                    isExpanded,
+                    locale,
+                });
+            });
+        } else {
+            updateA11yStatus(() => {
+                return getStateChangeMessage({
+                    isExpanded,
+                    resultCount,
+                    previousResultCount,
+                    locale,
+                });
+            });
+        }
+    }, [
+        selectedItem,
+        prevSelectedItem,
+        searchAttributes,
+        isInitialMount,
+        locale,
+        isExpanded,
+        resultCount,
+        previousResultCount,
+    ]);
+};

--- a/packages/ffe-searchable-dropdown-react/src/filterDropdownList.js
+++ b/packages/ffe-searchable-dropdown-react/src/filterDropdownList.js
@@ -1,8 +1,0 @@
-export default (dropdownList, searchAttributes, inputValue) => {
-    const inputValueLowerCase = inputValue.toLowerCase();
-    return dropdownList.filter(item =>
-        searchAttributes
-            .map(searchAttribute => item[searchAttribute].toLowerCase())
-            .some(itemAttribute => itemAttribute.includes(inputValueLowerCase)),
-    );
-};

--- a/packages/ffe-searchable-dropdown-react/src/findSelectedItem.js
+++ b/packages/ffe-searchable-dropdown-react/src/findSelectedItem.js
@@ -1,4 +1,0 @@
-export default (value, dropdownList, dropdownAttributes) => {
-    const [searchAttribute] = dropdownAttributes;
-    return dropdownList.find(item => item[searchAttribute] === value) || null;
-};

--- a/packages/ffe-searchable-dropdown-react/src/getListToRender.js
+++ b/packages/ffe-searchable-dropdown-react/src/getListToRender.js
@@ -1,0 +1,35 @@
+const filterDropdownList = (dropdownList, searchAttributes, inputValue) => {
+    const inputValueLowerCase = inputValue.toLowerCase();
+    return dropdownList.filter(item =>
+        searchAttributes
+            .map(searchAttribute => item[searchAttribute].toLowerCase())
+            .some(itemAttribute => itemAttribute.includes(inputValueLowerCase)),
+    );
+};
+
+export const getListToRender = ({
+    inputValue,
+    searchAttributes,
+    maxRenderedDropdownElements,
+    dropdownList,
+    noMatchDropdownList,
+}) => {
+    const trimmedInput = inputValue ? inputValue.trim() : '';
+
+    const shouldFilter = trimmedInput.length > 0;
+
+    const dropdownListFiltered = shouldFilter
+        ? filterDropdownList(
+              dropdownList,
+              searchAttributes,
+              trimmedInput,
+          ).slice(0, maxRenderedDropdownElements)
+        : dropdownList.slice(0, maxRenderedDropdownElements);
+
+    return {
+        listToRender: dropdownListFiltered.length
+            ? dropdownListFiltered
+            : noMatchDropdownList || [],
+        noMatch: !dropdownListFiltered.length,
+    };
+};

--- a/packages/ffe-searchable-dropdown-react/src/getNewHighlightedIndex.js
+++ b/packages/ffe-searchable-dropdown-react/src/getNewHighlightedIndex.js
@@ -1,0 +1,13 @@
+export const getNewHighlightedIndexUp = (currentIndex, numberOfElements) => {
+    if (currentIndex === 0) {
+        return numberOfElements - 1;
+    }
+    return currentIndex - 1;
+};
+
+export const getNewHighlightedIndexDown = (currentIndex, numberOfElements) => {
+    if (currentIndex === numberOfElements - 1) {
+        return 0;
+    }
+    return currentIndex + 1;
+};

--- a/packages/ffe-searchable-dropdown-react/src/reducer.js
+++ b/packages/ffe-searchable-dropdown-react/src/reducer.js
@@ -1,0 +1,130 @@
+import { getListToRender } from './getListToRender';
+
+export const stateChangeTypes = {
+    InputBlur: 'InputBlur',
+    InputFocus: 'InputFocus',
+    InputClick: 'InputClick',
+    InputChange: 'InputChange',
+    InputKeyDownEscape: 'InputKeyDownEscape',
+    InputKeyDownEnter: 'InputKeyDownEnter',
+    InputKeyDownArrowDown: 'InputKeyDownArrowDown',
+    InputKeyDownArrowUp: 'InputKeyDownArrowUp',
+    ClearButtonPressed: 'ClearButtonPressed',
+    ToggleButtonPressed: 'ToggleButtonPressed',
+    ItemOnClick: 'ItemOnMouseDown',
+    ItemOnMouseEnter: 'ItemOnMouseEnter',
+    FocusMovedOutSide: 'FocusMovedOutSide',
+};
+
+export const createReducer = ({
+    searchAttributes,
+    dropdownList,
+    noMatchDropdownList,
+    maxRenderedDropdownElements,
+}) => (state, action) => {
+    switch (action.type) {
+        case stateChangeTypes.InputBlur:
+        case stateChangeTypes.InputKeyDownEscape:
+            return {
+                ...state,
+                noMatch: false,
+                isExpanded: false,
+                highlightedIndex: -1,
+                inputValue: state.selectedItem
+                    ? state.selectedItem[searchAttributes[0]]
+                    : '',
+            };
+        case stateChangeTypes.InputClick: {
+            const { noMatch, listToRender } = getListToRender({
+                inputValue: state.inputValue,
+                searchAttributes,
+                maxRenderedDropdownElements,
+                dropdownList,
+                noMatchDropdownList,
+            });
+
+            return {
+                ...state,
+                isExpanded: true,
+                listToRender,
+                prevResultCount: state.listToRender.length,
+                noMatch,
+            };
+        }
+        case stateChangeTypes.InputChange: {
+            const { noMatch, listToRender } = getListToRender({
+                inputValue: action.payload.inputValue,
+                searchAttributes,
+                maxRenderedDropdownElements,
+                dropdownList,
+                noMatchDropdownList,
+            });
+
+            return {
+                ...state,
+                isExpanded: true,
+                inputValue: action.payload.inputValue,
+                prevResultCount: state.listToRender.length,
+                listToRender,
+                noMatch,
+            };
+        }
+        case stateChangeTypes.ClearButtonPressed: {
+            const { noMatch, listToRender } = getListToRender({
+                inputValue: '',
+                searchAttributes,
+                maxRenderedDropdownElements,
+                dropdownList,
+                prevResultCount: state.listToRender.length,
+                noMatchDropdownList,
+            });
+            return {
+                ...state,
+                inputValue: '',
+                prevSelectedItem: state.selectedItem,
+                selectedItem: null,
+                listToRender,
+                noMatch,
+            };
+        }
+        case stateChangeTypes.ToggleButtonPressed:
+            return {
+                ...state,
+                isExpanded: !state.isExpanded,
+            };
+        case stateChangeTypes.ItemOnClick:
+        case stateChangeTypes.InputKeyDownEnter:
+            return {
+                ...state,
+                isExpanded: false,
+                highlightedIndex: -1,
+                prevSelectedItem: state.selectedItem,
+                selectedItem: action.payload.selectedItem,
+                inputValue: action.payload.selectedItem[searchAttributes[0]],
+            };
+
+        case stateChangeTypes.InputKeyDownArrowDown:
+        case stateChangeTypes.InputKeyDownArrowUp: {
+            return {
+                ...state,
+                highlightedIndex: action.payload.highlightedIndex,
+            };
+        }
+
+        case stateChangeTypes.ItemOnMouseEnter: {
+            return {
+                ...state,
+                highlightedIndex: action.payload.highlightedIndex,
+            };
+        }
+        case stateChangeTypes.FocusMovedOutSide: {
+            return {
+                ...state,
+                isExpanded: false,
+                highlightedIndex: -1,
+            };
+        }
+        default:
+            return state;
+    }
+};

--- a/packages/ffe-searchable-dropdown-react/src/scrollIntoView.js
+++ b/packages/ffe-searchable-dropdown-react/src/scrollIntoView.js
@@ -1,0 +1,19 @@
+import computeScrollIntoView from 'compute-scroll-into-view';
+
+export const scrollIntoView = (node, menuNode) => {
+    if (!node) {
+        return;
+    }
+
+    const actions = computeScrollIntoView(node, {
+        boundary: menuNode,
+        block: 'nearest',
+        scrollMode: 'if-needed',
+    });
+    actions.forEach(({ el, top, left }) => {
+        // eslint-disable-next-line no-param-reassign
+        el.scrollTop = top;
+        // eslint-disable-next-line no-param-reassign
+        el.scrollLeft = left;
+    });
+};

--- a/packages/ffe-searchable-dropdown-react/src/translations.js
+++ b/packages/ffe-searchable-dropdown-react/src/translations.js
@@ -18,21 +18,80 @@ export const getButtonLabelClear = locale => {
 export const getButtonLabelClose = locale => {
     switch (locale) {
         case nn:
-            return 'lukk meny';
+            return 'lukk alternativer';
         case en:
-            return 'close menu';
+            return 'close alternatives';
         default:
-            return 'lukk meny';
+            return 'lukk alternativer';
     }
 };
 
 export const getButtonLabelOpen = locale => {
     switch (locale) {
         case nn:
-            return 'åpne meny';
+            return 'åpne alternativer';
         case en:
-            return 'open menu';
+            return 'open alternatives';
         default:
-            return 'åpne meny';
+            return 'åpne alternativer';
+    }
+};
+
+export const getNotMatchText = locale => {
+    switch (locale) {
+        case nn:
+            return 'Søket gav ingen treff';
+        case en:
+            return 'The search gave no result';
+        default:
+            return 'Søket ga ingen treff';
+    }
+};
+
+export const getItemClearedA11yStatus = locale => {
+    switch (locale) {
+        case nn:
+            return `Valt element har vorte fjerna.`;
+        case en:
+            return `Selected item has been removed.`;
+        default:
+            return `Valgt element har blitt fjernet.`;
+    }
+};
+
+export const getItemSelectedA11yStatus = (locale, item) => {
+    switch (locale) {
+        case nn:
+            return `Element ${item} er valgt.`;
+        case en:
+            return `Item ${item} has been selected.`;
+        default:
+            return `Element ${item} er valgt.`;
+    }
+};
+
+export const getNoResultA11yStatus = locale => {
+    switch (locale) {
+        case nn:
+            return 'Ingen resultat er tilgjengelege.';
+        case en:
+            return 'No results are available.';
+        default:
+            return 'Ingen resultater er tilgjengelige.';
+    }
+};
+
+export const getResultCountChangedA11yStatus = (locale, nrOfItems) => {
+    switch (locale) {
+        case nn:
+            return `${nrOfItems} resultat er tilgjengeleg, bruk opp- og nedpiltastene for å navigera. Trykk Enter for å velja.`;
+        case en:
+            return `${nrOfItems} result${
+                nrOfItems === 1 ? ' is' : 's are'
+            } available, use up and down arrow keys to navigate. Press Enter key to select.`;
+        default:
+            return `${nrOfItems} resultat${
+                nrOfItems === 1 ? '' : 'er'
+            } er tilgjengelig, bruk opp- og nedpiltastene for å navigere. Trykk Enter for å velge.`;
     }
 };


### PR DESCRIPTION
## Beskrivelse

Denne konkurerer vell egentligen med https://github.com/SpareBank1/designsystem/pull/1088. 

* Det viser seg att det finnes 2 versjoner av combobox. wai-aria 1.0 vs  wai-aria 1.1. Kort førtalt så har den 1.0 bedre støtte og nya wai-aria 1.1 er ett problem for safari med voiceover kan det se ut som. Slik jag skjønner det er version 1.0 ikke på noen måte deprecated og det er vad feks google bruker i sin søkeboks. Jag har på bakgrund av att downshift (https://www.downshift-js.com/) som vi bruker lager combobox enligt wai-aria 1.1 laget en egen implementasjon tungt inspererad av downshift men med combobox pattern fra wai-aria 1.0. 

wai-aria 1.1
![image](https://user-images.githubusercontent.com/2248579/113513775-85936200-956b-11eb-9f3c-43c549f418f5.png)

wai-aria 1.0
![image](https://user-images.githubusercontent.com/2248579/113513794-9a6ff580-956b-11eb-8769-ab530f374b02.png)

mer info her: https://www.levelaccess.com/differences-aria-1-0-1-1-changes-rolecombobox/ 

* Så har jag fjernet expandering på focus med bakgrund av dette. Click fungerer som før. 
https://stackoverflow.com/questions/59207174/is-aria-expanded-only-for-click-interaction-or-can-it-be-used-for-focus-as

* Jag har laget status meldninger når man endrer som ligner veldigt mye på som downshift bruker. 
Får vi denne att bruke gott må vi se på AccountSelector også. Den bruker wai-aria 1.1 og sliter også med Voiceover. 

## Testing

Testet selv med Talkback på emulator.
Denne branchen finnes på linken under hvis noen har lust att testa. 
https://thirsty-euler-224e8b.netlify.app/styleguidist/index.html#!/SearchableDropdown
