### PR TITLE
refactor(ffe-account-selector-react): Pass event instead of value to …

### DIFF
--- a/packages/ffe-account-selector-react/src/components/account-selector/AccountSelector.js
+++ b/packages/ffe-account-selector-react/src/components/account-selector/AccountSelector.js
@@ -50,9 +50,9 @@ class AccountSelector extends Component {
         this.props.onAccountSelected(account);
     }
 
-    onInputChange(value) {
+    onInputChange(value, event) {
         this.enableFilter = true;
-        this.props.onChange(value);
+        this.props.onChange(value, event);
     }
 
     onSuggestionSelect(suggestion) {

--- a/packages/ffe-account-selector-react/src/components/account-selector/AccountSelector.md
+++ b/packages/ffe-account-selector-react/src/components/account-selector/AccountSelector.md
@@ -42,5 +42,5 @@ initialState = { value: '' };
         value={state.value}
         selectedAccount={state.selectedAccount}
     />
-</React.Fragment>
+</React.Fragment>;
 ```

--- a/packages/ffe-account-selector-react/src/components/base-selector/BaseSelector.js
+++ b/packages/ffe-account-selector-react/src/components/base-selector/BaseSelector.js
@@ -44,15 +44,13 @@ class BaseSelector extends Component {
         return 0;
     }
 
-    onInputChange(val) {
-        if (val !== this.props.value) {
+    onInputChange(event) {
+        if (event.target.value !== this.props.value) {
             this.setState(
                 { showSuggestions: true, highlightedSuggestionIndex: -1 },
-                () => {
-                    this.props.onChange(val);
-                    this._onSuggestionListChange();
-                },
+                () => this._onSuggestionListChange(),
             );
+            this.props.onChange(event.target.value, event);
         }
     }
 

--- a/packages/ffe-account-selector-react/src/components/base-selector/BaseSelector.spec.js
+++ b/packages/ffe-account-selector-react/src/components/base-selector/BaseSelector.spec.js
@@ -53,6 +53,7 @@ function assertHomeEnd(keyCode, stubMethodName) {
 describe('<BaseSelector> methods', () => {
     it('should show suggestions on input change', done => {
         const value = 'test';
+        const event = { target: { value } };
         const onChangeSpy = jest.fn();
         const onSuggestionListChangeSpy = jest.fn();
         const component = mountBaseSelector({
@@ -60,9 +61,9 @@ describe('<BaseSelector> methods', () => {
             onSuggestionListChange: onSuggestionListChangeSpy,
         }).instance();
 
-        component.onInputChange(value);
+        component.onInputChange(event);
         expect(component.state.showSuggestions).toBe(true);
-        expect(onChangeSpy).toHaveBeenCalledWith(value);
+        expect(onChangeSpy).toHaveBeenCalledWith(value, event);
         setTimeout(() => {
             expect(onSuggestionListChangeSpy).toHaveBeenCalledTimes(1);
             done();
@@ -260,7 +261,7 @@ describe('<BaseSelector> methods', () => {
             .find('.ffe-base-selector__input-field')
             .simulate('change', event);
 
-        expect(onInputChange).toHaveBeenCalledWith(value);
+        expect(onInputChange).toHaveBeenCalledTimes(1);
     });
 
     it('should call onBlur on input blur', () => {

--- a/packages/ffe-account-selector-react/src/subcomponents/input-field/InputField.js
+++ b/packages/ffe-account-selector-react/src/subcomponents/input-field/InputField.js
@@ -27,8 +27,6 @@ const InputField = props => {
         onChange,
         onReset,
     } = props;
-    const handleChange = ({ target: { value: newValue } }) =>
-        onChange(newValue);
 
     const handleReset = e => {
         e.preventDefault();
@@ -72,7 +70,7 @@ const InputField = props => {
                 aria-autocomplete="list"
                 name={name}
                 onClick={onClick}
-                onChange={handleChange}
+                onChange={onChange}
                 readOnly={readOnly}
             />
             {showReset && (


### PR DESCRIPTION
…onChange in accountSelector

<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse

<!-- Detaljert beskrivelse av endringene dine. Skjermskudd er lov. -->
Sender videre hele eventet i stedet for event.target.value. Har lagt til breaking change, men vet ikke om jeg har gjort det på riktig måte. :sweat_smile: 

## Motivasjon og kontekst

<!-- Hvorfor trengs denne endringen, og hva løser den? -->
I pm-betaling trenger vi hele eventet for å håndtere formattert kontonummer riktig. 