### PR TITLE
Set MuseoSans as fallback font

### DIFF
--- a/packages/ffe-buttons/less/base-button.less
+++ b/packages/ffe-buttons/less/base-button.less
@@ -59,7 +59,7 @@
     color: @ffe-white;
     cursor: pointer;
     display: flex;
-    font-family: 'SpareBank1-regular', arial, sans-serif;
+    font-family: 'SpareBank1-regular', 'MuseoSans-500', arial, sans-serif;
     justify-content: center;
     line-height: 24px;
     overflow: hidden;

--- a/packages/ffe-buttons/less/inline-base-button.less
+++ b/packages/ffe-buttons/less/inline-base-button.less
@@ -18,7 +18,7 @@
     border-radius: 6px;
     cursor: pointer;
     display: inline-flex;
-    font-family: 'SpareBank1-regular', arial, sans-serif;
+    font-family: 'SpareBank1-regular', 'MuseoSans-500', arial, sans-serif;
     margin: 0 -4px; // Hack to allow box-shadow to float outside content on focus
     overflow: hidden;
     padding: 0 @ffe-spacing-2xs;

--- a/packages/ffe-cards/less/ffe-link-card.less
+++ b/packages/ffe-cards/less/ffe-link-card.less
@@ -134,7 +134,8 @@
 
     &--large > &__details {
         color: @ffe-blue-royal;
-        font-family: 'SpareBank1-medium', arial, sans-serif;
+        font-family: 'SpareBank1-medium', 'MuseoSansRounded-700', arial,
+            sans-serif;
         font-size: 1.25rem;
         line-height: 2.2rem;
         .native & {
@@ -239,7 +240,8 @@
 
         &--medium > &__heading,
         &--large > &__heading {
-            font-family: 'SpareBank1-regular', arial, sans-serif;
+            font-family: 'SpareBank1-regular', 'MuseoSans-500', arial,
+                sans-serif;
             font-size: 1.25rem;
             margin-bottom: 20px;
             margin-top: 0;
@@ -254,7 +256,8 @@
         &--medium > &__details,
         &--large > &__details {
             color: @ffe-blue-royal;
-            font-family: 'SpareBank1-medium', arial, sans-serif;
+            font-family: 'SpareBank1-medium', 'MuseoSansRounded-700', arial,
+                sans-serif;
             font-size: 1.5rem;
             line-height: 6.875rem;
             position: absolute;

--- a/packages/ffe-cards/less/ffe-product-card.less
+++ b/packages/ffe-cards/less/ffe-product-card.less
@@ -132,7 +132,7 @@
     }
 
     .ffe-product-card__heading {
-        font-family: 'SpareBank1-regular', arial, sans-serif;
+        font-family: 'SpareBank1-regular', 'MuseoSans-500', arial, sans-serif;
         font-size: 1.25rem;
         max-width: 100%;
         margin-top: 17px;

--- a/packages/ffe-core/less/typography.less
+++ b/packages/ffe-core/less/typography.less
@@ -171,7 +171,7 @@
 
 .ffe-small-text {
     color: @ffe-grey-charcoal;
-    font-family: 'SpareBank1-regular', arial, sans-serif;
+    font-family: 'SpareBank1-regular', 'MuseoSans-500', arial, sans-serif;
     font-weight: normal;
     line-height: 1.25rem;
     .ffe-fontsize-small-text();
@@ -182,7 +182,7 @@
 
 .ffe-micro-text {
     color: @ffe-grey-charcoal;
-    font-family: 'SpareBank1-regular', arial, sans-serif;
+    font-family: 'SpareBank1-regular', 'MuseoSans-500', arial, sans-serif;
     font-weight: normal;
     line-height: 1.25rem;
     .ffe-fontsize-micro-text();
@@ -242,19 +242,20 @@
 
 .ffe-h1,
 .ffe-h2 {
-    font-family: 'SpareBank1-title-medium', arial, sans-serif;
+    font-family: 'SpareBank1-title-medium', 'MuseoSansRounded-700', arial,
+        sans-serif;
 }
 
 .ffe-h3,
 .ffe-h4,
 .ffe-h5,
 .ffe-h6 {
-    font-family: 'SpareBank1-medium', arial, sans-serif;
+    font-family: 'SpareBank1-medium', 'MuseoSansRounded-700', arial, sans-serif;
 }
 
 .ffe-body-text {
     color: @ffe-black;
-    font-family: 'SpareBank1-regular', arial, sans-serif;
+    font-family: 'SpareBank1-regular', 'MuseoSans-500', arial, sans-serif;
     line-height: 1.5rem;
     .ffe-fontsize-body-text();
     .native & {
@@ -286,7 +287,7 @@
 
 .ffe-lead-paragraph,
 .ffe-sub-lead-paragraph {
-    font-family: 'SpareBank1-regular', arial, sans-serif;
+    font-family: 'SpareBank1-regular', 'MuseoSans-500', arial, sans-serif;
     margin-top: 0;
 }
 
@@ -368,7 +369,7 @@
 }
 
 .ffe-strong-text {
-    font-family: 'SpareBank1-medium', arial, sans-serif;
+    font-family: 'SpareBank1-medium', 'MuseoSansRounded-700', arial, sans-serif;
     font-weight: normal;
 }
 

--- a/packages/ffe-form/less/dropdown.less
+++ b/packages/ffe-form/less/dropdown.less
@@ -39,7 +39,7 @@
         }
     }
 
-    font-family: 'SpareBank1-regular', arial, sans-serif;
+    font-family: 'SpareBank1-regular', 'MuseoSans-500', arial, sans-serif;
     height: 45px;
     padding: 0 @ffe-spacing-lg 0 @ffe-spacing-sm;
     line-height: 20px;

--- a/packages/ffe-form/less/form-label.less
+++ b/packages/ffe-form/less/form-label.less
@@ -12,7 +12,7 @@
     padding: @ffe-spacing-xs 0 @ffe-spacing-2xs;
     display: inline-block;
     position: relative;
-    font-family: 'SpareBank1-regular', arial, sans-serif;
+    font-family: 'SpareBank1-regular', 'MuseoSans-500', arial, sans-serif;
     .ffe-fontsize-h6();
 
     font-weight: 500;

--- a/packages/ffe-form/less/input-field.less
+++ b/packages/ffe-form/less/input-field.less
@@ -16,7 +16,7 @@
     display: block;
     height: 45px;
     padding: 0 @ffe-spacing-sm;
-    font-family: 'SpareBank1-regular', arial, sans-serif;
+    font-family: 'SpareBank1-regular', 'MuseoSans-500', arial, sans-serif;
     color: @ffe-black;
     border-radius: 4px;
     border: 2px solid @ffe-grey-silver;

--- a/packages/ffe-form/less/radio-switch.less
+++ b/packages/ffe-form/less/radio-switch.less
@@ -23,7 +23,7 @@
     min-width: 100px;
     text-align: left;
     color: @ffe-blue-azure;
-    font-family: 'SpareBank1-medium', arial, sans-serif;
+    font-family: 'SpareBank1-medium', 'MuseoSansRounded-700', arial, sans-serif;
     cursor: pointer;
     transition: all @ffe-transition-duration @ffe-ease;
     box-shadow: 0 1px 2px 1px rgba(0, 0, 0, 0.05);

--- a/packages/ffe-form/less/textarea.less
+++ b/packages/ffe-form/less/textarea.less
@@ -12,7 +12,7 @@
     display: block;
     width: 100%;
     padding: @ffe-spacing-sm;
-    font-family: 'SpareBank1-regular', arial, sans-serif;
+    font-family: 'SpareBank1-regular', 'MuseoSans-500', arial, sans-serif;
     border-radius: 4px;
     border: 2px solid @ffe-grey-silver;
     transition: all @ffe-transition-duration @ffe-ease;

--- a/packages/ffe-header/less/ffe-header.less
+++ b/packages/ffe-header/less/ffe-header.less
@@ -306,7 +306,8 @@
     }
 
     &__notification-bubble {
-        font-family: 'SpareBank1-medium', arial, sans-serif;
+        font-family: 'SpareBank1-medium', 'MuseoSansRounded-700', arial,
+            sans-serif;
         font-weight: normal;
         font-size: 0.75rem;
         display: inline-block;

--- a/packages/ffe-message-box/less/ffe-message-box.less
+++ b/packages/ffe-message-box/less/ffe-message-box.less
@@ -180,7 +180,8 @@
 
         &:hover,
         &:focus {
-            font-family: 'SpareBank1-medium', arial, sans-serif;
+            font-family: 'SpareBank1-medium', 'MuseoSansRounded-700', arial,
+                sans-serif;
         }
     }
 }

--- a/packages/ffe-tabs/less/tab-button.less
+++ b/packages/ffe-tabs/less/tab-button.less
@@ -17,7 +17,7 @@
     color: @ffe-grey-charcoal;
     cursor: pointer;
     display: block;
-    font-family: 'SpareBank1-regular', arial, sans-serif;
+    font-family: 'SpareBank1-regular', 'MuseoSans-500', arial, sans-serif;
     font-size: 1rem;
     outline: none;
     overflow: hidden;

--- a/packages/ffe-tabs/less/tab.less
+++ b/packages/ffe-tabs/less/tab.less
@@ -15,7 +15,7 @@
     color: @ffe-grey-charcoal;
     cursor: pointer;
     display: block;
-    font-family: 'SpareBank1-regular', arial, sans-serif;
+    font-family: 'SpareBank1-regular', 'MuseoSans-500', arial, sans-serif;
     font-size: 1rem;
     outline: none;
     overflow: hidden;


### PR DESCRIPTION
Denne endring legger til MuseoSans (den gamle font) som fallback overalt der den nye SpareBank1-fonten blir brukt. Dette gjør at skriftbildet i denne overgangsfasen er alltid stylet, uansett om @font-face-definisjonen er oppdatert eller ikke.

Fallbacks:
* SpareBank1-regular -> MuseoSans-500
* SpareBank1-medium -> MuseoSansRounded-700
* SpareBank1-title-medium -> MuseoSansRounded-700