### PR TITLE
feat(ffe-searchable-dropdown-react): Allow selecting item programmatically

### DIFF
--- a/packages/ffe-searchable-dropdown-react/src/SearchableDropdown.md
+++ b/packages/ffe-searchable-dropdown-react/src/SearchableDropdown.md
@@ -143,13 +143,36 @@ const searchMatcher = (inputValue, searchAttributes) => item => {
 </InputGroup>;
 ```
 
+Du kan sende inn et `selectedItem` for å programmatisk bestemme hvilket element som skal vises som valgt.
+
+```js
+const { InputGroup } = require('../../ffe-form-react');
+const companies = require('../exampleData').companiesWithMessageCount;
+const labelId = 'labelId5';
+
+initialState = { item: companies[2] };
+
+<InputGroup label="Velg bedrift" labelId={labelId}>
+    <SearchableDropdown
+        labelId={labelId}
+        inputProps={{ placeholder: 'Velg' }}
+        dropdownAttributes={['organizationName', 'organizationNumber']}
+        dropdownList={companies}
+        onChange={item => setState({ item })}
+        searchAttributes={['organizationName', 'organizationNumber']}
+        locale="nb"
+        selectedItem={state.item}
+    />
+</InputGroup>;
+```
+
 Variant _dark_ for interne løsninger med mørk bakgrunn.
 
 ```js { "props": { "className": "sb1ds-example-dark" } }
 const { InputGroup, Label } = require('../../ffe-form-react');
 const companies = require('../exampleData').companiesWithMessageCount;
-const labelId = 'labelId5';
-const inputId = 'inputId5';
+const labelId = 'labelId6';
+const inputId = 'inputId6';
 <div className="ffe-input-group">
     <Label htmlFor={inputId} dark={true} id={labelId}>
         Velg bedrift

--- a/packages/ffe-searchable-dropdown-react/src/SearchableDropdown.spec.js
+++ b/packages/ffe-searchable-dropdown-react/src/SearchableDropdown.spec.js
@@ -255,23 +255,6 @@ describe('SearchableDropdown', () => {
         ).toBeInTheDocument();
     });
 
-    it('should use initialValue', () => {
-        render(
-            <SearchableDropdown
-                id="id"
-                labelId="labelId"
-                dropdownAttributes={['organizationName', 'organizationNumber']}
-                dropdownList={companies}
-                initialValue={companies[1]}
-                searchAttributes={['organizationName', 'organizationNumber']}
-                locale="nb"
-            />,
-        );
-
-        const input = screen.getByRole('combobox');
-        expect(input.value).toEqual('Sønn & co');
-    });
-
     it('should open and close', function() {
         render(
             <SearchableDropdown
@@ -618,5 +601,145 @@ describe('SearchableDropdown', () => {
         expect(screen.queryByText('812602372')).toBeNull();
         expect(screen.getByText('Beslag skytter')).toBeInTheDocument();
         expect(screen.getByText('812602552')).toBeInTheDocument();
+    });
+
+    it('allows passing a selected item', () => {
+        const onChange = jest.fn();
+
+        const { rerender } = render(
+            <SearchableDropdown
+                id="id"
+                labelId="labelId"
+                dropdownAttributes={['organizationName', 'organizationNumber']}
+                dropdownList={companies}
+                onChange={onChange}
+                searchAttributes={['organizationName', 'organizationNumber']}
+                locale="nb"
+            />,
+        );
+
+        const input = screen.getByRole('combobox');
+
+        expect(input.value).toBe('');
+
+        rerender(
+            <SearchableDropdown
+                id="id"
+                labelId="labelId"
+                dropdownAttributes={['organizationName', 'organizationNumber']}
+                dropdownList={companies}
+                onChange={onChange}
+                searchAttributes={['organizationName', 'organizationNumber']}
+                locale="nb"
+                selectedItem={companies[2]}
+            />,
+        );
+
+        expect(input.value).toBe('Beslag skytter');
+    });
+
+    it('allows for writing and selecting even when passing selectedItem', () => {
+        const onChange = jest.fn();
+        render(
+            <SearchableDropdown
+                id="id"
+                labelId="labelId"
+                dropdownAttributes={['organizationName', 'organizationNumber']}
+                dropdownList={companies}
+                onChange={onChange}
+                searchAttributes={['organizationName', 'organizationNumber']}
+                locale="nb"
+                selectedItem={companies[1]}
+            />,
+        );
+
+        const input = screen.getByRole('combobox');
+
+        expect(input.value).toBe('Sønn & co');
+
+        userEvent.clear(input);
+        userEvent.type(input, 'Be');
+
+        userEvent.click(screen.getByText('Beslag skytter'), { button: 1 });
+
+        expect(onChange).toHaveBeenCalledTimes(1);
+        expect(onChange).toHaveBeenCalledWith(companies[2]);
+        expect(input.value).toEqual('Beslag skytter');
+    });
+
+    it('clears selected item dropdownList changes so that it no longer contains the item in the selectedItem prop', () => {
+        const onChange = jest.fn();
+
+        const { rerender } = render(
+            <SearchableDropdown
+                id="id"
+                labelId="labelId"
+                dropdownAttributes={['organizationName', 'organizationNumber']}
+                dropdownList={companies}
+                onChange={onChange}
+                searchAttributes={['organizationName', 'organizationNumber']}
+                locale="nb"
+                selectedItem={companies[2]}
+            />,
+        );
+
+        const input = screen.getByRole('combobox');
+
+        expect(input.value).toBe('Beslag skytter');
+
+        rerender(
+            <SearchableDropdown
+                id="id"
+                labelId="labelId"
+                dropdownAttributes={['organizationName', 'organizationNumber']}
+                dropdownList={companies.slice(0, 2)}
+                onChange={onChange}
+                searchAttributes={['organizationName', 'organizationNumber']}
+                locale="nb"
+                selectedItem={companies[2]}
+            />,
+        );
+
+        expect(input.value).toBe('');
+    });
+
+    it('clears selected item if the selectedItem prop changes to something that does not exist in dropdownList', () => {
+        const onChange = jest.fn();
+
+        const { rerender } = render(
+            <SearchableDropdown
+                id="id"
+                labelId="labelId"
+                dropdownAttributes={['organizationName', 'organizationNumber']}
+                dropdownList={companies}
+                onChange={onChange}
+                searchAttributes={['organizationName', 'organizationNumber']}
+                locale="nb"
+                selectedItem={companies[2]}
+            />,
+        );
+
+        const input = screen.getByRole('combobox');
+
+        expect(input.value).toBe('Beslag skytter');
+
+        rerender(
+            <SearchableDropdown
+                id="id"
+                labelId="labelId"
+                dropdownAttributes={['organizationName', 'organizationNumber']}
+                dropdownList={companies}
+                onChange={onChange}
+                searchAttributes={['organizationName', 'organizationNumber']}
+                locale="nb"
+                selectedItem={{
+                    organizationName: 'Min nye bedrift',
+                    organizationNumber: '8888',
+                    quantityUnprocessedMessages: 9,
+                }}
+            />,
+        );
+
+        expect(input.value).toBe('');
     });
 });

--- a/packages/ffe-searchable-dropdown-react/src/index.d.ts
+++ b/packages/ffe-searchable-dropdown-react/src/index.d.ts
@@ -18,7 +18,7 @@ export interface SearchableDropdownProps<T> {
     dropdownAttributes: (keyof T)[];
     searchAttributes: (keyof T)[];
     inputProps?: React.InputHTMLAttributes<HTMLInputElement>;
-    initialValue?: T;
+    selectedItem?: T;
     maxRenderedDropdownElements?: number;
     onChange?: (dropdownListItem: T) => any;
     dark?: boolean;

--- a/packages/ffe-searchable-dropdown-react/src/reducer.js
+++ b/packages/ffe-searchable-dropdown-react/src/reducer.js
@@ -14,6 +14,8 @@ export const stateChangeTypes = {
     ItemOnClick: 'ItemOnMouseDown',
     ItemOnMouseEnter: 'ItemOnMouseEnter',
     FocusMovedOutSide: 'FocusMovedOutSide',
+    ItemSelectedProgrammatically: 'ItemSelectedProgrammatically',
+    ItemClearedProgrammatically: 'ItemClearedProgrammatically',
 };
 
 export const createReducer = ({
@@ -76,6 +78,7 @@ export const createReducer = ({
                 noMatch,
             };
         }
+        case stateChangeTypes.ItemClearedProgrammatically:
         case stateChangeTypes.ClearedInputField:
         case stateChangeTypes.ClearButtonPressed: {
             const { noMatch, listToRender } = getListToRender({
@@ -101,6 +104,7 @@ export const createReducer = ({
                 ...state,
                 isExpanded: !state.isExpanded,
             };
+        case stateChangeTypes.ItemSelectedProgrammatically:
         case stateChangeTypes.ItemOnClick:
         case stateChangeTypes.InputKeyDownEnter:
             return {


### PR DESCRIPTION
BREAKING CHANGE: Replaced `initialValue` with `selectedItem`

`selectedItem` is an OPTIONAL prop which enables you to programmatically decide which item
is displayed in the input field. When the user selects a different item, you should
update the `selectedItem` value to reflect this newly chosen item. If not, your props
and the internal state of SearchableDropdown will become out of sync.

## Motivasjon og kontekst

Dette er en fortsettelse av #1100 , men det PRet ble etterhvert så svært at det var like så greit å ta dette i et nytt PR. 
Dette gjør at man kan programmatisk sette valgt element også etter initiell last.