### PR TITLE
feat(ffe-account-selector-react): Make AccountSelector use SearchableDropdown under the hood

### DIFF
--- a/packages/ffe-account-selector-react/less/account-suggestion.less
+++ b/packages/ffe-account-selector-react/less/account-suggestion.less
@@ -16,6 +16,12 @@
     &--highlighted {
         background: @ffe-blue-azure;
         color: @ffe-white;
+
+        .native & {
+            @media (prefers-color-scheme: dark) {
+                background: @ffe-blue-azure;
+            }
+        }
         .ffe-account-suggestion__name,
         .ffe-account-suggestion__details {
             color: @ffe-white;

--- a/packages/ffe-account-selector-react/less/ffe-account-selector.less
+++ b/packages/ffe-account-selector-react/less/ffe-account-selector.less
@@ -1,3 +1,13 @@
+@details-height: 32px;
+
+.ffe-account-selector-container {
+    /*
+     * Disables margin collapse, which allows styling based on
+     * withSpaceForDetails even when AccountSelector is wrapped in InputGroup
+     */
+    padding: 0.05px;
+}
+
 .ffe-account-selector {
     @import 'account-suggestion';
     @import 'mixins';
@@ -6,10 +16,14 @@
     position: relative;
     display: block;
 
+    &--with-space-for-details {
+        margin-bottom: @details-height;
+    }
+
     &__details {
-        font-size: 0.875rem;
-        padding: @ffe-spacing-xs @ffe-spacing-2xs;
+        padding: @ffe-spacing-2xs;
         color: @ffe-black;
+        min-height: @details-height;
 
         .native & {
             @media (prefers-color-scheme: dark) {

--- a/packages/ffe-account-selector-react/package.json
+++ b/packages/ffe-account-selector-react/package.json
@@ -38,6 +38,7 @@
     "@sb1/ffe-formatters": "^4.0.0",
     "@sb1/ffe-icons-react": "^7.2.18",
     "@sb1/ffe-spinner-react": "^5.0.3",
+    "@sb1/ffe-searchable-dropdown-react": "^11.1.0",
     "classnames": "^2.2.5",
     "prop-types": "^15.6.0",
     "react-auto-bind": "^0.4.2",

--- a/packages/ffe-account-selector-react/src/components/account-selector/AccountSelector.js
+++ b/packages/ffe-account-selector-react/src/components/account-selector/AccountSelector.js
@@ -1,152 +1,188 @@
-import React, { Component } from 'react';
-import autoBind from 'react-auto-bind';
-import { func, string, arrayOf, bool } from 'prop-types';
-import classNames from 'classnames';
-
-import BaseSelector from '../base-selector';
+import React, { useState } from 'react';
 import {
-    AccountDetails,
-    AccountNoMatch,
-    AccountSuggestion,
-} from '../../subcomponents/account';
+    func,
+    string,
+    arrayOf,
+    bool,
+    shape,
+    object,
+    oneOfType,
+} from 'prop-types';
+import classNames from 'classnames';
+import SearchableDropdown from '@sb1/ffe-searchable-dropdown-react';
+
+import { AccountDetails, AccountSuggestion } from '../../subcomponents/account';
 import { Account, Locale } from '../../util/types';
-import { createAccountFilter } from '../../filter/filters';
+import { formatIncompleteAccountNumber } from '../../util/format';
 
-class AccountSelector extends Component {
-    constructor(props) {
-        super(props);
-        autoBind(this);
+const AccountSelector = ({
+    className,
+    id,
+    locale,
+    selectedAccount,
+    showBalance = false,
+    noMatches,
+    accounts,
+    onAccountSelected,
+    allowCustomAccount = false,
+    labelId,
+    listElementBody,
+    onReset,
+    inputProps,
+    formatAccountNumber = true,
+    ariaInvalid,
+    withSpaceForDetails = true,
+}) => {
+    const [inputValue, setInputValue] = useState('');
 
-        this.baseSelector = null;
-
-        this.enableFilter = false;
-    }
-
-    renderSuggestion(account) {
-        return (
-            <AccountSuggestion
-                account={account}
-                locale={this.props.locale}
-                showBalance={this.props.showBalance}
-            />
+    /*
+     * This matcher function closely resembles the default one of SearchableDropdown,
+     * but it ignores all spaces and periods so that account number formatting won't mess with the search.
+     */
+    const searchMatcherIgnoringAccountNumberFormatting = (
+        searchString,
+        searchAttributes,
+    ) => item => {
+        const cleanString = value =>
+            `${value}`
+                .replace(/(\s|\.)/g, '') // Remove all spaces and periods
+                .toLowerCase();
+        const cleanedSearchString = cleanString(searchString);
+        return searchAttributes.some(searchAttribute =>
+            cleanString(item[searchAttribute]).includes(cleanedSearchString),
         );
-    }
+    };
 
-    assignBaseSelectorRef(baseSelector) {
-        this.baseSelector = baseSelector;
-    }
-
-    renderNoMatches() {
-        return (
-            <AccountNoMatch
-                value={this.props.noMatches}
-                locale={this.props.locale}
-            />
-        );
-    }
-
-    onAccountSelect(account) {
-        this.enableFilter = false;
-        this.props.onAccountSelected(account);
-    }
-
-    onInputChange(value) {
-        this.enableFilter = true;
-        this.props.onChange(value);
-    }
-
-    onSuggestionSelect(suggestion) {
-        if (suggestion) {
-            this.baseSelector.showOrHideSuggestions(false, () =>
-                this.onAccountSelect(suggestion),
-            );
+    const onInputChange = event => {
+        setInputValue(event.target.value);
+        if (inputProps && inputProps.onChange) {
+            inputProps.onChange();
         }
+    };
+
+    const handleAccountSelected = value => {
+        const hasResetSelection = value === null;
+        const hasSelectedCustomAccount = !value?.accountNumber;
+        if (hasResetSelection) {
+            setInputValue('');
+            onReset();
+        } else if (hasSelectedCustomAccount) {
+            onAccountSelected({ name: '', accountNumber: value.name });
+        } else {
+            onAccountSelected(value);
+        }
+    };
+
+    let formatter;
+    if (formatAccountNumber) {
+        formatter = formatIncompleteAccountNumber;
     }
 
-    filterSuggestions() {
-        const { value, accounts } = this.props;
-        const suggFilt = createAccountFilter(this.enableFilter);
-        return accounts.filter(suggFilt(value));
-    }
+    const customNoMatch = allowCustomAccount
+        ? {
+              dropdownList: [
+                  {
+                      name: formatter ? formatter(inputValue) : inputValue,
+                      accountNumber: '',
+                  },
+              ],
+          }
+        : noMatches;
 
-    render() {
-        const {
-            className,
-            id,
-            locale,
-            selectedAccount,
-            showBalance,
-            highCapacity,
-        } = this.props;
-        return (
+    const dropdownAttributes = showBalance
+        ? ['name', 'accountNumber', 'balance']
+        : ['name', 'accountNumber'];
+
+    return (
+        <div className="ffe-account-selector-container">
             <div
-                className={classNames('ffe-account-selector', className)}
-                id={`${id}-container`}
+                className={classNames('ffe-account-selector', {
+                    'ffe-account-selector--with-space-for-details':
+                        !selectedAccount && withSpaceForDetails,
+                    className,
+                })}
+                id={`${id}-account-selector-container`}
             >
-                <BaseSelector
-                    ref={this.assignBaseSelectorRef}
-                    renderSuggestion={this.renderSuggestion}
-                    renderNoMatches={this.renderNoMatches}
-                    shouldHideSuggestionsOnSelect={true}
-                    shouldSelectHighlightedOnTab={true}
-                    shouldHideSuggestionsOnBlur={true}
-                    shouldHideSuggestionsOnReset={false}
-                    onSuggestionSelect={this.onSuggestionSelect}
-                    suggestionFilter={createAccountFilter(this.enableFilter)}
-                    suggestions={this.filterSuggestions()}
-                    {...this.props}
-                    onSelect={this.onAccountSelect}
-                    onChange={this.onInputChange}
+                <SearchableDropdown
+                    id={id}
+                    labelId={labelId}
+                    inputProps={{
+                        ...inputProps,
+                        onChange: onInputChange,
+                    }}
+                    dropdownAttributes={dropdownAttributes}
+                    dropdownList={accounts}
+                    noMatch={customNoMatch}
+                    formatter={formatter}
+                    onChange={handleAccountSelected}
+                    searchAttributes={['name', 'accountNumber']}
                     locale={locale}
-                    highCapacity={highCapacity}
+                    listElementBody={listElementBody || AccountSuggestion}
+                    ariaInvalid={ariaInvalid}
+                    searchMatcher={searchMatcherIgnoringAccountNumberFormatting}
+                    selectedItem={selectedAccount}
                 />
                 {selectedAccount && (
                     <AccountDetails
                         account={selectedAccount}
                         locale={locale}
-                        showBalance={showBalance}
+                        showBalance={
+                            showBalance &&
+                            typeof selectedAccount.balance === 'number'
+                        }
                     />
                 )}
             </div>
-        );
-    }
-}
+        </div>
+    );
+};
 
 AccountSelector.propTypes = {
     /**
      * Array of objects:
      *  {
      *      accountNumber: string.isRequired,
-     *      balance: number,
-     *      currencyCode: string.
      *      name: string.isRequired,
+     *      balance: number,
+     *      currencyCode: string,
      *  }
      */
-    accounts: arrayOf(Account),
+    accounts: arrayOf(Account).isRequired,
     className: string,
     id: string.isRequired,
     /** 'nb', 'nn', or 'en' */
     locale: Locale.isRequired,
     /** Overrides default string for all locales. */
-    noMatches: string,
-    /** Called when an account is clicked (or Enter is pressed when highlighted) */
+    noMatches: shape({
+        text: string.isRequired,
+        dropdownList: arrayOf(object),
+    }),
+    labelId: string.isRequired,
+    /** Returns the selected account object */
     onAccountSelected: func.isRequired,
-    /** Called on changes in the input field */
-    onChange: func.isRequired,
+    /**
+     * Called when clicking the clear button X or when
+     * emptying the input field and moving focus away from the account selector
+     * */
+    onReset: func.isRequired,
     selectedAccount: Account,
-    /** Default true. */
+    /** Default false. */
     showBalance: bool,
-    value: string.isRequired,
+    /** Default true. */
+    formatAccountNumber: bool,
     /**
-     * Disables the input-field. Useful when shown in native apps,
-     * where the textual input and keyboard can be distracting.
+     * Allows selecting the text the user writes even if it does not match anything in the accounts array.
+     * Useful e.g. if you want to pay to account that is not in your recipients list.
      */
-    readOnly: bool,
-    /**
-     * For situations where AccountSelector might be populated with hundreds of accounts
-     * uses react-window for performance optimization, default false
-     */
-    highCapacity: bool,
+    allowCustomAccount: bool,
+    /** Custom element to use for each item in the dropdown list */
+    listElementBody: func,
+    /** Props passed to the input field */
+    inputProps: shape(),
+    /** Defines if should save space for account details that is shown when an account is selected */
+    withSpaceForDetails: bool,
+    /** Sets aria-invalid on input field  */
+    ariaInvalid: oneOfType([string, bool]).isRequired,
 };
 
 export default AccountSelector;

--- a/packages/ffe-account-selector-react/src/components/account-selector/AccountSelector.md
+++ b/packages/ffe-account-selector-react/src/components/account-selector/AccountSelector.md
@@ -1,10 +1,10 @@
 Kontovelger for én konto.
 
 ```js
-initialState = { value: '' };
+initialState = { value: undefined };
+const label1 = 'label1';
 
-<React.Fragment>
-    <Label htmlFor="account-selector-single">Velg konto</Label>
+<InputGroup label="Velg konto" extraMargin={false} labelId={label1}>
     <AccountSelector
         accounts={[
             {
@@ -34,13 +34,253 @@ initialState = { value: '' };
         ]}
         id="account-selector-single"
         locale="nb"
-        onAccountSelected={acc =>
-            setState({ value: acc.name, selectedAccount: acc })
-        }
-        onChange={value => setState({ value })}
-        onReset={() => setState({ value: '', selectedAccount: null })}
-        value={state.value}
-        selectedAccount={state.selectedAccount}
+        onAccountSelected={value => setState({ value })}
+        onReset={() => setState({ value: '' })}
+        selectedAccount={state.value}
+        labelId={label1}
     />
-</React.Fragment>
+</InputGroup>;
+```
+
+Kan vise beløp
+
+```js
+initialState = { value: undefined };
+const label2 = 'label2';
+
+<InputGroup label="Velg konto" extraMargin={false} labelId={label2}>
+    <AccountSelector
+        accounts={[
+            {
+                accountNumber: '1234 56 789101',
+                name: 'Brukskonto',
+                currencyCode: 'NOK',
+                balance: 1337,
+            },
+            {
+                accountNumber: '1234 56 789102',
+                name: 'Brukskonto2',
+                currencyCode: 'NOK',
+                balance: 13337,
+            },
+            {
+                accountNumber: '2234 56 789102',
+                name: 'Sparekonto1',
+                currencyCode: 'EUR',
+                balance: 109236,
+            },
+            {
+                accountNumber: '1253 47 789102',
+                name: 'Sparekonto2',
+                currencyCode: 'NOK',
+                balance: 0,
+            },
+        ]}
+        id="account-selector-single"
+        locale="nb"
+        onAccountSelected={value => setState({ value })}
+        onReset={() => setState({ value: '' })}
+        selectedAccount={state.value}
+        showBalance
+        labelId={label2}
+    />
+</InputGroup>;
+```
+
+Kan tillate egeninnskrevet konto
+
+```js
+initialState = { value: undefined };
+const label4 = 'label4';
+
+<InputGroup label="Velg konto" extraMargin={false} labelId={label4}>
+    <AccountSelector
+        accounts={[
+            {
+                accountNumber: '1234 56 789101',
+                name: 'Brukskonto',
+                currencyCode: 'NOK',
+                balance: 1337,
+            },
+            {
+                accountNumber: '1234 56 789102',
+                name: 'Brukskonto2',
+                currencyCode: 'NOK',
+                balance: 13337,
+            },
+            {
+                accountNumber: '2234 56 789102',
+                name: 'Sparekonto1',
+                currencyCode: 'NOK',
+                balance: 109236,
+            },
+            {
+                accountNumber: '1253 47 789102',
+                name: 'Sparekonto2',
+                currencyCode: 'NOK',
+                balance: 0,
+            },
+        ]}
+        id="account-selector-single"
+        locale="nb"
+        onAccountSelected={value => setState({ value })}
+        onReset={() => setState({ value: '' })}
+        selectedAccount={state.value}
+        allowCustomAccount
+        labelId={label4}
+    />
+</InputGroup>;
+```
+
+Kan skru av at kontonummer blir formattert mens man skriver
+
+```js
+initialState = { value: undefined };
+const label3 = 'label3';
+
+<InputGroup label="Velg konto" extraMargin={false} labelId={label3}>
+    <AccountSelector
+        accounts={[
+            {
+                accountNumber: '1234 56 789101',
+                name: 'Brukskonto',
+                currencyCode: 'NOK',
+                balance: 1337,
+            },
+            {
+                accountNumber: '1234 56 789102',
+                name: 'Brukskonto2',
+                currencyCode: 'NOK',
+                balance: 13337,
+            },
+            {
+                accountNumber: '2234 56 789102',
+                name: 'Sparekonto1',
+                currencyCode: 'NOK',
+                balance: 109236,
+            },
+            {
+                accountNumber: '1253 47 789102',
+                name: 'Sparekonto2',
+                currencyCode: 'NOK',
+                balance: 0,
+            },
+        ]}
+        id="account-selector-single"
+        locale="nb"
+        onAccountSelected={value => setState({ value })}
+        onReset={() => setState({ value: '' })}
+        selectedAccount={state.value}
+        formatAccountNumber={false}
+        labelId={label3}
+    />
+</InputGroup>;
+```
+
+Kan velge å ikke holde av plass for visning av valgt konto
+
+```js
+initialState = { value: undefined };
+const label4 = 'label4';
+
+<InputGroup label="Velg konto" extraMargin={false} labelId={label4}>
+    <AccountSelector
+        accounts={[
+            {
+                accountNumber: '1234 56 789101',
+                name: 'Brukskonto',
+                currencyCode: 'NOK',
+                balance: 1337,
+            },
+            {
+                accountNumber: '1234 56 789102',
+                name: 'Brukskonto2',
+                currencyCode: 'NOK',
+                balance: 13337,
+            },
+            {
+                accountNumber: '2234 56 789102',
+                name: 'Sparekonto1',
+                currencyCode: 'NOK',
+                balance: 109236,
+            },
+            {
+                accountNumber: '1253 47 789102',
+                name: 'Sparekonto2',
+                currencyCode: 'NOK',
+                balance: 0,
+            },
+        ]}
+        id="account-selector-single"
+        locale="nb"
+        onAccountSelected={value => setState({ value })}
+        onReset={() => setState({ value: '' })}
+        selectedAccount={state.value}
+        allowCustomAccount
+        labelId={label4}
+        withSpaceForDetails={false}
+    />
+</InputGroup>;
+```
+
+Med egendefinert listeutseende
+
+```js
+initialState = { value: undefined };
+const label5 = 'label5';
+
+const CustomListElementBody = ({ item, isHighlighted }) => {
+    return (
+        <div
+            style={{
+                padding: '8px',
+                background: isHighlighted ? '#ff9100' : 'white',
+            }}
+        >
+            <div>{item.name}</div>
+            <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+                <SmallText>{item.accountNumber}</SmallText>
+                <SmallText>{item.amount}</SmallText>
+            </div>
+        </div>
+    );
+};
+
+<InputGroup label="Velg konto" extraMargin={false} labelId={label5}>
+    <AccountSelector
+        accounts={[
+            {
+                accountNumber: '1234 56 789101',
+                name: 'Brukskonto',
+                currencyCode: 'NOK',
+                balance: 1337,
+            },
+            {
+                accountNumber: '1234 56 789102',
+                name: 'Brukskonto2',
+                currencyCode: 'NOK',
+                balance: 13337,
+            },
+            {
+                accountNumber: '2234 56 789102',
+                name: 'Sparekonto1',
+                currencyCode: 'NOK',
+                balance: 109236,
+            },
+            {
+                accountNumber: '1253 47 789102',
+                name: 'Sparekonto2',
+                currencyCode: 'NOK',
+                balance: 0,
+            },
+        ]}
+        id="account-selector-single"
+        locale="nb"
+        onAccountSelected={value => setState({ value })}
+        onReset={() => setState({ value: '' })}
+        selectedAccount={state.value}
+        labelId={label5}
+        listElementBody={CustomListElementBody}
+    />
+</InputGroup>;
 ```

--- a/packages/ffe-account-selector-react/src/components/account-selector/AccountSelector.spec.js
+++ b/packages/ffe-account-selector-react/src/components/account-selector/AccountSelector.spec.js
@@ -1,81 +1,514 @@
 import React from 'react';
-import { mount } from 'enzyme';
+import { render, fireEvent, screen } from '@testing-library/react';
 
 import AccountSelector from './AccountSelector';
-import Input from '../../subcomponents/input-field';
-import { SuggestionItem } from '../../subcomponents/suggestion';
 
-const accounts = [
-    {
-        id: '1',
-        name: 'konto 1',
-        accountNumber: '111222333',
-        organisationId: '987654321',
-        accountGroupIds: ['1'],
-        currencyCode: 'NOK',
-    },
-    {
-        id: '2',
-        name: 'kontoo 2',
-        accountNumber: '222333444',
-        organisationId: '123456789',
-        accountGroupIds: ['1', '2'],
-        currencyCode: 'EUR',
-    },
-    {
-        id: '3',
-        name: 'kontoo 3',
-        accountNumber: '333444555',
-        organisationId: '123456789',
-        accountGroupIds: [],
-        currencyCode: 'NOK',
-    },
-];
-
-function propsAccountSelector() {
-    return {
-        accounts: [...accounts],
-        className: 'klasse',
-        value: '',
-        id: 'konto-id',
-        locale: 'nb',
-        noMatches: 'Iiik!',
-        onAccountSelected: () => {},
-        onChange: () => {},
-        selectedAccount: accounts[1],
-        showBalance: false,
-    };
-}
-
-function mountAccountSelector(props) {
-    return mount(<AccountSelector {...propsAccountSelector()} {...props} />);
-}
-
-describe('<AccountSelector> methods', () => {
-    it('should filter suggestions when input set to "oo"', () => {
-        const component = mountAccountSelector();
-        component.instance().onInputChange('');
-
-        expect(component.instance().baseSelector.props.suggestions.length).toBe(
-            3,
-        );
-
-        component.setProps({ value: 'oo' });
-        expect(component.instance().baseSelector.props.suggestions.length).toBe(
-            2,
+describe('AccountSelector', () => {
+    beforeAll(() => {
+        /*
+         * Mocking offsetHeight and offsetWidth makes AutoSizer from react-virtualized work as expected.
+         * Based on https://github.com/bvaughn/react-virtualized/issues/493#issuecomment-640084107.
+         */
+        jest.spyOn(
+            HTMLElement.prototype,
+            'offsetHeight',
+            'get',
+        ).mockReturnValue(50);
+        jest.spyOn(HTMLElement.prototype, 'offsetWidth', 'get').mockReturnValue(
+            50,
         );
     });
 
-    it('calls onSuggestionSelect with accounts[0] when the first item is selected', () => {
-        const onSuggestionSelectSpy = jest.fn();
-        const component = mountAccountSelector({
-            onSuggestionSelect: onSuggestionSelectSpy,
-        });
-        const input = component.find(Input);
-        input.simulate('focus');
-        const suggestionListItem = component.find(SuggestionItem).first();
-        suggestionListItem.simulate('mousedown');
+    afterAll(() => {
+        jest.restoreAllMocks();
+    });
 
-        expect(onSuggestionSelectSpy).toHaveBeenCalledWith(accounts[0]);
+    const accounts = [
+        {
+            accountNumber: '1234 56 789101',
+            name: 'Brukskonto',
+            currencyCode: 'NOK',
+            balance: 1337,
+        },
+        {
+            accountNumber: '1234 56 789102',
+            name: 'Jeg er en konto',
+            currencyCode: 'NOK',
+            balance: 13337,
+        },
+        {
+            accountNumber: '2234 56 789102',
+            name: 'Sparekonto',
+            currencyCode: 'NOK',
+            balance: 109236,
+        },
+        {
+            accountNumber: '1253 47 789102',
+            name: 'Gris',
+            currencyCode: 'NOK',
+            balance: 0,
+        },
+    ];
+
+    let selectedAccount;
+
+    const onAccountSelected = value => {
+        selectedAccount = value;
+    };
+
+    const onReset = () => {
+        selectedAccount = undefined;
+    };
+
+    beforeEach(() => {
+        selectedAccount = undefined;
+    });
+
+    it('should show filtered result', () => {
+        render(
+            <AccountSelector
+                id="id"
+                labelId="labelId"
+                accounts={accounts}
+                locale="nb"
+                onAccountSelected={onAccountSelected}
+                onReset={onReset}
+            />,
+        );
+
+        const input = screen.getByRole('combobox');
+
+        fireEvent.click(input);
+
+        expect(screen.getByText('Brukskonto')).toBeInTheDocument();
+        expect(screen.getByText('1234 56 789101')).toBeInTheDocument();
+        expect(screen.getByText('Jeg er en konto')).toBeInTheDocument();
+        expect(screen.getByText('1234 56 789102')).toBeInTheDocument();
+        expect(screen.getByText('Sparekonto')).toBeInTheDocument();
+        expect(screen.getByText('2234 56 789102')).toBeInTheDocument();
+        expect(screen.getByText('Gris')).toBeInTheDocument();
+        expect(screen.getByText('1253 47 789102')).toBeInTheDocument();
+
+        fireEvent.change(input, { target: { value: 'konto' } });
+
+        expect(screen.getByText('Brukskonto')).toBeInTheDocument();
+        expect(screen.getByText('1234 56 789101')).toBeInTheDocument();
+        expect(screen.getByText('Jeg er en konto')).toBeInTheDocument();
+        expect(screen.getByText('1234 56 789102')).toBeInTheDocument();
+        expect(screen.getByText('Sparekonto')).toBeInTheDocument();
+        expect(screen.getByText('2234 56 789102')).toBeInTheDocument();
+        expect(screen.queryByText('Gris')).toBeNull();
+        expect(screen.queryByText('1253 47 789102')).toBeNull();
+    });
+
+    it('should ignore spaces, periods and case when filtering', () => {
+        render(
+            <AccountSelector
+                id="id"
+                labelId="labelId"
+                accounts={accounts.concat([
+                    {
+                        accountNumber: '3485.42.80352',
+                        name: 'Hopps.ann heisann',
+                        currencyCode: 'NOK',
+                        balance: 7488,
+                    },
+                ])}
+                locale="nb"
+                onAccountSelected={onAccountSelected}
+                onReset={onReset}
+            />,
+        );
+
+        const input = screen.getByRole('combobox');
+
+        fireEvent.click(input);
+
+        expect(screen.getByText('Brukskonto')).toBeInTheDocument();
+        expect(screen.getByText('1234 56 789101')).toBeInTheDocument();
+        expect(screen.getByText('Jeg er en konto')).toBeInTheDocument();
+        expect(screen.getByText('1234 56 789102')).toBeInTheDocument();
+        expect(screen.getByText('Sparekonto')).toBeInTheDocument();
+        expect(screen.getByText('2234 56 789102')).toBeInTheDocument();
+        expect(screen.getByText('Gris')).toBeInTheDocument();
+        expect(screen.getByText('1253 47 789102')).toBeInTheDocument();
+        expect(screen.getByText('Hopps.ann heisann')).toBeInTheDocument();
+        expect(screen.getByText('3485.42.80352')).toBeInTheDocument();
+
+        fireEvent.change(input, { target: { value: 'JeG.eRe.n Kont o' } });
+
+        expect(screen.queryByText('Brukskonto')).toBeNull();
+        expect(screen.queryByText('1234 56 789101')).toBeNull();
+        expect(screen.getByText('Jeg er en konto')).toBeInTheDocument();
+        expect(screen.getByText('1234 56 789102')).toBeInTheDocument();
+        expect(screen.queryByText('Sparekonto')).toBeNull();
+        expect(screen.queryByText('2234 56 789102')).toBeNull();
+        expect(screen.queryByText('Gris')).toBeNull();
+        expect(screen.queryByText('1253 47 789102')).toBeNull();
+        expect(screen.queryByText('Hopps.ann heisann')).toBeNull();
+        expect(screen.queryByText('3485.42.80352')).toBeNull();
+
+        fireEvent.change(input, { target: { value: '3485 4280352' } });
+
+        expect(screen.queryByText('Brukskonto')).toBeNull();
+        expect(screen.queryByText('1234 56 789101')).toBeNull();
+        expect(screen.queryByText('Jeg er en konto')).toBeNull();
+        expect(screen.queryByText('1234 56 789102')).toBeNull();
+        expect(screen.queryByText('Sparekonto')).toBeNull();
+        expect(screen.queryByText('2234 56 789102')).toBeNull();
+        expect(screen.queryByText('Gris')).toBeNull();
+        expect(screen.queryByText('1253 47 789102')).toBeNull();
+        expect(screen.getByText('Hopps.ann heisann')).toBeInTheDocument();
+        expect(screen.getByText('3485.42.80352')).toBeInTheDocument();
+    });
+
+    it('should display account info after selection', () => {
+        const { rerender } = render(
+            <AccountSelector
+                id="id"
+                labelId="labelId"
+                accounts={accounts}
+                locale="nb"
+                onAccountSelected={onAccountSelected}
+                onReset={onReset}
+                selectedAccount={selectedAccount}
+            />,
+        );
+        expect(screen.queryByText('1234 56 789102')).toBeNull();
+
+        const input = screen.getByRole('combobox');
+
+        fireEvent.click(input);
+        fireEvent.click(screen.getByText('Jeg er en konto'));
+
+        rerender(
+            <AccountSelector
+                id="id"
+                labelId="labelId"
+                accounts={accounts}
+                locale="nb"
+                onAccountSelected={onAccountSelected}
+                onReset={onReset}
+                selectedAccount={selectedAccount}
+            />,
+        );
+
+        expect(screen.getByText('1234 56 789102')).toBeInTheDocument();
+    });
+
+    it('should display balance when specified', () => {
+        const { rerender } = render(
+            <AccountSelector
+                id="id"
+                labelId="labelId"
+                accounts={accounts}
+                locale="nb"
+                onAccountSelected={onAccountSelected}
+                onReset={onReset}
+                selectedAccount={selectedAccount}
+                showBalance={true}
+            />,
+        );
+
+        const input = screen.getByRole('combobox');
+
+        fireEvent.click(input);
+        expect(screen.getByText('1 337,00 kr')).toBeInTheDocument();
+        fireEvent.click(screen.getByText('Brukskonto'));
+
+        rerender(
+            <AccountSelector
+                id="id"
+                labelId="labelId"
+                accounts={accounts}
+                locale="nb"
+                onAccountSelected={onAccountSelected}
+                onReset={onReset}
+                selectedAccount={selectedAccount}
+                showBalance={true}
+            />,
+        );
+
+        expect(screen.getByText('1 337,00 kr')).toBeInTheDocument();
+        expect(screen.getByText('1234 56 789101')).toBeInTheDocument();
+
+        rerender(
+            <AccountSelector
+                id="id"
+                labelId="labelId"
+                accounts={accounts}
+                locale="nb"
+                onAccountSelected={onAccountSelected}
+                onReset={onReset}
+                selectedAccount={selectedAccount}
+                showBalance={false}
+            />,
+        );
+
+        expect(screen.queryByText('1 337,00 kr')).toBeNull();
+        expect(screen.getByText('1234 56 789101')).toBeInTheDocument();
+
+        fireEvent.click(input);
+        expect(screen.queryByText('1 337,00 kr')).toBeNull();
+    });
+
+    it('should allow selecting custom account when specified', () => {
+        const { rerender } = render(
+            <AccountSelector
+                id="id"
+                labelId="labelId"
+                accounts={accounts}
+                locale="nb"
+                onAccountSelected={onAccountSelected}
+                onReset={onReset}
+                selectedAccount={selectedAccount}
+                allowCustomAccount={true}
+            />,
+        );
+
+        const input = screen.getByRole('combobox');
+
+        fireEvent.click(input);
+
+        expect(screen.getByText('Brukskonto')).toBeInTheDocument();
+        expect(screen.queryByText('BrukskoABC')).toBeNull();
+
+        fireEvent.change(input, { target: { value: 'BrukskoABC' } });
+
+        expect(screen.queryByText('Brukskonto')).toBeNull();
+        expect(screen.getByText('BrukskoABC')).toBeInTheDocument();
+
+        fireEvent.click(screen.getByText('BrukskoABC'));
+
+        rerender(
+            <AccountSelector
+                id="id"
+                labelId="labelId"
+                accounts={accounts}
+                locale="nb"
+                onAccountSelected={onAccountSelected}
+                onReset={onReset}
+                selectedAccount={selectedAccount}
+                allowCustomAccount={true}
+            />,
+        );
+
+        expect(screen.getByText('BrukskoABC')).toBeInTheDocument();
+    });
+
+    it('should not show custom account when some account matches search', () => {
+        render(
+            <AccountSelector
+                id="id"
+                labelId="labelId"
+                accounts={accounts}
+                locale="nb"
+                onAccountSelected={onAccountSelected}
+                onReset={onReset}
+                selectedAccount={selectedAccount}
+                allowCustomAccount={true}
+            />,
+        );
+
+        const input = screen.getByRole('combobox');
+
+        fireEvent.click(input);
+
+        expect(screen.getByText('Brukskonto')).toBeInTheDocument();
+        expect(screen.queryByText('BrukskoABC')).toBeNull();
+
+        fireEvent.change(input, { target: { value: 'Bruksko' } });
+
+        expect(screen.getAllByText('Bruksko', { exact: false })).toHaveLength(
+            1,
+        );
+    });
+
+    it('should be able to render custom list items', () => {
+        const CustomListItemBody = ({
+            // eslint-disable-next-line react/prop-types
+            item: { accountNumber, name, balance, currencyCode },
+        }) => (
+            <div>
+                <span>{accountNumber}</span>
+                <span>FOR et navn! {name}</span>
+                <span>Litt av en saldo! {balance}</span>
+                <span>{currencyCode}</span>
+            </div>
+        );
+
+        render(
+            <AccountSelector
+                id="id"
+                labelId="labelId"
+                accounts={accounts}
+                locale="nb"
+                onAccountSelected={onAccountSelected}
+                onReset={onReset}
+                listElementBody={CustomListItemBody}
+            />,
+        );
+
+        const input = screen.getByRole('combobox');
+
+        fireEvent.click(input);
+
+        expect(
+            screen.getByText('FOR et navn! Jeg er en konto'),
+        ).toBeInTheDocument();
+        expect(screen.getByText('Litt av en saldo! 13337')).toBeInTheDocument();
+    });
+
+    it('should format input field while typing if value only contains digits and/or spaces', () => {
+        render(
+            <AccountSelector
+                id="id"
+                labelId="labelId"
+                accounts={accounts}
+                locale="nb"
+                onAccountSelected={onAccountSelected}
+                onReset={onReset}
+            />,
+        );
+
+        const input = screen.getByRole('combobox');
+
+        fireEvent.change(input, { target: { value: 'ab1de' } });
+        expect(input.getAttribute('value')).toEqual('ab1de');
+
+        fireEvent.change(input, { target: { value: 'ab1de ' } });
+        expect(input.getAttribute('value')).toEqual('ab1de ');
+
+        fireEvent.change(input, { target: { value: '1234.' } });
+        expect(input.getAttribute('value')).toEqual('1234.');
+
+        fireEvent.change(input, { target: { value: '1234.5' } });
+        expect(input.getAttribute('value')).toEqual('1234.5');
+
+        fireEvent.change(input, { target: { value: '4321' } });
+        expect(input.getAttribute('value')).toEqual('4321');
+
+        fireEvent.change(input, { target: { value: '54321' } });
+        expect(input.getAttribute('value')).toEqual('5432 1');
+
+        fireEvent.change(input, { target: { value: '5432 1 ' } });
+        expect(input.getAttribute('value')).toEqual('5432 1');
+
+        fireEvent.change(input, { target: { value: '543216789101' } });
+        expect(input.getAttribute('value')).toEqual('5432 16 789101');
+    });
+
+    it('should not format input field when formatAccountNumber is false', () => {
+        render(
+            <AccountSelector
+                id="id"
+                labelId="labelId"
+                accounts={accounts}
+                locale="nb"
+                onAccountSelected={onAccountSelected}
+                onReset={onReset}
+                formatAccountNumber={false}
+            />,
+        );
+
+        const input = screen.getByRole('combobox');
+
+        fireEvent.change(input, { target: { value: '54321' } });
+        expect(input.getAttribute('value')).toEqual('54321');
+
+        fireEvent.change(input, { target: { value: '543216789101' } });
+        expect(input.getAttribute('value')).toEqual('543216789101');
+    });
+
+    it('should reset input field and selected account on reset', () => {
+        const { rerender } = render(
+            <AccountSelector
+                id="id"
+                labelId="labelId"
+                accounts={accounts}
+                locale="nb"
+                onAccountSelected={onAccountSelected}
+                onReset={onReset}
+            />,
+        );
+
+        const input = screen.getByRole('combobox');
+
+        fireEvent.click(input);
+        fireEvent.click(screen.getByText('Jeg er en konto'));
+
+        rerender(
+            <AccountSelector
+                id="id"
+                labelId="labelId"
+                accounts={accounts}
+                locale="nb"
+                onAccountSelected={onAccountSelected}
+                onReset={onReset}
+                selectedAccount={selectedAccount}
+            />,
+        );
+
+        expect(screen.getByText('1234 56 789102')).toBeInTheDocument();
+
+        fireEvent.click(screen.getByLabelText('fjern valgt'));
+
+        rerender(
+            <AccountSelector
+                id="id"
+                labelId="labelId"
+                accounts={accounts}
+                locale="nb"
+                onAccountSelected={onAccountSelected}
+                onReset={onReset}
+                selectedAccount={selectedAccount}
+            />,
+        );
+
+        expect(screen.queryByText('1234 56 789102')).toBeNull();
+    });
+
+    it('should allow changing selectedAccount even if selectedAccount is defined on first render (initial value)', () => {
+        selectedAccount = accounts[2];
+
+        const { rerender } = render(
+            <AccountSelector
+                id="id"
+                labelId="labelId"
+                accounts={accounts}
+                locale="nb"
+                onAccountSelected={onAccountSelected}
+                onReset={onReset}
+                ariaInvalid={false}
+                selectedAccount={selectedAccount}
+            />,
+        );
+
+        const input = screen.getByRole('combobox');
+
+        expect(screen.getByText('2234 56 789102')).toBeInTheDocument();
+        expect(screen.queryByText('1234 56 789102')).toBeNull();
+        expect(input.value).toBe('Sparekonto');
+
+        fireEvent.click(screen.getByLabelText('fjern valgt'));
+        fireEvent.click(input);
+        fireEvent.click(screen.getByText('Jeg er en konto'));
+
+        rerender(
+            <AccountSelector
+                id="id"
+                labelId="labelId"
+                accounts={accounts}
+                locale="nb"
+                onAccountSelected={onAccountSelected}
+                onReset={onReset}
+                ariaInvalid={false}
+                selectedAccount={selectedAccount}
+            />,
+        );
+
+        expect(screen.queryByText('2234 56 789102')).toBeNull();
+        expect(screen.getByText('1234 56 789102')).toBeInTheDocument();
+        expect(input.value).toBe('Jeg er en konto');
     });
 });

--- a/packages/ffe-account-selector-react/src/index.d.ts
+++ b/packages/ffe-account-selector-react/src/index.d.ts
@@ -7,25 +7,38 @@ export interface Account {
     balance?: number;
 }
 
+interface ListElementBodyProps {
+    item: Account;
+    isHighlighted: boolean;
+    locale: string;
+    dropdownAttributes: string[];
+}
+
+interface NoMatch {
+    text: string;
+    dropdownList?: Account[];
+}
+
 export interface AccountSelectorProps {
-    accounts?: Array<Account>;
+    accounts: Array<Account>;
     className?: string;
     id: string;
     locale: string;
-    noMatches?: string;
+    noMatches?: NoMatch;
+    inputProps?: React.InputHTMLAttributes<HTMLInputElement>;
     onAccountSelected: (account: Account) => void;
-    onChange: (value: string) => void;
+    onReset: () => void;
     selectedAccount?: Account;
     showBalance?: boolean;
-    value: string;
-    readOnly?: boolean;
-    highCapacity?: boolean;
+    formatAccountNumber?: boolean;
+    labelId: string;
+    allowCustomAccount?: boolean;
+    listElementBody?: (props: ListElementBodyProps) => React.FC<HTMLDivElement>;
+    withSpaceForDetails?: boolean;
+    ariaInvalid: boolean;
 }
 
-declare class AccountSelector extends React.Component<
-    AccountSelectorProps,
-    any
-> {}
+declare class AccountSelector extends React.Component<AccountSelectorProps> {}
 
 export interface AccountSelectorMultiProps {
     accounts?: Array<Account>;

--- a/packages/ffe-account-selector-react/src/subcomponents/account/AccountDetails.js
+++ b/packages/ffe-account-selector-react/src/subcomponents/account/AccountDetails.js
@@ -7,7 +7,7 @@ import { Account, Locale } from '../../util/types';
 function AccountDetails({ account, locale, showBalance = true }) {
     const { balance, accountNumber, currencyCode } = account;
     return (
-        <div className="ffe-account-selector__details">
+        <div className="ffe-small-text ffe-account-selector__details">
             <div className="ffe-account-selector__details--left">
                 {accountFormatter(accountNumber)}
             </div>

--- a/packages/ffe-account-selector-react/src/subcomponents/account/AccountSuggestion.js
+++ b/packages/ffe-account-selector-react/src/subcomponents/account/AccountSuggestion.js
@@ -1,13 +1,28 @@
 import React from 'react';
-import { bool } from 'prop-types';
+import { bool, arrayOf, string } from 'prop-types';
+import classNames from 'classnames';
 
 import { accountFormatter, balanceWithCurrency } from '../../util/format';
 import { Account, Locale } from '../../util/types';
 
-const AccountSuggestionItem = ({ account, locale, showBalance = true }) => {
-    const { accountNumber, balance, name, currencyCode } = account;
+const AccountSuggestionItem = ({
+    item,
+    isHighlighted,
+    locale,
+    dropdownAttributes,
+}) => {
+    const { accountNumber, balance, name, currencyCode } = item;
+    const shouldShowBalance =
+        dropdownAttributes.includes('balance') && typeof balance === 'number';
     return (
-        <div className="ffe-account-suggestion__account">
+        <div
+            className={classNames(
+                'ffe-account-suggestion ffe-account-suggestion__account',
+                {
+                    'ffe-account-suggestion--highlighted': isHighlighted,
+                },
+            )}
+        >
             <span className="ffe-account-suggestion__name ffe-link-text ffe-link-text--no-underline">
                 {name}
             </span>
@@ -15,7 +30,7 @@ const AccountSuggestionItem = ({ account, locale, showBalance = true }) => {
                 <span className="ffe-account-suggestion__number">
                     {accountFormatter(accountNumber)}
                 </span>
-                {showBalance && (
+                {shouldShowBalance && (
                     <span className="ffe-account-suggestion__balance">
                         {balanceWithCurrency(balance, locale, currencyCode)}
                     </span>
@@ -26,9 +41,10 @@ const AccountSuggestionItem = ({ account, locale, showBalance = true }) => {
 };
 
 AccountSuggestionItem.propTypes = {
-    account: Account.isRequired,
+    item: Account.isRequired,
     locale: Locale.isRequired,
-    showBalance: bool,
+    isHighlighted: bool.isRequired,
+    dropdownAttributes: arrayOf(string).isRequired,
 };
 
 export default AccountSuggestionItem;

--- a/packages/ffe-account-selector-react/src/util/format.js
+++ b/packages/ffe-account-selector-react/src/util/format.js
@@ -41,3 +41,20 @@ export function balanceWithCurrency(balance = '', locale, currencyCode) {
         ? `${currencyAffix} ${amount}`
         : `${amount} ${currencyAffix}`;
 }
+
+export const formatIncompleteAccountNumber = accountNumber => {
+    const matchDigits = /^\d+$/;
+
+    if (typeof accountNumber !== 'string' || !accountNumber) {
+        return accountNumber;
+    }
+
+    const accountNumberWithoutSpaces = accountNumber.replace(/\s/g, ''); // remove spaces
+
+    if (matchDigits.test(accountNumberWithoutSpaces)) {
+        return accountNumberWithoutSpaces
+            .replace(/(\d{4})(\d{1})/, '$1 $2')
+            .replace(/ (\d{2})(\d{1})/, ' $1 $2');
+    }
+    return accountNumber || '';
+};

--- a/packages/ffe-account-selector-react/src/util/format.spec.js
+++ b/packages/ffe-account-selector-react/src/util/format.spec.js
@@ -1,4 +1,8 @@
-import { isValidNorwegianAccountNumber, accountFormatter } from './format';
+import {
+    isValidNorwegianAccountNumber,
+    accountFormatter,
+    formatIncompleteAccountNumber,
+} from './format';
 
 const validNorwegianAccountNumber = '42000231376';
 const inValidNorwegianAccountNumber = '42000231377';
@@ -13,6 +17,31 @@ describe('accountFormatter', () => {
     it('should return formatted norwegian account number', () => {
         expect(accountFormatter(validNorwegianAccountNumber)).toBe(
             '4200 02 31376',
+        );
+    });
+});
+
+describe('formatIncompleteAccountNumber', () => {
+    it('should return unformatted int for int value', () => {
+        expect(formatIncompleteAccountNumber(123456)).toBe(123456);
+    });
+    it('should return empty string for empty string', () => {
+        expect(formatIncompleteAccountNumber('')).toBe('');
+    });
+    it('should return formatted norwegian account number for complete account number', () => {
+        expect(formatIncompleteAccountNumber(validNorwegianAccountNumber)).toBe(
+            '4200 02 31376',
+        );
+    });
+    it('should return formatted string for partial account number', () => {
+        expect(formatIncompleteAccountNumber('1234')).toBe('1234');
+        expect(formatIncompleteAccountNumber('12345')).toBe('1234 5');
+        expect(formatIncompleteAccountNumber('123456')).toBe('1234 56');
+        expect(formatIncompleteAccountNumber('1234567')).toBe('1234 56 7');
+    });
+    it('should return formatted string even if string is longer than an account number', () => {
+        expect(formatIncompleteAccountNumber('123456789101112131415')).toBe(
+            '1234 56 789101112131415',
         );
     });
 });


### PR DESCRIPTION
BREAKING CHANGE: Make `AccountSelector` use `SearchableDropdown` under the hood

This means many of the props and some of the details of the functionality of
`AccountSelector` have changed.
Reusing SearchableDropdown in `AccountSelector` means we don't have to reinvent the wheel.
As a result, support for `highCapacity` has been removed.
`AccountSelectorMulti` remains the same as before.

New props:
```
export interface AccountSelectorProps<T> {
    accounts: Array<Account>;
    className?: string;
    id: string;
    locale: string;
    noMatches?: NoMatch<T>;
    inputProps?: React.InputHTMLAttributes<HTMLInputElement>;
    onAccountSelected: (account: Account) => void;
    onReset: () => void;
    selectedAccount?: Account;
    showBalance?: boolean;
    formatAccountNumber?: boolean;
    labelId: string;
    allowCustomAccount?: boolean;
    listElementBody?: (
        props: ListElementBodyProps<T>,
    ) => React.FC<HTMLDivElement>;
    saveSpaceForDetails?: boolean;
    ariaInvalid: boolean;
}
```

Old props:
```
export interface AccountSelectorProps {
    accounts?: Array<Account>;
    className?: string;
    id: string;
    locale: string;
    noMatches?: string;
    onAccountSelected: (account: Account) => void;
    onChange: (value: string) => void;
    selectedAccount?: Account;
    showBalance?: boolean;
    value: string;
    readOnly?: boolean;
    highCapacity?: boolean;
}
```