### PR TITLE
fix(ffe-datepicker-react): make the datepicker work in shadow dom

### DIFF
--- a/packages/ffe-datepicker-react/src/datepicker/Datepicker.js
+++ b/packages/ffe-datepicker-react/src/datepicker/Datepicker.js
@@ -172,10 +172,7 @@ export default class Datepicker extends Component {
     }
 
     globalClickHandler(evt) {
-        if (
-            this.state.displayDatePicker &&
-            !this._datepickerNode.contains(evt.target)
-        ) {
+        if (this.state.displayDatePicker && !evt.__isEventFromFFEDatepicker) {
             this.closeCalendar();
         }
     }
@@ -188,6 +185,16 @@ export default class Datepicker extends Component {
         } else {
             this.closeCalendar();
         }
+    }
+
+    /**
+     * Adds a flag on the click event so that the globalClickHandler()
+     * can determine whether or not this event originated from this
+     * component
+     */
+    addFlagOnClickEventClickHandler(evt) {
+        // eslint-disable-next-line no-param-reassign
+        evt.nativeEvent.__isEventFromFFEDatepicker = true;
     }
 
     divBlurHandler(evt) {
@@ -301,8 +308,10 @@ export default class Datepicker extends Component {
                             ? `ffe-datepicker-label-${this.datepickerId}`
                             : undefined
                     }
+                    role="none"
                     aria-label={label ? undefined : i18n[language].CHOOSE_DATE}
                     className={datepickerClassName}
+                    onClick={this.addFlagOnClickEventClickHandler}
                     ref={c => {
                         this._datepickerNode = c;
                     }}


### PR DESCRIPTION
We should always close an opened datepicker, whenever a click happens
outside the datepicker. To enable this, the datepicker registers a
global click handler on window, that checks the origin of every click
event.

Previously, the global click handler used Element.contains() to check if
the event target was contained in the components DOM tree. This does not
work if the component is rendered in a shadow DOM, since events
originating from a shadow DOM are retargeted, and thus the event target
is not contained in the components DOM tree. The result is that the same
click event that opens the datepicker, also closes the datepicker when
the event bubbles to window.

We make the datepicker work in shadow DOM by setting a flag on all click
events originating from the datepicker, and change the logic in the
global click handler to check for this flag instead of using
Element.contains().


