### PR TITLE
feat(ffe-searchable-dropdown-react): Add support for tens of thousands of options

### DIFF
--- a/packages/ffe-searchable-dropdown-react/exampleData.js
+++ b/packages/ffe-searchable-dropdown-react/exampleData.js
@@ -235,3 +235,9 @@ exports.yrker = [
     { kode: '203', beskrivelse: 'Betongarbeider' },
     { kode: '204', beskrivelse: 'Betongpumpeoperatør' },
 ];
+
+const listWithThirtyThousandElements = new Array(30000)
+    .fill(null)
+    .map((_, i) => ({ organizationName: `Navn ${i}` }));
+
+exports.listWithThirtyThousandElements = listWithThirtyThousandElements;

--- a/packages/ffe-searchable-dropdown-react/less/searchable-dropdown.less
+++ b/packages/ffe-searchable-dropdown-react/less/searchable-dropdown.less
@@ -72,6 +72,15 @@
             }
         }
 
+        &:hover {
+            background: @ffe-blue-pale;
+            .native & {
+                @media (prefers-color-scheme: dark) {
+                    background: @ffe-grey-darkmode;
+                }
+            }
+        }
+
         &--highlighted {
             background: @ffe-blue-azure;
             color: @ffe-white;

--- a/packages/ffe-searchable-dropdown-react/package.json
+++ b/packages/ffe-searchable-dropdown-react/package.json
@@ -36,7 +36,8 @@
     "compute-scroll-into-view": "^1.0.17",
     "lodash.isequal": "^4.5.0",
     "prop-types": "^15.6.0",
-    "react-custom-scrollbars": "^4.2.1"
+    "react-custom-scrollbars": "^4.2.1",
+    "react-virtualized": "^9.22.3"
   },
   "devDependencies": {
     "eslint": "^5.9.0",

--- a/packages/ffe-searchable-dropdown-react/src/List.js
+++ b/packages/ffe-searchable-dropdown-react/src/List.js
@@ -1,0 +1,191 @@
+import {
+    CellMeasurer,
+    CellMeasurerCache,
+    List as VirtualizedList,
+    AutoSizer,
+} from 'react-virtualized';
+import React from 'react';
+import { Scrollbars } from 'react-custom-scrollbars';
+import {
+    arrayOf,
+    any,
+    bool,
+    func,
+    number,
+    object,
+    oneOf,
+    shape,
+    string,
+} from 'prop-types';
+
+import { locales } from './translations';
+import ListItemContainer from './ListItemContainer';
+import { stateChangeTypes } from './reducer';
+import NoMatch from './NoMatch';
+
+export default class List extends React.PureComponent {
+    state = {
+        optionHeight: 40,
+    };
+
+    constructor(props, context) {
+        super(props, context);
+
+        this._cache = new CellMeasurerCache({
+            fixedWidth: true,
+            minHeight: 10,
+        });
+
+        this.rowRenderer = this.rowRenderer.bind(this);
+        this.handleScroll = this.handleScroll.bind(this);
+
+        this.listRef = React.createRef();
+    }
+
+    handleScroll = event => {
+        const { scrollTop, scrollLeft } = event.target;
+        const { Grid } = this.listRef.current;
+        Grid.handleScrollEvent({ scrollTop, scrollLeft });
+    };
+
+    componentDidMount() {
+        requestAnimationFrame(() => {
+            const firstOption = this.listRef.current?.Grid?._scrollingContainer?.querySelector(
+                '[role="option"]',
+            );
+
+            if (firstOption?.offsetHeight) {
+                this.setState({
+                    ...this.state,
+                    optionHeight: firstOption.offsetHeight,
+                });
+            }
+        });
+    }
+
+    render() {
+        const {
+            isNoMatch,
+            noMatch,
+            listToRender,
+            noMatchMessageId,
+        } = this.props;
+        const { optionHeight } = this.state;
+
+        const maxHeight = 300;
+        const heightOfAllOptions =
+            optionHeight * listToRender.length +
+            (isNoMatch && noMatch.text ? optionHeight : 0);
+        const height =
+            heightOfAllOptions > maxHeight ? maxHeight : heightOfAllOptions;
+
+        return (
+            <AutoSizer disableHeight={true}>
+                {({ width }) => {
+                    return (
+                        <Scrollbars
+                            onScroll={this.handleScroll}
+                            style={{ height, width }}
+                        >
+                            {isNoMatch && (
+                                <NoMatch
+                                    noMatch={noMatch}
+                                    noMatchMessageId={noMatchMessageId}
+                                    listToRender={listToRender}
+                                />
+                            )}
+                            <VirtualizedList
+                                ref={this.listRef}
+                                deferredMeasurementCache={this._cache}
+                                height={height}
+                                overscanRowCount={10}
+                                // Required to make Scrollbars work
+                                style={{
+                                    overflowX: false,
+                                    overflowY: false,
+                                }}
+                                rowCount={listToRender.length}
+                                rowHeight={this._cache.rowHeight}
+                                rowRenderer={this.rowRenderer}
+                                width={width}
+                            />
+                        </Scrollbars>
+                    );
+                }}
+            </AutoSizer>
+        );
+    }
+
+    rowRenderer({ index, parent, style }) {
+        const {
+            ListItemBodyElement,
+            listToRender,
+            highlightedIndex,
+            dispatch,
+            dropdownAttributes,
+            locale,
+            refs,
+            onChange,
+            focusInput,
+        } = this.props;
+        const item = listToRender[index];
+        const itemKey = Object.values(item).join('-');
+
+        return (
+            <CellMeasurer
+                cache={this._cache}
+                columnIndex={0}
+                key={itemKey}
+                rowIndex={index}
+                parent={parent}
+            >
+                {({ registerChild }) => (
+                    <div ref={registerChild} style={style}>
+                        <ListItemContainer
+                            key={itemKey}
+                            ref={refs[index]}
+                            isHighlighted={highlightedIndex === index}
+                            onClick={() => {
+                                onChange(item);
+                                dispatch({
+                                    type: stateChangeTypes.ItemOnClick,
+                                    payload: { selectedItem: item },
+                                });
+                                focusInput();
+                            }}
+                            item={item}
+                        >
+                            {props => {
+                                return (
+                                    <ListItemBodyElement
+                                        {...props}
+                                        dropdownAttributes={dropdownAttributes}
+                                        locale={locale}
+                                    />
+                                );
+                            }}
+                        </ListItemContainer>
+                    </div>
+                )}
+            </CellMeasurer>
+        );
+    }
+}
+
+List.propTypes = {
+    listToRender: arrayOf(object).isRequired,
+    noMatch: shape({
+        text: string,
+        dropdownList: arrayOf(object),
+    }),
+    noMatchMessageId: string,
+    ListItemBodyElement: func,
+    highlightedIndex: number,
+    dispatch: func,
+    dropdownAttributes: arrayOf(string).isRequired,
+    locale: oneOf(Object.values(locales)).isRequired,
+    refs: arrayOf(any).isRequired,
+    onChange: func.isRequired,
+    focusInput: func.isRequired,
+    isNoMatch: bool.isRequired,
+};

--- a/packages/ffe-searchable-dropdown-react/src/NoMatch.js
+++ b/packages/ffe-searchable-dropdown-react/src/NoMatch.js
@@ -1,0 +1,35 @@
+import React from 'react';
+import { arrayOf, object, shape, string } from 'prop-types';
+
+import { Paragraph } from '@sb1/ffe-core-react';
+import { getNotMatchText } from './translations';
+
+const NoMatch = ({ noMatch, noMatchMessageId, listToRender }) => (
+    <div>
+        {noMatch.text ? (
+            <div className="ffe-searchable-dropdown__no-match">
+                <Paragraph id={noMatchMessageId}>{noMatch.text}</Paragraph>
+            </div>
+        ) : (
+            listToRender.length === 0 && (
+                <Paragraph
+                    id={noMatchMessageId}
+                    className="ffe-screenreader-only"
+                >
+                    {getNotMatchText()}
+                </Paragraph>
+            )
+        )}
+    </div>
+);
+
+NoMatch.propTypes = {
+    noMatch: shape({
+        text: string,
+        dropdownList: arrayOf(object),
+    }),
+    noMatchMessageId: string,
+    listToRender: arrayOf(object).isRequired,
+};
+
+export default NoMatch;

--- a/packages/ffe-searchable-dropdown-react/src/SearchableDropdown.js
+++ b/packages/ffe-searchable-dropdown-react/src/SearchableDropdown.js
@@ -18,18 +18,15 @@ import {
     string,
 } from 'prop-types';
 import classNames from 'classnames';
-import { Scrollbars } from 'react-custom-scrollbars';
 import isEqual from 'lodash.isequal';
 import { ChevronIkon, KryssIkon } from '@sb1/ffe-icons-react';
-import { Paragraph } from '@sb1/ffe-core-react';
 
-import ListItemContainer from './ListItemContainer';
+import List from './List';
 import ListItemBody from './ListItemBody';
 import {
     getButtonLabelClear,
     getButtonLabelClose,
     getButtonLabelOpen,
-    getNotMatchText,
     locales,
 } from './translations';
 import { v4 as uuid } from 'uuid';
@@ -103,7 +100,7 @@ const SearchableDropdown = ({
 
     const ListItemBodyElement = CustomListItemBody || ListItemBody;
     const listBoxRef = useRef(uuid());
-    const notMatchMessageId = useRef(uuid());
+    const noMatchMessageId = useRef(uuid());
     const shouldFocusToggleButton = useRef(false);
     const shouldFocusInput = useRef(false);
 
@@ -189,6 +186,14 @@ const SearchableDropdown = ({
             document.removeEventListener('focusin', handleContainerFocus);
         };
     }, []);
+
+    const focusToggleButton = () => {
+        shouldFocusToggleButton.current = true;
+    };
+
+    const focusInput = () => {
+        shouldFocusInput.current = true;
+    };
 
     const handleKeyDown = event => {
         if (event.key === ENTER && state.highlightedIndex >= 0) {
@@ -276,7 +281,7 @@ const SearchableDropdown = ({
                     aria-describedby={
                         [
                             inputProps['aria-describedby'],
-                            state.noMatch && notMatchMessageId.current,
+                            state.noMatch && noMatchMessageId.current,
                         ]
                             .filter(Boolean)
                             .join(' ') || null
@@ -316,7 +321,7 @@ const SearchableDropdown = ({
                     onClick={() => {
                         dispatch({ type: stateChangeTypes.ClearButtonPressed });
                         onChange(null);
-                        shouldFocusToggleButton.current = true;
+                        focusToggleButton();
                     }}
                 >
                     <KryssIkon />
@@ -351,76 +356,25 @@ const SearchableDropdown = ({
                     'ffe-searchable-dropdown__list--open': state.isExpanded,
                 })}
             >
-                <Scrollbars autoHeight={true} autoHeightMax={300}>
-                    {state.noMatch && (
-                        <>
-                            {noMatch.text ? (
-                                <div className="ffe-searchable-dropdown__no-match">
-                                    <Paragraph id={notMatchMessageId.current}>
-                                        {noMatch.text}
-                                    </Paragraph>
-                                </div>
-                            ) : (
-                                state.listToRender.length === 0 && (
-                                    <Paragraph
-                                        id={notMatchMessageId.current}
-                                        className="ffe-screenreader-only"
-                                    >
-                                        {getNotMatchText()}
-                                    </Paragraph>
-                                )
-                            )}
-                        </>
+                <div id={listBoxRef.current} role="listbox">
+                    {state.isExpanded && (
+                        <List
+                            listBoxRef={listBoxRef}
+                            listToRender={state.listToRender}
+                            ListItemBodyElement={ListItemBodyElement}
+                            highlightedIndex={state.highlightedIndex}
+                            dispatch={dispatch}
+                            dropdownAttributes={dropdownAttributes}
+                            locale={locale}
+                            refs={refs}
+                            onChange={onChange}
+                            isNoMatch={state.noMatch}
+                            noMatch={noMatch}
+                            noMatchMessageId={noMatchMessageId.current}
+                            focusInput={focusInput}
+                        />
                     )}
-                    <div id={listBoxRef.current} role="listbox">
-                        {state.isExpanded &&
-                            state.listToRender.map((item, index) => {
-                                const key = Object.values(item)
-                                    .join('-')
-                                    .replace(/\s/g, '-');
-                                return (
-                                    <ListItemContainer
-                                        key={key}
-                                        ref={refs[index]}
-                                        isHighlighted={
-                                            state.highlightedIndex === index
-                                        }
-                                        onMouseEnter={e => {
-                                            dispatch({
-                                                type:
-                                                    stateChangeTypes.ItemOnMouseEnter,
-                                                payload: {
-                                                    highlightedIndex: index,
-                                                },
-                                            });
-                                        }}
-                                        onClick={() => {
-                                            onChange(item);
-                                            dispatch({
-                                                type:
-                                                    stateChangeTypes.ItemOnClick,
-                                                payload: { selectedItem: item },
-                                            });
-                                            shouldFocusInput.current = true;
-                                        }}
-                                        item={item}
-                                    >
-                                        {props => {
-                                            return (
-                                                <ListItemBodyElement
-                                                    {...props}
-                                                    dropdownAttributes={
-                                                        dropdownAttributes
-                                                    }
-                                                    locale={locale}
-                                                />
-                                            );
-                                        }}
-                                    </ListItemContainer>
-                                );
-                            })}
-                    </div>
-                </Scrollbars>
+                </div>
             </div>
         </div>
     );

--- a/packages/ffe-searchable-dropdown-react/src/SearchableDropdown.md
+++ b/packages/ffe-searchable-dropdown-react/src/SearchableDropdown.md
@@ -14,7 +14,6 @@ const labelId = 'labelId1';
 <InputGroup label="Velg bedrift" labelId={labelId}>
     <SearchableDropdown
         labelId={labelId}
-        initialValue={companies[1]}
         inputProps={{ placeholder: 'Velg' }}
         dropdownAttributes={['organizationName']}
         dropdownList={companies}
@@ -190,4 +189,26 @@ const inputId = 'inputId6';
         locale="nb"
     />
 </div>;
+```
+
+Kan rendre titusenvis av valgalternativer uten ytelsesproblemer.
+
+```js
+const { InputGroup } = require('../../ffe-form-react');
+const listWithThirtyThousandElements = require('../exampleData')
+    .listWithThirtyThousandElements;
+const labelId = 'labelId1';
+
+<InputGroup label="Velg bedrift" labelId={labelId}>
+    <SearchableDropdown
+        labelId={labelId}
+        inputProps={{ placeholder: 'Velg' }}
+        dropdownAttributes={['organizationName']}
+        dropdownList={listWithThirtyThousandElements}
+        noMatch={{ text: 'Søket ga ingen treff' }}
+        onChange={item => setState({ item })}
+        searchAttributes={['organizationName']}
+        locale="nb"
+    />
+</InputGroup>;
 ```

--- a/packages/ffe-searchable-dropdown-react/src/SearchableDropdown.spec.js
+++ b/packages/ffe-searchable-dropdown-react/src/SearchableDropdown.spec.js
@@ -5,6 +5,25 @@ import userEvent from '@testing-library/user-event';
 import SearchableDropdown from './SearchableDropdown';
 
 describe('SearchableDropdown', () => {
+    beforeAll(() => {
+        /*
+         * Mocking offsetHeight and offsetWidth makes AutoSizer from react-virtualized work as expected.
+         * Based on https://github.com/bvaughn/react-virtualized/issues/493#issuecomment-640084107.
+         */
+        jest.spyOn(
+            HTMLElement.prototype,
+            'offsetHeight',
+            'get',
+        ).mockReturnValue(50);
+        jest.spyOn(HTMLElement.prototype, 'offsetWidth', 'get').mockReturnValue(
+            50,
+        );
+    });
+
+    afterAll(() => {
+        jest.restoreAllMocks();
+    });
+
     const companies = [
         {
             organizationName: 'Bedriften',


### PR DESCRIPTION
Using react-virtualzed we only render the list options that are dislayed to the user.
This enables us to go from at most a few thousand options to virtually an unlimited amount.
This implementation has been tested with 300000 options on Chrome.

This aims to solve the same issue that the highCapacity prop of AccountSelector was
introduced to solve in 93f21898c85988153091b15af7704df1d51ef105

--------------------

Jeg har testet dette på TalkBack og sammenlignet med prod, og det ser ut til å funke likt.