### PR TITLE
fix(ffe-searchable-dropdown-react): make it work in shadow dom

### DIFF
--- a/packages/ffe-searchable-dropdown-react/src/SearchableDropdown.js
+++ b/packages/ffe-searchable-dropdown-react/src/SearchableDropdown.js
@@ -170,8 +170,16 @@ const SearchableDropdown = ({
         isInitialMountRef.current = false;
     }, []);
 
+    /**
+     * Because of changes in event handling between react v16 and v17, the check for the
+     * event flag will only work in react v17. Therefore, we also check Element.contains()
+     * to keep react v16 compatibility.
+     */
     const handleContainerFocus = e => {
-        if (!containerRef.current.contains(e.target)) {
+        const isFocusInside =
+            containerRef.current.contains(e.target) ||
+            e.__isEventFromFFESearchableDropdown;
+        if (!isFocusInside) {
             dispatch({
                 type: stateChangeTypes.FocusMovedOutSide,
             });
@@ -194,6 +202,16 @@ const SearchableDropdown = ({
     const focusInput = () => {
         shouldFocusInput.current = true;
     };
+
+    /**
+     * Adds a flag on the event so that handleContainerFocus()
+     * can determine whether or not this event originated from this
+     * component
+     */
+    function addFlagOnEventHandler(event) {
+        // eslint-disable-next-line no-param-reassign
+        event.nativeEvent.__isEventFromFFESearchableDropdown = true;
+    }
 
     const handleKeyDown = event => {
         if (event.key === ENTER && state.highlightedIndex >= 0) {
@@ -257,6 +275,8 @@ const SearchableDropdown = ({
                 'ffe-searchable-dropdown--dark': dark,
             })}
             ref={containerRef}
+            onMouseDown={addFlagOnEventHandler}
+            onFocus={addFlagOnEventHandler}
         >
             <div>
                 <input


### PR DESCRIPTION
Clicks outside the component should close the list of suggestions.
This is currently enabled by registering a global event handler on
document, that listens for "mousedown" and "focusin" event, which
closes the list of suggestions if the event originated outside the
component.

Previously, the global event handler used Element.contains() to check if
the event target was contained in the components DOM tree. This does not
work if the component is rendered in a shadow DOM, since events
originating from a shadow DOM are retargeted, and thus the event target
is not contained in the components DOM tree. The result is that the same
mousedown event that should choose a suggestion, instead ends up closing
the list of suggestions.

We make the searchable dropdown work in shadow DOM by setting a flag on
all mousedown and focusin events originating from the component, and
changing the logic in the global event handler to check for this flag.

NB: The "event flag" check will only work in react v17, due to changes
in event handling in react v17. This in turns means that this fix will
only have an effect in react v17, but shadow DOM is broken with
earlier react versions than v16 anyway.

Jeg har testet denne med både react v17 og v16
