### PR TITLE
feat(ffe-searchable-dropdown-react): Set selectedItem to item in drop…

### DIFF
--- a/packages/ffe-searchable-dropdown-react/less/searchable-dropdown.less
+++ b/packages/ffe-searchable-dropdown-react/less/searchable-dropdown.less
@@ -81,7 +81,8 @@
             }
         }
 
-        &--highlighted {
+        &--highlighted,
+        &--highlighted:hover {
             background: @ffe-blue-azure;
             color: @ffe-white;
             .native & {

--- a/packages/ffe-searchable-dropdown-react/src/SearchableDropdown.js
+++ b/packages/ffe-searchable-dropdown-react/src/SearchableDropdown.js
@@ -62,6 +62,7 @@ const SearchableDropdown = ({
     formatter = value => value,
     searchMatcher,
     selectedItem,
+    allowCustomItem = false,
 }) => {
     const [state, dispatch] = useReducer(
         createReducer({
@@ -123,10 +124,11 @@ const SearchableDropdown = ({
     };
 
     useEffect(() => {
-        if (
-            selectedItem &&
-            dropdownList.some(item => isEqual(item, selectedItem))
-        ) {
+        const isSelectedItemInDropdownList = dropdownList.some(item =>
+            isEqual(item, selectedItem),
+        );
+
+        if (selectedItem && (isSelectedItemInDropdownList || allowCustomItem)) {
             dispatch({
                 type: stateChangeTypes.ItemSelectedProgrammatically,
                 payload: { selectedItem },
@@ -136,7 +138,7 @@ const SearchableDropdown = ({
                 type: stateChangeTypes.ItemClearedProgrammatically,
             });
         }
-    }, [selectedItem, dropdownList, dispatch]);
+    }, [selectedItem, dropdownList, dispatch, allowCustomItem]);
 
     useSetAllyMessageItemSelection({
         searchAttributes,
@@ -459,6 +461,8 @@ SearchableDropdown.propTypes = {
      * (inputValue: string, searchAttributes: string[]) => (item) => boolean
      */
     searchMatcher: func,
+    /** Allow selectedItem to not match any of the elements in dropdownList */
+    allowCustomItem: bool,
 };
 
 export default SearchableDropdown;

--- a/packages/ffe-searchable-dropdown-react/src/SearchableDropdown.md
+++ b/packages/ffe-searchable-dropdown-react/src/SearchableDropdown.md
@@ -212,3 +212,41 @@ const labelId = 'labelId1';
     />
 </InputGroup>;
 ```
+
+Du kan sende inn et `selectedItem` som ikke matcher noen av elementene i lista ved å sende inn proppen `allowCustomItem`.
+
+```js
+const { InputGroup } = require('../../ffe-form-react');
+const companies = require('../exampleData').companiesWithMessageCount;
+const labelId = 'labelId5';
+
+initialState = {
+    item: {
+        organizationName: 'Kaffekoppene',
+        organizationNumber: '812602221234',
+        quantityUnprocessedMessages: 1,
+    },
+};
+
+<InputGroup label="Velg bedrift" labelId={labelId}>
+    <SearchableDropdown
+        labelId={labelId}
+        inputProps={{ placeholder: 'Velg' }}
+        dropdownAttributes={['organizationName', 'organizationNumber']}
+        dropdownList={companies}
+        onChange={item => setState({ item })}
+        searchAttributes={['organizationName', 'organizationNumber']}
+        locale="nb"
+        selectedItem={state.item}
+        allowCustomItem
+        noMatch={{
+            dropdownList: [
+                {
+                    organizationName: 'Kaffekoppene',
+                    organizationNumber: '812602221234',
+                },
+            ],
+        }}
+    />
+</InputGroup>;
+```

--- a/packages/ffe-searchable-dropdown-react/src/SearchableDropdown.spec.js
+++ b/packages/ffe-searchable-dropdown-react/src/SearchableDropdown.spec.js
@@ -761,4 +761,37 @@ describe('SearchableDropdown', () => {
 
         expect(input.value).toBe('');
     });
+
+    it('should set selected item to the single item matching element in dropdown list when losing focus', () => {
+        const onChange = jest.fn();
+        render(
+            <div>
+                <button>Knapp</button>
+                <SearchableDropdown
+                    id="id"
+                    labelId="labelId"
+                    dropdownAttributes={[
+                        'organizationName',
+                        'organizationNumber',
+                    ]}
+                    dropdownList={companies}
+                    onChange={onChange}
+                    searchAttributes={[
+                        'organizationName',
+                        'organizationNumber',
+                    ]}
+                    locale="nb"
+                />
+            </div>,
+        );
+
+        const input = screen.getByRole('combobox');
+        userEvent.type(input, 'Bedriften');
+
+        act(() => {
+            userEvent.click(screen.getByText('Knapp'));
+        });
+
+        expect(input.value).toEqual('Bedriften');
+    });
 });

--- a/packages/ffe-searchable-dropdown-react/src/reducer.js
+++ b/packages/ffe-searchable-dropdown-react/src/reducer.js
@@ -1,3 +1,4 @@
+import isEqual from 'lodash.isequal';
 import { getListToRender } from './getListToRender';
 
 export const stateChangeTypes = {
@@ -131,14 +132,34 @@ export const createReducer = ({
             };
         }
         case stateChangeTypes.FocusMovedOutSide: {
+            const { listToRender } = getListToRender({
+                inputValue: state.inputValue,
+                searchAttributes,
+                maxRenderedDropdownElements,
+                dropdownList,
+                noMatchDropdownList,
+                searchMatcher,
+            });
+
+            const matchingItem = listToRender.find(item =>
+                searchAttributes.some(searchAttribute =>
+                    isEqual(item[searchAttribute], state.inputValue),
+                ),
+            );
+            const selectedItem =
+                listToRender.length === 1 && matchingItem
+                    ? matchingItem
+                    : state.selectedItem;
+
             return {
                 ...state,
                 isExpanded: false,
                 highlightedIndex: -1,
                 inputValue:
-                    state.selectedItem && state.inputValue !== ''
-                        ? state.selectedItem[searchAttributes[0]]
+                    selectedItem && state.inputValue !== ''
+                        ? selectedItem[searchAttributes[0]]
                         : '',
+                selectedItem,
             };
         }
         default:


### PR DESCRIPTION
…downList matching inputValue and accept selectedItem not matching item in dropdownList when `allowCustomItem` is passed

## Beskrivelse

Dersom man skriver inn en verdi som matcher ett element i lista, så virker det naturlig å skulle sette det som valgt element ved onBlur.

Vi vil også legge til muligheten til å sende inn et `selectedItem` som ikke finnes i selve lista, men kun når det tillates med `allowCustomItem`. Det trengs i kontovelgeren. Nå i kontovelgeren når vi setter customAccount, så vil den valgte kontoen kun vises i detaljene på bunnen, ikke i selve input-feltet.

Så etter dette er merget må jeg legge til en liten ting i kontovelgeren også. :)

## Testing

Har testet i designsystemet. Oppdaget disse tingene da jeg tok i bruk kontovelgeren i pm-betaling.
