### PR TITLE
feat(ffe-account-selector-react): Show account number in input field …

### DIFF
--- a/packages/ffe-account-selector-react/src/components/account-selector/AccountSelector.js
+++ b/packages/ffe-account-selector-react/src/components/account-selector/AccountSelector.js
@@ -35,6 +35,11 @@ const AccountSelector = ({
 }) => {
     const [inputValue, setInputValue] = useState('');
 
+    let formatter;
+    if (formatAccountNumber) {
+        formatter = formatIncompleteAccountNumber;
+    }
+
     /*
      * This matcher function closely resembles the default one of SearchableDropdown,
      * but it ignores all spaces and periods so that account number formatting won't mess with the search.
@@ -55,8 +60,20 @@ const AccountSelector = ({
 
     const onInputChange = event => {
         setInputValue(event.target.value);
-        if (inputProps && inputProps.onChange) {
+        if (inputProps?.onChange) {
             inputProps.onChange();
+        }
+    };
+
+    const handleBlur = () => {
+        if (allowCustomAccount) {
+            onAccountSelected({
+                name: inputValue,
+                accountNumber: inputValue,
+            });
+        }
+        if (inputProps?.onBlur) {
+            inputProps.onBlur();
         }
     };
 
@@ -67,16 +84,14 @@ const AccountSelector = ({
             setInputValue('');
             onReset();
         } else if (hasSelectedCustomAccount) {
-            onAccountSelected({ name: '', accountNumber: value.name });
+            onAccountSelected({
+                name: value.name,
+                accountNumber: value.name,
+            });
         } else {
             onAccountSelected(value);
         }
     };
-
-    let formatter;
-    if (formatAccountNumber) {
-        formatter = formatIncompleteAccountNumber;
-    }
 
     const customNoMatch = allowCustomAccount
         ? {
@@ -109,6 +124,7 @@ const AccountSelector = ({
                     inputProps={{
                         ...inputProps,
                         onChange: onInputChange,
+                        onBlur: handleBlur,
                     }}
                     dropdownAttributes={dropdownAttributes}
                     dropdownList={accounts}
@@ -121,6 +137,7 @@ const AccountSelector = ({
                     ariaInvalid={ariaInvalid}
                     searchMatcher={searchMatcherIgnoringAccountNumberFormatting}
                     selectedItem={selectedAccount}
+                    allowCustomItem={allowCustomAccount}
                 />
                 {selectedAccount && (
                     <AccountDetails

--- a/packages/ffe-account-selector-react/src/components/account-selector/AccountSelector.spec.js
+++ b/packages/ffe-account-selector-react/src/components/account-selector/AccountSelector.spec.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { render, fireEvent, screen } from '@testing-library/react';
 
 import AccountSelector from './AccountSelector';
+import userEvent from '@testing-library/user-event';
 
 describe('AccountSelector', () => {
     beforeAll(() => {
@@ -294,6 +295,31 @@ describe('AccountSelector', () => {
         );
 
         expect(screen.getByText('BrukskoABC')).toBeInTheDocument();
+    });
+
+    it('should allow selecting custom account when specified on blur', () => {
+        const handleAccountSelected = jest.fn();
+        render(
+            <div>
+                <button>Knapp</button>
+                <AccountSelector
+                    id="id"
+                    labelId="labelId"
+                    accounts={accounts}
+                    locale="nb"
+                    onAccountSelected={handleAccountSelected}
+                    onReset={onReset}
+                    selectedAccount={selectedAccount}
+                    allowCustomAccount={true}
+                />
+            </div>,
+        );
+
+        const input = screen.getByRole('combobox');
+        userEvent.type(input, 'BrukskoABC');
+        userEvent.click(screen.getByText('Knapp'));
+        expect(handleAccountSelected).toHaveBeenCalledTimes(1);
+        expect(input.value).toEqual('BrukskoABC');
     });
 
     it('should not show custom account when some account matches search', () => {


### PR DESCRIPTION
…when customAccount is allowed

## Beskrivelse

Her er noen endringer etter endringene i `SearchableDropdown`. Tilpasser kontovelgeren så `selectedAccount` settes ved `onBlur` når det kun er ett element i lista. Ved `customAccount` vil det alltid være et element i lista. Dersom verdien i input-feltet ikke matcher noen elementer i lista, så havner automatisk verdien i input-feltet i lista.

## Testing

Har testet nøye i designsystemet.

