### PR TITLE
fix(ffe-account-selector-react): Do not set account to inputValue if …

### DIFF
--- a/packages/ffe-account-selector-react/src/components/account-selector/AccountSelector.js
+++ b/packages/ffe-account-selector-react/src/components/account-selector/AccountSelector.js
@@ -66,7 +66,12 @@ const AccountSelector = ({
     };
 
     const handleBlur = () => {
-        if (allowCustomAccount) {
+        const shouldSetCustomAccount =
+            inputValue &&
+            inputValue !== selectedAccount?.name &&
+            allowCustomAccount;
+
+        if (shouldSetCustomAccount) {
             onAccountSelected({
                 name: inputValue,
                 accountNumber: inputValue,
@@ -88,8 +93,10 @@ const AccountSelector = ({
                 name: value.name,
                 accountNumber: value.name,
             });
+            setInputValue(value.name);
         } else {
             onAccountSelected(value);
+            setInputValue(value.name);
         }
     };
 

--- a/packages/ffe-account-selector-react/src/components/account-selector/AccountSelector.md
+++ b/packages/ffe-account-selector-react/src/components/account-selector/AccountSelector.md
@@ -35,7 +35,7 @@ const label1 = 'label1';
         id="account-selector-single"
         locale="nb"
         onAccountSelected={value => setState({ value })}
-        onReset={() => setState({ value: '' })}
+        onReset={() => setState({ value: undefined })}
         selectedAccount={state.value}
         labelId={label1}
     />
@@ -79,7 +79,7 @@ const label2 = 'label2';
         id="account-selector-single"
         locale="nb"
         onAccountSelected={value => setState({ value })}
-        onReset={() => setState({ value: '' })}
+        onReset={() => setState({ value: undefined })}
         selectedAccount={state.value}
         showBalance
         labelId={label2}
@@ -124,7 +124,7 @@ const label4 = 'label4';
         id="account-selector-single"
         locale="nb"
         onAccountSelected={value => setState({ value })}
-        onReset={() => setState({ value: '' })}
+        onReset={() => setState({ value: undefined })}
         selectedAccount={state.value}
         allowCustomAccount
         labelId={label4}
@@ -169,7 +169,7 @@ const label3 = 'label3';
         id="account-selector-single"
         locale="nb"
         onAccountSelected={value => setState({ value })}
-        onReset={() => setState({ value: '' })}
+        onReset={() => setState({ value: undefined })}
         selectedAccount={state.value}
         formatAccountNumber={false}
         labelId={label3}
@@ -214,7 +214,7 @@ const label4 = 'label4';
         id="account-selector-single"
         locale="nb"
         onAccountSelected={value => setState({ value })}
-        onReset={() => setState({ value: '' })}
+        onReset={() => setState({ value: undefined })}
         selectedAccount={state.value}
         allowCustomAccount
         labelId={label4}
@@ -277,7 +277,7 @@ const CustomListElementBody = ({ item, isHighlighted }) => {
         id="account-selector-single"
         locale="nb"
         onAccountSelected={value => setState({ value })}
-        onReset={() => setState({ value: '' })}
+        onReset={() => setState({ value: undefined })}
         selectedAccount={state.value}
         labelId={label5}
         listElementBody={CustomListElementBody}


### PR DESCRIPTION
…account is chosen from dropdown

## Beskrivelse

Jeg oppdaget en bug. Dersom man har satt `allowCustomAccount` til `true`, og man velger konto fra dropdownen, blir inputValuen satt som valgt konto i stedet for det man faktisk har valgt. Denne feilen oppstod etter endringene jeg gjorde i forrige PR som jeg merga i dag tidlig. Forhåpentligvis har ikke mange bumpa til siste versjon og i tillegg sendt inn `allowCustomAccount` til true :sweat_smile: :crossed_fingers: 
