### PR TITLE
fix(ffe-account-selector-react): Do not set account to inputValue if …

### DIFF
--- a/packages/ffe-account-selector-react/src/components/account-selector/AccountSelector.md
+++ b/packages/ffe-account-selector-react/src/components/account-selector/AccountSelector.md
@@ -1,7 +1,7 @@
 Kontovelger for én konto.
 
 ```js
-initialState = { value: undefined };
+initialState = { value: null };
 const label1 = 'label1';
 
 <InputGroup label="Velg konto" extraMargin={false} labelId={label1}>
@@ -35,9 +35,10 @@ const label1 = 'label1';
         id="account-selector-single"
         locale="nb"
         onAccountSelected={value => setState({ value })}
-        onReset={() => setState({ value: '' })}
+        onReset={() => setState({ value: null })}
         selectedAccount={state.value}
         labelId={label1}
+        ariaInvalid={false}
     />
 </InputGroup>;
 ```
@@ -45,7 +46,7 @@ const label1 = 'label1';
 Kan vise beløp
 
 ```js
-initialState = { value: undefined };
+initialState = { value: null };
 const label2 = 'label2';
 
 <InputGroup label="Velg konto" extraMargin={false} labelId={label2}>
@@ -79,10 +80,11 @@ const label2 = 'label2';
         id="account-selector-single"
         locale="nb"
         onAccountSelected={value => setState({ value })}
-        onReset={() => setState({ value: '' })}
+        onReset={() => setState({ value: null })}
         selectedAccount={state.value}
         showBalance
         labelId={label2}
+        ariaInvalid={false}
     />
 </InputGroup>;
 ```
@@ -90,7 +92,7 @@ const label2 = 'label2';
 Kan tillate egeninnskrevet konto
 
 ```js
-initialState = { value: undefined };
+initialState = { value: null };
 const label4 = 'label4';
 
 <InputGroup label="Velg konto" extraMargin={false} labelId={label4}>
@@ -124,10 +126,11 @@ const label4 = 'label4';
         id="account-selector-single"
         locale="nb"
         onAccountSelected={value => setState({ value })}
-        onReset={() => setState({ value: '' })}
+        onReset={() => setState({ value: null })}
         selectedAccount={state.value}
         allowCustomAccount
         labelId={label4}
+        ariaInvalid={false}
     />
 </InputGroup>;
 ```
@@ -135,7 +138,7 @@ const label4 = 'label4';
 Kan skru av at kontonummer blir formattert mens man skriver
 
 ```js
-initialState = { value: undefined };
+initialState = { value: null };
 const label3 = 'label3';
 
 <InputGroup label="Velg konto" extraMargin={false} labelId={label3}>
@@ -169,10 +172,11 @@ const label3 = 'label3';
         id="account-selector-single"
         locale="nb"
         onAccountSelected={value => setState({ value })}
-        onReset={() => setState({ value: '' })}
+        onReset={() => setState({ value: null })}
         selectedAccount={state.value}
         formatAccountNumber={false}
         labelId={label3}
+        ariaInvalid={false}
     />
 </InputGroup>;
 ```
@@ -180,7 +184,7 @@ const label3 = 'label3';
 Kan velge å ikke holde av plass for visning av valgt konto
 
 ```js
-initialState = { value: undefined };
+initialState = { value: null };
 const label4 = 'label4';
 
 <InputGroup label="Velg konto" extraMargin={false} labelId={label4}>
@@ -214,11 +218,12 @@ const label4 = 'label4';
         id="account-selector-single"
         locale="nb"
         onAccountSelected={value => setState({ value })}
-        onReset={() => setState({ value: '' })}
+        onReset={() => setState({ value: null })}
         selectedAccount={state.value}
         allowCustomAccount
         labelId={label4}
         withSpaceForDetails={false}
+        ariaInvalid={false}
     />
 </InputGroup>;
 ```
@@ -226,7 +231,7 @@ const label4 = 'label4';
 Med egendefinert listeutseende
 
 ```js
-initialState = { value: undefined };
+initialState = { value: null };
 const label5 = 'label5';
 
 const CustomListElementBody = ({ item, isHighlighted }) => {
@@ -277,10 +282,11 @@ const CustomListElementBody = ({ item, isHighlighted }) => {
         id="account-selector-single"
         locale="nb"
         onAccountSelected={value => setState({ value })}
-        onReset={() => setState({ value: '' })}
+        onReset={() => setState({ value: null })}
         selectedAccount={state.value}
         labelId={label5}
         listElementBody={CustomListElementBody}
+        ariaInvalid={false}
     />
 </InputGroup>;
 ```

--- a/packages/ffe-account-selector-react/src/components/account-selector/AccountSelector.spec.js
+++ b/packages/ffe-account-selector-react/src/components/account-selector/AccountSelector.spec.js
@@ -350,6 +350,81 @@ describe('AccountSelector', () => {
         );
     });
 
+    it('should set custom account number when account number is valid on blur', () => {
+        const validNorwegianAccountNumber = '4200 02 31376';
+        const inValidNorwegianAccountNumber = '4200 02 31377';
+        const handleAccountSelected = jest.fn();
+
+        render(
+            <div>
+                <button>Knapp</button>
+                <AccountSelector
+                    id="id"
+                    labelId="labelId"
+                    accounts={accounts}
+                    locale="nb"
+                    onAccountSelected={handleAccountSelected}
+                    onReset={onReset}
+                    selectedAccount={selectedAccount}
+                    allowCustomAccount={true}
+                    ariaInvalid={false}
+                />
+            </div>,
+        );
+
+        const input = screen.getByRole('combobox');
+        userEvent.type(input, inValidNorwegianAccountNumber);
+        userEvent.click(screen.getByText('Knapp'));
+
+        expect(handleAccountSelected).toHaveBeenCalledWith({
+            name: inValidNorwegianAccountNumber,
+            accountNumber: '',
+        });
+
+        userEvent.clear(input);
+        userEvent.type(input, validNorwegianAccountNumber);
+        userEvent.click(screen.getByText('Knapp'));
+
+        expect(handleAccountSelected).toHaveBeenCalledWith({
+            name: validNorwegianAccountNumber,
+            accountNumber: validNorwegianAccountNumber,
+        });
+    });
+
+    it('should not set custom account on blur when allowCustomAccount is not specified', () => {
+        const validNorwegianAccountNumber = '4200 02 31376';
+        const inValidNorwegianAccountNumber = '4200 02 31377';
+        const handleAccountSelected = jest.fn();
+
+        render(
+            <div>
+                <button>Knapp</button>
+                <AccountSelector
+                    id="id"
+                    labelId="labelId"
+                    accounts={accounts}
+                    locale="nb"
+                    onAccountSelected={handleAccountSelected}
+                    onReset={onReset}
+                    selectedAccount={selectedAccount}
+                    ariaInvalid={false}
+                />
+            </div>,
+        );
+
+        const input = screen.getByRole('combobox');
+        userEvent.type(input, inValidNorwegianAccountNumber);
+        userEvent.click(screen.getByText('Knapp'));
+
+        expect(input.getAttribute('value')).toEqual('');
+
+        userEvent.clear(input);
+        userEvent.type(input, validNorwegianAccountNumber);
+        userEvent.click(screen.getByText('Knapp'));
+
+        expect(input.getAttribute('value')).toEqual('');
+    });
+
     it('should be able to render custom list items', () => {
         const CustomListItemBody = ({
             // eslint-disable-next-line react/prop-types


### PR DESCRIPTION
…account is chosen from dropdown

## Beskrivelse

Jeg oppdaget en bug. Dersom man har satt allowCustomAccount til true, og man velger konto fra dropdownen, blir inputValuen satt som valgt konto i stedet for det man faktisk har valgt. Denne feilen oppstod etter endringene jeg gjorde i forrige PR som jeg merga i dag tidlig. Forhåpentligvis har ikke mange bumpa til siste versjon og i tillegg sendt inn allowCustomAccount til true. I tillegg la jeg ekstra sjekker på om vi skal sette kun kontonavn eller kontonummer ved onBlur. 

Har testet at dette blir riktig:

- Dersom man velger konto selv ved å trykke på konto i lista, så blir denne valgt
- Dersom man skriver inn et kontonavn eller kontonummer som matcher element i lista, skal denne bli vaøgt
- Dersom man skriver inn et gyldig kontonummer som ikke finnes i lista, skal denne bli valgt
- Dersom man skriver inn noe som ikke matcher noe i lista eller er et gyldig kontonummer, skal kun navn bi satt

