### PR TITLE
fix(ffe-cards): Added dark background-color for ffe-product-card

### DIFF
--- a/packages/ffe-cards/less/ffe-product-card.less
+++ b/packages/ffe-cards/less/ffe-product-card.less
@@ -32,7 +32,8 @@
     .card-sequential-animation();
     .native & {
         @media (prefers-color-scheme: dark) {
-            border-color: @ffe-blue-azure-darkmode;
+            background-color: @ffe-grey-darkmode;
+            border-color: @ffe-grey-darkmode;
         }
     }
 


### PR DESCRIPTION
Støtte for darkmode ffe-product-card etter at overrides for disse er fjernet fra ffe-core

<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse

<!-- Detaljert beskrivelse av endringene dine. Skjermskudd er lov. -->
I nyeste utgave av ffe-core er dark-mode-overrides fjernet, se changelog.md, For å kunne støtte nyeste versjon av denne pakken trengs det derfor å legge til styling for background-color og border i ffe-cards.


## Motivasjon og kontekst

<!-- Hvorfor trengs denne endringen, og hva løser den? -->
Se beskrivelse ovenfor

## Testing

<!-- Hvordan har du har testet endringene dine? Ta gjerne med systeminfo o.l -->

<!--

Helt til slutt, har du ..

.. lest retningslinjene våre for bidrag?
.. tatt en siste sjekk for kode og skrivefeil, debug informasjon o.l?
.. kjørt og eventuelt oppdatert testene?
.. kommentert og dokumentert det som trengs?
.. knyttet denne opp til relaterte issues?

-->
