### PR TITLE
feat(ffe-form-react): Extend Description prop in RadioButtonInputGroup

### DIFF
--- a/packages/ffe-form-react/src/RadioButtonInputGroup.js
+++ b/packages/ffe-form-react/src/RadioButtonInputGroup.js
@@ -62,7 +62,10 @@ const RadioButtonInputGroup = props => {
                 </legend>
             )}
 
-            {description && <div className="ffe-small-text">{description}</div>}
+            {typeof description === 'string' && (
+                <div className="ffe-small-text">{description}</div>
+            )}
+            {React.isValidElement(description) && description}
 
             {children({ ...buttonProps, dark })}
 
@@ -91,7 +94,7 @@ RadioButtonInputGroup.propTypes = {
     /** Additional class names applied to the fieldset */
     className: string,
     /** To just render a static, always visible tooltip, use this. */
-    description: string,
+    description: oneOfType([node, string]),
     /** Reserve space for showing `fieldMessage`s so content below don't move
      *  vertically if an errormessage shows up. Note that this will only reserve
      *  space for one line of content, so keep messages short.

--- a/packages/ffe-form-react/src/RadioButtonInputGroup.spec.js
+++ b/packages/ffe-form-react/src/RadioButtonInputGroup.spec.js
@@ -160,6 +160,22 @@ describe('<RadioButtonInputGroup />', () => {
             );
         });
     });
+    describe('description', () => {
+        it('renders if string', () => {
+            const wrapper = getWrapper({ description: 'description text' });
+            expect(wrapper.text().includes('description text')).toBe(true);
+        });
+        it('renders if ReactNode', () => {
+            const wrapper = getWrapper({
+                description: (
+                    <Tooltip>Description text as Tooltip component</Tooltip>
+                ),
+            });
+            expect(wrapper.find('Tooltip').prop('children')).toBe(
+                'Description text as Tooltip component',
+            );
+        });
+    });
     describe('fieldMessage', () => {
         it('does not render if not set', () => {
             const wrapper = getWrapper({ fieldMessage: undefined });

--- a/packages/ffe-form-react/src/index.d.ts
+++ b/packages/ffe-form-react/src/index.d.ts
@@ -125,7 +125,7 @@ interface WeakFieldSetAttributes
 export interface RadioButtonInputGroupProps extends WeakFieldSetAttributes {
     children: React.ReactNode;
     className?: string;
-    description?: string;
+    description?: string | React.ReactNode;
     extraMargin?: boolean;
     fieldMessage?: string | React.ReactNode;
     inline?: boolean;


### PR DESCRIPTION
This commit changes the Description prop in RadioButtonInputGroup to be either a string or a ReactNode. This is not a breaking change as it only extends the allowed prop type.

This fixes issue #1112