### PR TITLE
feat(ffe-core): add more colour variants for WCAG purposes

### DIFF
--- a/packages/ffe-core/less/colors.less
+++ b/packages/ffe-core/less/colors.less
@@ -90,12 +90,14 @@
 @ffe-farge-villblomst-70: tint(@ffe-farge-villblomst, 30%);
 @ffe-farge-villblomst-30: tint(@ffe-farge-villblomst, 70%);
 @ffe-farge-nordlys: #33af85;
+@ffe-farge-nordlys-wcag: #257e60;
 @ffe-farge-nordlys-70: tint(@ffe-farge-nordlys, 30%);
 @ffe-farge-nordlys-30: tint(@ffe-farge-nordlys, 70%);
 @ffe-farge-lyng: #873953;
 @ffe-farge-lyng-70: tint(@ffe-farge-lyng, 30%);
 @ffe-farge-lyng-30: tint(@ffe-farge-lyng, 70%);
 @ffe-farge-baer: #e44244;
+@ffe-farge-baer-wcag: #e12d2f;
 @ffe-farge-baer-70: tint(@ffe-farge-baer, 30%);
 @ffe-farge-baer-30: tint(@ffe-farge-baer, 70%);
 @ffe-farge-skog: #285949;
@@ -113,7 +115,9 @@
 @ffe-farge-svart: #020a0a;
 @ffe-farge-koksgraa: #323232;
 @ffe-farge-moerkgraa: #676767;
+@ffe-farge-moerkgraa-wcag: #4a4a4a;
 @ffe-farge-graa: #adadad;
+@ffe-farge-graa-wcag: #949494;
 @ffe-farge-lysgraa: #d8d8d8;
 @ffe-farge-moerkvarmgraa: #848383;
 @ffe-farge-varmgraa: #9b9797;


### PR DESCRIPTION
## Beskrivelse
Legger til 4 LESS fargevariabler.
Disse fargene er mørkere varianter av fargene vi allerede har. 

## Motivasjon og kontekst

Fargene er lagt til for å oppfylle WCAG krav om fargekontrast i enkelte komponenter.
Fargene brukes blant annet i context message komponentene etter visuell justering, og jeg ser det sannsynlig at fargene kommer til å gjenbrukes i andre komponenter også i fremtiden.

## Testing

Bare CSS endring, så ikke testet
