### PR TITLE
feat(ffe-form-react): Make PhoneNumber accept FieldMessage

### DIFF
--- a/packages/ffe-form-react/src/PhoneNumber.md
+++ b/packages/ffe-form-react/src/PhoneNumber.md
@@ -1,17 +1,47 @@
 Telefonnummer med landskode
 
 ```js
-<PhoneNumber
-    number="123123123"    
-/>
+<PhoneNumber number="123123123" />
 ```
 
 Variant _dark_ for interne løsninger med mørk bakgrunn.
 
 ```js { "props": { "className": "sb1ds-example-dark" } }
+<PhoneNumber dark={true} number="22882288" />
+```
 
-<PhoneNumber dark={true}
-    number="22882288"    
-/>
+PhoneNumber med feilmelding på landkode
 
+```js
+const { PhoneNumber } = require('.');
+
+<PhoneNumber
+    number="12345678"
+    countryCode=""
+    countryCodeFieldMessage="Dette feltet er påkrevd"
+/>;
+```
+
+PhoneNumber med feilmelding på telefonnummer
+
+```js
+const { PhoneNumber } = require('.');
+
+<PhoneNumber
+    number=""
+    countryCode="47"
+    numberFieldMessage="Dette feltet er påkrevd"
+/>;
+```
+
+PhoneNumber med felles feilmelding på landkode og telefonnummer
+
+```js
+const { PhoneNumber } = require('.');
+
+<PhoneNumber
+    number=""
+    countryCode=""
+    countryCodeAndNumberFieldMessage="Både landkode og telefonnummer feltene er påkrevd"
+/>;
 ```

--- a/packages/ffe-form-react/src/PhoneNumber.spec.js
+++ b/packages/ffe-form-react/src/PhoneNumber.spec.js
@@ -3,16 +3,15 @@ import { shallow } from 'enzyme';
 
 import PhoneNumber from './PhoneNumber';
 
-const getWrapper = props => shallow(<PhoneNumber {...props}/>);
+const getWrapper = props => shallow(<PhoneNumber {...props} />);
 
 describe('renders correctly', () => {
-
     it('should exist', () => {
         const wrapper = getWrapper({});
         expect(wrapper.exists()).toBe(true);
     });
 
-    it('should default to norwegian country code', function () {
+    it('should default to norwegian country code', function() {
         const wrapper = getWrapper({});
         const input = wrapper.find('input');
         expect(input.at(0).props().value).toEqual('47');
@@ -20,49 +19,82 @@ describe('renders correctly', () => {
 
     it('should default to nb locale', () => {
         const wrapper = getWrapper({});
-        const countryCode = wrapper.find('label').at(0).props().children;
+        const countryCode = wrapper
+            .find('label')
+            .at(0)
+            .props().children;
         expect(countryCode).toEqual('Landskode');
     });
 
     it('should render using locale prop', () => {
         const wrapper = getWrapper({ locale: 'en' });
-        const countryCode = wrapper.find('label').at(0).props().children;
+        const countryCode = wrapper
+            .find('label')
+            .at(0)
+            .props().children;
         expect(countryCode).toEqual('Country code');
     });
 
-    it('should render using disabled prop', function () {
+    it('should render using disabled prop', function() {
         const wrapper = getWrapper({ disabled: true });
         const inputs = wrapper.find('input');
         expect(inputs.at(0).props().disabled).toBe(true);
         expect(inputs.at(1).props().disabled).toBe(true);
     });
 
-    it('should render using invalid props', function () {
-        const wrapper = getWrapper({ countryCodeInvalid: true, numberInvalid: true });
+    it('should render using countryCodeFieldMessage prop', function() {
+        const wrapper = getWrapper({
+            countryCodeFieldMessage: 'Denne ble feil',
+        });
+        const inputs = wrapper.find('input');
+        expect(inputs.at(0).prop('aria-invalid')).toBe(true);
+        expect(inputs.at(1).prop('aria-invalid')).toBe(false);
+    });
+
+    it('should render using numberFieldMessage prop', function() {
+        const wrapper = getWrapper({ numberFieldMessage: 'Denne ble feil' });
+        const inputs = wrapper.find('input');
+        expect(inputs.at(0).prop('aria-invalid')).toBe(false);
+        expect(inputs.at(1).prop('aria-invalid')).toBe(true);
+    });
+
+    it('should render using countryCodeAndNumberFieldMessage prop', function() {
+        const wrapper = getWrapper({
+            countryCodeAndNumberFieldMessage: 'Denne ble feil',
+        });
         const inputs = wrapper.find('input');
         expect(inputs.at(0).prop('aria-invalid')).toBe(true);
         expect(inputs.at(1).prop('aria-invalid')).toBe(true);
     });
 
-    it('should render country code and number sent by prop', function () {
-        const wrapper = getWrapper({ countryCode: '46', number:'92929292' });
+    it('should render country code and number sent by prop', function() {
+        const wrapper = getWrapper({ countryCode: '46', number: '92929292' });
         const input = wrapper.find('input');
         expect(input.at(0).props().value).toEqual('46');
         expect(input.at(1).props().value).toEqual('92929292');
     });
 
     it('should render class sent by prop', () => {
-        const wrapper = getWrapper({ className:'myClassName' });
+        const wrapper = getWrapper({ className: 'myClassName' });
         expect(wrapper.find('.myClassName').exists()).toBe(true);
     });
 
     it('should call change listeners on change', () => {
         const spyA = jest.fn();
         const spyB = jest.fn();
-        const wrapper = getWrapper({ onNumberChange: spyA, onCountryCodeChange: spyB });
+        const wrapper = getWrapper({
+            onNumberChange: spyA,
+            onCountryCodeChange: spyB,
+        });
 
-        wrapper.find('input').at(0).simulate('change');
-        wrapper.find('input').at(1).simulate('change');
+        wrapper
+            .find('input')
+            .at(0)
+            .simulate('change');
+        wrapper
+            .find('input')
+            .at(1)
+            .simulate('change');
 
         expect(spyA).toHaveBeenCalledTimes(1);
         expect(spyB).toHaveBeenCalledTimes(1);
@@ -71,10 +103,19 @@ describe('renders correctly', () => {
     it('should call blur listeners on blur', () => {
         const spyA = jest.fn();
         const spyB = jest.fn();
-        const wrapper = getWrapper({ onNumberBlur: spyA, onCountryCodeBlur: spyB });
+        const wrapper = getWrapper({
+            onNumberBlur: spyA,
+            onCountryCodeBlur: spyB,
+        });
 
-        wrapper.find('input').at(0).simulate('blur');
-        wrapper.find('input').at(1).simulate('blur');
+        wrapper
+            .find('input')
+            .at(0)
+            .simulate('blur');
+        wrapper
+            .find('input')
+            .at(1)
+            .simulate('blur');
 
         expect(spyA).toHaveBeenCalledTimes(1);
         expect(spyB).toHaveBeenCalledTimes(1);

--- a/packages/ffe-form-react/src/index.d.ts
+++ b/packages/ffe-form-react/src/index.d.ts
@@ -34,9 +34,11 @@ export interface PhoneNumberProps {
     onNumberBlur?: React.FocusEventHandler<HTMLInputElement>;
     locale?: string;
     disabled?: boolean;
-    countryCodeInvalid?: boolean;
-    numberInvalid?: boolean;
+    countryCodeFieldMessage?: string | React.ReactNode;
+    numberFieldMessage?: string | React.ReactNode;
+    countryCodeAndNumberFieldMessage?: string | React.ReactNode;
     className?: string;
+    extraMargin?: boolean;
     dark?: boolean;
     countryCodeRef?: React.Ref<HTMLInputElement>;
     numberRef?: React.Ref<HTMLInputElement>;

--- a/packages/ffe-form/less/phone-number.less
+++ b/packages/ffe-form/less/phone-number.less
@@ -20,8 +20,6 @@
 // Styleguide ffe-form.phone-number
 
 .ffe-phone-number {
-    display: flex;
-
     &__input-group {
         display: flex;
     }


### PR DESCRIPTION
BREAKING CHANGE: Replaces countryCodeInvalid and numberInvalid with countryCodeFieldMessage, numberFieldMessage and countryCodeAndNumberFieldMessage.

This commit changes how the components shows invalidation errors. It replaces countryCodeInvalid and numberInvalid with countryCodeFieldMessage, numberFieldMessage and countryCodeAndNumberFieldMessage. This makes it possible to render an error message instead of just making the input field red.

The design has been discussed with Kjersti Velten, Bernadette Ann Eirheim and Bjørg Andrea Lysbakken.

![image](https://user-images.githubusercontent.com/6777340/122347097-f7affc00-cf49-11eb-81ac-c2ce7cba1ee9.png)
