### PR TITLE
fix(designsystem): adjust makefile to BSD `find`

### DIFF
--- a/designsystem/Makefile
+++ b/designsystem/Makefile
@@ -7,7 +7,7 @@ reactDocgen := ../node_modules/.bin/react-docgen
 lerna := ./node_modules/.bin/lerna
 
 EXAMPLE_FILES = $(shell find examples/ -type f -name '*.jsx')
-REACT_FILES = $(shell cd ../packages && find ffe-*-react/src -regex '.*\/[A-Z]\([A-Za-z]\)+.js')
+REACT_FILES = $(shell cd ../packages && find ffe-*-react/src -type f -name '*.js'| grep '\/[A-Z][A-Za-z]\+.js\>')
 
 
 all: build


### PR DESCRIPTION
This change fixes a problem with `make` on Mac OS because of Mac OS using BSD find instead of GNU findutils, which is more common on Linux.

