### PR TITLE
feat(ffe-chart-donut-react): support single label prop

### DIFF
--- a/packages/ffe-chart-donut-react/src/ChartDonut.js
+++ b/packages/ffe-chart-donut-react/src/ChartDonut.js
@@ -1,13 +1,13 @@
 import React from 'react';
-import { number, string } from 'prop-types';
+import { node, number, string } from 'prop-types';
 
 const NON_BREAKING_SPACE = '\u00A0';
 
 const RADIUS = 150;
 const CIRCUMFERENCE = 2 * Math.PI * RADIUS;
 
-function ChartDonut({ name, percentage, firstLabel, lastLabel }) {
-    const offset = CIRCUMFERENCE - CIRCUMFERENCE / 100 * percentage;
+function ChartDonut({ name, percentage, firstLabel, lastLabel, label }) {
+    const offset = CIRCUMFERENCE - (CIRCUMFERENCE / 100) * percentage;
 
     /*
         The rendered circle consists of two half-circles with a gap between them.
@@ -76,28 +76,31 @@ function ChartDonut({ name, percentage, firstLabel, lastLabel }) {
                 <div className="ffe-chart-donut__name ffe-strong-text">
                     {name}
                 </div>
-                <div className="ffe-chart-donut__fractions">
-                    <div className="ffe-chart-donut__fraction ffe-chart-donut__fraction--cobalt">
-                        <div className="ffe-chart-donut__amount ffe-strong-text">
-                            {`${Number(100 - percentage).toFixed(
-                                0,
-                            )}${NON_BREAKING_SPACE}%`}
+                {firstLabel && lastLabel && (
+                    <div className="ffe-chart-donut__fractions">
+                        <div className="ffe-chart-donut__fraction ffe-chart-donut__fraction--cobalt">
+                            <div className="ffe-chart-donut__amount ffe-strong-text">
+                                {`${Number(100 - percentage).toFixed(
+                                    0,
+                                )}${NON_BREAKING_SPACE}%`}
+                            </div>
+                            <div className="ffe-chart-donut__type ffe-micro-text">
+                                {firstLabel}
+                            </div>
                         </div>
-                        <div className="ffe-chart-donut__type ffe-micro-text">
-                            {firstLabel}
+                        <div className="ffe-chart-donut__fraction ffe-chart-donut__fraction--sky">
+                            <div className="ffe-chart-donut__amount ffe-strong-text">
+                                {`${Number(percentage).toFixed(
+                                    0,
+                                )}${NON_BREAKING_SPACE}%`}
+                            </div>
+                            <div className="ffe-chart-donut__type ffe-micro-text">
+                                {lastLabel}
+                            </div>
                         </div>
                     </div>
-                    <div className="ffe-chart-donut__fraction ffe-chart-donut__fraction--sky">
-                        <div className="ffe-chart-donut__amount ffe-strong-text">
-                            {`${Number(percentage).toFixed(
-                                0,
-                            )}${NON_BREAKING_SPACE}%`}
-                        </div>
-                        <div className="ffe-chart-donut__type ffe-micro-text">
-                            {lastLabel}
-                        </div>
-                    </div>
-                </div>
+                )}
+                {!firstLabel && !lastLabel && label}
             </div>
         </div>
     );
@@ -105,9 +108,11 @@ function ChartDonut({ name, percentage, firstLabel, lastLabel }) {
 
 ChartDonut.propTypes = {
     /** Short text labeling left value, like "empty", "said yes" etc */
-    firstLabel: string.isRequired,
+    firstLabel: string,
     /** Short text labeling right value, like "full", "said no" etc */
-    lastLabel: string.isRequired,
+    lastLabel: string,
+    /** React node to be inserted directly under the chart's name, alternative to first/last label */
+    label: node,
     /** Short text labeling the graph in total, like "percentage", "voted this year" etc */
     name: string.isRequired,
     /** The percentage for the right-most value */

--- a/packages/ffe-chart-donut-react/src/ChartDonut.md
+++ b/packages/ffe-chart-donut-react/src/ChartDonut.md
@@ -1,8 +1,29 @@
 ```javascript
-    <ChartDonut
-        firstLabel="First label"
-        lastLabel="Last label"
-        name="Name"
-        percentage={42}
-    />
+<ChartDonut
+    firstLabel="First label"
+    lastLabel="Last label"
+    name="Name"
+    percentage={42}
+/>
+```
+
+Ønskes full kontroll over label-teksten sender man bare inn `label` i stedet for `firstLabel` og `lastLabel`
+
+```javascript
+<ChartDonut
+    label={
+        <div
+            style={{
+                marginTop: 10,
+                textAlign: 'center',
+                width: '100%',
+            }}
+        >
+            Du har selv ansvar
+            <strong>for all styling</strong>
+        </div>
+    }
+    name="Name"
+    percentage={42}
+/>
 ```


### PR DESCRIPTION
Adds support for sending a single self-styled label-node
instead of using the `firstLabel` and `lastLabel` props.

<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse

<!-- Detaljert beskrivelse av endringene dine. Skjermskudd er lov. -->

## Motivasjon og kontekst

Vi har noen designere som ønsket mer kontroll over hvordan vi viser teksten inne i rundingen men ser fortsatt verdien av å gjenbruke selve "skallet".

## Testing

Startet opp designsystemet lokalt, oppdatert `.md` fila og verifisert at det fungerer.

