### PR TITLE
feat(ffe-searchable-dropdown-react): Select single matching item on blur

### DIFF
--- a/packages/ffe-searchable-dropdown-react/src/SearchableDropdown.js
+++ b/packages/ffe-searchable-dropdown-react/src/SearchableDropdown.js
@@ -69,6 +69,7 @@ const SearchableDropdown = ({
             maxRenderedDropdownElements,
             noMatchDropdownList: noMatch.dropdownList,
             searchMatcher,
+            onChange,
         }),
         {
             isExpanded: false,
@@ -87,6 +88,7 @@ const SearchableDropdown = ({
                     maxRenderedDropdownElements,
                     dropdownList,
                     searchMatcher,
+                    showAllItemsInDropdown: !!selectedItem,
                 }),
             };
         },
@@ -110,14 +112,6 @@ const SearchableDropdown = ({
     const handleInputBlur = e => {
         if (inputProps.onBlur) {
             inputProps.onBlur(e);
-        }
-
-        const hasEmptiedInputFieldWithoutClearButton =
-            state.inputValue.trim() === '' && state.selectedItem;
-
-        if (hasEmptiedInputFieldWithoutClearButton) {
-            dispatch({ type: stateChangeTypes.ClearedInputField });
-            onChange(null);
         }
     };
 

--- a/packages/ffe-searchable-dropdown-react/src/SearchableDropdown.spec.js
+++ b/packages/ffe-searchable-dropdown-react/src/SearchableDropdown.spec.js
@@ -484,8 +484,8 @@ describe('SearchableDropdown', () => {
         expect(input.value).toEqual('Bedriften');
 
         userEvent.clear(input);
-        userEvent.type(input, 'Sø');
-        expect(input.value).toEqual('Sø');
+        userEvent.type(input, 'B');
+        expect(input.value).toEqual('B');
 
         userEvent.type(input, '{esc}');
         expect(input.value).toEqual('Bedriften');
@@ -516,7 +516,7 @@ describe('SearchableDropdown', () => {
         expect(document.activeElement).toEqual(toggleButton);
     });
 
-    it('should reset the input value to the selected item when losing focus', () => {
+    it('should select item when losing focus if there is one single match', () => {
         const onChange = jest.fn();
         render(
             <div>
@@ -541,10 +541,6 @@ describe('SearchableDropdown', () => {
 
         const input = screen.getByRole('combobox');
 
-        userEvent.type(input, 'Be');
-        userEvent.click(screen.getByText('Bedriften'), { button: 1 });
-        expect(input.value).toEqual('Bedriften');
-
         userEvent.clear(input);
         userEvent.type(input, 'Besla');
         expect(input.value).toEqual('Besla');
@@ -552,7 +548,7 @@ describe('SearchableDropdown', () => {
         act(() => {
             userEvent.click(screen.getByText('Knapp'));
         });
-        expect(input.value).toEqual('Bedriften');
+        expect(input.value).toEqual('Beslag skytter');
     });
 
     it('should format input value when passing formatter', () => {

--- a/packages/ffe-searchable-dropdown-react/src/getListToRender.js
+++ b/packages/ffe-searchable-dropdown-react/src/getListToRender.js
@@ -24,6 +24,7 @@ export const getListToRender = ({
     dropdownList,
     noMatchDropdownList,
     searchMatcher,
+    showAllItemsInDropdown,
 }) => {
     const trimmedInput = inputValue ? inputValue.trim() : '';
 
@@ -38,10 +39,19 @@ export const getListToRender = ({
           ).slice(0, maxRenderedDropdownElements)
         : dropdownList.slice(0, maxRenderedDropdownElements);
 
+    const listToRender = () => {
+        if (showAllItemsInDropdown) {
+            return dropdownList;
+        } else if (dropdownListFiltered.length) {
+            return dropdownListFiltered;
+        } else if (noMatchDropdownList) {
+            return noMatchDropdownList;
+        }
+        return [];
+    };
+
     return {
-        listToRender: dropdownListFiltered.length
-            ? dropdownListFiltered
-            : noMatchDropdownList || [],
+        listToRender: listToRender(),
         noMatch: !dropdownListFiltered.length,
     };
 };

--- a/packages/ffe-searchable-dropdown-react/src/reducer.js
+++ b/packages/ffe-searchable-dropdown-react/src/reducer.js
@@ -9,7 +9,6 @@ export const stateChangeTypes = {
     InputKeyDownArrowDown: 'InputKeyDownArrowDown',
     InputKeyDownArrowUp: 'InputKeyDownArrowUp',
     ClearButtonPressed: 'ClearButtonPressed',
-    ClearedInputField: 'ClearedInputField',
     ToggleButtonPressed: 'ToggleButtonPressed',
     ItemOnClick: 'ItemOnMouseDown',
     ItemOnMouseEnter: 'ItemOnMouseEnter',
@@ -23,6 +22,7 @@ export const createReducer = ({
     noMatchDropdownList,
     maxRenderedDropdownElements,
     searchMatcher,
+    onChange,
 }) => (state, action) => {
     switch (action.type) {
         case stateChangeTypes.InputKeyDownEscape:
@@ -43,6 +43,7 @@ export const createReducer = ({
                 dropdownList,
                 noMatchDropdownList,
                 searchMatcher,
+                showAllItemsInDropdown: true,
             });
 
             return {
@@ -61,6 +62,7 @@ export const createReducer = ({
                 dropdownList,
                 noMatchDropdownList,
                 searchMatcher,
+                showAllItemsInDropdown: false,
             });
 
             return {
@@ -77,7 +79,6 @@ export const createReducer = ({
                 noMatch,
             };
         }
-        case stateChangeTypes.ClearedInputField:
         case stateChangeTypes.ClearButtonPressed: {
             const { noMatch, listToRender } = getListToRender({
                 inputValue: '',
@@ -87,6 +88,7 @@ export const createReducer = ({
                 prevResultCount: state.listToRender.length,
                 noMatchDropdownList,
                 searchMatcher,
+                showAllItemsInDropdown: true,
             });
             return {
                 ...state,
@@ -130,14 +132,38 @@ export const createReducer = ({
             };
         }
         case stateChangeTypes.FocusMovedOutSide: {
+            const { listToRender } = getListToRender({
+                inputValue: state.inputValue,
+                searchAttributes,
+                maxRenderedDropdownElements,
+                dropdownList,
+                noMatchDropdownList,
+                searchMatcher,
+                showAllItemsInDropdown: false,
+            });
+
+            const selectedItem =
+                state.inputValue !== ''
+                    ? listToRender.length === 1
+                        ? listToRender[0]
+                        : state.selectedItem
+                    : null;
+
+            const inputValue =
+                selectedItem && state.inputValue !== ''
+                    ? selectedItem[searchAttributes[0]]
+                    : '';
+
+            if (selectedItem !== state.selectedItem) {
+                onChange(selectedItem);
+            }
+
             return {
                 ...state,
                 isExpanded: false,
                 highlightedIndex: -1,
-                inputValue:
-                    state.selectedItem && state.inputValue !== ''
-                        ? state.selectedItem[searchAttributes[0]]
-                        : '',
+                inputValue,
+                selectedItem,
             };
         }
         default:


### PR DESCRIPTION
... and show all elements in dropdown when item is selected

<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse

Vi måtte dessverre fjerne den tidligere onBlur-funksjonaliteten, men her har vi en ny, forenkla og forbedra funksjonalitet.

Dersom et er ett matching element i dropdown-lista, så skal denne bli valgt ved onBlur.
I tillegg til dette vil vi vise hele dropdown-lista dersom et element er valgt. Det er ikke så veldig åpenbart at man må tømme feltet for å få opp hele dropdown-lista igjen.

Nå når vi skriver noe i feltet, vil `selectedItem` bli satt til `null` fram til noe nytt er valgt.

Bare å komme med noen tanker eller bekymringer hvis dere har noen. :) 

## Motivasjon og kontekst

Et par timer etter å ha tatt i bruk kontovelgeren ser vi tydelig at brukere er forvirra, som er forståelig.
Brukere tror dropdown-lista er tom når et element er valgt.
Brukere tror det ikke er mulig å velge element siden det ikke funker å skrive det inn for så å trykke seg videre uten å aktivt trykke på elementet i lista.

## Testing

Har testet selv, men supert om en av dere vil teste i tilfelle dere oppdager noen bugs :)

Min kontovelger-partner (Torkjel) har ferie.