### PR TITLE
fix(ffe-system-message): colour update to match new profile

### DIFF
--- a/packages/ffe-system-message/less/ffe-system-message.less
+++ b/packages/ffe-system-message/less/ffe-system-message.less
@@ -26,7 +26,7 @@
 // Styleguide ffe-system-message
 
 .ffe-system-message-wrapper {
-    color: @ffe-black;
+    color: @ffe-farge-svart;
     fill: currentColor;
     transition: height @ffe-transition-duration @ffe-ease-in-out-back;
     overflow: hidden;
@@ -37,8 +37,8 @@
     }
 
     &--error {
-        background-color: @ffe-orange-salmon;
-        fill: @ffe-red;
+        background-color: @ffe-farge-baer-30;
+        fill: @ffe-farge-baer-wcag;
         .native & {
             @media (prefers-color-scheme: dark) {
                 background-color: @ffe-grey-charcoal-darkmode;
@@ -48,8 +48,8 @@
     }
 
     &--info {
-        background-color: @ffe-blue-pale;
-        fill: @ffe-blue-royal;
+        background-color: @ffe-farge-frost-30;
+        fill: @ffe-farge-fjell;
         .native & {
             @media (prefers-color-scheme: dark) {
                 background-color: @ffe-grey-charcoal-darkmode;
@@ -58,11 +58,10 @@
         }
     }
 
-    // TODO: Change color to one in the style guide
     &--news {
-        background-color: #4a5155;
+        background-color: @ffe-farge-moerkgraa-wcag;
         color: @ffe-white;
-        fill: #4a5155;
+        fill: @ffe-farge-fjell;
         .native & {
             @media (prefers-color-scheme: dark) {
                 background-color: @ffe-grey-charcoal-darkmode;
@@ -73,8 +72,8 @@
     }
 
     &--success {
-        background-color: @ffe-green-mint;
-        fill: @ffe-green-shamrock;
+        background-color: @ffe-farge-nordlys-30;
+        fill: @ffe-farge-nordlys-wcag;
         .native & {
             @media (prefers-color-scheme: dark) {
                 background-color: @ffe-grey-charcoal-darkmode;
@@ -96,8 +95,8 @@
         background: @ffe-white;
         border-radius: 50%;
         display: inline-flex;
-        height: 1.7em;
-        width: 1.7em;
+        height: 2rem;
+        width: 2rem;
         margin-right: @ffe-spacing-sm;
         .native & {
             @media (prefers-color-scheme: dark) {
@@ -133,13 +132,18 @@
         color: inherit;
         cursor: pointer;
         align-self: flex-start;
-        height: 16px;
-        margin: @ffe-spacing-2xs 0 @ffe-spacing-2xs @ffe-spacing-2xs;
-        padding: 0;
-        width: 16px;
+        height: 1em;
+        padding: @ffe-spacing-sm;
+        box-sizing: content-box;
+        fill: @ffe-farge-moerkgraa;
 
+        &:hover {
+            fill: @ffe-farge-svart;
+        }
+        &:focus {
+            outline: 2px solid @ffe-farge-vann;
+        }
         > svg {
-            fill: @ffe-black;
             height: 100%;
             width: 100%;
             .native & {
@@ -147,13 +151,15 @@
                     fill: @ffe-grey-cloud-darkmode;
                 }
             }
-
-            .ffe-system-message-wrapper--news & {
-                fill: @ffe-white;
-                .native & {
-                    @media (prefers-color-scheme: dark) {
-                        fill: @ffe-grey-cloud-darkmode;
-                    }
+        }
+        .ffe-system-message-wrapper--news & {
+            fill: @ffe-farge-hvit;
+            &:hover {
+                fill: @ffe-farge-lysvarmgraa;
+            }
+            .native & {
+                @media (prefers-color-scheme: dark) {
+                    fill: @ffe-grey-cloud-darkmode;
                 }
             }
         }

--- a/packages/ffe-system-message/less/ffe-system-message.less
+++ b/packages/ffe-system-message/less/ffe-system-message.less
@@ -127,11 +127,12 @@
         flex: 0 0 auto;
         appearance: none;
         background: transparent;
-        border: 0;
+        border: 2px solid transparent;
         border-radius: 0;
         color: inherit;
         cursor: pointer;
         align-self: flex-start;
+        width: 1em;
         height: 1em;
         padding: @ffe-spacing-sm;
         box-sizing: content-box;
@@ -141,7 +142,8 @@
             fill: @ffe-farge-svart;
         }
         &:focus {
-            outline: 2px solid @ffe-farge-vann;
+            border: 2px solid @ffe-farge-vann;
+            border-radius: 5px;
         }
         > svg {
             height: 100%;

--- a/packages/ffe-system-message/less/ffe-system-message.less
+++ b/packages/ffe-system-message/less/ffe-system-message.less
@@ -30,21 +30,11 @@
     fill: currentColor;
     transition: height @ffe-transition-duration @ffe-ease-in-out-back;
     overflow: hidden;
-    .native & {
-        @media (prefers-color-scheme: dark) {
-            color: @ffe-grey-cloud-darkmode;
-        }
-    }
+    border-radius: 5px;
 
     &--error {
         background-color: @ffe-farge-baer-30;
         fill: @ffe-farge-baer-wcag;
-        .native & {
-            @media (prefers-color-scheme: dark) {
-                background-color: @ffe-grey-charcoal-darkmode;
-                fill: @ffe-red-darkmode;
-            }
-        }
     }
 
     &--info {
@@ -52,8 +42,7 @@
         fill: @ffe-farge-fjell;
         .native & {
             @media (prefers-color-scheme: dark) {
-                background-color: @ffe-grey-charcoal-darkmode;
-                fill: @ffe-blue-azure-darkmode;
+                background-color: @ffe-farge-vann-30;
             }
         }
     }
@@ -62,23 +51,11 @@
         background-color: @ffe-farge-moerkgraa-wcag;
         color: @ffe-white;
         fill: @ffe-farge-fjell;
-        .native & {
-            @media (prefers-color-scheme: dark) {
-                background-color: @ffe-grey-charcoal-darkmode;
-                color: @ffe-grey-cloud-darkmode;
-                fill: @ffe-blue-azure-darkmode;
-            }
-        }
     }
 
     &--success {
         background-color: @ffe-farge-nordlys-30;
         fill: @ffe-farge-nordlys-wcag;
-        .native & {
-            @media (prefers-color-scheme: dark) {
-                background-color: @ffe-grey-charcoal-darkmode;
-            }
-        }
     }
 }
 
@@ -98,11 +75,6 @@
         height: 2rem;
         width: 2rem;
         margin-right: @ffe-spacing-sm;
-        .native & {
-            @media (prefers-color-scheme: dark) {
-                background: @ffe-grey-darkmode;
-            }
-        }
 
         > svg {
             height: 50%;
@@ -150,7 +122,7 @@
             width: 100%;
             .native & {
                 @media (prefers-color-scheme: dark) {
-                    fill: @ffe-grey-cloud-darkmode;
+                    fill: inherit;
                 }
             }
         }
@@ -159,10 +131,8 @@
             &:hover {
                 fill: @ffe-farge-lysvarmgraa;
             }
-            .native & {
-                @media (prefers-color-scheme: dark) {
-                    fill: @ffe-grey-cloud-darkmode;
-                }
+            &:focus {
+                border: 2px solid @ffe-farge-hvit;
             }
         }
     }

--- a/packages/ffe-system-message/less/ffe-system-message.less
+++ b/packages/ffe-system-message/less/ffe-system-message.less
@@ -100,7 +100,7 @@
         appearance: none;
         background: transparent;
         border: 2px solid transparent;
-        border-radius: 0;
+        border-radius: 5px;
         color: inherit;
         cursor: pointer;
         align-self: flex-start;
@@ -115,7 +115,6 @@
         }
         &:focus {
             border: 2px solid @ffe-farge-vann;
-            border-radius: 5px;
         }
         > svg {
             height: 100%;


### PR DESCRIPTION
## Beskrivelse

Oppdaterte systemmeldinger til å ha nye farger fra den nye visuelle profilen.
Gjorde lukke knappen større for å oppfylle wcag anbefaling om klikkbart område, og 
la til hover og focus effect på knappen.
Skissene innholdt ikke hover effect på info meldingen, så her har jeg gått for lys varm grå for hover farge. 
![Skjermbilde 2021-06-24 kl  15 25 30](https://user-images.githubusercontent.com/39946146/123272975-88ff0f80-d502-11eb-9343-8d0fff5c3840.png)

![Skjermbilde 2021-07-05 kl  15 55 35](https://user-images.githubusercontent.com/39946146/124482354-7a89e100-dda9-11eb-98b2-eda94ca510ff.png)

## Motivasjon og kontekst

Endringen er lagt til for å få systemmelding til å passe den nye visuelle profilen, og for å bedre oppfylle wcag krav

## Testing

Testet ved å kjøre opp endringene  og se endringen av komponentene i dokumentasjonen.  Jeg har også kontrast sjekket hover fargen jeg la til på info boksen, og den skal oppfylle AA kravet. 
