### PR TITLE
fix(ffe-searchable-dropdown-react): Have separate list for highCapaci…

### DIFF
--- a/packages/ffe-searchable-dropdown-react/src/HighCapacityResults.js
+++ b/packages/ffe-searchable-dropdown-react/src/HighCapacityResults.js
@@ -23,7 +23,7 @@ import ListItemContainer from './ListItemContainer';
 import { stateChangeTypes } from './reducer';
 import NoMatch from './NoMatch';
 
-export default class List extends React.PureComponent {
+export default class HighCapacityResults extends React.PureComponent {
     state = {
         optionHeight: 40,
     };
@@ -172,7 +172,7 @@ export default class List extends React.PureComponent {
     }
 }
 
-List.propTypes = {
+HighCapacityResults.propTypes = {
     listToRender: arrayOf(object).isRequired,
     noMatch: shape({
         text: string,

--- a/packages/ffe-searchable-dropdown-react/src/Results.js
+++ b/packages/ffe-searchable-dropdown-react/src/Results.js
@@ -1,0 +1,89 @@
+import React from 'react';
+import { Scrollbars } from 'react-custom-scrollbars';
+import {
+    arrayOf,
+    any,
+    bool,
+    func,
+    number,
+    object,
+    oneOf,
+    shape,
+    string,
+} from 'prop-types';
+
+import { locales } from './translations';
+import ListItemContainer from './ListItemContainer';
+import { stateChangeTypes } from './reducer';
+import NoMatch from './NoMatch';
+
+const Results = ({
+    isNoMatch,
+    noMatch,
+    listToRender,
+    noMatchMessageId,
+    ListItemBodyElement,
+    refs,
+    highlightedIndex,
+    dropdownAttributes,
+    dispatch,
+    locale,
+    onChange,
+    focusInput,
+}) => {
+    return (
+        <Scrollbars autoHeight={true} autoHeightMax={300}>
+            {isNoMatch && (
+                <NoMatch
+                    noMatch={noMatch}
+                    noMatchMessageId={noMatchMessageId}
+                    listToRender={listToRender}
+                />
+            )}
+            {listToRender.map((item, index) => (
+                <ListItemContainer
+                    key={Object.values(item).join('-')}
+                    ref={refs[index]}
+                    isHighlighted={highlightedIndex === index}
+                    onClick={() => {
+                        onChange(item);
+                        dispatch({
+                            type: stateChangeTypes.ItemOnClick,
+                            payload: { selectedItem: item },
+                        });
+                        focusInput();
+                    }}
+                    item={item}
+                >
+                    {props => (
+                        <ListItemBodyElement
+                            {...props}
+                            dropdownAttributes={dropdownAttributes}
+                            locale={locale}
+                        />
+                    )}
+                </ListItemContainer>
+            ))}
+        </Scrollbars>
+    );
+};
+
+Results.propTypes = {
+    listToRender: arrayOf(object).isRequired,
+    noMatch: shape({
+        text: string,
+        dropdownList: arrayOf(object),
+    }),
+    noMatchMessageId: string,
+    ListItemBodyElement: func,
+    highlightedIndex: number,
+    dispatch: func,
+    dropdownAttributes: arrayOf(string).isRequired,
+    locale: oneOf(Object.values(locales)).isRequired,
+    refs: arrayOf(any).isRequired,
+    onChange: func.isRequired,
+    focusInput: func.isRequired,
+    isNoMatch: bool.isRequired,
+};
+
+export default Results;

--- a/packages/ffe-searchable-dropdown-react/src/SearchableDropdown.js
+++ b/packages/ffe-searchable-dropdown-react/src/SearchableDropdown.js
@@ -20,7 +20,7 @@ import {
 import classNames from 'classnames';
 import { ChevronIkon, KryssIkon } from '@sb1/ffe-icons-react';
 
-import List from './List';
+import HighCapacityResults from './HighCapacityResults';
 import ListItemBody from './ListItemBody';
 import {
     getButtonLabelClear,
@@ -37,6 +37,7 @@ import {
     getNewHighlightedIndexDown,
 } from './getNewHighlightedIndex';
 import { useSetAllyMessageItemSelection } from './a11y';
+import Results from './Results';
 
 const ARROW_UP = 'ArrowUp';
 const ARROW_DOWN = 'ArrowDown';
@@ -61,6 +62,7 @@ const SearchableDropdown = ({
     formatter = value => value,
     searchMatcher,
     selectedItem,
+    highCapacity = false,
 }) => {
     const [state, dispatch] = useReducer(
         createReducer({
@@ -252,6 +254,8 @@ const SearchableDropdown = ({
         }
     };
 
+    const ResultsElement = highCapacity ? HighCapacityResults : Results;
+
     return (
         <div // eslint-disable-line jsx-a11y/no-static-element-interactions
             onKeyDown={handleKeyDown}
@@ -362,7 +366,7 @@ const SearchableDropdown = ({
             >
                 <div id={listBoxRef.current} role="listbox">
                     {state.isExpanded && (
-                        <List
+                        <ResultsElement
                             listBoxRef={listBoxRef}
                             listToRender={state.listToRender}
                             ListItemBodyElement={ListItemBodyElement}
@@ -443,6 +447,12 @@ SearchableDropdown.propTypes = {
      * (inputValue: string, searchAttributes: string[]) => (item) => boolean
      */
     searchMatcher: func,
+
+    /**
+     * For situations where SearchableDropdown might be populated with hundreds of accounts
+     * uses react-window for performance optimization, default false
+     */
+    highCapacity: bool,
 };
 
 export default SearchableDropdown;

--- a/packages/ffe-searchable-dropdown-react/src/SearchableDropdown.md
+++ b/packages/ffe-searchable-dropdown-react/src/SearchableDropdown.md
@@ -209,6 +209,7 @@ const labelId = 'labelId1';
         onChange={item => setState({ item })}
         searchAttributes={['organizationName']}
         locale="nb"
+        highCapacity={true}
     />
 </InputGroup>;
 ```

--- a/packages/ffe-searchable-dropdown-react/src/index.d.ts
+++ b/packages/ffe-searchable-dropdown-react/src/index.d.ts
@@ -33,6 +33,7 @@ export interface SearchableDropdownProps<T> {
         inputValue: string,
         searchAttributes: (keyof T)[],
     ) => (item: T) => boolean;
+    hichCapacity?: boolean;
 }
 
 declare class SearchableDropdown<T> extends React.Component<

--- a/packages/ffe-searchable-dropdown-react/src/reducer.js
+++ b/packages/ffe-searchable-dropdown-react/src/reducer.js
@@ -11,7 +11,6 @@ export const stateChangeTypes = {
     ClearButtonPressed: 'ClearButtonPressed',
     ToggleButtonPressed: 'ToggleButtonPressed',
     ItemOnClick: 'ItemOnMouseDown',
-    ItemOnMouseEnter: 'ItemOnMouseEnter',
     FocusMovedOutSide: 'FocusMovedOutSide',
     ItemSelectedProgrammatically: 'ItemSelectedProgrammatically',
 };
@@ -125,12 +124,6 @@ export const createReducer = ({
             };
         }
 
-        case stateChangeTypes.ItemOnMouseEnter: {
-            return {
-                ...state,
-                highlightedIndex: action.payload.highlightedIndex,
-            };
-        }
         case stateChangeTypes.FocusMovedOutSide: {
             const { listToRender } = getListToRender({
                 inputValue: state.inputValue,


### PR DESCRIPTION
…ty and lowCapacity

... HighCapacityList.js is not working for screen readers.
BREAKING CHANGES: You have to pass prop `highCapacity` in order to have lists with hundreds of items

## Beskrivelse

Viser HighCapacityList dersom det er definert.
Viser LowCapacityList dersom highCapacity ikke er definert. Denne lista er sånn lista var før i la opp til at det var mulig med highCapacity (https://github.com/SpareBank1/designsystem/commit/d5dc190bbb34986da928b6925a6396d6a78d62c6#diff-213c799381ade1e9ed80e204dd0ecc109f061b1c1abc4790fe4cfe0a5ee88a75)

Fjerna også ubrukt logikk i reduceren.

## Motivasjon og kontekst

Lista for `highCapacity` gjør at skjermleser på iPhone ikke lenger funker. Så frem til vi finner en fiks på det (som er litt vanskelig), viser vi kun lista for `highCapacity` når det er definert. Det var sånn det fungerte før etter vi skrev om kontovelgeren og searchable-dropdown. I tillegg til at skjermleser ikke funker på highCapacity-lista, så skjer det noen stylingbugs mtp. høyde og lignende som vi har slitt litt med med `VirtualizedList`. Så jeg tenker at hvert fall foreløpig er det best å kun bruke highCapacity-lista når det er nødvendig. 

## Testing

Har et eksempel for highCapacity og flere for lowCapacity og har testet på disse, men har ikke testa med skjermleser. Får ikke testa på mobil, men du Peter hadde en måte å lage et testmiljø så vi kan teste på mobil? Hadde du hatt mulighet til å vise meg hvordan vi gjør det? :) 


Er det forresten sånn at det blir en ny major version nå som det er en breaking change? Det vil si at versjonen vi bruker i account-selector, ikke vil automatisk oppdatere seg til denne nye versjonen?
