### PR TITLE
fix(ffe-searchable-dropdown-react): Do not automatically change passe…

### DIFF
--- a/packages/ffe-searchable-dropdown-react/src/SearchableDropdown.js
+++ b/packages/ffe-searchable-dropdown-react/src/SearchableDropdown.js
@@ -115,6 +115,7 @@ const SearchableDropdown = ({
         if (inputProps.onBlur) {
             inputProps.onBlur(e);
         }
+        dispatch({ type: stateChangeTypes.InputBlur });
     };
 
     useEffect(() => {

--- a/packages/ffe-searchable-dropdown-react/src/SearchableDropdown.spec.js
+++ b/packages/ffe-searchable-dropdown-react/src/SearchableDropdown.spec.js
@@ -681,4 +681,85 @@ describe('SearchableDropdown', () => {
         expect(onChange).toHaveBeenCalledWith(companies[2]);
         expect(input.value).toEqual('Beslag skytter');
     });
+
+    it('should not automatically change selectedItem if object structure is different from previous but the actual content is still the same content', () => {
+        const onChange = jest.fn();
+        render(
+            <div>
+                <button>Knapp</button>
+                <SearchableDropdown
+                    id="id"
+                    labelId="labelId"
+                    dropdownAttributes={[
+                        'organizationName',
+                        'organizationNumber',
+                    ]}
+                    dropdownList={companies}
+                    onChange={onChange}
+                    searchAttributes={[
+                        'organizationName',
+                        'organizationNumber',
+                    ]}
+                    selectedItem={{
+                        organizationNumber: '912602370',
+                        quantityUnprocessedMessages: 5,
+                        organizationName: 'Bedriften',
+                    }}
+                    locale="nb"
+                />
+            </div>,
+        );
+
+        const input = screen.getByRole('combobox');
+        userEvent.click(input);
+        act(() => {
+            userEvent.click(screen.getByText('Knapp'));
+        });
+        expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it('should allow passing a selectedItem with same organizationName as dropdownListItems but different organizationNumber without it being changed', () => {
+        const onChange = jest.fn();
+
+        const noMatchDropDownList = [
+            {
+                organizationName: 'Bedriften',
+                organizationNumber: '1111111',
+                quantityUnprocessedMessages: 7,
+            },
+        ];
+
+        render(
+            <div>
+                <button>Knapp</button>
+                <SearchableDropdown
+                    id="id"
+                    labelId="labelId"
+                    dropdownAttributes={[
+                        'organizationName',
+                        'organizationNumber',
+                    ]}
+                    dropdownList={companies}
+                    onChange={onChange}
+                    searchAttributes={[
+                        'organizationName',
+                        'organizationNumber',
+                    ]}
+                    locale="nb"
+                    noMatch={{
+                        text: '',
+                        dropdownList: noMatchDropDownList,
+                    }}
+                    selectedItem={noMatchDropDownList[0]}
+                />
+            </div>,
+        );
+
+        const input = screen.getByRole('combobox');
+        userEvent.click(input);
+        act(() => {
+            userEvent.click(screen.getByText('Knapp'));
+        });
+        expect(onChange).not.toHaveBeenCalled();
+    });
 });


### PR DESCRIPTION
…d selecteditem

Not even if it has the same name as an element in the dropdownlist

## Beskrivelse

Dersom man sendte inn et selectedItem som ikke matchet noen elementer i lista, men hadde samme navn som et av de, så endret den automatisk til det elementet, selv om man hadde sendt inn et helt annet selectedItem.

I tillegg endret den automatisk selectedItem dersom objektet sin struktur var ulik selv om selve innholdet i objektet var det samme.

Så her er de to tingene fikset blant annet ved å heller flytte funksjunaliteten inn i `InputBlur` i stedet for `FocusMovedOutSide`. 

## Testing

Test gjerne at det funker fint med onBlur og det å velge på vanlig måte osv. her: 
https://vigilant-franklin-9cf4e0.netlify.app/styleguidist/index.html#!/SearchableDropdown