### PR TITLE
fix(ffe-context-message): oppdater darkmode styling til ny profil

### DIFF
--- a/packages/ffe-context-message/less/ffe-context-message.less
+++ b/packages/ffe-context-message/less/ffe-context-message.less
@@ -55,11 +55,11 @@
     .ffe-body-text {
         .native & {
             @media (prefers-color-scheme: dark) {
-                color: @ffe-grey-cloud-darkmode;
+                color: @ffe-farge-svart;
             }
             a {
                 @media (prefers-color-scheme: dark) {
-                    color: @ffe-grey-cloud-darkmode;
+                    color: @ffe-farge-svart;
                 }
             }
         }
@@ -87,11 +87,6 @@
         border-radius: 50%;
         height: 4em;
         width: 4em;
-        .native & {
-            @media (prefers-color-scheme: dark) {
-                background-color: @ffe-grey-darkmode;
-            }
-        }
 
         &-svg {
             height: 2.2em;
@@ -100,7 +95,7 @@
             fill: @ffe-blue-royal;
             .native & {
                 @media (prefers-color-scheme: dark) {
-                    fill: @ffe-white-darkmode;
+                    fill: @ffe-farge-fjell;
                 }
             }
         }
@@ -189,7 +184,7 @@
         background-color: @ffe-farge-frost-30;
         .native & {
             @media (prefers-color-scheme: dark) {
-                background-color: @ffe-grey-charcoal-darkmode;
+                background-color: @ffe-farge-vann-30;
             }
         }
     }
@@ -198,19 +193,13 @@
         background-color: @ffe-farge-sand-70;
         .native & {
             @media (prefers-color-scheme: dark) {
-                background-color: @ffe-grey-charcoal-darkmode;
+                background-color: @ffe-farge-sand;
             }
         }
     }
 
     &--success {
         background-color: @ffe-farge-nordlys-30;
-        .native & {
-            @media (prefers-color-scheme: dark) {
-                background-color: @ffe-grey-charcoal-darkmode;
-            }
-        }
-
         .ffe-context-message-content__icon-svg {
             fill: @ffe-farge-nordlys-wcag;
         }
@@ -218,11 +207,6 @@
 
     &--error {
         background-color: @ffe-farge-baer-30;
-        .native & {
-            @media (prefers-color-scheme: dark) {
-                background-color: @ffe-grey-charcoal-darkmode;
-            }
-        }
 
         .ffe-context-message-content__header {
             color: @ffe-black;


### PR DESCRIPTION
## Beskrivelse

Oppdaterte darkmode styling, istedenfor at alle blir grå/sorte har meldingene nå enten samme eller en justert versjon av fargen som er i light mode. 

## Motivasjon og kontekst

I forbindelse med justering av visuelle profilen ser vi også nærmere på darkmode, og vi ønsker å gå gjennom komponentene for å sørge for god nok kontrast og god brukeropplevelse også i darkmode. 

## Testing

Kjørt opp lokalt og testet opp mot dokumentasjonen. 
![Skjermbilde 2021-07-05 kl  16 19 39](https://user-images.githubusercontent.com/39946146/124485415-d1dd8080-ddac-11eb-9d4c-b5ff9d3741aa.png)

