### PR TITLE
fix(ffe-searchable-dropdown-react): Do onBlur functionality if clicke…

### DIFF
--- a/packages/ffe-searchable-dropdown-react/src/SearchableDropdown.js
+++ b/packages/ffe-searchable-dropdown-react/src/SearchableDropdown.js
@@ -115,7 +115,6 @@ const SearchableDropdown = ({
         if (inputProps.onBlur) {
             inputProps.onBlur(e);
         }
-        dispatch({ type: stateChangeTypes.InputBlur });
     };
 
     useEffect(() => {
@@ -166,9 +165,18 @@ const SearchableDropdown = ({
         const isFocusInside =
             containerRef.current.contains(e.target) ||
             e.__isEventFromFFESearchableDropdown;
+
         if (!isFocusInside) {
             dispatch({
                 type: stateChangeTypes.FocusMovedOutSide,
+            });
+        }
+
+        const hasBlurred =
+            !isFocusInside && document.activeElement === inputRef.current;
+        if (hasBlurred) {
+            dispatch({
+                type: stateChangeTypes.InputBlur,
             });
         }
     };


### PR DESCRIPTION
…d outside dropdown on blur

## Beskrivelse

Dersom man skriver inn det elementet man vil velge, for så å trykke på det elementet det matcher i lista, så kjører en onBlur-funksjonaliteten i stedet for funksjonaliteten for å velge element ved å klikke i lista. Så her har jeg (enda) en fiks på at man kun skal kjøre onBlur-funksjonaliteten når man trykker utenfor hele dropdownen, ikke bare input-feltet

## Motivasjon og kontekst

Uten denne fiksen blir det trøblete å søke for så å velge element ved å trykke på elementet i lista.

## Testing

Har testet selv, men fint om du også tester for sikkerhetsskyld. 
https://optimistic-saha-971b1b.netlify.app/styleguidist/index.html#!/SearchableDropdown
