### PR TITLE
feat(designsystem): Add playwright-axe tests for systemmessage component

### DIFF
--- a/designsystem/tests/SystemMessage.spec.js
+++ b/designsystem/tests/SystemMessage.spec.js
@@ -1,0 +1,38 @@
+const { test, expect } = require('@playwright/test');
+const { visitPage, expectNoAxeViolations } = require('./utils');
+const variations = [
+    'SystemErrorMessage',
+    'SystemErrorMessage-alertFalse',
+    'SystemInfoMessage',
+    'SystemNewsMessage',
+    'SystemSuccessMessage',
+];
+
+variations.forEach(variation =>
+    test.describe(variation, () => {
+        test.beforeEach(async ({ page }) => visitPage(page, variation, true));
+        expectNoAxeViolations();
+    }),
+);
+
+test.describe('SystemErrorMessage', () => {
+    test.beforeEach(async ({ page }) => visitPage(page, 'SystemErrorMessage'));
+    test('have role="alert" attribute', async ({ page }) => {
+        const messageBox = await (
+            await page.$('.ffe-system-message-wrapper--error')
+        ).getAttribute('role');
+        expect(messageBox).toBe('alert');
+    });
+});
+
+test.describe('SystemErrorMessage-alertFalse', () => {
+    test.beforeEach(async ({ page }) =>
+        visitPage(page, 'SystemErrorMessage-alertFalse'),
+    );
+    test('dont have role="alert" attribute', async ({ page }) => {
+        const messageBox = await (
+            await page.$('.ffe-system-message-wrapper--error')
+        ).getAttribute('role');
+        expect(messageBox).toBeFalsy();
+    });
+});


### PR DESCRIPTION
Lagt til Playwright tester som tester opp mot Axe til komponentene i systemmessage pakken. 
Disse  bare kjører igjennom alle variantene av systemmessage som ligger på sb1ds-examples.neflify.app
og tester opp mot axe, og om den fjerner/legger til role=alert  som den skal. 

## Motivasjon og kontekst

Vi ønsker å automatisere mer Uu-tester på sikt og dette er første steg i den retningen. 

## Testing
Har kjørt testene lokalt. De er også helt identiske tester som allerede ligger inne. 