### PR TITLE
Update message box styling

### DIFF
--- a/designsystem/examples/message-box/ErrorMessage-alertFalse.jsx
+++ b/designsystem/examples/message-box/ErrorMessage-alertFalse.jsx
@@ -1,10 +1,7 @@
 import { ErrorMessage } from '@sb1/ffe-message-box-react';
-import { Paragraph } from '@sb1/ffe-core-react';
 
 <ErrorMessage title="Fikk ikke kalkulert pris" alert={false}>
-    <Paragraph>
-        Det ser ut til at vi har litt problemer med priskalkuleringstjenestene
-        våre akkurat nå. Hvis problemet vedvarer, kan du ta kontakt med
-        kundesupport, så hjelper vi deg.
-    </Paragraph>
+    Det ser ut til at vi har litt problemer med priskalkuleringstjenestene
+    våre akkurat nå. Hvis problemet vedvarer, kan du ta kontakt med
+    kundesupport, så hjelper vi deg.
 </ErrorMessage>

--- a/designsystem/examples/message-box/ErrorMessage.jsx
+++ b/designsystem/examples/message-box/ErrorMessage.jsx
@@ -1,10 +1,7 @@
 import { ErrorMessage } from '@sb1/ffe-message-box-react';
-import { Paragraph } from '@sb1/ffe-core-react';
 
 <ErrorMessage title="Fikk ikke kalkulert pris">
-    <Paragraph>
-        Det ser ut til at vi har litt problemer med priskalkuleringstjenestene
-        våre akkurat nå. Hvis problemet vedvarer, kan du ta kontakt med
-        kundesupport, så hjelper vi deg.
-    </Paragraph>
+    Det ser ut til at vi har litt problemer med priskalkuleringstjenestene
+    våre akkurat nå. Hvis problemet vedvarer, kan du ta kontakt med
+    kundesupport, så hjelper vi deg.
 </ErrorMessage>

--- a/designsystem/examples/message-box/InfoMessage-customIcon.jsx
+++ b/designsystem/examples/message-box/InfoMessage-customIcon.jsx
@@ -3,8 +3,6 @@ import { Paragraph } from '@sb1/ffe-core-react';
 import { HandlevognIkon } from '@sb1/ffe-icons-react';
 
 <InfoMessage title="Handlevognen din er tom" icon={<HandlevognIkon/>}>
-    <Paragraph>
-        Du har ingenting i handlevognen din.
-    </Paragraph>
+    Du har ingenting i handlevognen din.
 </InfoMessage>;
 

--- a/designsystem/examples/message-box/InfoMessage-customIcon.jsx
+++ b/designsystem/examples/message-box/InfoMessage-customIcon.jsx
@@ -1,5 +1,4 @@
 import { InfoMessage } from '@sb1/ffe-message-box-react';
-import { Paragraph } from '@sb1/ffe-core-react';
 import { HandlevognIkon } from '@sb1/ffe-icons-react';
 
 <InfoMessage title="Handlevognen din er tom" icon={<HandlevognIkon/>}>

--- a/designsystem/examples/message-box/InfoMessage.jsx
+++ b/designsystem/examples/message-box/InfoMessage.jsx
@@ -1,9 +1,6 @@
 import { InfoMessage } from '@sb1/ffe-message-box-react';
-import { Paragraph } from '@sb1/ffe-core-react';
 
 <InfoMessage title="Du har ingen kort">
-    <Paragraph>
-        Denne tjenesten er kun tilgjengelig for deg med et debitkort eller
-        kredittkort fra SpareBank 1.
-    </Paragraph>
+    Denne tjenesten er kun tilgjengelig for deg med et debitkort eller
+    kredittkort fra SpareBank 1.
 </InfoMessage>

--- a/designsystem/examples/message-box/SuccessMessage.jsx
+++ b/designsystem/examples/message-box/SuccessMessage.jsx
@@ -1,6 +1,5 @@
 import { SuccessMessage } from '@sb1/ffe-message-box-react';
-import { Paragraph } from '@sb1/ffe-core-react';
 
 <SuccessMessage title="Betalingen ble gjennomført">
-    <Paragraph>Nå er du helt gjeldsfri! Hurra!</Paragraph>
+    Nå er du helt gjeldsfri! Hurra!
 </SuccessMessage>

--- a/designsystem/examples/message-box/TipsMessage.jsx
+++ b/designsystem/examples/message-box/TipsMessage.jsx
@@ -1,9 +1,6 @@
 import { TipsMessage } from '@sb1/ffe-message-box-react';
-import { Paragraph } from '@sb1/ffe-core-react';
 
 <TipsMessage title="Reiseforsikringen dekker alt utenfor hjemmet!">
-    <Paragraph>
-        Reiseforsikringen gjelder ikke bare når du er på ferie. Les mer om hva
-        som dekkes i vilkårene.
-    </Paragraph>
+    Reiseforsikringen gjelder ikke bare når du er på ferie. Les mer om hva
+    som dekkes i vilkårene.
 </TipsMessage>

--- a/packages/ffe-message-box-react/src/BaseMessage.js
+++ b/packages/ffe-message-box-react/src/BaseMessage.js
@@ -44,7 +44,7 @@ const BaseMessage = props => {
                         {title}
                     </div>
                 )}
-                {content && <p className="ffe-body-text">{content}</p>}
+                {content && <p>{content}</p>}
                 {!content && children}
             </div>
         </div>

--- a/packages/ffe-message-box-react/src/BaseMessage.js
+++ b/packages/ffe-message-box-react/src/BaseMessage.js
@@ -38,7 +38,7 @@ const BaseMessage = props => {
                     <div
                         className={classNames(
                             'ffe-h4',
-                            `ffe-message-box__title--${type}`,
+                            `ffe-message-box__title`,
                         )}
                     >
                         {title}

--- a/packages/ffe-message-box-react/src/BaseMessage.spec.js
+++ b/packages/ffe-message-box-react/src/BaseMessage.spec.js
@@ -23,10 +23,11 @@ describe('<BaseMessage />', () => {
             expect(
                 typedWrapper.find(`.ffe-message-box__icon--${type}`).exists(),
             ).toBe(true);
-            expect(
-                typedWrapper.find(`.ffe-message-box__title--${type}`).exists(),
-            ).toBe(true);
         });
+    });
+    it('renders with correct title class', () => {
+        const wrapper = getWrapper({ title: 'test title' });
+        expect(wrapper.find(`.ffe-message-box__title`).exists()).toBe(true);
     });
     it('renders an icon by default', () => {
         const wrapper = getWrapper();

--- a/packages/ffe-message-box/less/ffe-message-box.less
+++ b/packages/ffe-message-box/less/ffe-message-box.less
@@ -27,80 +27,47 @@
     &__box {
         padding: @ffe-spacing-xl @ffe-spacing-lg;
         border-radius: 5px;
-
-        @media (min-width: @breakpoint-md) {
-            padding: @ffe-spacing-xl @ffe-spacing-xl;
+        color: @ffe-farge-svart;
+        .native & {
+            @media (prefers-color-scheme: dark) {
+                color: @ffe-farge-svart;
+            }
         }
 
         &--tips {
-            background-color: @ffe-sand;
+            background-color: @ffe-farge-sand-70;
             .native & {
                 @media (prefers-color-scheme: dark) {
-                    background-color: @ffe-grey-charcoal-darkmode;
+                    background-color: @ffe-farge-sand;
                 }
             }
         }
 
         &--info {
-            background-color: @ffe-blue-pale;
+            background-color: @ffe-farge-frost-30;
             .native & {
                 @media (prefers-color-scheme: dark) {
-                    background-color: @ffe-grey-charcoal-darkmode;
+                    background-color: @ffe-farge-vann-30;
                 }
             }
         }
 
         &--success {
-            background-color: @ffe-green-mint;
-            .native & {
-                @media (prefers-color-scheme: dark) {
-                    background-color: @ffe-grey-charcoal-darkmode;
-                }
-            }
+            background-color: @ffe-farge-nordlys-30;
         }
 
         &--error {
-            background-color: @ffe-orange-salmon;
-            .native & {
-                @media (prefers-color-scheme: dark) {
-                    background-color: @ffe-grey-charcoal-darkmode;
-                }
-            }
+            background-color: @ffe-farge-baer-30;
         }
     }
 
     &__title {
-        &--success {
-            color: @ffe-black;
-            .native & {
-                @media (prefers-color-scheme: dark) {
-                    color: @ffe-white-darkmode;
-                }
-            }
-        }
-
-        &--error {
-            color: @ffe-black;
-            .native & {
-                @media (prefers-color-scheme: dark) {
-                    color: @ffe-white-darkmode;
-                }
-            }
-        }
-
-        &--tips {
-            .native & {
-                @media (prefers-color-scheme: dark) {
-                    color: @ffe-white-darkmode;
-                }
-            }
-        }
-
-        &--info {
-            .native & {
-                @media (prefers-color-scheme: dark) {
-                    color: @ffe-white-darkmode;
-                }
+        color: @ffe-black;
+        font-size: 18px;
+        margin-bottom: @ffe-spacing-sm;
+        .native & {
+            @media (prefers-color-scheme: dark) {
+                color: @ffe-black;
             }
         }
     }
@@ -113,53 +80,24 @@
     }
 
     &__icon {
-        background-color: #fff;
+        background-color: @ffe-farge-hvit;
         border-radius: 50%;
-        display: inline-block;
-        fill: #002776;
-        height: 80px;
+        display: inline-flex;
+        fill: @ffe-farge-fjell;
+        height: 64px;
         margin-bottom: -16px;
-        padding: @ffe-spacing-xs;
-        padding-top: @ffe-spacing-sm;
+        align-items: center;
+        justify-content: center;
         position: relative;
-        top: 12px;
-        width: 80px;
-        .native & {
-            @media (prefers-color-scheme: dark) {
-                background-color: @ffe-grey-darkmode;
-                fill: @ffe-blue-azure-darkmode;
-            }
-        }
+        top: 16px;
+        width: 64px;
 
         &--error svg {
-            fill: @ffe-orange-fire;
-            .native & {
-                @media (prefers-color-scheme: dark) {
-                    fill: @ffe-red-darkmode;
-                }
-            }
-        }
-
-        &--info svg {
-            fill: @ffe-blue-royal;
-            .native & {
-                @media (prefers-color-scheme: dark) {
-                    fill: @ffe-blue-azure-darkmode;
-                }
-            }
+            fill: @ffe-farge-baer-wcag;
         }
 
         &--success svg {
-            fill: @ffe-green-shamrock;
-        }
-
-        &--tips svg {
-            fill: @ffe-blue-royal;
-            .native & {
-                @media (prefers-color-scheme: dark) {
-                    fill: @ffe-blue-azure-darkmode;
-                }
-            }
+            fill: @ffe-farge-nordlys-wcag;
         }
     }
 

--- a/packages/ffe-message-box/less/ffe-message-box.less
+++ b/packages/ffe-message-box/less/ffe-message-box.less
@@ -23,6 +23,13 @@
 
 .ffe-message-box {
     text-align: center;
+    .ffe-body-paragraph {
+        .native & {
+            @media (prefers-color-scheme: dark) {
+                color: @ffe-farge-svart;
+            }
+        }
+    }
 
     &__box {
         padding: @ffe-spacing-xl @ffe-spacing-lg;
@@ -62,12 +69,12 @@
     }
 
     &__title {
-        color: @ffe-black;
+        color: @ffe-farge-svart;
         font-size: 18px;
         margin-bottom: @ffe-spacing-sm;
         .native & {
             @media (prefers-color-scheme: dark) {
-                color: @ffe-black;
+                color: @ffe-farge-svart;
             }
         }
     }
@@ -77,6 +84,11 @@
         margin: 0;
         line-height: 2;
         text-align: left;
+        .native {
+            li {
+                color: @ffe-farge-svart;
+            }
+        }
     }
 
     &__icon {
@@ -103,11 +115,11 @@
 
     @media print {
         &__box {
-            border: 2px dashed @ffe-black;
+            border: 2px dashed @ffe-farge-svart;
         }
 
         &__icon {
-            border-bottom: 2px dashed @ffe-black;
+            border-bottom: 2px dashed @ffe-farge-svart;
             margin-bottom: -33.5px;
         }
     }

--- a/src/styles/styles.less
+++ b/src/styles/styles.less
@@ -145,12 +145,10 @@ body.native {
     }
 
     background-color: @ffe-black-darkmode;
-
-    li,
-    p:not(.ffe-lead-paragraph) {
+    li[class^='rsg'],
+    p[class^='rsg'] {
         color: @ffe-grey-cloud-darkmode;
     }
-
     a:not(h1, h2, h3, h4, h5, h6) {
         color: @ffe-blue-azure-darkmode;
         border-color: @ffe-blue-azure-darkmode;

--- a/styleguide-content/komponenter/meldinger-bokser.md
+++ b/styleguide-content/komponenter/meldinger-bokser.md
@@ -1,7 +1,5 @@
-
 Hold det kort og konsist! Det skal være reelle tips/informasjon til brukeren, ikke informasjon vi ønsker å forklare her
-fordi vi ikke finner noe annet sted å gjøre det. For mye tekst kan føre til at komponenten mister sin verdi. 
-
+fordi vi ikke finner noe annet sted å gjøre det. For mye tekst kan føre til at komponenten mister sin verdi.
 
 Det finnes fire forskjellige typer:
 
@@ -21,9 +19,7 @@ const {
         <GridRow>
             <GridCol md={6}>
                 <TipsMessage title="Overskrift">
-                    <p className="ffe-body-paragraph">
-                        Brødtekst som beskriver i mer detalj
-                    </p>
+                    Brødtekst som beskriver i mer detalj
                 </TipsMessage>
             </GridCol>
             <GridCol md={6}>
@@ -38,9 +34,7 @@ const {
         <GridRow>
             <GridCol md={6}>
                 <InfoMessage title="Overskrift">
-                    <p className="ffe-body-paragraph">
-                        Brødtekst som beskriver i mer detalj
-                    </p>
+                    Brødtekst som beskriver i mer detalj
                 </InfoMessage>
             </GridCol>
             <GridCol md={6}>
@@ -55,9 +49,7 @@ const {
         <GridRow>
             <GridCol md={6}>
                 <SuccessMessage title="Overskrift">
-                    <p className="ffe-body-paragraph">
-                        Brødtekst som beskriver i mer detalj hva som har skjedd
-                    </p>
+                    Brødtekst som beskriver i mer detalj hva som har skjedd
                 </SuccessMessage>
             </GridCol>
             <GridCol md={6}>
@@ -72,9 +64,7 @@ const {
         <GridRow>
             <GridCol md={6}>
                 <ErrorMessage title="Overskrift">
-                    <p className="ffe-body-paragraph">
-                        Brødtekst som beskriver feilsituasjonen i mer detalj
-                    </p>
+                    Brødtekst som beskriver feilsituasjonen i mer detalj
                 </ErrorMessage>
             </GridCol>
             <GridCol md={6}>


### PR DESCRIPTION
## Beskrivelse

Denne PR'en oppdaterer designet på meldingsboks til å passe den justerte visuelle profilen.
Endringen innebærer endring av bakgrunnsfarge på boksene, inkl. darkmode.
Tittelen skal se lik ut i alle typene, så jeg slettet type fra klassenavnet og stylet tittel klassen.

Ikon boksen er også gjort mindre og jeg skiftet fra inline-block til inline-flex for å midtstille alt, istedenfor å bruke px verdier.  Sirkelen er nå 64px og ikke 80px, og blir hvit i darkmode, istedenfor sort. 

Må forsatt se på hva vi gjør med listene. 
![Skjermbilde 2021-07-09 kl  15 40 16](https://user-images.githubusercontent.com/39946146/125086510-01053200-e0cc-11eb-8d51-747c453b2ce7.png)
![Skjermbilde 2021-07-09 kl  15 40 47](https://user-images.githubusercontent.com/39946146/125086586-0f534e00-e0cc-11eb-9e58-63a954086beb.png)


## Motivasjon og kontekst

Jobber med å oppdatere stylingen basert på justert visuell profil.

## Testing

Testet i Firefox ved å kjøre opp på localhost å se mot dokumentasjonen. 
