### PR TITLE
feat(ffe-searchable-dropdown-react): focus clear button instead of input field on option click

### DIFF
--- a/packages/ffe-searchable-dropdown-react/src/HighCapacityResults.js
+++ b/packages/ffe-searchable-dropdown-react/src/HighCapacityResults.js
@@ -126,7 +126,7 @@ export default class HighCapacityResults extends React.PureComponent {
             locale,
             refs,
             onChange,
-            focusInput,
+            focusClearButton,
         } = this.props;
         const item = listToRender[index];
         const itemKey = Object.values(item).join('-');
@@ -151,7 +151,7 @@ export default class HighCapacityResults extends React.PureComponent {
                                     type: stateChangeTypes.ItemOnClick,
                                     payload: { selectedItem: item },
                                 });
-                                focusInput();
+                                focusClearButton();
                             }}
                             item={item}
                         >
@@ -186,6 +186,6 @@ HighCapacityResults.propTypes = {
     locale: oneOf(Object.values(locales)).isRequired,
     refs: arrayOf(any).isRequired,
     onChange: func.isRequired,
-    focusInput: func.isRequired,
+    focusClearButton: func.isRequired,
     isNoMatch: bool.isRequired,
 };

--- a/packages/ffe-searchable-dropdown-react/src/Results.js
+++ b/packages/ffe-searchable-dropdown-react/src/Results.js
@@ -29,7 +29,7 @@ const Results = ({
     dispatch,
     locale,
     onChange,
-    focusInput,
+    focusClearButton,
 }) => {
     return (
         <Scrollbars autoHeight={true} autoHeightMax={300}>
@@ -51,7 +51,7 @@ const Results = ({
                             type: stateChangeTypes.ItemOnClick,
                             payload: { selectedItem: item },
                         });
-                        focusInput();
+                        focusClearButton();
                     }}
                     item={item}
                 >
@@ -82,7 +82,7 @@ Results.propTypes = {
     locale: oneOf(Object.values(locales)).isRequired,
     refs: arrayOf(any).isRequired,
     onChange: func.isRequired,
-    focusInput: func.isRequired,
+    focusClearButton: func.isRequired,
     isNoMatch: bool.isRequired,
 };
 

--- a/packages/ffe-searchable-dropdown-react/src/SearchableDropdown.js
+++ b/packages/ffe-searchable-dropdown-react/src/SearchableDropdown.js
@@ -98,13 +98,15 @@ const SearchableDropdown = ({
     const isInitialMountRef = useRef(true);
     const [refs, setRefs] = useState([]);
     const inputRef = useRef();
-    const toggleButtonRef = useRef();
+    const openButtonRef = useRef();
+    const clearButtonRef = useRef();
     const containerRef = useRef();
 
     const ListItemBodyElement = CustomListItemBody || ListItemBody;
     const listBoxRef = useRef(uuid());
     const noMatchMessageId = useRef(uuid());
-    const shouldFocusToggleButton = useRef(false);
+    const shouldFocusOpenButton = useRef(false);
+    const shouldFocusClearButton = useRef(false);
     const shouldFocusInput = useRef(false);
 
     const handleInputClick = () => {
@@ -143,12 +145,15 @@ const SearchableDropdown = ({
     }, [state.listToRender.length]);
 
     useLayoutEffect(() => {
-        if (shouldFocusToggleButton.current) {
-            toggleButtonRef.current.focus();
-            shouldFocusToggleButton.current = false;
+        if (shouldFocusOpenButton.current) {
+            openButtonRef.current.focus();
+            shouldFocusOpenButton.current = false;
         } else if (shouldFocusInput.current) {
             inputRef.current.focus();
             shouldFocusInput.current = false;
+        } else if (shouldFocusClearButton.current) {
+            clearButtonRef.current.focus();
+            shouldFocusClearButton.current = false;
         }
     });
 
@@ -182,12 +187,12 @@ const SearchableDropdown = ({
         };
     }, []);
 
-    const focusToggleButton = () => {
-        shouldFocusToggleButton.current = true;
+    const focusOpenButton = () => {
+        shouldFocusOpenButton.current = true;
     };
 
-    const focusInput = () => {
-        shouldFocusInput.current = true;
+    const focusClearButton = () => {
+        shouldFocusClearButton.current = true;
     };
 
     /**
@@ -210,7 +215,7 @@ const SearchableDropdown = ({
                 },
             });
             onChange(state.listToRender[state.highlightedIndex]);
-            shouldFocusInput.current = true;
+            focusClearButton();
             return;
         } else if (event.key === ESCAPE) {
             dispatch({ type: stateChangeTypes.InputKeyDownEscape });
@@ -320,6 +325,7 @@ const SearchableDropdown = ({
                 />
                 <button
                     type="button"
+                    ref={clearButtonRef}
                     aria-label={getButtonLabelClear(locale)}
                     className={classNames(
                         'ffe-searchable-dropdown__button ffe-searchable-dropdown__button--cross',
@@ -330,14 +336,14 @@ const SearchableDropdown = ({
                     onClick={() => {
                         dispatch({ type: stateChangeTypes.ClearButtonPressed });
                         onChange(null);
-                        focusToggleButton();
+                        focusOpenButton();
                     }}
                 >
                     <KryssIkon />
                 </button>
                 <button
                     type="button"
-                    ref={toggleButtonRef}
+                    ref={openButtonRef}
                     aria-label={
                         state.isExpanded
                             ? getButtonLabelClose(locale)
@@ -380,7 +386,7 @@ const SearchableDropdown = ({
                             isNoMatch={state.noMatch}
                             noMatch={noMatch}
                             noMatchMessageId={noMatchMessageId.current}
-                            focusInput={focusInput}
+                            focusClearButton={focusClearButton}
                         />
                     )}
                 </div>

--- a/packages/ffe-searchable-dropdown-react/src/SearchableDropdown.spec.js
+++ b/packages/ffe-searchable-dropdown-react/src/SearchableDropdown.spec.js
@@ -491,7 +491,7 @@ describe('SearchableDropdown', () => {
         expect(input.value).toEqual('Bedriften');
     });
 
-    it('should move focus to input field when selecting from dropdown, and to toggle button when clicking clear button', () => {
+    it('should move focus to clear button when selecting from dropdown, and to toggle button when clicking clear button', () => {
         const onChange = jest.fn();
         render(
             <SearchableDropdown
@@ -508,9 +508,9 @@ describe('SearchableDropdown', () => {
         const input = screen.getByRole('combobox');
         userEvent.click(input);
         userEvent.click(screen.getByText('Bedriften'), { button: 1 });
-        expect(document.activeElement).toEqual(input);
-
         const clearButton = screen.getByLabelText('fjern valgt');
+        expect(document.activeElement).toEqual(clearButton);
+
         userEvent.click(clearButton, { button: 1 });
         const toggleButton = screen.getByLabelText('åpne alternativer');
         expect(document.activeElement).toEqual(toggleButton);

--- a/packages/ffe-searchable-dropdown-react/src/a11y.js
+++ b/packages/ffe-searchable-dropdown-react/src/a11y.js
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import {
     getItemClearedA11yStatus,
     getItemSelectedA11yStatus,
@@ -110,15 +110,25 @@ export const useSetAllyMessageItemSelection = ({
     previousResultCount,
     isExpanded,
 }) => {
+    const selectedItemRef = useRef(null);
+    const prevSelectedItemRef = useRef(null);
+
     useEffect(() => {
         if (isInitialMount) {
             return;
         }
 
+        const selectedItemValue = selectedItem?.[searchAttributes[0]];
+        const prevSelectedItemValue = prevSelectedItem?.[searchAttributes[0]];
+        const selectedItemHasChanged =
+            selectedItemRef.current !== selectedItemValue &&
+            prevSelectedItemRef.current !== prevSelectedItemValue;
         if (
-            selectedItem?.[searchAttributes[0]] !==
-            prevSelectedItem?.[searchAttributes[0]]
+            selectedItemValue !== prevSelectedItemValue &&
+            selectedItemHasChanged
         ) {
+            selectedItemRef.current = selectedItemValue;
+            prevSelectedItemRef.current = prevSelectedItemValue;
             updateA11yStatus(() => {
                 return getItemSelectedMessage({
                     selectedItem,


### PR DESCRIPTION
Focusing the input field would make the keyboard pop up on mobile devices
even if the user only clicked the toggle button
and selected straight from the dropdown like a regular select element.

<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse

<!-- Detaljert beskrivelse av endringene dine. Skjermskudd er lov. -->

## Motivasjon og kontekst

<!-- Hvorfor trengs denne endringen, og hva løser den? -->

## Testing

<!-- Hvordan har du har testet endringene dine? Ta gjerne med systeminfo o.l -->

<!--

Helt til slutt, har du ..

.. lest retningslinjene våre for bidrag?
.. tatt en siste sjekk for kode og skrivefeil, debug informasjon o.l?
.. kjørt og eventuelt oppdatert testene?
.. kommentert og dokumentert det som trengs?
.. knyttet denne opp til relaterte issues?

-->
