### PR TITLE
feat(ffe-form-react): fieldMessage as function

### DIFF
--- a/packages/ffe-form-react/src/InputGroup.js
+++ b/packages/ffe-form-react/src/InputGroup.js
@@ -21,9 +21,10 @@ const InputGroup = ({
 }) => {
     const [id] = useState(inputId ? inputId : `input-${uuid()}`);
     const descriptionId = description ? `${id}-description` : undefined;
-    const fieldMessageId = fieldMessage
-        ? (fieldMessage.props && fieldMessage.props.id) || `${id}-fieldmessage`
-        : undefined;
+    const fieldMessageReturn =
+        typeof fieldMessage === 'function'
+            ? fieldMessage(`${id}-fieldmessage`)
+            : null;
 
     if (React.Children.count(children) > 1) {
         throw new Error(
@@ -31,6 +32,16 @@ const InputGroup = ({
                 'InputGroup, please use the function-as-a-child pattern outlined in the documentation.',
         );
     }
+
+    const getFieldMessageId = () => {
+        if (fieldMessage?.props?.id) {
+            return fieldMessage.props.id;
+        } else if (typeof fieldMessage === 'string' || fieldMessageReturn) {
+            return `${id}-fieldmessage`;
+        }
+    };
+
+    const fieldMessageId = getFieldMessageId();
 
     if (
         onTooltipToggle &&
@@ -52,7 +63,8 @@ const InputGroup = ({
     const isInvalid =
         !!fieldMessage &&
         (typeof fieldMessage === 'string' ||
-            fieldMessage.type === ErrorFieldMessage);
+            fieldMessage.type === ErrorFieldMessage ||
+            !!fieldMessageReturn);
 
     const hasMessage = !!fieldMessage;
 
@@ -117,6 +129,7 @@ const InputGroup = ({
                 React.cloneElement(fieldMessage, {
                     id: fieldMessageId,
                 })}
+            {fieldMessageReturn}
         </div>
     );
 };
@@ -135,7 +148,7 @@ InputGroup.propTypes = {
      */
     extraMargin: bool,
     /** Use the ErrorFieldMessage component if you need more flexibility in how the content is rendered. */
-    fieldMessage: oneOfType([string, node]),
+    fieldMessage: oneOfType([string, node, func]),
     /** To just render a static, always visible tooltip, use this. */
     description: string,
     /** Use the Label component if you need more flexibility in how the content is rendered. */

--- a/packages/ffe-form-react/src/InputGroup.md
+++ b/packages/ffe-form-react/src/InputGroup.md
@@ -264,5 +264,16 @@ const { Input } = require('.');
             onBlur={e => console.log('onBlur', e.target.value)}
         />
     </InputGroup>
+
+    <InputGroup
+        label="Email"
+        fieldMessage={fieldMessageId => (
+            <ErrorFieldMessage id={fieldMessageId}>
+                Jeg er en returverdi av en funksjon
+            </ErrorFieldMessage>
+        )}
+    >
+        <Input name="email" />
+    </InputGroup>
 </React.Fragment>;
 ```

--- a/packages/ffe-form-react/src/InputGroup.spec.js
+++ b/packages/ffe-form-react/src/InputGroup.spec.js
@@ -252,4 +252,38 @@ describe('<InputGroup>', () => {
             wrapper.find('.ffe-small-text').prop('id'),
         );
     });
+
+    describe('function as fieldMessage', () => {
+        it('should set up aria-describedby and call function with fieldMessageId', () => {
+            const wrapper = getWrapper({
+                fieldMessage: fieldMessageId => (
+                    <div id={fieldMessageId} data-testid="error-element">
+                        Jag er en feil
+                    </div>
+                ),
+            });
+
+            const input = wrapper.find(Input);
+
+            const ariaDescribedBy = input.prop('aria-describedby');
+            const errorMessageId = wrapper
+                .find({ 'data-testid': 'error-element' })
+                .prop('id');
+            expect(ariaDescribedBy).toEqual(errorMessageId);
+            expect(input.prop('aria-invalid')).toEqual('true');
+        });
+
+        it('should be possible to return falsy value', () => {
+            const wrapper = getWrapper({
+                fieldMessage: () => null,
+            });
+            const input = wrapper.find(Input);
+            const ariaDescribedBy = input.prop('aria-describedby');
+            expect(ariaDescribedBy).toBeUndefined();
+            expect(
+                wrapper.find({ 'data-testid': 'error-element' }).exists(),
+            ).toBeFalsy();
+            expect(input.prop('aria-invalid')).toEqual('false');
+        });
+    });
 });


### PR DESCRIPTION
## Beskrivelse

Team sparing og måten vi lager forms på har slitit med denne komponenten en stund nå og på tide og ta tjuren vid hornen. 
Issues vårt er ju att vi brukt kompenten slik

```
<InputGroup fieldMessage={<FormError name="email"/>} />

```

Det funker dåligt da aria-invalid ikke blir korrekt satt. Løsningen her lar deg bruke en funksjon. som fieldMessage. Her er hvordan jag ser før meg att vi på team sparing kan bruke dette. 

```
import React from 'react';
import {useForm} from 'react-final-form';
import {ErrorFieldMessage, InputGroup} from '@sb1/ffe-form-react';
import {FormApi} from "final-form";

const getFormError = (form: FormApi) => (name: string) => (fieldMessageId: string) => {
    const state = form.getState();

    return state.submitFailed && state.errors?[name]
        ? <ErrorFieldMessage id={fieldMessageId}>Dette gikk ju ikke så bra {state.errors?[name]}</ErrorFieldMessage>
        : null;
}

const Demo: React.FC = () => {

    const form: FormApi = useForm()
    const formError = getFormError(form);

    return (
        <InputGroup fieldMessage={formError('email')}>
            <input name="email" type="text" />
        </InputGroup>
    )

}

```

## Testing
Laget tester og sjekket att det gamla ikke brakk. 
