### PR TITLE
fix(ffe-context-message): fjerner overstyring av linkfarge samt oppda…

### DIFF
--- a/packages/ffe-context-message/less/ffe-context-message.less
+++ b/packages/ffe-context-message/less/ffe-context-message.less
@@ -57,11 +57,9 @@
             @media (prefers-color-scheme: dark) {
                 color: @ffe-farge-svart;
             }
-            a {
-                @media (prefers-color-scheme: dark) {
-                    color: @ffe-farge-svart;
-                }
-            }
+        }
+        .ffe-link-text {
+            color: @ffe-farge-fjell;
         }
     }
 
@@ -69,7 +67,7 @@
         &:extend(.ffe-h5);
         .native & {
             @media (prefers-color-scheme: dark) {
-                color: @ffe-white-darkmode;
+                color: @ffe-farge-hvit;
             }
         }
 
@@ -83,7 +81,7 @@
         flex-shrink: 0;
         justify-content: center;
         margin-bottom: @app-margin;
-        background-color: @ffe-white;
+        background-color: @ffe-farge-hvit;
         border-radius: 50%;
         height: 4em;
         width: 4em;
@@ -92,12 +90,7 @@
             height: 2.2em;
             width: 2.2em;
             padding: @ffe-spacing-2xs;
-            fill: @ffe-blue-royal;
-            .native & {
-                @media (prefers-color-scheme: dark) {
-                    fill: @ffe-farge-fjell;
-                }
-            }
+            fill: @ffe-farge-fjell;
         }
 
         @media (min-width: @breakpoint-sm) {
@@ -121,11 +114,7 @@
         background-color: transparent;
         height: 1em;
         width: 1em;
-        .native & {
-            @media (prefers-color-scheme: dark) {
-                fill: @ffe-grey-silver-darkmode;
-            }
-        }
+
         &:hover {
             fill: @ffe-farge-svart;
         }
@@ -172,11 +161,6 @@
             width: 1.5em;
             padding: @ffe-spacing-2xs;
             fill: @ffe-farge-fjell;
-            .native & {
-                @media (prefers-color-scheme: dark) {
-                    fill: @ffe-white-darkmode;
-                }
-            }
         }
     }
 
@@ -209,23 +193,11 @@
         background-color: @ffe-farge-baer-30;
 
         .ffe-context-message-content__header {
-            color: @ffe-black;
-
-            .native & {
-                @media (prefers-color-scheme: dark) {
-                    color: @ffe-white-darkmode;
-                }
-            }
+            color: @ffe-farge-svart;
         }
 
         .ffe-context-message-content__icon-svg {
             fill: @ffe-farge-baer-wcag;
-
-            .native & {
-                @media (prefers-color-scheme: dark) {
-                    fill: @ffe-red-darkmode;
-                }
-            }
         }
     }
 }


### PR DESCRIPTION
…terte farger

BREAKING CHANGE: dersom man bruker lenker i en kontekstmelding må fargen på disse spesifiseres

<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse

* Fjerner en overstyring på farge på `.native .ffe-context-message-content .ffe-body-text a`. Denne innebar at alle lenker i en kontekstmelding fikk svart farge i darkmode, uavhengig av klasse. En følgefeil av dette var svart tekst på shortcutbutton

![image](https://user-images.githubusercontent.com/463847/128183856-63772ae7-7cab-45f8-8a54-05aae81f876c.png)

* Fjerner også overstyring av tekstfarge på header, som ikke lenger skal være hvit i darkmode (se skjermskudd over)
* Oppdaterer en del fargevariabler som ikke ble med i forrige runde


## Motivasjon og kontekst

Endringen er nødvendig for at kontekstmeldinger skal rendres riktig både med og uten darkmode aktivert.

<!--

Helt til slutt, har du ..

.. lest retningslinjene våre for bidrag?
.. tatt en siste sjekk for kode og skrivefeil, debug informasjon o.l?
.. kjørt og eventuelt oppdatert testene?
.. kommentert og dokumentert det som trengs?
.. knyttet denne opp til relaterte issues?

-->
