### PR TITLE
fix(ffe-formatters): formatCurrency also accepts a number

### DIFF
--- a/packages/ffe-formatters/src/formatCurrency.spec.js
+++ b/packages/ffe-formatters/src/formatCurrency.spec.js
@@ -4,14 +4,14 @@ import formatCurrency from './formatCurrency';
 describe('format currency', () => {
     test('does not show decimals for whole moneys', () => {
         expect(formatCurrency('999.00')).toBe(`kr${NON_BREAKING_SPACE}999,–`);
-        expect(formatCurrency('1234')).toBe(
+        expect(formatCurrency(1234)).toBe(
             `kr${NON_BREAKING_SPACE}1${NON_BREAKING_SPACE}234,–`,
         );
     });
 
     test('show decimals for moneys which are not whole', () => {
         expect(formatCurrency('999.99')).toBe(`kr${NON_BREAKING_SPACE}999,99`);
-        expect(formatCurrency('1234.90')).toBe(
+        expect(formatCurrency(1234.90)).toBe(
             `kr${NON_BREAKING_SPACE}1${NON_BREAKING_SPACE}234,90`,
         );
     });
@@ -23,7 +23,7 @@ describe('format currency', () => {
         expect(formatCurrency('1234', { postfix: '' })).toBe(
             `kr${NON_BREAKING_SPACE}1${NON_BREAKING_SPACE}234`,
         );
-        expect(formatCurrency('1234', { prefix: '', postfix: '' })).toBe(
+        expect(formatCurrency(1234, { prefix: '', postfix: '' })).toBe(
             `1${NON_BREAKING_SPACE}234`,
         );
     });

--- a/packages/ffe-formatters/src/index.d.ts
+++ b/packages/ffe-formatters/src/index.d.ts
@@ -2,7 +2,7 @@ declare module '@sb1/ffe-formatters' {
     export function formatAccountNumber(accountNumber: string): string;
 
     export function formatCurrency(
-        amount: string,
+        amount: number | string,
         opts?: { prefix?: string; postfix?: string },
     ): string;
 


### PR DESCRIPTION
## Beskrivelse

Etter å ha bumpet til ffe-formatters 4.0.0 fikk vi endelig typede funksjoner, men jeg merket da at vi fikk en del klager på bruken av `formatCurrency`. Vi sender `number` til denne funksjonen, men den er kun typet med `string`.

## Motivasjon og kontekst

Denne endringen løser problemet beskrevet ovenfor. Funksjonen fungerer like godt med både `number` og `string`. Faktisk så bruker den `formatNumber` internt, og denne er typet med å kunne ta både `number` og `string`. Det gir derfor ingen mening å være mer begrensende med denne funksjonen.

## Testing

Jeg skrev i commiten "This commit doesn't change any code", men det er kanskje ikke heelt sant, siden jeg endrer litt på testene. For å verifisere at funksjonen fungere fint med `numner` input, endret jeg noen av testene til å sende inn tall istedenfor tekst. Testene kjører like grønt som før.