### PR TITLE
docs: Forbedre dokumentasjon for meldinger

### DIFF
--- a/src/styles/examples/examples.less
+++ b/src/styles/examples/examples.less
@@ -62,3 +62,12 @@
 .sb1ds-dos-donts {
     margin-bottom: @ffe-spacing-lg;
 }
+
+.sb1ds-example--grid__col-2 {
+    display: grid;
+    grid-template-columns: repeat(2, auto);
+    grid-column-gap: 0.5rem;
+    grid-row-gap: 0.5rem;
+    align-items: start;
+    margin: @ffe-spacing-xs 0;
+}

--- a/styleguide-content/komponenter/meldinger-bokser.md
+++ b/styleguide-content/komponenter/meldinger-bokser.md
@@ -1,14 +1,44 @@
+Meldingsbokser inneholder reelle tips eller informasjon til brukere. Disse holdes konsise, og ikke brukes til å forklare ting "man ikke finner noe annet sted til".
 
-Hold det kort og konsist! Det skal være reelle tips/informasjon til brukeren, ikke informasjon vi ønsker å forklare her
-fordi vi ikke finner noe annet sted å gjøre det. For mye tekst kan føre til at komponenten mister sin verdi. 
+Bruk Meldingsbokser når:
 
+✅ Du trenger å informere kort om ett tema
 
-Det finnes fire forskjellige typer:
+✅ Du trenger å utheve noe informasjon fra enn større sammenheng.
 
-1.  Tips
-2.  Info
-3.  Suksess
-4.  Error
+✅ Du har innhold som skal utheves, men som er selvforklarende uten kontekst.
+
+```jsx
+<React.Fragment>
+    <div className="sb1ds-example--grid__col-2">
+        <TipsMessage title="Kjøre bil i utlandet?">
+            <p className="ffe-body-paragraph">
+                Dersom du skal ha med bilen til utlandet, anbefaler vi at du har
+                med deg grønt kort. Grønt kort er et internasjonalt
+                forsikringsbevis som viser at du har en gyldig
+                ansvarsforsikring.
+            </p>
+        </TipsMessage>
+        <InfoMessage title="Ingen transaksjoner">
+            <p className="ffe-body-paragraph">
+                Fant ingen transaksoner å vise for den valgte perioden.
+            </p>
+        </InfoMessage>
+        <SuccessMessage title="Overskrift">
+            <p className="ffe-body-paragraph">
+                Brødtekst som beskriver i mer detalj hva som har skjedd
+            </p>
+        </SuccessMessage>
+        <ErrorMessage title="Overskrift">
+            <p className="ffe-body-paragraph">
+                Brødtekst som beskriver feilsituasjonen i mer detalj
+            </p>
+        </ErrorMessage>
+    </div>
+</React.Fragment>
+```
+
+#### Med liste
 
 ```jsx
 const {
@@ -17,75 +47,19 @@ const {
 } = require('../../packages/ffe-message-box-react/src');
 
 <React.Fragment>
-    <Grid>
-        <GridRow>
-            <GridCol md={6}>
-                <TipsMessage title="Overskrift">
-                    <p className="ffe-body-paragraph">
-                        Brødtekst som beskriver i mer detalj
-                    </p>
-                </TipsMessage>
-            </GridCol>
-            <GridCol md={6}>
-                <TipsMessage title="Overskrift">
-                    <InfoMessageList>
-                        <InfoMessageListItem>Punkt én</InfoMessageListItem>
-                        <InfoMessageListItem>Punkt to</InfoMessageListItem>
-                    </InfoMessageList>
-                </TipsMessage>
-            </GridCol>
-        </GridRow>
-        <GridRow>
-            <GridCol md={6}>
-                <InfoMessage title="Overskrift">
-                    <p className="ffe-body-paragraph">
-                        Brødtekst som beskriver i mer detalj
-                    </p>
-                </InfoMessage>
-            </GridCol>
-            <GridCol md={6}>
-                <InfoMessage title="Overskrift">
-                    <InfoMessageList>
-                        <InfoMessageListItem>Punkt én</InfoMessageListItem>
-                        <InfoMessageListItem>Punkt to</InfoMessageListItem>
-                    </InfoMessageList>
-                </InfoMessage>
-            </GridCol>
-        </GridRow>
-        <GridRow>
-            <GridCol md={6}>
-                <SuccessMessage title="Overskrift">
-                    <p className="ffe-body-paragraph">
-                        Brødtekst som beskriver i mer detalj hva som har skjedd
-                    </p>
-                </SuccessMessage>
-            </GridCol>
-            <GridCol md={6}>
-                <SuccessMessage title="Overskrift">
-                    <InfoMessageList>
-                        <InfoMessageListItem>Punkt én</InfoMessageListItem>
-                        <InfoMessageListItem>Punkt to</InfoMessageListItem>
-                    </InfoMessageList>
-                </SuccessMessage>
-            </GridCol>
-        </GridRow>
-        <GridRow>
-            <GridCol md={6}>
-                <ErrorMessage title="Overskrift">
-                    <p className="ffe-body-paragraph">
-                        Brødtekst som beskriver feilsituasjonen i mer detalj
-                    </p>
-                </ErrorMessage>
-            </GridCol>
-            <GridCol md={6}>
-                <ErrorMessage title="Overskrift">
-                    <InfoMessageList>
-                        <InfoMessageListItem>Feil én</InfoMessageListItem>
-                        <InfoMessageListItem>Feil to</InfoMessageListItem>
-                    </InfoMessageList>
-                </ErrorMessage>
-            </GridCol>
-        </GridRow>
-    </Grid>
+    <div className="sb1ds-example--grid__col-2">
+        <TipsMessage title="Overskrift">
+            <InfoMessageList>
+                <InfoMessageListItem>Punkt én</InfoMessageListItem>
+                <InfoMessageListItem>Punkt to</InfoMessageListItem>
+            </InfoMessageList>
+        </TipsMessage>
+        <InfoMessage title="Overskrift">
+            <InfoMessageList>
+                <InfoMessageListItem>Punkt én</InfoMessageListItem>
+                <InfoMessageListItem>Punkt to</InfoMessageListItem>
+            </InfoMessageList>
+        </InfoMessage>
+    </div>
 </React.Fragment>;
 ```

--- a/styleguide-content/komponenter/meldinger-farger.md
+++ b/styleguide-content/komponenter/meldinger-farger.md
@@ -1,0 +1,19 @@
+Alle meldingskomponentene kommer i 4 farge-varianter.
+
+Hvilken av disse man skal bruke, avhenger av hva slags informasjon man prøver å formidle. Er det ren informasjon, som brukeren bør få med seg, er info varianten god å bruke.
+
+#### Tips / News
+
+Tips kan brukes dersom man ønsker å tipse brukeren om alternativer, eller andre valg. Dette kan også være informasjon som brukere ikke må forholde seg til. F.eks tips til andre tjenester, forenkling av prosesser etc.
+
+#### Info
+
+Info brukes der man ønsker å informere om noe som ikke er kritisk informasjon. Det kan for eksempel være planlagt vedlikehold, endring av tjenester eller ønske om at brukerne bekrefter kontaktinformasjon.
+
+#### Suksess
+
+Suksess varianten brukes til å formidle "gode nyheter", eller når ønsket respons på en handling skjer. Dette kan f.eks være om en tjeneste blir tilgjengelig igjen, eller om betaling er gjennomført.
+
+#### Error
+
+Error-varianten brukes kun i sammenhenger der det har skjedd en feil, eller om det er en pågående feil. Dette kan f.eks være at en tjeneste er nede akkurat nå, eller at en betaling ikke gikk igjennom.

--- a/styleguide-content/komponenter/meldinger-kontekstuelle.md
+++ b/styleguide-content/komponenter/meldinger-kontekstuelle.md
@@ -1,48 +1,29 @@
-```jsx
-const { InfoIkon } = require('../../packages/ffe-icons-react/lib');
+Konteksuelle meldinger er informasjon som skal gis i en kontekst. Dette er meldinger som skal utheves, men som kun gir mening i konteksten den er plassert. I motsetning til systemmeldinger, kan disse meldingene plasseres midt i innholdet på siden.
 
-<ContextInfoMessage icon={<InfoIkon />}>
-    Denne seksjonen er ikke ferdig skrevet enda
-</ContextInfoMessage>;
-```
+Bruk kontekstuelle meldinger når:
 
-Kommer i samme variasjoner av fargedrakt som [Meldinger, bokser](#meldinger-bokser).
-Kontekstuelle meldinger har i tillegg flere variasjoner innad i samme type melding.
+✅ Du vil gi ekstra informasjon i en gitt situasjon
+
+❌ Ikke bruk hvis man egentlig bare trenger en brødtekst.
 
 ```jsx
-const { InfoIkon } = require('../../packages/ffe-icons-react/lib');
+const { LyspareIkon } = require('../../packages/ffe-icons-react/lib');
 
 <React.Fragment>
-    <Grid>
-        <GridRow>
-            <GridCol md={6}>
-                <ContextInfoMessage>Standard</ContextInfoMessage>
-            </GridCol>
-            <GridCol md={6}>
-                <ContextInfoMessage compact={true}>
-                    Kompakt variant
-                </ContextInfoMessage>
-            </GridCol>
-        </GridRow>
-        <GridRow>
-            <GridCol md={6}>
-                <ContextInfoMessage header="Til info">
-                    Med header
-                </ContextInfoMessage>
-            </GridCol>
-            <GridCol md={6}>
-                <ContextInfoMessage icon={<InfoIkon />}>
-                    Med ikon
-                </ContextInfoMessage>
-            </GridCol>
-        </GridRow>
-        <GridRow>
-            <GridCol>
-                <ContextInfoMessage showCloseButton={true}>
-                    Lukkbar
-                </ContextInfoMessage>
-            </GridCol>
-        </GridRow>
-    </Grid>
+    <div className="sb1ds-example--grid__col-2">
+        <ContextInfoMessage>
+            Tilgangen til dine kontoer i "Annen bank" har utløpt
+        </ContextInfoMessage>
+        <ContextErrorMessage compact={true}>
+            Kompakt variant
+        </ContextErrorMessage>
+        <ContextSuccessMessage headerText="Hurra!">
+            Betalingen ble registrert!
+        </ContextSuccessMessage>
+        <ContextTipMessage icon={<LyspareIkon />}>
+            Visste du at du kan få en skattefordel ved sparing i IPS?
+        </ContextTipMessage>
+        <ContextInfoMessage showCloseButton={true}>Lukkbar</ContextInfoMessage>
+    </div>
 </React.Fragment>;
 ```

--- a/styleguide-content/komponenter/meldinger-system.md
+++ b/styleguide-content/komponenter/meldinger-system.md
@@ -1,16 +1,14 @@
-Denne typen meldinger skal kun benyttes til viktige meldinger som skal eksponeres til brukeren, men som
-er av midlertidig art.
+Systemmeldinger skal kun benyttes til viktige, men midlertidige meldinger. Disse meldingene plasseres direkte under headeren, og det skal helst kun brukes 1 per side.
 
-Systemmeldingen plasseres direkte under headeren. Teksten venstrejusteres, og venstre marg følger det øvrige innholdet
-på siden. Lukk-knappen høyrejusteres til å være på linje med høyre marg. Meldingen plasseres i vanlig layout flow. Dersom
-flere meldinger skal vises samtidig (frarådes) legges disse under hverandre som i listen under.
+Bruk systemmelding:
 
-Det finnes fire typer:
+✅ Der meldingen skal vises i en gitt tidsperiode
 
-1.  Info
-2.  News
-3.  Success
-4.  Error
+✅ Når det skal brukes til informasjon, som ikke krever en handling fra bruker.
+
+❌ Ikke bruk der det ikke gir mening at meldingen er rett under header.
+
+❌ Ikke bruk om der det skal vises mange meldinger samtidig.
 
 ```jsx
 <React.Fragment>
@@ -18,11 +16,9 @@ Det finnes fire typer:
         Mobilbanken vil være utilgjengelig førstkommende fredag kl 19-20.
     </SystemInfoMessage>
     <SystemNewsMessage>
-        Mobilbanken vil være utilgjengelig førstkommende fredag kl 19-20.
+        Kontoret holdes stengt tilogmed fredag kl 14.
     </SystemNewsMessage>
-    <SystemSuccessMessage>
-        Mobilbanken vil være utilgjengelig førstkommende fredag kl 19-20.
-    </SystemSuccessMessage>
+    <SystemSuccessMessage>Pengene er overført!</SystemSuccessMessage>
     <SystemErrorMessage>
         Noen av systemene våre er dessverre utilgjengelige akkurat nå.
     </SystemErrorMessage>

--- a/styleguide-content/komponenter/meldinger.md
+++ b/styleguide-content/komponenter/meldinger.md
@@ -1,14 +1,9 @@
-Målet med meldinger er å bekrefte og skape trygghet hos brukeren, slik at hun/han opplever kontroll over situasjonen.
+I designsystemet finnes det 3 forskjellige meldingskomponenter, og hvilken som skal brukes kommer ann på hva slags type informasjon man ønsker å gi brukeren. Felles for alle er at de bør holdes korte og konsiste, innholde relevante tips eller informasjon som brukeren trenger å vite. Eksempler på situasjoner der meldinger kan brukes er f.eks når systemet er nede, betaling er gjennomført eller at det kommer en eller flere endringer på en tjeneste.
 
-Prinsipper:
+Målet med meldinger er å bekrefte å skape trygghet hos brukere slik at de opplever kontroll over situasjonen.
 
--   Relevante og informative
--   Meldingsboksen er responsive, tilpasses innholdets lengde og skaleres etter flaten den vises i.
--   Teksten skal være forståelig og vennlig (følge retningslinjer for [stil og tone](/stil-og-tone.html))
--   Vi skiller på meldinger som er fra systemet og de som er fra SpareBank 1.
--   Boksene skal ha overskrift, og teksten skal være midtstilt, men i de tilfellene man har punkter vil teksten være    
-    venstrejustert.
+Noen prinsipper som bør følges er:
 
-Meldingsbokser brukes når man skal informere brukeren om diverse endringer/oppdateringer. Dette kan f.eks være når
-systemet er nede eller at betalingen er gjennomført. Hold innholdet kort og konsist, det skal være relevante tips
-eller informasjon som brukeren behøver å vite.
+-   Meldingene skal være relevante og informative
+-   Selve meldingsboksen skal være responsive, og tilpasses innholdets lengde og skaleres etter flaten den vises i. (f.eks full bredde på mobil)
+-   Teksten skal følge retningslinjene nevnt i [Stil og tone](/stil-og-tone.html).

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -302,6 +302,11 @@ module.exports = {
                     content: 'styleguide-content/komponenter/meldinger.md',
                     sections: [
                         {
+                            name: 'Valg av farge-variant',
+                            content:
+                                'styleguide-content/komponenter/meldinger-farger.md',
+                        },
+                        {
                             name: 'Meldingsbokser',
                             content:
                                 'styleguide-content/komponenter/meldinger-bokser.md',


### PR DESCRIPTION
## Beskrivelse

Dokumentasjonen for meldinger var ganske mangelfull, så har skrevet om all dokumentasjonen og prøvd å få inn
noen konkrete tips, og eksempler tatt fra virkeligheten.
Har også fjernet grid komponenten fra eksemplene, siden vi er usikre på hva vi skal gjøre med den komponenten - pluss at jeg synes det rotet til "kode eksempelet" en del. 

Fikset også feil i ett eksempel, der header eksempelet på kontekstmelding ikke fungerte, da den hadde byttet prop-navn.

En annen ting som er verdt å legge merke til er at jeg har fjernet en del av teksten som bare omhandlet selve designet av boksene, da jeg ikke så helt poenget med å beskrive det, når det er snakk om ferdige komponenter som skal brukes.

![Skjermbilde 2021-08-11 kl  17 05 21](https://user-images.githubusercontent.com/39946146/129054719-b07de550-d1ca-42b9-8d34-e236341a2173.png)
![Skjermbilde 2021-08-11 kl  17 05 29](https://user-images.githubusercontent.com/39946146/129054725-f933c7bd-5853-4551-884e-715b36eacf0e.png)

## Motivasjon og kontekst

Målet er at det skal være enklere for brukere å skjønne hvilken boks som skal brukes til hvilket scenario, 
og få bedre oversikt over hva som finnes av varianter.

## Testing
Kjørt opp lokalt, og testet at eksemplene vises riktig på mindre skjerm

