### PR TITLE
Fix context message tittel farge

### DIFF
--- a/packages/ffe-context-message-react/src/ContextErrorMessage.md
+++ b/packages/ffe-context-message-react/src/ContextErrorMessage.md
@@ -15,7 +15,7 @@ const { UtropstegnIkon } = require('@sb1/ffe-icons-react');
 ```
 
 ```js
-<ContextErrorMessage header="Opps...">
+<ContextErrorMessage headerText="Opps...">
     Dette gikk ikke som forventet i det hele tatt!
 </ContextErrorMessage>
 ```

--- a/packages/ffe-context-message-react/src/ContextInfoMessage.md
+++ b/packages/ffe-context-message-react/src/ContextInfoMessage.md
@@ -13,7 +13,7 @@ const { InfoIkon } = require('@sb1/ffe-icons-react');
 ```
 
 ```js
-<ContextInfoMessage header="Til info">
+<ContextInfoMessage headerText="Til info">
     Nå har det kommet noe nytt og spennende fra SpareBank 1!
 </ContextInfoMessage>
 ```

--- a/packages/ffe-context-message-react/src/ContextSuccessMessage.md
+++ b/packages/ffe-context-message-react/src/ContextSuccessMessage.md
@@ -11,7 +11,7 @@ const { HakeIkon } = require('@sb1/ffe-icons-react');
 ```
 
 ```js
-<ContextSuccessMessage header="Hurra!">
+<ContextSuccessMessage headerText="Hurra!">
     Betalingen ble registrert!
 </ContextSuccessMessage>
 ```

--- a/packages/ffe-context-message-react/src/ContextTipMessage.md
+++ b/packages/ffe-context-message-react/src/ContextTipMessage.md
@@ -13,7 +13,7 @@ const { LyspareIkon } = require('@sb1/ffe-icons-react');
 ```
 
 ```js
-<ContextTipMessage header="Tips">
+<ContextTipMessage headerText="Tips">
     Visste du at du kan få en skattefordel ved sparing i IPS?
 </ContextTipMessage>
 ```

--- a/packages/ffe-context-message/less/ffe-context-message.less
+++ b/packages/ffe-context-message/less/ffe-context-message.less
@@ -65,6 +65,7 @@
 
     &__header {
         &:extend(.ffe-h5);
+
         color: @ffe-farge-svart;
         margin-bottom: @ffe-spacing-2xs;
     }

--- a/packages/ffe-context-message/less/ffe-context-message.less
+++ b/packages/ffe-context-message/less/ffe-context-message.less
@@ -65,12 +65,7 @@
 
     &__header {
         &:extend(.ffe-h5);
-        .native & {
-            @media (prefers-color-scheme: dark) {
-                color: @ffe-farge-hvit;
-            }
-        }
-
+        color: @ffe-farge-svart;
         margin-bottom: @ffe-spacing-2xs;
     }
 


### PR DESCRIPTION
## Beskrivelse

Kontekstmeldingene har en tittel property, som hadde feil navn i eksemplene som var vist på github, så rettet til nytt prop navn.  Fargen på tittelen var også fortsatt blå, men den er nå endret til sort både i light og dark mode, sånn at den blir lik de andre boksene.

## Motivasjon og kontekst

Fint å ha riktig farge på tittelen i kontekstbokser, slik at vi ikke får problemer med kontrast.
Også fint at eksempelene på github er oppdatert med riktig propnavn.

## Testing

Kjørt opp lokalt, og sjekket om fargen nå er riktig på tittel i light og darkmode. 
Endringen på github er ikke testet, men det er bare en markdown endring.

