### PR TITLE
Hardkode farger

### DIFF
--- a/packages/ffe-core/less/colors.less
+++ b/packages/ffe-core/less/colors.less
@@ -67,48 +67,48 @@
 
 // Primærpalett
 @ffe-farge-fjell: #002776;
-@ffe-farge-fjell-70: tint(@ffe-farge-fjell, 30%);
-@ffe-farge-fjell-30: tint(@ffe-farge-fjell, 70%);
+@ffe-farge-fjell-70: #4d689f);
+@ffe-farge-fjell-30: #b3bed6;
 @ffe-farge-vann: #005aa4;
-@ffe-farge-vann-70: tint(@ffe-farge-vann, 30%);
-@ffe-farge-vann-30: tint(@ffe-farge-vann, 70%);
+@ffe-farge-vann-70: #4d8cbf;
+@ffe-farge-vann-30: #b3cee4;
 @ffe-farge-sand: #f8e9dd;
-@ffe-farge-sand-70: tint(@ffe-farge-sand, 30%);
-@ffe-farge-sand-30: tint(@ffe-farge-sand, 70%);
+@ffe-farge-sand-70: #faf0e7;
+@ffe-farge-sand-30: #fdf8f5;
 @ffe-farge-frost: #7eb5d2;
-@ffe-farge-frost-70: tint(@ffe-farge-frost, 30%);
-@ffe-farge-frost-30: tint(@ffe-farge-frost, 70%);
+@ffe-farge-frost-70: #a5cbe0;
+@ffe-farge-frost-30: #d8e9f2;
 @ffe-farge-syrin: #d3d3ea;
-@ffe-farge-syrin-70: tint(@ffe-farge-syrin, 30%);
-@ffe-farge-syrin-30: tint(@ffe-farge-syrin, 70%);
+@ffe-farge-syrin-70: #e0e0f0;
+@ffe-farge-syrin-30: #f2f2f9;
 
 // Støttefarger
 @ffe-farge-myrull: #fae4e0;
-@ffe-farge-myrull-70: tint(@ffe-farge-myrull, 30%);
-@ffe-farge-myrull-30: tint(@ffe-farge-myrull, 70%);
+@ffe-farge-myrull-70: #fcece9;
+@ffe-farge-myrull-30: #fef7f6;
 @ffe-farge-villblomst: #ee8d9c;
-@ffe-farge-villblomst-70: tint(@ffe-farge-villblomst, 30%);
-@ffe-farge-villblomst-30: tint(@ffe-farge-villblomst, 70%);
+@ffe-farge-villblomst-70: #f3afba;
+@ffe-farge-villblomst-30: #fadde1;
 @ffe-farge-nordlys: #33af85;
 @ffe-farge-nordlys-wcag: #257e60;
-@ffe-farge-nordlys-70: tint(@ffe-farge-nordlys, 30%);
-@ffe-farge-nordlys-30: tint(@ffe-farge-nordlys, 70%);
+@ffe-farge-nordlys-70: #70c7aa;
+@ffe-farge-nordlys-30: #c2e7da;
 @ffe-farge-lyng: #873953;
-@ffe-farge-lyng-70: tint(@ffe-farge-lyng, 30%);
-@ffe-farge-lyng-30: tint(@ffe-farge-lyng, 70%);
+@ffe-farge-lyng-70: #ab7487;
+@ffe-farge-lyng-30: #dbc4cb;
 @ffe-farge-baer: #e44244;
 @ffe-farge-baer-wcag: #e12d2f;
-@ffe-farge-baer-70: tint(@ffe-farge-baer, 30%);
-@ffe-farge-baer-30: tint(@ffe-farge-baer, 70%);
+@ffe-farge-baer-70: #ec7b7c;
+@ffe-farge-baer-30: #f7c6c7;
 @ffe-farge-skog: #285949;
-@ffe-farge-skog-70: tint(@ffe-farge-skog, 30%);
-@ffe-farge-skog-30: tint(@ffe-farge-skog, 70%);
+@ffe-farge-skog-70: #698b80;
+@ffe-farge-skog-30: #bfcdc8;
 @ffe-farge-multe: #f8b181;
-@ffe-farge-multe-70: tint(@ffe-farge-multe, 30%);
-@ffe-farge-multe-30: tint(@ffe-farge-multe, 70%);
+@ffe-farge-multe-70: #fac8a7;
+@ffe-farge-multe-30: #fde8d9;
 @ffe-farge-sol: #dc8000;
-@ffe-farge-sol-70: tint(@ffe-farge-sol, 30%);
-@ffe-farge-sol-30: tint(@ffe-farge-sol, 70%);
+@ffe-farge-sol-70: #e7a64d;
+@ffe-farge-sol-30: #f5d9b3;
 
 // Nøytrale farger
 @ffe-farge-natt: #001032;

--- a/packages/ffe-core/less/colors.less
+++ b/packages/ffe-core/less/colors.less
@@ -67,7 +67,7 @@
 
 // Primærpalett
 @ffe-farge-fjell: #002776;
-@ffe-farge-fjell-70: #4d689f);
+@ffe-farge-fjell-70: #4d689f;
 @ffe-farge-fjell-30: #b3bed6;
 @ffe-farge-vann: #005aa4;
 @ffe-farge-vann-70: #4d8cbf;


### PR DESCRIPTION
Farger med tint() blir ikke eksportert riktig


## Beskrivelse


## Motivasjon og kontekst
For å kunne importere fargene herfra 

import { black, fargeLyng, fargeSyrin } from '@sb1/ffe-core';

slik som 

import { black, fargeLyng30, fargeSyrin70 } from '@sb1/ffe-core';

## Testing
har ikke testet
