### PR TITLE
Oppdaterte farger i ffe-core

### DIFF
--- a/packages/ffe-core/less/colors.less
+++ b/packages/ffe-core/less/colors.less
@@ -70,7 +70,6 @@
 @ffe-farge-fjell-70: tint(@ffe-farge-fjell, 30%);
 @ffe-farge-fjell-30: tint(@ffe-farge-fjell, 70%);
 @ffe-farge-vann: #005aa4;
-@ffe-farge-vann-hover: #00437a;
 @ffe-farge-vann-70: tint(@ffe-farge-vann, 30%);
 @ffe-farge-vann-30: tint(@ffe-farge-vann, 70%);
 @ffe-farge-vann-30-hover: #e1ebf4;
@@ -117,7 +116,6 @@
 @ffe-farge-svart: #020a0a;
 @ffe-farge-koksgraa: #323232;
 @ffe-farge-moerkgraa: #676767;
-@ffe-farge-moerkgraa-wcag: #4a4a4a;
 @ffe-farge-graa: #adadad;
 @ffe-farge-graa-wcag: #949494;
 @ffe-farge-lysgraa: #d8d8d8;
@@ -125,13 +123,3 @@
 @ffe-farge-varmgraa: #9b9797;
 @ffe-farge-lysvarmgraa: #d7d2cb;
 @ffe-farge-hvit: #fff;
-
-// Dark mode
-@ffe-farge-darkmode-svart: #000000; // Default background color
-@ffe-farge-darkmode-hvit: #ffffff; // Emphasized text
-@ffe-farge-darkmode-koksgraa: #1c1c1c; // Emphasized surfaces
-@ffe-farge-darkmode-moerkgraa: #292929; // Interactive surfaces
-@ffe-farge-darkmode-graa: #858585; // Borders and accents
-@ffe-farge-darkmode-lysgraa: #cccccc; // Default font color on default background and form labels
-@ffe-farge-darkmode-vann: #0a91ff; // Primary interaction and icon color
-@ffe-farge-darkmode-baer: #ff2424; // Tweaked ffe-red for better contrast

--- a/packages/ffe-core/less/themes.less
+++ b/packages/ffe-core/less/themes.less
@@ -1,11 +1,11 @@
 // Sets default body color and background color for light and dark themes
 .ffe-body {
-    color: @ffe-black;
-    background-color: @ffe-white;
+    color: @ffe-farge-svart;
+    background-color: @ffe-farge-hvit;
     &.native {
         @media (prefers-color-scheme: dark) {
-            color: @ffe-grey-cloud-darkmode;
-            background-color: @ffe-black-darkmode;
+            color: @ffe-farge-lysgraa;
+            background-color: @ffe-farge-svart;
         }
     }
 }

--- a/packages/ffe-core/less/typography.less
+++ b/packages/ffe-core/less/typography.less
@@ -170,22 +170,32 @@
 }
 
 .ffe-small-text {
-    color: @ffe-grey-charcoal;
+    color: @ffe-farge-svart;
     font-family: 'SpareBank1-regular', 'MuseoSans-500', arial, sans-serif;
     font-weight: normal;
     line-height: 1.25rem;
     .ffe-fontsize-small-text();
+    .native & {
+        @media (prefers-color-scheme: dark) {
+            color: @ffe-farge-lysgraa;
+        }
+    }
     &--dark {
         color: @ffe-white;
     }
 }
 
 .ffe-micro-text {
-    color: @ffe-grey-charcoal;
+    color: @ffe-farge-svart;
     font-family: 'SpareBank1-regular', 'MuseoSans-500', arial, sans-serif;
     font-weight: normal;
     line-height: 1.25rem;
     .ffe-fontsize-micro-text();
+    .native & {
+        @media (prefers-color-scheme: dark) {
+            color: @ffe-farge-lysgraa;
+        }
+    }
 }
 
 .ffe-h1,
@@ -194,21 +204,21 @@
 .ffe-h4,
 .ffe-h5,
 .ffe-h6 {
-    color: @ffe-blue-royal;
+    color: @ffe-farge-fjell;
     font-weight: normal;
     margin-bottom: 10px;
     margin-top: 0;
     .native & {
         @media (prefers-color-scheme: dark) {
-            color: @ffe-white-darkmode;
+            color: @ffe-farge-vann-70;
         }
     }
 
     &--error {
-        color: @ffe-orange-fire;
+        color: @ffe-farge-baer-wcag;
         .native & {
             @media (prefers-color-scheme: dark) {
-                color: @ffe-red-darkmode;
+                color: @ffe-farge-baer;
             }
         }
     }
@@ -222,11 +232,11 @@
     }
 
     &--with-border {
-        border-bottom: 1px solid @ffe-grey-silver;
+        border-bottom: 1px solid @ffe-farge-lysgraa;
         padding-bottom: 10px;
         .native & {
             @media (prefers-color-scheme: dark) {
-                border-color: @ffe-grey-silver-darkmode;
+                border-color: @ffe-farge-graa;
             }
         }
     }
@@ -254,13 +264,13 @@
 }
 
 .ffe-body-text {
-    color: @ffe-black;
+    color: @ffe-farge-svart;
     font-family: 'SpareBank1-regular', 'MuseoSans-500', arial, sans-serif;
     line-height: 1.5rem;
     .ffe-fontsize-body-text();
     .native & {
         @media (prefers-color-scheme: dark) {
-            color: @ffe-grey-cloud-darkmode;
+            color: @ffe-farge-lysgraa;
         }
     }
 }
@@ -269,10 +279,10 @@
     margin-bottom: 1em;
     margin-top: 0;
     line-height: 1.5rem;
-    color: @ffe-black;
+    color: @ffe-farge-svart;
     .native & {
         @media (prefers-color-scheme: dark) {
-            color: @ffe-grey-cloud-darkmode;
+            color: @ffe-farge-lysgraa;
         }
     }
 
@@ -292,60 +302,60 @@
 }
 
 .ffe-lead-paragraph {
-    color: @ffe-blue-royal;
+    color: @ffe-farge-fjell;
     line-height: 1.75rem;
     .ffe-fontsize-lead-paragraph();
     .native & {
         @media (prefers-color-scheme: dark) {
-            color: @ffe-white-darkmode;
+            color: @ffe-farge-hvit;
         }
     }
 }
 
 .ffe-sub-lead-paragraph {
-    color: @ffe-black;
+    color: @ffe-farge-svart;
     line-height: 1.5rem;
     .ffe-fontsize-sub-lead-paragraph();
     .native & {
         @media (prefers-color-scheme: dark) {
-            color: @ffe-grey-cloud-darkmode;
+            color: @ffe-farge-lysgraa;
         }
     }
 }
 
 .ffe-link-text {
-    border-bottom: 1px solid @ffe-blue-azure;
-    color: @ffe-blue-azure;
+    border-bottom: 1px solid @ffe-farge-vann;
+    color: @ffe-farge-vann;
     cursor: pointer;
     text-decoration: none;
     word-wrap: break-word;
     line-height: 1em;
     .native & {
         @media (prefers-color-scheme: dark) {
-            color: @ffe-blue-azure-darkmode;
+            color: @ffe-farge-vann-70;
         }
     }
 
     &:hover {
-        border-bottom-color: @ffe-blue-cobalt;
-        color: @ffe-blue-cobalt;
+        border-bottom-color: @ffe-farge-fjell;
+        color: @ffe-farge-fjell;
         text-decoration: none;
         .native & {
             @media (prefers-color-scheme: dark) {
-                color: ligthen(@ffe-blue-azure-darkmode, 10%);
-                border-color: ligthen(@ffe-blue-azure-darkmode, 10%);
+                color: @ffe-farge-vann-30;
+                border-color: @ffe-farge-vann-30;
             }
         }
     }
 
     &:visited {
-        border-bottom-color: @ffe-purple-violet;
-        color: @ffe-purple-violet;
+        border-bottom-color: @ffe-farge-lyng;
+        color: @ffe-farge-lyng;
         text-decoration: none;
         .native & {
             @media (prefers-color-scheme: dark) {
-                color: darken(@ffe-blue-azure-darkmode, 10%);
-                border-color: darken(@ffe-blue-azure-darkmode, 10%);
+                color: @ffe-farge-lyng-30;
+                border-color: @ffe-farge-lyng-30;
             }
         }
     }
@@ -357,13 +367,13 @@
 
 .ffe-divider-line {
     border: none;
-    border-bottom: solid 1px @ffe-grey-silver;
+    border-bottom: solid 1px @ffe-farge-lysgraa;
     padding-top: 1px;
     padding-bottom: 1px;
     width: 100%;
     .native & {
         @media (prefers-color-scheme: dark) {
-            border-color: @ffe-grey-silver-darkmode;
+            border-color: @ffe-farge-graa;
         }
     }
 }
@@ -378,13 +388,13 @@
 }
 
 .ffe-pre-text {
-    background-color: @ffe-sand-ivory;
+    background-color: @ffe-farge-sand-70;
     font-family: consolas, menlo, monaco, monospace;
     margin: 0;
     text-align: left;
     .native & {
         @media (prefers-color-scheme: dark) {
-            border-color: @ffe-grey-charcoal-darkmode;
+            background-color: @ffe-farge-koksgraa;
         }
     }
 }

--- a/packages/ffe-header/less/ffe-header.less
+++ b/packages/ffe-header/less/ffe-header.less
@@ -47,7 +47,7 @@
         &:link,
         &:visited,
         &:active {
-            color: @ffe-farge-moerkgraa-wcag;
+            color: @ffe-farge-moerkgraa;
             text-decoration: none;
         }
 

--- a/packages/ffe-system-message/less/ffe-system-message.less
+++ b/packages/ffe-system-message/less/ffe-system-message.less
@@ -48,7 +48,7 @@
     }
 
     &--news {
-        background-color: @ffe-farge-moerkgraa-wcag;
+        background-color: @ffe-farge-moerkgraa;
         color: @ffe-white;
         fill: @ffe-farge-fjell;
     }

--- a/src/styles/examples/color.less
+++ b/src/styles/examples/color.less
@@ -319,44 +319,6 @@
             background-color: @ffe-red-darkmode;
             color: @ffe-farge-hvit;
         }
-
-        &--darkmode-svart {
-            background-color: @ffe-farge-darkmode-svart;
-            color: @ffe-farge-hvit;
-        }
-
-        &--darkmode-hvit {
-            background-color: @ffe-farge-darkmode-hvit;
-        }
-
-        &--darkmode-koksgraa {
-            background-color: @ffe-farge-darkmode-koksgraa;
-            color: @ffe-farge-hvit;
-        }
-
-        &--darkmode-graa {
-            background-color: @ffe-farge-darkmode-graa;
-            color: @ffe-farge-hvit;
-        }
-
-        &--darkmode-moerkgraa {
-            background-color: @ffe-farge-darkmode-moerkgraa;
-            color: @ffe-farge-hvit;
-        }
-
-        &--darkmode-lysgraa {
-            background-color: @ffe-farge-darkmode-lysgraa;
-        }
-
-        &--darkmode-vann {
-            background-color: @ffe-farge-darkmode-vann;
-            color: @ffe-farge-hvit;
-        }
-
-        &--darkmode-baer {
-            background-color: @ffe-farge-darkmode-baer;
-            color: @ffe-farge-hvit;
-        }
     }
 
     &__color-properties {


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse

* Oppdaterte farger i ffe-core, i henhold til ny profil
* Fjerner dupliserte og/eller ubrukte farger fra paletten
  * Fixes #1178 
* `ffe-farge-moerkgraa-wcag` skal ikke lenger være en del av paletten og er derfor erstattet med `ffe-farge-moerkgraa` i ffe-header og ffe-system-message
  * Fixes #1177 

## Motivasjon og kontekst

Oppdateringen er en del av utrullingen av justert visuell profil

## Testing

Testet lokalt

