### PR TITLE
fix(ffe-context-message): Stopp lukkeknapp fra å gå over teksten

### DIFF
--- a/packages/ffe-context-message/less/ffe-context-message.less
+++ b/packages/ffe-context-message/less/ffe-context-message.less
@@ -97,9 +97,7 @@
     }
 
     &__close-button {
-        position: absolute;
-        top: 3.5px;
-        right: 1em;
+        flex: 0 0 auto;
         cursor: pointer;
         color: @ffe-farge-moerkgraa;
         fill: @ffe-farge-moerkgraa;
@@ -110,6 +108,7 @@
         background-color: transparent;
         height: 1em;
         width: 1em;
+        margin: 0.2rem 0.2rem 0 0;
 
         &:hover {
             fill: @ffe-farge-svart;
@@ -136,6 +135,8 @@
     position: relative;
     border-radius: 5px;
     width: 100%;
+    display: flex;
+    justify-content: space-between;
 
     &--compact {
         .ffe-context-message-content {


### PR DESCRIPTION
## Beskrivelse
Når teksten i ContextMessage ble langt nok, gikk den over lukkeknappen. 
Dette er fordi knappen var satt til position: absolute. Endringen nå gjør at man gjør meldingen om til en flex grid,
og plasserer lukke knappen basert på det, istedenfor "absolute"

## Motivasjon og kontekst
Fikk inn issue på problemet, for situasjoner der man har lange meldinger.

## Testing

Har kjørt opp lokalt og sjekket opp mot dokumentasjonen