### PR TITLE
fix(ffe-datepicker): legg til min-høyde

### DIFF
--- a/packages/ffe-datepicker/less/calendar.less
+++ b/packages/ffe-datepicker/less/calendar.less
@@ -20,6 +20,7 @@
         &--above {
             top: inherit;
             bottom: 55px;
+            min-height: 339px;
         }
     }
 


### PR DESCRIPTION
## Beskrivelse
Satte en min-høyde på datepickeren når man har "calendarAbove" satt til true. 
Min-høyden er størrelsen på boksen når den har 6 uker.

## Motivasjon og kontekst
Det var en del tilbakemeldinger på at kalenderen hoppet opp og ned, når man bladde seg gjennom måneder, med ulik antall uker. Det ble oppfattet som irriterende  

## Testing

Kjørt opp lokalt og testet på eksempelet i dokumentasjonen, på stor og liten skjerm