### PR TITLE
breakpoints as css custom media queries

### DIFF
--- a/packages/ffe-core/package.json
+++ b/packages/ffe-core/package.json
@@ -19,7 +19,7 @@
     "lint": "stylelint less/*.less",
     "test": "npm run lint",
     "clean": "rm -rf css/ gen-src/ lib/",
-    "build": "./scripts/build.js tokens.config.js && tsc gen-src/index.ts --declaration --outDir lib"
+    "build": "./scripts/build.js tokens.config.js && ./scripts/build-custom-mq.js less/breakpoints.less css/custom-media-queries.css && tsc gen-src/index.ts --declaration --outDir lib"
   },
   "devDependencies": {
     "case": "^1.5.5",

--- a/packages/ffe-core/scripts/build-custom-mq.js
+++ b/packages/ffe-core/scripts/build-custom-mq.js
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+const path = require('path');
+const postcss = require('postcss');
+
+const renderLessVarsToCSSProps = require('./lib/renderLessVarsToCSSProps');
+const writeToFile = require('./lib/writeToFile');
+
+const lessFile = process.argv[2];
+const customMqFile = process.argv[3];
+
+if (!customMqFile) {
+    console.error('Usage: build-custom-mq.js input.less output.css');
+    process.exit(1);
+}
+
+/**
+ * convert css custom props. to css custom media queries
+ *
+ * input:  @breakpoint-sm: 480px;
+ * result: @custom-media --ffe-breakpoint-sm screen and (min-width: 480px);
+ */
+renderLessVarsToCSSProps(path.resolve(lessFile))
+    .then(css =>
+        postcss().process(css, {
+            from: false,
+            hideNothingWarning: true,
+        }),
+    )
+    .then(({ root }) => {
+        let str = '';
+
+        root.walkDecls(decl => {
+            str += `@custom-media ${decl.prop.replace(
+                /^--(ffe-)?/,
+                '--ffe-',
+            )} screen and (min-width: ${decl.value});\n`;
+        });
+
+        return str;
+    })
+    .then(writeToFile(customMqFile))
+    .catch(err => {
+        console.error(err);
+        process.exit(1);
+    });


### PR DESCRIPTION
## Beskrivelse

Legger til et script i ffe-core som tar `breakpoints.less` og bygger om disse breakpoints til [custom media queries](https://drafts.csswg.org/mediaqueries-5/#custom-mq) i css.

## Motivasjon og kontekst

Media-queries i css fungerer ikke sammen med custom props og dette er ikke mulig: `@media (var(--breakpoint-sm))`. Så med denne endring blir dette mulig som alternativ: 

```css
@import "@sb1/ffe-core/css/custom-media-queries.css";

@media (--ffe-breakpoint-sm) { /* tilsvarer screen and (min-width: 480px) */
 ....
}

```

## Testing

Kjør `npm run  build` i `./packages/ffe-core` og se på `css/custom-media-queries.css`