### PR TITLE
fix(ffe-core): endrer farge på visited i darkmode

### DIFF
--- a/packages/ffe-core/less/typography.less
+++ b/packages/ffe-core/less/typography.less
@@ -354,8 +354,8 @@
         text-decoration: none;
         .native & {
             @media (prefers-color-scheme: dark) {
-                color: @ffe-farge-lyng-30;
-                border-color: @ffe-farge-lyng-30;
+                color: @ffe-farge-lyng-70;
+                border-color: @ffe-farge-lyng-70;
             }
         }
     }


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse

Farge på `:visited` i dark mode endres fra `@ffe-farge-lyng-30` til `@ffe-farge-lyng-70`

## Motivasjon og kontekst

Fixes #1210 

## Testing

Testet lokalt
