### PR TITLE
Justere meldingsbokser darkmode farger

### DIFF
--- a/packages/ffe-context-message/less/ffe-context-message.less
+++ b/packages/ffe-context-message/less/ffe-context-message.less
@@ -81,12 +81,21 @@
         border-radius: 50%;
         height: 4em;
         width: 4em;
-
+        .native & {
+            @media (prefers-color-scheme: dark) {
+                background-color: @ffe-farge-svart;
+            }
+        }
         &-svg {
             height: 2.2em;
             width: 2.2em;
             padding: @ffe-spacing-2xs;
             fill: @ffe-farge-fjell;
+            .native & {
+                @media (prefers-color-scheme: dark) {
+                    fill: @ffe-farge-vann-70;
+                }
+            }
         }
 
         @media (min-width: @breakpoint-sm) {
@@ -158,6 +167,11 @@
             width: 1.5em;
             padding: @ffe-spacing-2xs;
             fill: @ffe-farge-fjell;
+            .native & {
+                @media (prefers-color-scheme: dark) {
+                    fill: @ffe-farge-vann-70;
+                }
+            }
         }
     }
 
@@ -182,7 +196,7 @@
     &--success {
         background-color: @ffe-farge-nordlys-30;
         .ffe-context-message-content__icon-svg {
-            fill: @ffe-farge-nordlys-wcag;
+            fill: @ffe-farge-nordlys;
         }
     }
 
@@ -194,7 +208,7 @@
         }
 
         .ffe-context-message-content__icon-svg {
-            fill: @ffe-farge-baer-wcag;
+            fill: @ffe-farge-baer;
         }
     }
 }

--- a/packages/ffe-message-box/less/ffe-message-box.less
+++ b/packages/ffe-message-box/less/ffe-message-box.less
@@ -103,13 +103,18 @@
         position: relative;
         top: 16px;
         width: 64px;
-
+        .native & {
+            @media (prefers-color-scheme: dark) {
+                background-color: @ffe-farge-svart;
+                fill: @ffe-farge-vann-70;
+            }
+        }
         &--error svg {
-            fill: @ffe-farge-baer-wcag;
+            fill: @ffe-farge-baer;
         }
 
         &--success svg {
-            fill: @ffe-farge-nordlys-wcag;
+            fill: @ffe-farge-nordlys;
         }
     }
 

--- a/packages/ffe-system-message/less/ffe-system-message.less
+++ b/packages/ffe-system-message/less/ffe-system-message.less
@@ -35,6 +35,11 @@
     &--error {
         background-color: @ffe-farge-baer-30;
         fill: @ffe-farge-baer-wcag;
+        .native & {
+            @media (prefers-color-scheme: dark) {
+                fill: @ffe-farge-baer;
+            }
+        }
     }
 
     &--info {
@@ -43,6 +48,7 @@
         .native & {
             @media (prefers-color-scheme: dark) {
                 background-color: @ffe-farge-vann-30;
+                fill: @ffe-farge-vann-70;
             }
         }
     }
@@ -51,11 +57,21 @@
         background-color: @ffe-farge-moerkgraa;
         color: @ffe-white;
         fill: @ffe-farge-fjell;
+        .native & {
+            @media (prefers-color-scheme: dark) {
+                fill: @ffe-farge-vann-70;
+            }
+        }
     }
 
     &--success {
         background-color: @ffe-farge-nordlys-30;
         fill: @ffe-farge-nordlys-wcag;
+        .native & {
+            @media (prefers-color-scheme: dark) {
+                fill: @ffe-farge-nordlys;
+            }
+        }
     }
 }
 
@@ -75,7 +91,11 @@
         height: 2rem;
         width: 2rem;
         margin-right: @ffe-spacing-sm;
-
+        .native & {
+            @media (prefers-color-scheme: dark) {
+                background: @ffe-farge-svart;
+            }
+        }
         > svg {
             height: 50%;
             position: relative;


### PR DESCRIPTION
## Beskrivelse

Justerer darkmode fargene til alle meldingskomponentene. 
Denne vil gjøre sirklene ikonene ligger i sort i darkmode istedenfor hvit.
Alle ikonene vil også få en litt justert farge for å oppfylle kontrast krav på sort bakgrunn.

## Motivasjon og kontekst

Blir mer riktig i forhold til den justerte profilen.

## Testing
Testet med å kjøre opp lokalt og se at komponentene ser riktig ut.
