### PR TITLE
fix(ffe-core): justere lead og sublead

### DIFF
--- a/packages/ffe-core/less/font-sizes.less
+++ b/packages/ffe-core/less/font-sizes.less
@@ -25,7 +25,7 @@
 }
 
 .ffe-fontsize-sub-lead-paragraph() {
-    font-size: 1rem;
+    font-size: 1.063rem;
 
     .ffe-fontsize(@breakpoint-sm, {font-size: 1.125rem;});
 }

--- a/packages/ffe-core/less/typography.less
+++ b/packages/ffe-core/less/typography.less
@@ -303,7 +303,7 @@
 
 .ffe-lead-paragraph {
     color: @ffe-farge-fjell;
-    line-height: 1.75rem;
+    line-height: 1.5rem;
     .ffe-fontsize-lead-paragraph();
     .native & {
         @media (prefers-color-scheme: dark) {


### PR DESCRIPTION
## Beskrivelse

Endre linje høyde på Lead fra 28 til 24 px.
Endret tekststørrelsen på sublead på mobil fra 16-17 piksler. 
Begge verdiene er satt i rem, og jeg har bare regnet ut tilsvarende rem verdi, ved å anta at 1rem = 16px.

## Motivasjon og kontekst

Justering for å matche figma. 

## Testing
Bare sjekket at nye verdier ligger inne ved å kjøre og inspecte sub og lead paragrafer i dokumentasjonen. 
