### PR TITLE
fix(component-overview): endre collapse knapp til expandbutton komponent

### DIFF
--- a/component-overview/examples/collapse/Collapse-onRest.jsx
+++ b/component-overview/examples/collapse/Collapse-onRest.jsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import Collapse from '@sb1/ffe-collapse-react';
+import { ExpandButton } from '@sb1/ffe-buttons-react';
 
 () => {
     const [isOpen, setOpen] = useState(false);
@@ -7,9 +8,9 @@ import Collapse from '@sb1/ffe-collapse-react';
 
     return (
         <>
-            <button onClick={() => setOpen(!isOpen)}>
+            <ExpandButton isExpanded={isOpen} onClick={() => setOpen(!isOpen)}>
                 {isOpen ? 'Collapse' : 'Expand'}
-            </button>
+            </ExpandButton>
             <Collapse isOpen={isOpen} onRest={() => setRand(Math.random())}>
                 <div>
                     <p>Hello world</p>

--- a/component-overview/examples/collapse/Collapse.jsx
+++ b/component-overview/examples/collapse/Collapse.jsx
@@ -1,14 +1,15 @@
 import { useState } from 'react';
 import Collapse from '@sb1/ffe-collapse-react';
+import { ExpandButton } from '@sb1/ffe-buttons-react';
 
 () => {
     const [isOpen, setOpen] = useState(false);
 
     return (
         <>
-            <button onClick={() => setOpen(!isOpen)}>
+            <ExpandButton isExpanded={isOpen} onClick={() => setOpen(!isOpen)}>
                 {isOpen ? 'Collapse' : 'Expand'}
-            </button>
+            </ExpandButton>
             <Collapse isOpen={isOpen}>
                 <div>
                     <p>Hello world</p>


### PR DESCRIPTION
## Beskrivelse

Collapse er en funksjonell komponent i FFE, men i eksempelet brukte vi bare en standard HTML knapp istedenfor den faktiske expand knappen vi ønsker folk skal bruke.  Oppdaterer derfor eksempelet til å bruke ExpandButton-komponenten, slik at det blir mer riktig. 

## Testing

Bygget og kjørt opp lokalt