### PR TITLE
fix(ffe-buttons): Endre bakgrunnsfarge på secondary button i darkmode

### DIFF
--- a/packages/ffe-buttons/less/base-button.less
+++ b/packages/ffe-buttons/less/base-button.less
@@ -252,7 +252,7 @@
     .native & {
         @media (prefers-color-scheme: dark) {
             color: @ffe-farge-vann-30;
-            background-color: transparent;
+            background-color: @ffe-farge-svart;
             border-color: @ffe-farge-vann-70;
         }
     }


### PR DESCRIPTION
Endrer bakgrunnsfarge på secondary button i darkmode da teksten på knappen ikke synes hvis den brukes i en meldingsboks.

## Beskrivelse

![Image from iOS (1)](https://user-images.githubusercontent.com/69858000/135975967-c85230e6-2bc8-4956-a279-798850885679.jpg)

## Motivasjon og kontekst

Når knappen har en transparent bakgrunn på darkmode og når man bruker meldingsboks vil teksten på knappen forsvinne. Det er veldig lite brukervennlig. 

## Testing

Har testet lokalt ved å sjekke at CSSen har fått en bakgrunnsfarge.
