### PR TITLE
fix(component-overview): oppdater buttongroup eksempler

### DIFF
--- a/component-overview/examples/buttons/ButtonGroup-inline.jsx
+++ b/component-overview/examples/buttons/ButtonGroup-inline.jsx
@@ -1,38 +1,12 @@
 import {
     ButtonGroup,
-    ActionButton,
     PrimaryButton,
     SecondaryButton,
-    TertiaryButton,
 } from '@sb1/ffe-buttons-react';
 
 <>
     <ButtonGroup inline={true}>
-        <ActionButton>Neste</ActionButton>
-        <ActionButton element="a" href="#buttongroup">
-            Lenke
-        </ActionButton>
-        <SecondaryButton>Avbryt</SecondaryButton>
-        <SecondaryButton element="a" href="#buttongroup">
-            Lenke
-        </SecondaryButton>
-        <TertiaryButton>Hopp over</TertiaryButton>
-        <TertiaryButton element="a" href="#buttongroup">
-            Lenke
-        </TertiaryButton>
-    </ButtonGroup>
-    <ButtonGroup inline={true}>
+        <SecondaryButton>Forrige</SecondaryButton>
         <PrimaryButton>Neste</PrimaryButton>
-        <PrimaryButton element="a" href="#buttongroup">
-            Lenke
-        </PrimaryButton>
-        <SecondaryButton>Avbryt</SecondaryButton>
-        <SecondaryButton element="a" href="#buttongroup">
-            Lenke
-        </SecondaryButton>
-        <TertiaryButton>Hopp over</TertiaryButton>
-        <TertiaryButton element="a" href="#buttongroup">
-            Lenke
-        </TertiaryButton>
     </ButtonGroup>
 </>;

--- a/component-overview/examples/buttons/ButtonGroup-thin.jsx
+++ b/component-overview/examples/buttons/ButtonGroup-thin.jsx
@@ -1,6 +1,5 @@
 import {
     ButtonGroup,
-    ActionButton,
     PrimaryButton,
     SecondaryButton,
     TertiaryButton,
@@ -8,31 +7,10 @@ import {
 
 <>
     <ButtonGroup thin={true}>
-        <ActionButton>Neste</ActionButton>
-        <ActionButton element="a" href="#buttongroup">
-            Lenke
-        </ActionButton>
-        <SecondaryButton>Avbryt</SecondaryButton>
-        <SecondaryButton element="a" href="#buttongroup">
-            Lenke
-        </SecondaryButton>
-        <TertiaryButton>Hopp over</TertiaryButton>
-        <TertiaryButton element="a" href="#buttongroup">
-            Lenke
-        </TertiaryButton>
+        <SecondaryButton>Forrige</SecondaryButton>
+        <PrimaryButton>Neste</PrimaryButton>
     </ButtonGroup>
     <ButtonGroup thin={true}>
-        <PrimaryButton>Neste</PrimaryButton>
-        <PrimaryButton element="a" href="#buttongroup">
-            Lenke
-        </PrimaryButton>
-        <SecondaryButton>Avbryt</SecondaryButton>
-        <SecondaryButton element="a" href="#buttongroup">
-            Lenke
-        </SecondaryButton>
-        <TertiaryButton>Hopp over</TertiaryButton>
-        <TertiaryButton element="a" href="#buttongroup">
-            Lenke
-        </TertiaryButton>
+        <TertiaryButton>Avbryt</TertiaryButton>
     </ButtonGroup>
 </>;

--- a/component-overview/examples/buttons/ButtonGroup.jsx
+++ b/component-overview/examples/buttons/ButtonGroup.jsx
@@ -1,6 +1,5 @@
 import {
     ButtonGroup,
-    ActionButton,
     PrimaryButton,
     SecondaryButton,
     TertiaryButton,
@@ -8,31 +7,10 @@ import {
 
 <>
     <ButtonGroup>
-        <ActionButton>Neste</ActionButton>
-        <ActionButton element="a" href="#buttongroup">
-            Lenke
-        </ActionButton>
-        <SecondaryButton>Avbryt</SecondaryButton>
-        <SecondaryButton element="a" href="#buttongroup">
-            Lenke
-        </SecondaryButton>
-        <TertiaryButton>Hopp over</TertiaryButton>
-        <TertiaryButton element="a" href="#buttongroup">
-            Lenke
-        </TertiaryButton>
+        <SecondaryButton>Forrige</SecondaryButton>
+        <PrimaryButton>Neste</PrimaryButton>
     </ButtonGroup>
     <ButtonGroup>
-        <PrimaryButton>Neste</PrimaryButton>
-        <PrimaryButton element="a" href="#buttongroup">
-            Lenke
-        </PrimaryButton>
-        <SecondaryButton>Avbryt</SecondaryButton>
-        <SecondaryButton element="a" href="#buttongroup">
-            Lenke
-        </SecondaryButton>
-        <TertiaryButton>Hopp over</TertiaryButton>
-        <TertiaryButton element="a" href="#buttongroup">
-            Lenke
-        </TertiaryButton>
+        <TertiaryButton>Avbryt</TertiaryButton>
     </ButtonGroup>
 </>;


### PR DESCRIPTION
## Beskrivelse
Oppdater buttongroup eksemplene ved å fjerne en del knapper og heller bruke
en kombinasjon som faktisk brukes ute i applikasjonene.

## Motivasjon og kontekst
Buttongroup eksemplene var veldig like hverandre og vanskelig å se hva de egentlig viste.
Eksemplene listet ut mange knapper som aldri vil brukes sammen. 

## Testing
Bygget og kjørt opp component-overview lokalt. 
