### PR TITLE
Add open and close prop to account selector

### DIFF
--- a/packages/ffe-account-selector-react/src/components/account-selector/AccountSelector.js
+++ b/packages/ffe-account-selector-react/src/components/account-selector/AccountSelector.js
@@ -50,6 +50,8 @@ const AccountSelector = ({
     ariaInvalid,
     withSpaceForDetails = true,
     highCapacity = false,
+    onOpen,
+    onClose,
 }) => {
     const [inputValue, setInputValue] = useState(selectedAccount?.name || '');
 
@@ -57,11 +59,11 @@ const AccountSelector = ({
     if (formatAccountNumber) {
         formatter = formatIncompleteAccountNumber;
     }
-
     /*
      * This matcher function closely resembles the default one of SearchableDropdown,
      * but it ignores all spaces and periods so that account number formatting won't mess with the search.
      */
+
     const searchMatcherIgnoringAccountNumberFormatting = (
         searchString,
         searchAttributes,
@@ -75,7 +77,6 @@ const AccountSelector = ({
             cleanString(item[searchAttribute]).includes(cleanedSearchString),
         );
     };
-
     const onInputChange = event => {
         setInputValue(event.target.value);
         if (inputProps?.onChange) {
@@ -151,6 +152,8 @@ const AccountSelector = ({
                     searchMatcher={searchMatcherIgnoringAccountNumberFormatting}
                     selectedItem={selectedAccount}
                     highCapacity={highCapacity}
+                    onOpen={onOpen}
+                    onClose={onClose}
                 />
                 {selectedAccount && (
                     <AccountDetails
@@ -219,6 +222,10 @@ AccountSelector.propTypes = {
      * The account selector with highCapacity is currently not working with VoiceOver on ios.
      */
     highCapacity: bool,
+    /** Prop passed to the dropdown list */
+    onClose: func,
+    /** Prop passed to the dropdown list */
+    onOpen: func,
 };
 
 export default AccountSelector;

--- a/packages/ffe-account-selector-react/src/index.d.ts
+++ b/packages/ffe-account-selector-react/src/index.d.ts
@@ -37,6 +37,8 @@ export interface AccountSelectorProps {
     withSpaceForDetails?: boolean;
     ariaInvalid: boolean;
     highCapacity?: boolean;
+    onOpen?: () => void;
+    onClose?: () => void;
 }
 
 declare class AccountSelector extends React.Component<AccountSelectorProps> {}

--- a/packages/ffe-searchable-dropdown-react/src/SearchableDropdown.js
+++ b/packages/ffe-searchable-dropdown-react/src/SearchableDropdown.js
@@ -63,6 +63,8 @@ const SearchableDropdown = ({
     selectedItem,
     highCapacity = false,
     isLoading = false,
+    onOpen,
+    onClose,
 }) => {
     const [state, dispatch] = useReducer(
         createReducer({
@@ -164,6 +166,15 @@ const SearchableDropdown = ({
             type: stateChangeTypes.DropdownListPropUpdated,
         });
     }, [dropdownList, dispatch]);
+
+    useEffect(() => {
+        if (state.isExpanded && typeof onOpen === 'function') {
+            onOpen();
+        }
+        if (!state.isExpanded && typeof onClose === 'function') {
+            onClose();
+        }
+    }, [state.isExpanded]);
 
     /**
      * Because of changes in event handling between react v16 and v17, the check for the
@@ -441,6 +452,12 @@ SearchableDropdown.propTypes = {
      * that has loaded.
      */
     isLoading: bool,
+
+    /** Function used when dropdown opens */
+    onOpen: func,
+
+    /**  Function used when dropdown closes */
+    onClose: func,
 };
 
 export default SearchableDropdown;

--- a/packages/ffe-searchable-dropdown-react/src/index.d.ts
+++ b/packages/ffe-searchable-dropdown-react/src/index.d.ts
@@ -35,6 +35,8 @@ export interface SearchableDropdownProps<T> {
     ) => (item: T) => boolean;
     hichCapacity?: boolean;
     isLoading?: boolean;
+    onOpen?: () => void;
+    onClose?: () => void;
 }
 
 declare class SearchableDropdown<T> extends React.Component<


### PR DESCRIPTION
## Beskrivelse
Oppdatere `AccountSelector` til å kunne motta `onOpen` og `onClose` props, og sende de videre til `SearchableDropdown`

## Motivasjon og kontekst
pm-betaling opplever at scrolling i `AccountSelector` fort prompter swipeToRefresh på android. Valgt å holde selve funksjonene `disableSwipeToRefresh` og `enableSwipeToRefresh` som er hentet fra [mobilbank-communication](https://stash.intern.sparebank1.no/projects/MOB/repos/mobilbank-communication/browse/frontend/src/events/swipe-to-refresh.js) utenfor designsystemet. 