### PR TITLE
fix(ffe-buttons-react): remove disabled attribute when is-loading

### DIFF
--- a/packages/ffe-buttons-react/src/BaseButton.js
+++ b/packages/ffe-buttons-react/src/BaseButton.js
@@ -47,7 +47,6 @@ const BaseButton = props => {
                 { 'ffe-button--loading': isLoading && supportsSpinner },
                 className,
             )}
-            disabled={disabled || (isLoading && supportsSpinner)}
             ref={innerRef}
             {...rest}
         >

--- a/packages/ffe-buttons-react/src/BaseButton.spec.js
+++ b/packages/ffe-buttons-react/src/BaseButton.spec.js
@@ -70,7 +70,6 @@ describe('<BaseButton />', () => {
                 isLoading: true,
             });
             expect(wrapper.prop('aria-disabled')).toBe(true);
-            expect(wrapper.prop('disabled')).toBe(true);
         });
         it('does nothing for unsupported button type', () => {
             const wrapper = getWrapper({
@@ -80,7 +79,6 @@ describe('<BaseButton />', () => {
             expect(wrapper.hasClass('ffe-button--loading')).toBe(false);
             expect(wrapper.prop('aria-busy')).toBe(false);
             expect(wrapper.prop('aria-disabled')).toBe(false);
-            expect(wrapper.prop('disabled')).toBe(false);
         });
     });
 });


### PR DESCRIPTION
Fjern disabled fra button

## Beskrivelse

Tastaturbrukare mister focus når man setter knappen til `disabled` medan man lastar noe. Vi har allrede `aria-disabled`


## Testing

Brukte denne kodsnutten for og testa
```
const wait = ms => new Promise(
    (resolve) => setTimeout(resolve, ms)
);

const Demo = () => {
    const [isLoading, setIsLoading] = useState(false)

    const asyncCall = async () => {
        console.log(document.activeElement)
        setIsLoading(true)
        await wait(2000)
        setIsLoading(false)
        console.log(document.activeElement)
    }

    return <PrimaryButton isLoading={isLoading} onClick={asyncCall}>Click me!</PrimaryButton>

}

export default Demo;
```

Med disabled så går focus fra knappen til body:
![med-disabled](https://user-images.githubusercontent.com/2248579/137581529-4e338a4c-42a2-4d93-80f9-21190c7ccb19.png)

Med kun aria-disabled blir focus igjen på kanppen:
![uten-disabled](https://user-images.githubusercontent.com/2248579/137581533-4221971f-bc25-4a55-8c19-c0c937e53845.png)

