### PR TITLE
Fokusjusteringer på knapper og lenker

### DIFF
--- a/packages/ffe-buttons/less/base-button.less
+++ b/packages/ffe-buttons/less/base-button.less
@@ -311,6 +311,10 @@
             display: none;
         }
     }
+
+    &:focus:not(:focus-visible) {
+        border-color: transparent;
+    }
 }
 
 .ffe-button--condensed {

--- a/packages/ffe-buttons/less/inline-base-button.less
+++ b/packages/ffe-buttons/less/inline-base-button.less
@@ -30,7 +30,6 @@
         transform: scale(0.97);
     }
 
-    &:active,
     &:focus {
         box-shadow: 0 0 0 2px @ffe-farge-vann;
         outline: none;
@@ -39,6 +38,10 @@
                 box-shadow: 0 0 0 2px @ffe-farge-hvit;
             }
         }
+    }
+
+    &:focus:not(:focus-visible) {
+        box-shadow: none;
     }
 }
 
@@ -132,7 +135,6 @@
         width: 100%;
     }
 
-    &:active,
     &:focus {
         box-shadow: none;
         border-color: @ffe-farge-vann;
@@ -145,6 +147,10 @@
                 color: @ffe-farge-vann-30;
             }
         }
+    }
+
+    &:focus:not(:focus-visible) {
+        border-color: transparent;
     }
 
     &:hover {

--- a/packages/ffe-core/less/typography.less
+++ b/packages/ffe-core/less/typography.less
@@ -327,9 +327,13 @@
     text-decoration: none;
     word-wrap: break-word;
     line-height: 1em;
+    display: inline-block;
+    transition: all @ffe-transition-duration @ffe-ease;
+
     .native & {
         @media (prefers-color-scheme: dark) {
             color: @ffe-farge-vann-70;
+            border-color: @ffe-farge-vann-70;
         }
     }
 
@@ -359,6 +363,24 @@
 
     &--no-underline {
         border-bottom: none;
+    }
+
+    &:focus {
+        border-color: @ffe-farge-hvit;
+        border-radius: 1px;
+        background-color: @ffe-farge-vann;
+        box-shadow: 0 0 0 2px @ffe-farge-vann;
+        color: @ffe-farge-hvit;
+        outline: none;
+
+        .native & {
+            @media (prefers-color-scheme: dark) {
+                border-color: @ffe-farge-svart !important;
+                background-color: @ffe-farge-vann-70;
+                box-shadow: 0 0 0 2px @ffe-farge-vann-70;
+                color: @ffe-farge-svart !important;
+            }
+        }
     }
 }
 


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse

* Fjerner fokus-outline på inline-buttons (og task-button) sine `:active` states, slik at disse oppfører seg likt som andre knapper
* Legger til fokusmarkering på lenker som er i tråd med oppdatert visuell identitet. På disse valgte vi å bruke bakgrunnsfarge i stedet for outline, ettersom det er veldig lite plass til overs og en outline tildels kommer i veien for selve teksten.

![Screenshot 2021-10-18 at 15 02 34](https://user-images.githubusercontent.com/463847/137740771-9b2e36c5-f30a-4d01-8f5c-d0829131c0ac.png)
![Screenshot 2021-10-18 at 15 28 38](https://user-images.githubusercontent.com/463847/137740899-ecaf5b42-9c67-4040-890a-94f63f32afd8.png)



## Motivasjon og kontekst

Fixes #1232 
Fixes #1233 

## Testing

Testet lokalt
