### PR TITLE
fix(ffe-context-message): unngå å overstyre default farge på focus

### DIFF
--- a/packages/ffe-context-message/less/ffe-context-message.less
+++ b/packages/ffe-context-message/less/ffe-context-message.less
@@ -58,8 +58,9 @@
                 color: @ffe-farge-svart;
             }
         }
-        .ffe-link-text {
+        .ffe-link-text:not(:focus) {
             color: @ffe-farge-fjell;
+            border-color: @ffe-farge-fjell;
         }
     }
 


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse

Fjerner overstyring av farge på `.ffe-link-text` sin focus state i `.ffe-context-message`

## Motivasjon og kontekst

Fixes #1240

## Testing

Testet lokalt