### PR TITLE
Riktig font til kursiv tekst

### DIFF
--- a/packages/ffe-core/less/typography.less
+++ b/packages/ffe-core/less/typography.less
@@ -403,7 +403,7 @@
 }
 
 .ffe-em-text {
-    font-family: 'SpareBank1-italic', 'MuseoSansRounded-700', arial, sans-serif;
+    font-family: 'SpareBank1-italic', 'MuseoSans-500', arial, sans-serif;
     font-weight: normal;
     font-style: normal;
 }

--- a/packages/ffe-core/less/typography.less
+++ b/packages/ffe-core/less/typography.less
@@ -403,7 +403,9 @@
 }
 
 .ffe-em-text {
-    font-style: italic;
+    font-family: 'SpareBank1-italic', 'MuseoSansRounded-700', arial, sans-serif;
+    font-weight: normal;
+    font-style: normal;
 }
 
 .ffe-pre-text {

--- a/packages/ffe-webfonts/sb1-fonts-inline.less
+++ b/packages/ffe-webfonts/sb1-fonts-inline.less
@@ -15,6 +15,13 @@
 }
 
 @font-face {
+    font-family: 'SpareBank1-italic';
+    font-display: fallback;
+    src: data-uri('@{fonts-url}/SpareBank1-It-Web.woff2') format('woff2'),
+        data-uri('@{fonts-url}/SpareBank1-It-Web.woff') format('woff');
+}
+
+@font-face {
     font-family: 'SpareBank1-title-medium';
     font-display: fallback;
     src: data-uri('@{fonts-url}/SpareBank1-Title-Medium-Web.woff2')

--- a/packages/ffe-webfonts/sb1-fonts.less
+++ b/packages/ffe-webfonts/sb1-fonts.less
@@ -15,6 +15,13 @@
 }
 
 @font-face {
+    font-family: 'SpareBank1-italic';
+    font-display: fallback;
+    src: url('@{fonts-url}/SpareBank1-It-Web.woff2') format('woff2'),
+        url('@{fonts-url}/SpareBank1-It-Web.woff') format('woff');
+}
+
+@font-face {
     font-family: 'SpareBank1-title-medium';
     font-display: fallback;
     src: url('@{fonts-url}/SpareBank1-Title-Medium-Web.woff2') format('woff2'),


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse

Vi har en egen italic font som skal brukes til kursiv tekst, i stedet for kun `font-style`. Legger denne til og tar den i bruk i `.ffe-em-text`. 

![Screenshot 2021-10-22 at 12 44 34](https://user-images.githubusercontent.com/463847/138441244-4587b60e-0d6c-4396-ba24-7a569e7769ac.png)


## Motivasjon og kontekst

Fixes #1181 

## Testing

Testet lokalt