### PR TITLE
fix(component-overview): add npmrc file to not generate package-lock

### DIFF
--- a/component-overview/.npmrc
+++ b/component-overview/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false


### PR DESCRIPTION
## Beskrivelse

Legger til en .npmrc fil som sier at vi ikke vil generere package-lock fil i component overview
