### PR TITLE
Update grid background

### DIFF
--- a/component-overview/examples/grid/GridCol-background.jsx
+++ b/component-overview/examples/grid/GridCol-background.jsx
@@ -5,15 +5,15 @@ import { Label } from '@sb1/ffe-form-react';
 
 () => {
     const backgroundColors = [
-        'blue-ice',
-        'blue-pale',
-        'green-mint',
-        'grey-cloud',
+        'frost-30',
         'sand',
-        'grey-warm',
-        'orange-salmon',
-        'red',
-        'blue-sky',
+        'sand-70',
+        'sand-30',
+        'syrin-70',
+        'syrin-30',
+        'vann',
+        'fjell',
+        'hvit',
     ];
     const [bgColor, setBgColor] = useState(backgroundColors[0]);
 

--- a/component-overview/examples/grid/GridRow-background.jsx
+++ b/component-overview/examples/grid/GridRow-background.jsx
@@ -5,15 +5,15 @@ import { Label } from '@sb1/ffe-form-react';
 
 () => {
     const backgroundColors = [
-        'blue-ice',
-        'blue-pale',
-        'green-mint',
-        'grey-cloud',
+        'frost-30',
         'sand',
-        'grey-warm',
-        'orange-salmon',
-        'red',
-        'blue-sky',
+        'sand-70',
+        'sand-30',
+        'syrin-70',
+        'syrin-30',
+        'vann',
+        'fjell',
+        'hvit',
     ];
     const [bgColor, setBgColor] = useState(backgroundColors[0]);
 

--- a/packages/ffe-grid-react/src/GridCol.js
+++ b/packages/ffe-grid-react/src/GridCol.js
@@ -127,16 +127,15 @@ GridCol.defaultProps = {
 GridCol.propTypes = {
     /** Supported background colors */
     background: oneOf([
-        'blue-ice',
-        'blue-pale',
-        'green-mint',
-        'grey-cloud',
+        'frost-30',
         'sand',
-        'grey-warm',
-        'orange-salmon',
-        'red',
-        'blue-sky',
-        'white',
+        'sand-70',
+        'sand-30',
+        'syrin-70',
+        'syrin-30',
+        'vann',
+        'fjell',
+        'hvit',
     ]),
     /** Any extra classes are attached to the root node, in addition to ffe-grid__col classes */
     className: string,

--- a/packages/ffe-grid-react/src/GridRow.js
+++ b/packages/ffe-grid-react/src/GridRow.js
@@ -53,16 +53,15 @@ GridRow.defaultProps = {
 GridRow.propTypes = {
     /** Supported background colors */
     background: oneOf([
-        'blue-ice',
-        'blue-pale',
-        'green-mint',
-        'grey-cloud',
+        'frost-30',
         'sand',
-        'grey-warm',
-        'orange-salmon',
-        'red',
-        'blue-sky',
-        'white',
+        'sand-70',
+        'sand-30',
+        'syrin-70',
+        'syrin-30',
+        'vann',
+        'fjell',
+        'hvit',
     ]),
     /** Any extra classes are attached to the root node, in addition to ffe-grid__row classes */
     className: string,

--- a/packages/ffe-grid-react/src/background-colors.js
+++ b/packages/ffe-grid-react/src/background-colors.js
@@ -1,14 +1,26 @@
 export default [
+    'frost-30',
+    'sand',
+    'sand-70',
+    'sand-30',
+    'syrin-70',
+    'syrin-30',
+    'vann',
+    'fjell',
+    'hvit',
+];
+
+export const removedColors = [
+    'blue-cobalt',
+    'blue-royal',
+    'purple-magenta',
     'blue-ice',
     'blue-pale',
     'green-mint',
     'grey-cloud',
-    'sand',
     'grey-warm',
     'orange-salmon',
     'red',
     'blue-sky',
     'white',
 ];
-
-export const removedColors = ['blue-cobalt', 'blue-royal', 'purple-magenta'];

--- a/packages/ffe-grid-react/src/index.d.ts
+++ b/packages/ffe-grid-react/src/index.d.ts
@@ -15,16 +15,13 @@ export interface InlineGridProps extends React.HTMLAttributes<HTMLElement> {
 }
 
 type BackgroundColors =
-    | 'blue-ice'
-    | 'blue-pale'
-    | 'green-mint'
-    | 'grey-cloud'
+    | 'frost-30'
     | 'sand'
-    | 'grey-warm'
-    | 'orange-salmon'
-    | 'red'
-    | 'blue-sky'
-    | 'white';
+    | 'sand-70'
+    | 'sand-30'
+    | 'vann'
+    | 'fjell'
+    | 'hvit';
 
 export interface GridRowProps extends React.HTMLAttributes<HTMLElement> {
     background?: BackgroundColors;

--- a/packages/ffe-grid/less/ffe-grid.less
+++ b/packages/ffe-grid/less/ffe-grid.less
@@ -176,27 +176,8 @@
         margin-left: (@ffe-grid-gutter-lg / 2 * -1);
         margin-right: (@ffe-grid-gutter-lg / 2 * -1);
     }
-
-    &--bg-blue-ice {
-        background-color: @ffe-blue-ice;
-        .native & {
-            @media (prefers-color-scheme: dark) {
-                background-color: @ffe-black-darkmode;
-            }
-        }
-    }
-
-    &--bg-blue-pale {
-        background-color: @ffe-blue-pale;
-        .native & {
-            @media (prefers-color-scheme: dark) {
-                background-color: @ffe-black-darkmode;
-            }
-        }
-    }
-
-    &--bg-green-mint {
-        background-color: @ffe-green-mint;
+    &--bg-frost-30 {
+        background-color: @ffe-farge-frost-30;
         .native & {
             @media (prefers-color-scheme: dark) {
                 background-color: @ffe-black-darkmode;
@@ -205,7 +186,7 @@
     }
 
     &--bg-sand {
-        background-color: @ffe-sand;
+        background-color: @ffe-farge-sand;
         .native & {
             @media (prefers-color-scheme: dark) {
                 background-color: @ffe-black-darkmode;
@@ -213,8 +194,8 @@
         }
     }
 
-    &--bg-grey-cloud {
-        background-color: @ffe-grey-cloud;
+    &--bg-sand-70 {
+        background-color: @ffe-farge-sand-70;
         .native & {
             @media (prefers-color-scheme: dark) {
                 background-color: @ffe-black-darkmode;
@@ -222,8 +203,24 @@
         }
     }
 
-    &--bg-grey-warm {
-        background-color: @ffe-grey-warm;
+    &--bg-sand-30 {
+        background-color: @ffe-farge-sand-30;
+        .native & {
+            @media (prefers-color-scheme: dark) {
+                background-color: @ffe-black-darkmode;
+            }
+        }
+    }
+    &--bg-syrin-70 {
+        background-color: @ffe-farge-syrin-70;
+        .native & {
+            @media (prefers-color-scheme: dark) {
+                background-color: @ffe-black-darkmode;
+            }
+        }
+    }
+    &--bg-syrin-30 {
+        background-color: @ffe-farge-syrin-30;
         .native & {
             @media (prefers-color-scheme: dark) {
                 background-color: @ffe-black-darkmode;
@@ -231,8 +228,8 @@
         }
     }
 
-    &--bg-orange-salmon {
-        background-color: @ffe-orange-salmon;
+    &--bg-vann {
+        background-color: @ffe-farge-vann;
         .native & {
             @media (prefers-color-scheme: dark) {
                 background-color: @ffe-black-darkmode;
@@ -240,8 +237,8 @@
         }
     }
 
-    &--bg-red {
-        background-color: @ffe-red;
+    &--bg-fjell {
+        background-color: @ffe-farge-fjell;
         .native & {
             @media (prefers-color-scheme: dark) {
                 background-color: @ffe-black-darkmode;
@@ -249,17 +246,8 @@
         }
     }
 
-    &--bg-blue-sky {
-        background-color: @ffe-blue-sky;
-        .native & {
-            @media (prefers-color-scheme: dark) {
-                background-color: @ffe-black-darkmode;
-            }
-        }
-    }
-
-    &--bg-white {
-        background-color: @ffe-white;
+    &--bg-hvit {
+        background-color: @ffe-farge-hvit;
         .native & {
             @media (prefers-color-scheme: dark) {
                 background-color: @ffe-black-darkmode;
@@ -364,26 +352,8 @@
 }
 
 .ffe-grid__col {
-    &--bg-blue-ice {
-        background-color: @ffe-blue-ice;
-        .native & {
-            @media (prefers-color-scheme: dark) {
-                background-color: @ffe-black-darkmode;
-            }
-        }
-    }
-
-    &--bg-blue-pale {
-        background-color: @ffe-blue-pale;
-        .native & {
-            @media (prefers-color-scheme: dark) {
-                background-color: @ffe-black-darkmode;
-            }
-        }
-    }
-
-    &--bg-green-mint {
-        background-color: @ffe-green-mint;
+    &--bg-frost-30 {
+        background-color: @ffe-farge-frost-30;
         .native & {
             @media (prefers-color-scheme: dark) {
                 background-color: @ffe-black-darkmode;
@@ -392,7 +362,7 @@
     }
 
     &--bg-sand {
-        background-color: @ffe-sand;
+        background-color: @ffe-farge-sand;
         .native & {
             @media (prefers-color-scheme: dark) {
                 background-color: @ffe-black-darkmode;
@@ -400,8 +370,8 @@
         }
     }
 
-    &--bg-grey-cloud {
-        background-color: @ffe-grey-cloud;
+    &--bg-sand-70 {
+        background-color: @ffe-farge-sand-70;
         .native & {
             @media (prefers-color-scheme: dark) {
                 background-color: @ffe-black-darkmode;
@@ -409,8 +379,24 @@
         }
     }
 
-    &--bg-grey-warm {
-        background-color: @ffe-grey-warm;
+    &--bg-sand-30 {
+        background-color: @ffe-farge-sand-30;
+        .native & {
+            @media (prefers-color-scheme: dark) {
+                background-color: @ffe-black-darkmode;
+            }
+        }
+    }
+    &--bg-syrin-70 {
+        background-color: @ffe-farge-syrin-70;
+        .native & {
+            @media (prefers-color-scheme: dark) {
+                background-color: @ffe-black-darkmode;
+            }
+        }
+    }
+    &--bg-syrin-30 {
+        background-color: @ffe-farge-syrin-30;
         .native & {
             @media (prefers-color-scheme: dark) {
                 background-color: @ffe-black-darkmode;
@@ -418,8 +404,8 @@
         }
     }
 
-    &--bg-orange-salmon {
-        background-color: @ffe-orange-salmon;
+    &--bg-vann {
+        background-color: @ffe-farge-vann;
         .native & {
             @media (prefers-color-scheme: dark) {
                 background-color: @ffe-black-darkmode;
@@ -427,8 +413,8 @@
         }
     }
 
-    &--bg-red {
-        background-color: @ffe-red;
+    &--bg-fjell {
+        background-color: @ffe-farge-fjell;
         .native & {
             @media (prefers-color-scheme: dark) {
                 background-color: @ffe-black-darkmode;
@@ -436,17 +422,8 @@
         }
     }
 
-    &--bg-blue-sky {
-        background-color: @ffe-blue-sky;
-        .native & {
-            @media (prefers-color-scheme: dark) {
-                background-color: @ffe-black-darkmode;
-            }
-        }
-    }
-
-    &--bg-white {
-        background-color: @ffe-white;
+    &--bg-hvit {
+        background-color: @ffe-farge-hvit;
         .native & {
             @media (prefers-color-scheme: dark) {
                 background-color: @ffe-black-darkmode;


### PR DESCRIPTION
## Beskrivelse
Oppdaterer fargealternativene som kan brukes i GridRow og GridCol, alle gamle background verdier er oppdatert og fått nye navn som matcher de nye fargene. 

Denne PR'en oppdaterer CSS klassene som brukes til å sette bakgrunnsfarge, og navnene på properties som sendes inn i react komponenten, i tillegg til å oppdatere listen over fargealternativer som finnes i component-overview.

## Motivasjon og kontekst
Oppdatere backgrunnsfargene til å passe ny visuell profil.

## Testing
Testet med å bygge lokalt, og se at fargene vises riktig når man legger til riktig klassenavn