### PR TITLE
feat(ffe-core): add correct font sizes for tablet size

### DIFF
--- a/packages/ffe-core/less/font-sizes.less
+++ b/packages/ffe-core/less/font-sizes.less
@@ -33,19 +33,22 @@
 .ffe-fontsize-h1() {
     font-size: 1.75rem;
 
-    .ffe-fontsize(@breakpoint-sm, {font-size: 2.875rem;});
+    .ffe-fontsize(@breakpoint-sm, {font-size: 2.5rem;});
+    .ffe-fontsize(@breakpoint-md, {font-size: 2.875rem;});
 }
 
 .ffe-fontsize-h2() {
     font-size: 1.5rem;
 
-    .ffe-fontsize(@breakpoint-sm, {font-size: 2.25rem;});
+    .ffe-fontsize(@breakpoint-sm, {font-size: 2rem;});
+    .ffe-fontsize(@breakpoint-md, {font-size: 2.25rem;});
 }
 
 .ffe-fontsize-h3() {
     font-size: 1.25rem;
 
-    .ffe-fontsize(@breakpoint-sm, {font-size: 1.75rem;});
+    .ffe-fontsize(@breakpoint-sm, {font-size: 1.688rem;});
+    .ffe-fontsize(@breakpoint-md, {font-size: 1.75rem;});
 }
 
 .ffe-fontsize-h4() {


### PR DESCRIPTION
## Beskrivelse
Legger til media queries som setter riktig font størrelse på h1, h2 og h3 på tablet.
Dette ligger allerede i figma, men var ikke lagt til i FFE

## Motivasjon og kontekst
Blir enda litt bedre på akkurat tablet størrelsen med riktig font størrelse


## Testing
Bare CSS endringer, ikke testet
