### PR TITLE
Fiks issue der flere enn 1 datepicker kunne være åpne samtidig

### DIFF
--- a/component-overview/examples/datepicker/Datepicker-two.jsx
+++ b/component-overview/examples/datepicker/Datepicker-two.jsx
@@ -1,0 +1,37 @@
+import { useState } from 'react';
+import Datepicker from '@sb1/ffe-datepicker-react';
+import { Grid, GridRow, GridCol } from '@sb1/ffe-grid-react';
+
+() => {
+    const [date1, setDate1] = useState('01.01.2016');
+    const [date2, setDate2] = useState('02.01.2016');
+
+    return (
+        <Grid>
+            <GridRow>
+                <GridCol sm="5">
+                    <Datepicker
+                        inputProps={{ id: 'datepicker-1' }}
+                        label="Velg dato"
+                        language="en"
+                        maxDate="31.12.2016"
+                        minDate="01.01.2016"
+                        onChange={setDate1}
+                        value={date1}
+                    />
+                </GridCol>
+                <GridCol sm="5">
+                    <Datepicker
+                        inputProps={{ id: 'datepicker-2' }}
+                        label="Velg dato"
+                        language="en"
+                        maxDate="31.12.2016"
+                        minDate="01.01.2016"
+                        onChange={setDate2}
+                        value={date2}
+                    />
+                </GridCol>
+            </GridRow>
+        </Grid>
+    );
+};

--- a/packages/ffe-datepicker-react/src/datepicker/Datepicker.js
+++ b/packages/ffe-datepicker-react/src/datepicker/Datepicker.js
@@ -34,6 +34,9 @@ export default class Datepicker extends Component {
         this.calendarButtonClickHandler = this.calendarButtonClickHandler.bind(
             this,
         );
+        this.addFlagOnClickEventClickHandler = this.addFlagOnClickEventClickHandler.bind(
+            this,
+        );
         this.globalClickHandler = this.globalClickHandler.bind(this);
         this.escKeyHandler = this.escKeyHandler.bind(this);
         this.datePickedHandler = this.datePickedHandler.bind(this);
@@ -172,7 +175,10 @@ export default class Datepicker extends Component {
     }
 
     globalClickHandler(evt) {
-        if (this.state.displayDatePicker && !evt.__isEventFromFFEDatepicker) {
+        if (
+            this.state.displayDatePicker &&
+            evt.__datepickerID !== this.datepickerId
+        ) {
             this.closeCalendar();
         }
     }
@@ -189,12 +195,11 @@ export default class Datepicker extends Component {
 
     /**
      * Adds a flag on the click event so that the globalClickHandler()
-     * can determine whether or not this event originated from this
-     * component
+     * can determine whether or not the ID matches. Makes it so that only one datepicker can be open at the same time
      */
     addFlagOnClickEventClickHandler(evt) {
         // eslint-disable-next-line no-param-reassign
-        evt.nativeEvent.__isEventFromFFEDatepicker = true;
+        evt.nativeEvent.__datepickerID = this.datepickerId;
     }
 
     divBlurHandler(evt) {


### PR DESCRIPTION
## Beskrivelse
Datepickeren lukket kun kalenderen dersom det kom ett nytt event fra noe annet enn en datepicker. Dette gjorde at man kunne ha flere datepickere åpne samtidig noe som skaper en dårligere brukeropplevelse. 

Endringen gjør at vi nå sjekker mot en id. Er ID'en til det nye fokuselementet annerledes enn den gamle, så vil kalenderen lukke seg. 

I denne PR'en legges det også til ett eksempel under component-overview, der man har 2 datepickere på samme side. 

## Motivasjon og kontekst
Løser issue #1234 

## Testing
Testet ved å ta i bruk  eksempelet på component-overview, å sjekket om datepickeren oppførte seg som forventet