### PR TITLE
Legg til muligheten til å høyre-justere tekst i input felt

### DIFF
--- a/packages/ffe-form-react/src/Input.js
+++ b/packages/ffe-form-react/src/Input.js
@@ -3,13 +3,14 @@ import { bool, string } from 'prop-types';
 import classNames from 'classnames';
 
 const Input = React.forwardRef((props, ref) => {
-    const { className, inline, textLike, ...rest } = props;
+    const { className, inline, textLike, textRightAlign, ...rest } = props;
     return (
         <input
             className={classNames(
                 'ffe-input-field',
                 { 'ffe-input-field--inline': inline },
                 { 'ffe-input-field--text-like': textLike },
+                { 'ffe-input-field--text-right-align': textRightAlign },
                 className,
             )}
             ref={ref}
@@ -24,6 +25,8 @@ Input.propTypes = {
     inline: bool,
     /** Apply the text-like modifier by setting this to `true`. */
     textLike: bool,
+    /** Make the text right aligned */
+    textRightAlign: bool,
 };
 
 export default Input;

--- a/packages/ffe-form-react/src/Input.spec.js
+++ b/packages/ffe-form-react/src/Input.spec.js
@@ -35,4 +35,14 @@ describe('<Input />', () => {
         wrapper.setProps({ textLike: true });
         expect(wrapper.hasClass('ffe-input-field--text-like')).toBe(true);
     });
+    it('sets the correct class for textRightAlign', () => {
+        const wrapper = getWrapper();
+        expect(wrapper.hasClass('ffe-input-field--text-right-align')).toBe(
+            false,
+        );
+        wrapper.setProps({ textRightAlign: true });
+        expect(wrapper.hasClass('ffe-input-field--text-right-align')).toBe(
+            true,
+        );
+    });
 });

--- a/packages/ffe-form/less/input-field.less
+++ b/packages/ffe-form/less/input-field.less
@@ -58,6 +58,9 @@
         display: inline-block;
         width: auto;
     }
+    &--text-right-align {
+        text-align: right;
+    }
 
     &--condensed {
         height: 38px;


### PR DESCRIPTION

## Beskrivelse
Legger til prop og css-klasse som gjør det mulig å enkelt høyre justere teksten i ett input felt. 

## Motivasjon og kontekst
Da vi gikk gjennom en del komponenter som tidligere fantes i Figma, men ikke i koden så vi at det var en del som bruker input felt med høyrejustert tekst. Da spesielt i tilfeller der det er snakk å fylle inn ett beløp med en valuta satt bak feltet. 

Legger til muligheten til å høyrejustere teksten i inputfeltet i håp om at det møter disse behovene uten å måtte trenge en helt ny komponent. 

## Testing
Testet opp mot component-overview, med å legge til og fjerne textRightAlign prop.
