### PR TITLE
fix(ffe-grid): legg til hvit tekst på mørkere bakgrunner

### DIFF
--- a/packages/ffe-grid/less/ffe-grid.less
+++ b/packages/ffe-grid/less/ffe-grid.less
@@ -230,6 +230,7 @@
 
     &--bg-vann {
         background-color: @ffe-farge-vann;
+        color: @ffe-farge-hvit;
         .native & {
             @media (prefers-color-scheme: dark) {
                 background-color: @ffe-black-darkmode;
@@ -239,6 +240,7 @@
 
     &--bg-fjell {
         background-color: @ffe-farge-fjell;
+        color: @ffe-farge-hvit;
         .native & {
             @media (prefers-color-scheme: dark) {
                 background-color: @ffe-black-darkmode;
@@ -406,6 +408,7 @@
 
     &--bg-vann {
         background-color: @ffe-farge-vann;
+        color: @ffe-farge-hvit;
         .native & {
             @media (prefers-color-scheme: dark) {
                 background-color: @ffe-black-darkmode;
@@ -415,6 +418,7 @@
 
     &--bg-fjell {
         background-color: @ffe-farge-fjell;
+        color: @ffe-farge-hvit;
         .native & {
             @media (prefers-color-scheme: dark) {
                 background-color: @ffe-black-darkmode;


### PR DESCRIPTION
## Beskrivelse
Legger til hvit default tekstfarge på gridCol og gridRow som har bakgrunnsfarge fjell og vann.

## Motivasjon og kontekst
For å oppfylle kontrastkrav

## Testing
Testet opp mot component-overview eksempel.