### PR TITLE
chore: rename actions secret

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
                   fetch-depth: '0'
                   ref: 'main'
                   # Use personnel access token for bot account
-                  token: ${{ secrets.GITHUB_USER_TOKEN }}
+                  token: ${{ secrets.GH_USER_PAT }}
 
             - name: git config user
               run: |

--- a/.github/workflows/update-main.yml
+++ b/.github/workflows/update-main.yml
@@ -23,7 +23,7 @@ jobs:
                   # `token` cannot be `secrets.GITHUB_TOKEN` as commits
                   # with this token will not trigger workflow runs.
                   # https://docs.github.com/en/actions/reference/authentication-in-a-workflow#using-the-github_token-in-a-workflow
-                  token: ${{ secrets.GITHUB_USER_TOKEN }}
+                  token: ${{ secrets.GH_USER_PAT }}
 
             - name: Check if main branch is ahead of develop branch
               id: git-rev-list


### PR DESCRIPTION
GitHub does not allow name of secrets to be prefixed with GITHUB_ anymore.