### PR TITLE
fix(ffe-buttons): øker max border-radius

### DIFF
--- a/packages/ffe-buttons/less/base-button.less
+++ b/packages/ffe-buttons/less/base-button.less
@@ -54,7 +54,7 @@
     align-items: center;
     appearance: none;
     border: 2px solid transparent;
-    border-radius: 1.375rem;
+    border-radius: 6em;
     color: @ffe-farge-hvit;
     cursor: pointer;
     display: flex;


### PR DESCRIPTION
Øker `border-radius` for å støtte runde hjørner også på knapper som bryter over flere linjer.
Verdien er satt høyt ettersom browserne begrenser radius til 50% av elementets høyde uansett, så lenge man ikke definerer med prosent.

Fixes #1268 