### PR TITLE
Legg til vann-30 som grid bakgrunnsfarge

### DIFF
--- a/component-overview/examples/grid/GridCol-background.jsx
+++ b/component-overview/examples/grid/GridCol-background.jsx
@@ -12,6 +12,7 @@ import { Label } from '@sb1/ffe-form-react';
         'syrin-70',
         'syrin-30',
         'vann',
+        'vann-30',
         'fjell',
         'hvit',
     ];

--- a/component-overview/examples/grid/GridRow-background.jsx
+++ b/component-overview/examples/grid/GridRow-background.jsx
@@ -12,6 +12,7 @@ import { Label } from '@sb1/ffe-form-react';
         'syrin-70',
         'syrin-30',
         'vann',
+        'vann-30',
         'fjell',
         'hvit',
     ];

--- a/packages/ffe-grid-react/src/GridCol.js
+++ b/packages/ffe-grid-react/src/GridCol.js
@@ -134,6 +134,7 @@ GridCol.propTypes = {
         'syrin-70',
         'syrin-30',
         'vann',
+        'vann-30',
         'fjell',
         'hvit',
     ]),

--- a/packages/ffe-grid-react/src/GridRow.js
+++ b/packages/ffe-grid-react/src/GridRow.js
@@ -60,6 +60,7 @@ GridRow.propTypes = {
         'syrin-70',
         'syrin-30',
         'vann',
+        'vann-30',
         'fjell',
         'hvit',
     ]),

--- a/packages/ffe-grid-react/src/background-colors.js
+++ b/packages/ffe-grid-react/src/background-colors.js
@@ -6,6 +6,7 @@ export default [
     'syrin-70',
     'syrin-30',
     'vann',
+    'vann-30',
     'fjell',
     'hvit',
 ];

--- a/packages/ffe-grid-react/src/index.d.ts
+++ b/packages/ffe-grid-react/src/index.d.ts
@@ -20,6 +20,7 @@ type BackgroundColors =
     | 'sand-70'
     | 'sand-30'
     | 'vann'
+    | 'vann-30'
     | 'fjell'
     | 'hvit';
 

--- a/packages/ffe-grid/less/ffe-grid.less
+++ b/packages/ffe-grid/less/ffe-grid.less
@@ -237,6 +237,14 @@
             }
         }
     }
+    &--bg-vann-30 {
+        background-color: @ffe-farge-vann-30;
+        .native & {
+            @media (prefers-color-scheme: dark) {
+                background-color: @ffe-black-darkmode;
+            }
+        }
+    }
 
     &--bg-fjell {
         background-color: @ffe-farge-fjell;
@@ -415,7 +423,14 @@
             }
         }
     }
-
+    &--bg-vann-30 {
+        background-color: @ffe-farge-vann-30;
+        .native & {
+            @media (prefers-color-scheme: dark) {
+                background-color: @ffe-black-darkmode;
+            }
+        }
+    }
     &--bg-fjell {
         background-color: @ffe-farge-fjell;
         color: @ffe-farge-hvit;


### PR DESCRIPTION
## Beskrivelse
Legg til vann-30 som gyldig bakgrunnsfarge i gridCol og gridRow. 
Oppdaterer også eksempel i component overview

## Motivasjon og kontekst
Gir utviklere og designere ett farge alternativ til å bruke i grid.
Fargen ble etterspurt av en interaksjonsdesigner.

## Testing
Testet opp mot component-overview lokalt
