### PR TITLE
fix(ffe-buttons): litt mindre padding på mobil

### DIFF
--- a/packages/ffe-buttons/less/base-button.less
+++ b/packages/ffe-buttons/less/base-button.less
@@ -62,7 +62,7 @@
     justify-content: center;
     line-height: 24px;
     overflow: hidden;
-    padding: @ffe-spacing-xs @ffe-spacing-lg;
+    padding: @ffe-spacing-xs @ffe-spacing-md;
     position: relative;
     text-align: center;
     text-decoration: none;
@@ -116,6 +116,7 @@
     @media (min-width: @breakpoint-sm) {
         display: inline-flex;
         width: auto;
+        padding: @ffe-spacing-xs @ffe-spacing-lg;
     }
 }
 


### PR DESCRIPTION
redusert padding i knappene for å unngå at de bryter over flere linjer

<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Motivasjon og kontekst

Fixes #1267 