### PR TITLE
fix(ffe-core): fjerner inline-block fra lenker

### DIFF
--- a/packages/ffe-core/less/typography.less
+++ b/packages/ffe-core/less/typography.less
@@ -327,7 +327,6 @@
     text-decoration: none;
     word-wrap: break-word;
     line-height: 1em;
-    display: inline-block;
     transition: all @ffe-transition-duration @ffe-ease;
 
     .native & {


### PR DESCRIPTION
tekstlinker må være inline for å unngå problemer når de bryter over flere linjer

<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse

`ffe-link-text` er stylet med et pseudo-element som legger til underline, i stedet for med text-decoration. Når lenkene er `inline-block` og teksten bryter over flere linjer blir underline-effekten borte, og det ligger kun en border i bunn av den siste linja. Med `inline` i stedet får all tekst underline.

## Motivasjon og kontekst

`inline-block` ble innført for å få bedre kontroll over styling av focus state. Focus tar nå opp hele linjehøyden by default, men ser ellers lik ut som før.

## Testing

Testet lokalt.