### PR TITLE
fix(ffe-form-react): gjør name prop required

### DIFF
--- a/packages/ffe-form-react/src/RadioButtonInputGroup.js
+++ b/packages/ffe-form-react/src/RadioButtonInputGroup.js
@@ -111,8 +111,8 @@ RadioButtonInputGroup.propTypes = {
      * acessibility validation using a tool such as aXe DevTools.
      */
     label: oneOfType([node, string]),
-    /** The name of the radio button */
-    name: string,
+    /** The name of the radio button, required to avoid missing name */
+    name: string.isRequired,
     /** Change handler, receives value of selected radio button */
     onChange: func,
     /** The currently selected value */


### PR DESCRIPTION
BREAKING CHANGE:  Name property i RadioButtonInputGroup er nå required da alle
radio buttons skal ha navn.

## Beskrivelse
Gjør name propertien til radiobuttoninpiutgroup til required.

## Motivasjon og kontekst
Løser issues der noen radiobuttons ender opp uten navn. 

## Testing
Testet lokalt mot component-overview.  Fjernet name property fra eksempel å fikk feilmelding i terminalen. 
