### PR TITLE
fix(ffe-buttons): skjuler label når knapper har spinner

### DIFF
--- a/packages/ffe-buttons/less/base-button.less
+++ b/packages/ffe-buttons/less/base-button.less
@@ -338,6 +338,7 @@
     transition: transform @ffe-transition-duration @ffe-ease;
     .ffe-button--loading & {
         transform: translateY(-32px);
+        opacity: 0;
     }
 }
 


### PR DESCRIPTION
fikser en bug der `.ffe-button__label` var synlig utenfor knapper med `.ffe-button--loading`

<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse

Før:
![Screenshot 2021-11-24 at 10 21 58](https://user-images.githubusercontent.com/463847/143211287-3301353a-4d8a-47af-bd8d-1d77cd25982a.png)

Etter:
![Screenshot 2021-11-24 at 10 22 06](https://user-images.githubusercontent.com/463847/143211292-a3fd0207-9203-43f7-9b86-d02ab806ac36.png)


## Motivasjon og kontekst

`.ffe-button--loading .ffe-button__label` har sannsynligvis vært "synlig" lenge, men tilfeldigvis hatt samme farge som sidens bakgrunnsfarge i de fleste tilfeller. Bugen har blitt synlig etterhvert som flere og flere tar i bruk alternative bakgrunnsfarger.

## Testing

Testet lokalt