### PR TITLE
fix(ffe-form-react): gjør name prop required i TS

### DIFF
--- a/packages/ffe-form-react/src/index.d.ts
+++ b/packages/ffe-form-react/src/index.d.ts
@@ -120,7 +120,7 @@ export interface RadioButtonInputGroupProps extends WeakFieldSetAttributes {
     fieldMessage?: string | React.ReactNode;
     inline?: boolean;
     label?: string | React.ReactNode;
-    name?: string;
+    name: string;
     onChange?: React.ChangeEventHandler<HTMLInputElement>;
     selectedValue?: string | boolean | number;
     tooltip?: string | React.ReactNode;


### PR DESCRIPTION
Relatert til PR #1275 og issue #1264

PropTypes ble oppdatert i den andre PRen, har bare gjenspeiler endringen også i typescript-typene.

Fylte ikke ut templaten -da endringen er så liten. Men om det er ønskelig med mer context får dere si ifra.

