### PR TITLE
feat(ffe-core): default fontstørrelse med prosent

### DIFF
--- a/packages/ffe-core/less/ffe-normalize.less
+++ b/packages/ffe-core/less/ffe-normalize.less
@@ -1,7 +1,7 @@
 /* GAB: Use border-box: http://www.paulirish.com/2012/box-sizing-border-box-ftw/ */
 html {
     box-sizing: border-box;
-    font-size: 16px; /* Default font-size, sets rem value */
+    font-size: 100%; /* 16 px base in most browsers */
 }
 
 *,


### PR DESCRIPTION
Setter default fontstørrelse til 100%, som tilsvarer 16px i de fleste browsere. Størrelse definert med relativ enhet i stedet for px tillater at brukere selv kan endre tekststørrelse i browseren.

## Motivasjon og kontekst

Fontstørrelse kan for øyeblikket ikke endres i browser, fordi vi har definert basestørrelse med px.

## Testing

Testet lokalt i forskjellige browsere.
