### PR TITLE
Tillatt postfikser ved desimalbeløp som ikke er ,–

### DIFF
--- a/packages/ffe-formatters/src/formatCurrency.js
+++ b/packages/ffe-formatters/src/formatCurrency.js
@@ -12,7 +12,10 @@ export default function formatCurrency(amount, opts = {}) {
     // A ',-' postfix is not allowed for amounts with øre, see:
     // http://www.sprakradet.no/svardatabase/sporsmal-og-svar/kronebelop-rekkjefolgje-komma-og-strek/
     if (parseNumber(amount) % 1 !== 0) {
-        return `${prefix}${formatNumber(amount, { decimals: 2 })}`;
+        const decimalPostfix = ![',–', ',-'].includes(postfix) ? postfix : '';
+        return `${prefix}${formatNumber(amount, {
+            decimals: 2,
+        })}${decimalPostfix}`;
     }
 
     return `${prefix}${formatNumber(amount)}${postfix}`;

--- a/packages/ffe-formatters/src/formatCurrency.spec.js
+++ b/packages/ffe-formatters/src/formatCurrency.spec.js
@@ -27,4 +27,19 @@ describe('format currency', () => {
             `1${NON_BREAKING_SPACE}234`,
         );
     });
+
+    test.each([',–', `,-`])(
+        'does not allow %s postfix for decimals',
+        postfix => {
+            expect(formatCurrency('999.99', { postfix })).toBe(
+                `kr${NON_BREAKING_SPACE}999,99`,
+            );
+        },
+    );
+
+    test('does allow postfix not equal ,– for decimals', () => {
+        expect(formatCurrency('999.99', { prefix: '', postfix: 'kr' })).toBe(
+            `999,99kr`,
+        );
+    });
 });


### PR DESCRIPTION
## Beskrivelse
Har laget støtte for at formatCurrency tar med postfix ved desimalbeløp så lenge postfix ikke er lik ,- eller ,–.
Grunnen til at jeg også tok med ,- (ikke tankestrek) er at det er en vanlig feil å benytte, og jeg går ut i fra at språkrådets anbefallinger gjelder her også.

## Motivasjon og kontekst
Manglende postfix i våre løsninger der beløpet har ører.

## Testing
Automatiske testcaser

<!--

Helt til slutt, har du ..

.. lest retningslinjene våre for bidrag? (Ja)
.. tatt en siste sjekk for kode og skrivefeil, debug informasjon o.l? (Ja)
.. kjørt og eventuelt oppdatert testene? (Ja)
.. kommentert og dokumentert det som trengs?
.. knyttet denne opp til relaterte issues? (Usikker på hvordan - gjelder issue #1286)

-->
