### PR TITLE
chore: allow all versions of peer deps in eslint-config-ffe

### DIFF
--- a/linting/eslint-config-ffe/package.json
+++ b/linting/eslint-config-ffe/package.json
@@ -27,10 +27,10 @@
     "eslint-plugin-react-hooks": "^2.0.1"
   },
   "peerDependencies": {
-    "eslint": "^5.9.0",
-    "eslint-plugin-jsx-a11y": "^6.0.3",
-    "eslint-plugin-react": ">=6",
-    "eslint-plugin-react-hooks": "^2.0.1"
+    "eslint": "*",
+    "eslint-plugin-jsx-a11y": "*",
+    "eslint-plugin-react": "*",
+    "eslint-plugin-react-hooks": "*"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Beskrivelse

Endrer peer dependencies i eslint-config-ffe til å tillatte alle versjoner.

## Motivasjon og kontekst

Etter overgangen til npm 8 så kan vi ikke lenger installere `eslint-config-ffe` fordi den er låst til versjon `5.9.0` av eslint, og vi bruker eslint `8.1.0`.

Dette er et forsøk på å fikse det problemet ved å tillate alle versjoner av eslint og plugins.
