### PR TITLE
fix(ffe-buttons): mindre padding på sidene

### DIFF
--- a/packages/ffe-buttons/less/base-button.less
+++ b/packages/ffe-buttons/less/base-button.less
@@ -116,7 +116,6 @@
     @media (min-width: @breakpoint-sm) {
         display: inline-flex;
         width: auto;
-        padding: @ffe-spacing-xs @ffe-spacing-lg;
     }
 }
 


### PR DESCRIPTION
## Beskrivelse

redusert padding til høyre og venstre, tilsvarende paddingen som finnes på mobil

se også #1273 

## Motivasjon og kontekst

Padding er allerede justert for mobil, men samme verdier skulle gjelde også på store skjermer.