### PR TITLE
Toggle switch-komponent

### DIFF
--- a/component-overview/examples/form/ToggleSwitch-alignRight.jsx
+++ b/component-overview/examples/form/ToggleSwitch-alignRight.jsx
@@ -1,0 +1,3 @@
+import { ToggleSwitch } from '@sb1/ffe-form-react';
+
+<ToggleSwitch alignRight={true}>Jeg vil gjerne ha reklame</ToggleSwitch>;

--- a/component-overview/examples/form/ToggleSwitch.jsx
+++ b/component-overview/examples/form/ToggleSwitch.jsx
@@ -1,0 +1,3 @@
+import { ToggleSwitch } from '@sb1/ffe-form-react';
+
+<ToggleSwitch>Jeg vil gjerne ha reklame</ToggleSwitch>;

--- a/packages/ffe-form-react/src/ToggleSwitch.js
+++ b/packages/ffe-form-react/src/ToggleSwitch.js
@@ -1,0 +1,55 @@
+import React from 'react';
+import { bool, node, string } from 'prop-types';
+import { v4 as uuidv4 } from 'uuid';
+import classNames from 'classnames';
+
+class ToggleSwitch extends React.Component {
+    id = `toggle-${uuidv4()}`;
+
+    render() {
+        const { children, className, alignRight, id, ...rest } = this.props;
+
+        return (
+            <div
+                className={classNames(
+                    'ffe-toggle-switch',
+                    { 'ffe-toggle-switch--align-right': alignRight },
+                    className,
+                )}
+            >
+                <input
+                    className="ffe-toggle-switch__input"
+                    type="checkbox"
+                    id={id || this.id}
+                    {...rest}
+                />
+                <label
+                    className="ffe-toggle-switch__label"
+                    htmlFor={id || this.id}
+                >
+                    {children}
+                </label>
+            </div>
+        );
+    }
+}
+
+ToggleSwitch.propTypes = {
+    /** The label text */
+    children: node.isRequired,
+    /** Any extra classes */
+    className: string,
+    /** Overrides the generated id with a custom one */
+    id: string,
+    /** Overrides the value attribute of the input with a custom one */
+    value: string,
+    /** Aligns the switch to the right */
+    alignRight: bool,
+};
+
+ToggleSwitch.defaultProps = {
+    alignRight: false,
+    value: 'on',
+};
+
+export default ToggleSwitch;

--- a/packages/ffe-form-react/src/ToggleSwitch.spec.js
+++ b/packages/ffe-form-react/src/ToggleSwitch.spec.js
@@ -1,0 +1,79 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import ToggleSwitch from './ToggleSwitch';
+
+const getWrapper = props =>
+    shallow(<ToggleSwitch {...props}>Hello world</ToggleSwitch>);
+
+describe('<ToggleSwitch />', () => {
+    it('should render a checkbox', () => {
+        const wrapper = getWrapper();
+        expect(wrapper.find('input[type="checkbox"]').exists()).toBe(true);
+    });
+
+    it('should render a default value if passed', () => {
+        let wrapper = getWrapper();
+
+        expect(wrapper.find('input').prop('checked')).toBe(undefined);
+
+        wrapper = getWrapper({ checked: true });
+
+        expect(wrapper.find('input').prop('checked')).toBe(true);
+    });
+
+    it('should apply the same id to <label> and <input>', () => {
+        const wrapper = getWrapper({ name: 'Some text goes here' });
+
+        expect(wrapper.find('label').prop('htmlFor')).toBe(
+            wrapper.find('input').prop('id'),
+        );
+    });
+
+    it('should apply an unique id for each instance', () => {
+        const wrapper1 = getWrapper({ name: 'Some text goes here' });
+        const wrapper2 = getWrapper({ name: 'Some other text goes here' });
+
+        expect(wrapper1.find('input').prop('id')).not.toBe(
+            wrapper2.find('input').prop('id'),
+        );
+    });
+
+    it('should not change id when re-rendering an instance', () => {
+        const wrapper = getWrapper({ name: 'Some text goes here' });
+        const id = wrapper.find('input').prop('id');
+
+        // ShallowWrapper.update() alone does not force a re-render, it seems.
+        wrapper.instance().forceUpdate();
+        wrapper.update();
+        wrapper.setProps({});
+
+        expect(wrapper.find('input').prop('id')).toBe(id);
+    });
+
+    it('should allow to override the id', () => {
+        const id = 'this-is-not-a-generated-id';
+        const wrapper = getWrapper({ id, name: 'Some text goes here' });
+
+        expect(wrapper.find('label').prop('htmlFor')).toBe(id);
+        expect(wrapper.find('input').prop('id')).toBe(id);
+    });
+
+    it('should set arbitrary props (rest) on input', () => {
+        const wrapper = getWrapper({
+            name: 'toggle',
+            randomProp: 'false',
+            tabIndex: -1,
+        });
+
+        expect(wrapper.find('input').prop('name')).toBe('toggle');
+        expect(wrapper.find('input').prop('randomProp')).toBe('false');
+        expect(wrapper.find('input').prop('tabIndex')).toBe(-1);
+    });
+
+    it('should render children', () => {
+        const wrapper = getWrapper();
+
+        expect(wrapper.find('label').prop('children')).toBe('Hello world');
+    });
+});

--- a/packages/ffe-form-react/src/index.d.ts
+++ b/packages/ffe-form-react/src/index.d.ts
@@ -150,6 +150,15 @@ export interface TextAreaProps
     className?: string;
 }
 
+export interface ToggleSwitchProps
+    extends React.InputHTMLAttributes<HTMLInputElement> {
+    children: React.ReactNode;
+    className: string;
+    id: string;
+    value: string;
+    alignRight: boolean;
+}
+
 declare class Checkbox extends React.Component<CheckboxProps, any> {}
 declare class ErrorFieldMessage extends React.Component<
     BaseFieldMessageProps,
@@ -168,6 +177,7 @@ declare class PhoneNumber extends React.Component<PhoneNumberProps, any> {}
 declare class Label extends React.Component<LabelProps, any> {}
 declare class InputGroup extends React.Component<InputGroupProps, any> {}
 declare class Tooltip extends React.Component<TooltipProps, any> {}
+declare class ToggleSwitch extends React.Component<ToggleSwitchProps, any> {}
 declare class RadioBlock extends React.Component<RadioBlockProps, any> {}
 declare class RadioButton extends React.Component<RadioButtonProps, any> {}
 declare class RadioButtonInputGroup extends React.Component<

--- a/packages/ffe-form-react/src/index.js
+++ b/packages/ffe-form-react/src/index.js
@@ -12,6 +12,7 @@ import RadioButtonInputGroup from './RadioButtonInputGroup';
 import RadioSwitch from './RadioSwitch';
 import TextArea from './TextArea';
 import Tooltip from './Tooltip';
+import ToggleSwitch from './ToggleSwitch';
 
 export {
     Checkbox,
@@ -28,4 +29,5 @@ export {
     RadioSwitch,
     TextArea,
     Tooltip,
+    ToggleSwitch,
 };

--- a/packages/ffe-form/less/form.less
+++ b/packages/ffe-form/less/form.less
@@ -11,6 +11,7 @@
 @import 'radio-switch';
 @import 'radio-block';
 @import 'phone-number';
+@import 'toggle-switch';
 
 /* Form Layout */
 @import 'input-group';

--- a/packages/ffe-form/less/toggle-switch.less
+++ b/packages/ffe-form/less/toggle-switch.less
@@ -1,0 +1,149 @@
+// Toggle switch
+//
+// Markup:
+// <div class="ffe-toggle-switch ffe-toggle-switch{{modifier_class}}">
+//     <input type="checkbox" class="ffe-toggle-switch__input" id="toggle{{modifier_class}}" name="toggle{{modifier_class}}" value="on">
+//     <label class="ffe-toggle-switch__label" for="toggle{{modifier_class}}">
+//         Send meg spam
+//     </label>
+// </div>
+//
+// --align-right - Aligns the switch to the right
+//
+// Styleguide ffe-form.toggle-switch
+
+.ffe-toggle-switch {
+    &__input {
+        position: absolute;
+        opacity: 0;
+        cursor: pointer;
+    }
+
+    &__label {
+        position: relative;
+        cursor: pointer;
+        padding: 0 0 0 65px;
+        line-height: 32px;
+        height: 32px;
+        display: block;
+        color: @ffe-farge-fjell;
+
+        .native & {
+            @media (prefers-color-scheme: dark) {
+                color: @ffe-farge-hvit;
+            }
+        }
+
+        &::before {
+            display: inline-block;
+            content: '';
+            width: 50px;
+            height: 30px;
+            background: @ffe-farge-graa;
+            border-radius: 15px;
+            position: absolute;
+            z-index: 1;
+            left: 0;
+            transition: background 0.4s @ffe-ease,
+                box-shadow @ffe-transition-duration @ffe-ease;
+
+            .native & {
+                @media (prefers-color-scheme: dark) {
+                    background: @ffe-farge-varmgraa;
+                }
+            }
+        }
+
+        &::after {
+            display: inline-block;
+            content: '';
+            width: 24px;
+            height: 24px;
+            background: @ffe-farge-hvit;
+            border-radius: 13px;
+            position: absolute;
+            z-index: 2;
+            left: 3px;
+            top: 3px;
+            transition: transform @ffe-transition-duration @ffe-ease-in-out-back;
+
+            .native & {
+                @media (prefers-color-scheme: dark) {
+                    background: @ffe-farge-svart;
+                }
+            }
+        }
+
+        &:hover::before {
+            background: @ffe-farge-varmgraa;
+
+            .native & {
+                @media (prefers-color-scheme: dark) {
+                    background: @ffe-farge-graa;
+                }
+            }
+        }
+    }
+
+    &__input:checked + .ffe-toggle-switch__label::after {
+        transform: translateX(20px);
+    }
+
+    &__input:checked + .ffe-toggle-switch__label::before {
+        background: @ffe-farge-fjell;
+
+        .native & {
+            @media (prefers-color-scheme: dark) {
+                background: @ffe-farge-vann-70;
+            }
+        }
+    }
+
+    &__input:checked + .ffe-toggle-switch__label:hover::before {
+        background: @ffe-farge-fjell-70;
+
+        .native & {
+            @media (prefers-color-scheme: dark) {
+                background: @ffe-farge-vann-30;
+            }
+        }
+    }
+
+    &__input:focus:not(:focus-visible) + .ffe-toggle-switch__label::before {
+        box-shadow: none;
+
+        .native & {
+            @media (prefers-color-scheme: dark) {
+                box-shadow: none;
+            }
+        }
+    }
+
+    &__input:focus + .ffe-toggle-switch__label::before {
+        box-shadow: 0 0 0 3px @ffe-farge-hvit, 0 0 0 5px @ffe-farge-fjell;
+
+        .native & {
+            @media (prefers-color-scheme: dark) {
+                box-shadow: 0 0 0 3px @ffe-farge-svart,
+                    0 0 0 5px @ffe-farge-hvit;
+            }
+        }
+    }
+
+    &--align-right {
+        .ffe-toggle-switch__label {
+            padding: 0 65px 0 0;
+            text-align: right;
+
+            &::before {
+                left: auto;
+                right: 0;
+            }
+
+            &::after {
+                left: auto;
+                right: 23px;
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse

Ny komponent som passer for valg som kan skrus av eller på, med umiddelbar respons. Under panseret er dette en checkbox.

**Skjermskudd:**

![image](https://user-images.githubusercontent.com/463847/148364083-ae5fa0e4-4a5a-434d-8e20-9bf49dbc35b1.png)

Dette viser lys og mørk variant i følgende states:

* default
* default + hover
* valgt
* valgt + hover
* fokus (tastatur)


**Eksempler som viser transitions mellom forskjellige states:**

Default, hover, valgt
![image](https://i.imgur.com/r4qjT7X.gif)

Fokus
![image](https://i.imgur.com/auwGz4f.gif)

Dark mode - default, hover, valgt
![image](https://i.imgur.com/O1V9wii.gif)

Dark mode - fokus
![image](https://i.imgur.com/oetwuYx.gif)

## Motivasjon og kontekst

Dette er en gjenoppliving av en gammel PR (#527) for ny ToggleSwitch-komponent. I etterkant av at den forrige ble lagt på is har behovet blitt revurdert og vi har kommet frem til at vi likevel ønsker en slik komponent.
