### PR TITLE
fix(component-overview): oppdater farge i inlinegrid eksempel

### DIFF
--- a/component-overview/examples/grid/InlineGrid-nested.jsx
+++ b/component-overview/examples/grid/InlineGrid-nested.jsx
@@ -2,16 +2,16 @@ import { InlineGrid, GridRow, GridCol } from '@sb1/ffe-grid-react';
 
 <InlineGrid>
     <GridRow>
-        <GridCol sm="12" md="6" background="grey-warm">
+        <GridCol sm="12" md="6" background="sand-30">
             Litt innhold til venstre
         </GridCol>
         <GridCol sm="12" md="6">
             <InlineGrid>
                 <GridRow>
-                    <GridCol sm="6" background="blue-ice">
+                    <GridCol sm="6" background="frost-30">
                         Grid inni grid - venstre
                     </GridCol>
-                    <GridCol sm="6" background="green-mint">
+                    <GridCol sm="6" background="syrin-30">
                         Grid inni grid - høyre
                     </GridCol>
                 </GridRow>


### PR DESCRIPTION
## Beskrivelse
Nested Inlinegrid eksempelet brukte gamle og nå ugyldige bakgrunnsfarger inn i prop på GridCol.
Dette ga feilmelding istedenfor å vise eksempelet. 

## Motivasjon og kontekst
Det vises feilmelding istedenfor eksempel i dokumentasjonen. Ønsker å se eksempelet riktig. 

## Testing
Kjørt opp lokalt og testet mot component overview