### PR TITLE
searchable-dropdown / account-selector: change labelId to labelledById

### DIFF
--- a/component-overview/examples/account-selector/AccountSelector.jsx
+++ b/component-overview/examples/account-selector/AccountSelector.jsx
@@ -7,7 +7,7 @@ import { InputGroup } from '@sb1/ffe-form-react';
 
     const label1 = 'label1';
     return (
-        <InputGroup label="Velg konto" extraMargin={false} labelId={label1} >
+        <InputGroup label="Velg konto" extraMargin={false} labelId={label1}>
             <AccountSelector
                 accounts={[
                     {
@@ -40,8 +40,8 @@ import { InputGroup } from '@sb1/ffe-form-react';
                 onAccountSelected={val => setSelectedAccount(val)}
                 onReset={() => setSelectedAccount(null)}
                 selectedAccount={selectedAccount}
-                labelId={label1}
                 ariaInvalid={false}
             />
-        </InputGroup>);
-}
+        </InputGroup>
+    );
+};

--- a/component-overview/examples/dropdown/SearchableDropdown.jsx
+++ b/component-overview/examples/dropdown/SearchableDropdown.jsx
@@ -27,7 +27,7 @@ import { useState } from 'react';
         <InputGroup label="Velg bedrift" labelId={labelId}>
             <SearchableDropdown
                 id={id}
-                labelId={labelId}
+                labelledById={labelId}
                 inputProps={{ placeholder: 'Velg' }}
                 dropdownAttributes={['organizationName']}
                 dropdownList={companies}

--- a/packages/ffe-account-selector-react/src/components/account-selector/AccountSelector.js
+++ b/packages/ffe-account-selector-react/src/components/account-selector/AccountSelector.js
@@ -45,7 +45,7 @@ const AccountSelector = ({
     accounts,
     onAccountSelected,
     allowCustomAccount = false,
-    labelId,
+    labelledById,
     listElementBody,
     onReset,
     inputProps,
@@ -138,7 +138,7 @@ const AccountSelector = ({
             >
                 <SearchableDropdown
                     id={id}
-                    labelId={labelId}
+                    labelledById={labelledById}
                     inputProps={{
                         ...inputProps,
                         onChange: onInputChange,
@@ -193,7 +193,8 @@ AccountSelector.propTypes = {
         text: string.isRequired,
         dropdownList: arrayOf(object),
     }),
-    labelId: string.isRequired,
+    /** Id of element that labels input field */
+    labelledById: string,
     /** Returns the selected account object */
     onAccountSelected: func.isRequired,
     /**

--- a/packages/ffe-account-selector-react/src/index.d.ts
+++ b/packages/ffe-account-selector-react/src/index.d.ts
@@ -31,7 +31,7 @@ export interface AccountSelectorProps {
     selectedAccount?: Account;
     showBalance?: boolean;
     formatAccountNumber?: boolean;
-    labelId: string;
+    labelledById?: string;
     allowCustomAccount?: boolean;
     listElementBody?: (props: ListElementBodyProps) => React.FC<HTMLDivElement>;
     withSpaceForDetails?: boolean;

--- a/packages/ffe-searchable-dropdown-react/src/SearchableDropdown.js
+++ b/packages/ffe-searchable-dropdown-react/src/SearchableDropdown.js
@@ -46,7 +46,7 @@ const ENTER = 'Enter';
 
 const SearchableDropdown = ({
     id,
-    labelId,
+    labelledById,
     className,
     dropdownList,
     dropdownAttributes,
@@ -281,7 +281,7 @@ const SearchableDropdown = ({
                     {...inputProps}
                     ref={inputRef}
                     id={id}
-                    aria-labelledby={labelId}
+                    aria-labelledby={labelledById}
                     className="ffe-input-field"
                     onClick={handleInputClick}
                     onChange={e => {
@@ -389,8 +389,8 @@ SearchableDropdown.propTypes = {
     /** Id of drop down */
     id: string.isRequired,
 
-    /** Id of label */
-    labelId: string.isRequired,
+    /** Id of element that labels input field */
+    labelledById: string,
 
     /** Extra class */
     className: string,

--- a/packages/ffe-searchable-dropdown-react/src/index.d.ts
+++ b/packages/ffe-searchable-dropdown-react/src/index.d.ts
@@ -12,7 +12,7 @@ interface NoMatch<T> {
 
 export interface SearchableDropdownProps<T> {
     id: string;
-    labelId: string;
+    labelledById?: string;
     className?: string;
     dropdownList: T[];
     dropdownAttributes: (keyof T)[];


### PR DESCRIPTION
Siden man kan gi inn en `id` til input-elementet kan man gi dropdownen et label uten å **måtte** bruke `aria-labelledby`. Så den kan gjøres optional. I tillegg endrer jeg den fra `labelId` til `labelledById`, siden det er mer beskrivende etter min mening.

PS: Er dette riktig måte å lage en ny major-versjon på?