### PR TITLE
Bugfix: Legg til typer i ffe-collapse-react

### DIFF
--- a/packages/ffe-collapse-react/src/index.d.ts
+++ b/packages/ffe-collapse-react/src/index.d.ts
@@ -6,3 +6,5 @@ export interface CollapseProps extends React.HTMLProps<HTMLDivElement> {
 }
 
 declare class Collapse extends React.Component<CollapseProps, any> {}
+
+export default Collapse;


### PR DESCRIPTION
TypeScript klagde over at Collapse i @sb1/ffe-collapse-react ikke har sine typer i orden:
`TS2604: JSX element type 'Collapse' does not have any construct or call signatures.`

Denne endring gjør type-definisjonen tilgjengelig til compileren.