### PR TITLE
fix(ffe-searchable-dropdown-react): Fix highlighting of list element …

### DIFF
--- a/packages/ffe-searchable-dropdown-react/src/reducer.js
+++ b/packages/ffe-searchable-dropdown-react/src/reducer.js
@@ -73,7 +73,7 @@ export const createReducer = ({
                 listToRender,
                 highlightedIndex:
                     action.payload.inputValue.trim() === '' ||
-                    state.listToRender.length === 0
+                    listToRender.length === 0
                         ? -1
                         : 0,
                 noMatch,


### PR DESCRIPTION
…on input change

<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse

Ved endring av inputfelt sjekket vi opp mot listToRender et steg bak ikke den nyeste når vi skal sette highlightedIndex. Det gjør at vi ikke får highlight på elementet før ett steg for sent. Grunnen til at feilen ikke er oppdaget tidligere er fordi det kun skjer en synlig feil dersom lista et steg tilbake var tom og den nyeste ikke er tom.

## Motivasjon og kontekst

Denne feilen førte til at kunder uten mottakere i nettbanken ikke fikk skrevet inn til-kontonummer i betalingsskjema når de limte inn et kontonummer. Mens for kunder med mottakere funket det fint.

## Testing

Testet i chrome på desktop.

