### PR TITLE
fix(buildtool): bugfix for npm 6

### DIFF
--- a/buildtool/src/util/__snapshots__/createBabelArgs.spec.js.snap
+++ b/buildtool/src/util/__snapshots__/createBabelArgs.spec.js.snap
@@ -4,10 +4,12 @@ exports[`createBabelArgs cjs only 1`] = `
 Array [
   Array [
     "--package",
+    "@babel/core",
+    "--package",
     "@babel/cli",
     "babel",
     "--config-file",
-    "config/babel.config.js",
+    "buildtool/config/babel.config.js",
     "--ignore",
     "**/*.spec.js",
     "--env-name",
@@ -23,10 +25,12 @@ exports[`createBabelArgs esm only 1`] = `
 Array [
   Array [
     "--package",
+    "@babel/core",
+    "--package",
     "@babel/cli",
     "babel",
     "--config-file",
-    "config/babel.config.js",
+    "buildtool/config/babel.config.js",
     "--ignore",
     "**/*.spec.js",
     "--env-name",
@@ -42,10 +46,12 @@ exports[`createBabelArgs minimal args 1`] = `
 Array [
   Array [
     "--package",
+    "@babel/core",
+    "--package",
     "@babel/cli",
     "babel",
     "--config-file",
-    "config/babel.config.js",
+    "buildtool/config/babel.config.js",
     "--ignore",
     "**/*.spec.js",
     "--env-name",
@@ -56,10 +62,12 @@ Array [
   ],
   Array [
     "--package",
+    "@babel/core",
+    "--package",
     "@babel/cli",
     "babel",
     "--config-file",
-    "config/babel.config.js",
+    "buildtool/config/babel.config.js",
     "--ignore",
     "**/*.spec.js",
     "--env-name",
@@ -75,10 +83,12 @@ exports[`createBabelArgs with watch 1`] = `
 Array [
   Array [
     "--package",
+    "@babel/core",
+    "--package",
     "@babel/cli",
     "babel",
     "--config-file",
-    "config/babel.config.js",
+    "buildtool/config/babel.config.js",
     "--ignore",
     "**/*.spec.js",
     "--env-name",

--- a/buildtool/src/util/createBabelArgs.js
+++ b/buildtool/src/util/createBabelArgs.js
@@ -3,6 +3,8 @@ const path = require('path');
 module.exports = function(opts) {
     const shared = [
         '--package',
+        '@babel/core',
+        '--package',
         '@babel/cli',
         'babel',
         '--config-file',

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,9 @@
 module.exports = {
     moduleFileExtensions: ['js', 'jsx'],
-    testMatch: ['<rootDir>/packages/*/src/**/*.spec.(js|jsx)'],
+    testMatch: [
+        '<rootDir>/packages/*/src/**/*.spec.(js|jsx)',
+        '<rootDir>/buildtool/src/**/*.spec.(js|jsx)',
+    ],
     transform: {
         '^.+\\.(js|jsx|mjs)$': '<rootDir>/transform.js',
     },


### PR DESCRIPTION
## Beskrivelse

Byggscriptet i `buildtool` som kompilerer jsx til es/cjs med hjelp av babel og npx fungerte ikke med npm 6 og feilet med feilmeldingen `Error: Cannot find module '@babel/core'`. Denne endringen fikser dette.

## Testing

Kjør følgende på en maskin med npm 6 og se at prosjektet bygger:

```
npm install
npm run build
npm test
```