### PR TITLE
Default imports av ffe-icons-react

### DIFF
--- a/buildtool/config/babel.config.js
+++ b/buildtool/config/babel.config.js
@@ -9,4 +9,12 @@ module.exports = api => ({
         ],
         '@babel/react',
     ],
+    plugins: [
+        [
+            '../src/util/babel-plugin-ffe-icons',
+            {
+                sourceSubpath: api.env('es') ? 'es' : 'lib',
+            },
+        ],
+    ],
 });

--- a/buildtool/src/util/__snapshots__/babel-plugin-ffe-icons.spec.js.snap
+++ b/buildtool/src/util/__snapshots__/babel-plugin-ffe-icons.spec.js.snap
@@ -1,0 +1,15 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`change to default imports from esm snapshot 1`] = `
+"import React from 'react';
+import AtvIkon from \\"@sb1/ffe-icons-react/es/atv-ikon\\";
+import MinBamseIkon from \\"@sb1/ffe-icons-react/es/bamse-ikon\\";
+const foo = 'bar';"
+`;
+
+exports[`change to default imports snapshot 1`] = `
+"import React from 'react';
+import AtvIkon from \\"@sb1/ffe-icons-react/lib/atv-ikon\\";
+import MinBamseIkon from \\"@sb1/ffe-icons-react/lib/bamse-ikon\\";
+const foo = 'bar';"
+`;

--- a/buildtool/src/util/babel-plugin-ffe-icons.js
+++ b/buildtool/src/util/babel-plugin-ffe-icons.js
@@ -1,0 +1,21 @@
+const { kebab } = require('case');
+
+module.exports = ({ types: t }) => ({
+    visitor: {
+        ImportDeclaration(path, { opts }) {
+            if (path.node.source.value === '@sb1/ffe-icons-react') {
+                path.replaceWithMultiple(
+                    path.node.specifiers.map(spec => {
+                        const identifier = t.identifier(spec.local.name);
+                        const specifier = t.importDefaultSpecifier(identifier);
+                        const source = t.stringLiteral(
+                            `@sb1/ffe-icons-react/${opts.sourceSubpath ||
+                                'lib'}/${kebab(spec.imported.name)}`,
+                        );
+                        return t.importDeclaration([specifier], source);
+                    }),
+                );
+            }
+        },
+    },
+});

--- a/buildtool/src/util/babel-plugin-ffe-icons.spec.js
+++ b/buildtool/src/util/babel-plugin-ffe-icons.spec.js
@@ -1,0 +1,24 @@
+const babel = require('@babel/core');
+const plugin = require('./babel-plugin-ffe-icons');
+
+const actual = `import React from 'react';
+import { AtvIkon, BamseIkon as MinBamseIkon } from '@sb1/ffe-icons-react';
+const foo = 'bar';`;
+
+describe('change to default imports', () => {
+    const { code } = babel.transform(actual, { plugins: [plugin] });
+    test('imports from lib path', () =>
+        expect(code).toMatch('@sb1/ffe-icons-react/lib/bamse-ikon'));
+    test('imports icon name', () =>
+        expect(code).toMatch('import MinBamseIkon'));
+    test('snapshot', () => expect(code).toMatchSnapshot());
+});
+
+describe('change to default imports from esm', () => {
+    const { code } = babel.transform(actual, {
+        plugins: [[plugin, { sourceSubpath: 'es' }]],
+    });
+    test('imports from es path', () =>
+        expect(code).toMatch('@sb1/ffe-icons-react/es/bamse-ikon'));
+    test('snapshot', () => expect(code).toMatchSnapshot());
+});

--- a/packages/ffe-buttons-react/src/ExpandButton.js
+++ b/packages/ffe-buttons-react/src/ExpandButton.js
@@ -10,7 +10,7 @@ import {
     elementType,
 } from 'prop-types';
 import classNames from 'classnames';
-import KryssIkon from '@sb1/ffe-icons-react/lib/kryss-ikon';
+import { KryssIkon } from '@sb1/ffe-icons-react';
 
 const ExpandButton = props => {
     const {

--- a/packages/ffe-buttons-react/src/ExpandButton.spec.js
+++ b/packages/ffe-buttons-react/src/ExpandButton.spec.js
@@ -1,9 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 
-import BamseIkon from '@sb1/ffe-icons-react/lib/bamse-ikon';
-import BestikkIkon from '@sb1/ffe-icons-react/lib/bestikk-ikon';
-import KryssIkon from '@sb1/ffe-icons-react/lib/kryss-ikon';
+import { BamseIkon, BestikkIkon, KryssIkon } from '@sb1/ffe-icons-react';
 
 import ExpandButton from './ExpandButton';
 

--- a/packages/ffe-buttons-react/src/InlineExpandButton.js
+++ b/packages/ffe-buttons-react/src/InlineExpandButton.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { bool, func, node, oneOfType, object, shape } from 'prop-types';
-import ChevronIkon from '@sb1/ffe-icons-react/lib/chevron-ikon';
+import { ChevronIkon } from '@sb1/ffe-icons-react';
 
 import InlineButton from './InlineBaseButton';
 

--- a/packages/ffe-buttons-react/src/InlineExpandButton.spec.js
+++ b/packages/ffe-buttons-react/src/InlineExpandButton.spec.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import ChevronIkon from '@sb1/ffe-icons-react/lib/chevron-ikon';
+import { ChevronIkon } from '@sb1/ffe-icons-react';
 
 import InlineExpandButton from './InlineExpandButton';
 

--- a/packages/ffe-buttons-react/src/ShortcutButton.js
+++ b/packages/ffe-buttons-react/src/ShortcutButton.js
@@ -9,7 +9,7 @@ import {
     shape,
     elementType,
 } from 'prop-types';
-import ChevronIkon from '@sb1/ffe-icons-react/lib/chevron-ikon';
+import { ChevronIkon } from '@sb1/ffe-icons-react';
 import Button from './BaseButton';
 
 const ShortcutButton = props => (

--- a/packages/ffe-buttons-react/src/ShortcutButton.spec.js
+++ b/packages/ffe-buttons-react/src/ShortcutButton.spec.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import ChevronIkon from '@sb1/ffe-icons-react/lib/chevron-ikon';
+import { ChevronIkon } from '@sb1/ffe-icons-react';
 
 import ShortcutButton from './ShortcutButton';
 

--- a/packages/ffe-buttons-react/src/TaskButton.spec.js
+++ b/packages/ffe-buttons-react/src/TaskButton.spec.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import ChevronIkon from '@sb1/ffe-icons-react/lib/chevron-ikon';
+import { ChevronIkon } from '@sb1/ffe-icons-react';
 
 import TaskButton from './TaskButton';
 

--- a/packages/ffe-cards-react/package.json
+++ b/packages/ffe-cards-react/package.json
@@ -32,7 +32,6 @@
   },
   "devDependencies": {
     "@sb1/ffe-buildtool": "^0.3.2",
-    "@sb1/ffe-icons": "^12.16.0",
     "@sb1/ffe-icons-react": "^7.2.22",
     "enzyme": "^3.7.0",
     "enzyme-adapter-react-16": "^1.7.0",

--- a/packages/ffe-cards-react/src/IconCard/IconCard.spec.js
+++ b/packages/ffe-cards-react/src/IconCard/IconCard.spec.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { shallow } from 'enzyme';
 
 import IconCard from './IconCard';
-import SparegrisIkon from '../../../ffe-icons-react/lib/sparegris-ikon';
+import { SparegrisIkon } from '@sb1/ffe-icons-react';
 import { Text } from '../components';
 
 const getWrapper = props =>

--- a/packages/ffe-context-message-react/src/ContextErrorMessage.js
+++ b/packages/ffe-context-message-react/src/ContextErrorMessage.js
@@ -11,7 +11,7 @@ import {
 } from 'prop-types';
 import acceptedLocales from './locale/accepted-locales';
 import ContextMessage from './ContextMessage';
-import UtropstegnIkon from '@sb1/ffe-icons-react/lib/utropstegn-ikon';
+import { UtropstegnIkon } from '@sb1/ffe-icons-react';
 
 const ContextErrorMessage = props => {
     const { alert, ...rest } = props;

--- a/packages/ffe-context-message-react/src/ContextInfoMessage.js
+++ b/packages/ffe-context-message-react/src/ContextInfoMessage.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import ContextMessage from './ContextMessage';
-import InfoIkon from '@sb1/ffe-icons-react/lib/info-ikon';
+import { InfoIkon } from '@sb1/ffe-icons-react';
 
 const ContextInfoMessage = props => (
     <ContextMessage messageType="info" icon={<InfoIkon />} {...props} />

--- a/packages/ffe-context-message-react/src/ContextMessage.js
+++ b/packages/ffe-context-message-react/src/ContextMessage.js
@@ -10,7 +10,7 @@ import {
     object,
 } from 'prop-types';
 import classNames from 'classnames';
-import KryssIkon from '@sb1/ffe-icons-react/lib/kryss-ikon';
+import { KryssIkon } from '@sb1/ffe-icons-react';
 import acceptedLocales from './locale/accepted-locales';
 import texts from './locale/texts';
 import { v4 as uuid } from 'uuid';

--- a/packages/ffe-context-message-react/src/ContextMessage.spec.js
+++ b/packages/ffe-context-message-react/src/ContextMessage.spec.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { shallow, mount } from 'enzyme';
 
-import InfoSirkelIkon from '@sb1/ffe-icons-react/lib/info-sirkel-ikon';
+import { InfoSirkelIkon } from '@sb1/ffe-icons-react';
 
 import {
     ContextErrorMessage,

--- a/packages/ffe-context-message-react/src/ContextSuccessMessage.js
+++ b/packages/ffe-context-message-react/src/ContextSuccessMessage.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import ContextMessage from './ContextMessage';
-import HakeIkon from '@sb1/ffe-icons-react/lib/hake-ikon';
+import { HakeIkon } from '@sb1/ffe-icons-react';
 
 const ContextSuccessMessage = props => (
     <ContextMessage messageType="success" icon={<HakeIkon />} {...props} />

--- a/packages/ffe-context-message-react/src/ContextTipMessage.js
+++ b/packages/ffe-context-message-react/src/ContextTipMessage.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import ContextMessage from './ContextMessage';
-import LyspareIkon from '@sb1/ffe-icons-react/lib/lyspare-ikon';
+import { LyspareIkon } from '@sb1/ffe-icons-react';
 
 const ContextTipMessage = props => (
     <ContextMessage messageType="tip" icon={<LyspareIkon />} {...props} />

--- a/packages/ffe-datepicker-react/src/button/Button.js
+++ b/packages/ffe-datepicker-react/src/button/Button.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import { string, func, object } from 'prop-types';
-import KalenderIkon from '@sb1/ffe-icons-react/lib/kalender-ikon';
+import { KalenderIkon } from '@sb1/ffe-icons-react';
 import { validateDate } from '../util/dateUtil';
 import i18n from '../i18n/i18n';
 

--- a/packages/ffe-datepicker-react/src/calendar/Header.js
+++ b/packages/ffe-datepicker-react/src/calendar/Header.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { func, number, object, string } from 'prop-types';
-import ChevronIkon from '@sb1/ffe-icons-react/lib/chevron-ikon';
+import { ChevronIkon } from '@sb1/ffe-icons-react';
 
 export default function Header(props) {
     const {

--- a/packages/ffe-message-box-react/src/ErrorMessage.js
+++ b/packages/ffe-message-box-react/src/ErrorMessage.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { node, string, bool } from 'prop-types';
 
-import UtropstegnIkon from '@sb1/ffe-icons-react/lib/utropstegn-ikon';
+import { UtropstegnIkon } from '@sb1/ffe-icons-react';
 
 import BaseMessage from './BaseMessage';
 

--- a/packages/ffe-message-box-react/src/InfoMessage.js
+++ b/packages/ffe-message-box-react/src/InfoMessage.js
@@ -1,16 +1,12 @@
 import React from 'react';
 import { node, string } from 'prop-types';
 
-import InfoIkon from '@sb1/ffe-icons-react/lib/info-ikon';
+import { InfoIkon } from '@sb1/ffe-icons-react';
 
 import BaseMessage from './BaseMessage';
 
 const InfoMessage = props => (
-    <BaseMessage
-        type="info"
-        icon={<InfoIkon />}
-        {...props}
-    />
+    <BaseMessage type="info" icon={<InfoIkon />} {...props} />
 );
 
 InfoMessage.propTypes = {

--- a/packages/ffe-message-box-react/src/SuccessMessage.js
+++ b/packages/ffe-message-box-react/src/SuccessMessage.js
@@ -1,16 +1,12 @@
 import React from 'react';
 import { node, string } from 'prop-types';
 
-import HakeIkon from '@sb1/ffe-icons-react/lib/hake-ikon';
+import { HakeIkon } from '@sb1/ffe-icons-react';
 
 import BaseMessage from './BaseMessage';
 
 const SuccessMessage = props => (
-    <BaseMessage
-        type="success"
-        icon={<HakeIkon />}
-        {...props}
-    />
+    <BaseMessage type="success" icon={<HakeIkon />} {...props} />
 );
 
 SuccessMessage.propTypes = {

--- a/packages/ffe-message-box-react/src/TipsMessage.js
+++ b/packages/ffe-message-box-react/src/TipsMessage.js
@@ -1,16 +1,12 @@
 import React from 'react';
 import { node, string } from 'prop-types';
 
-import LyspareIkon from '@sb1/ffe-icons-react/lib/lyspare-ikon';
+import { LyspareIkon } from '@sb1/ffe-icons-react';
 
 import BaseMessage from './BaseMessage';
 
 const TipsMessage = props => (
-    <BaseMessage
-        type="tips"
-        icon={<LyspareIkon />}
-        {...props}
-    />
+    <BaseMessage type="tips" icon={<LyspareIkon />} {...props} />
 );
 
 TipsMessage.propTypes = {

--- a/packages/ffe-system-message-react/src/SystemErrorMessage.js
+++ b/packages/ffe-system-message-react/src/SystemErrorMessage.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { func, string, number, node, oneOf, bool } from 'prop-types';
-import UtropstegnIkon from '@sb1/ffe-icons-react/lib/utropstegn-ikon';
+import { UtropstegnIkon } from '@sb1/ffe-icons-react';
 
 import SystemMessage from './SystemMessage';
 

--- a/packages/ffe-system-message-react/src/SystemInfoMessage.js
+++ b/packages/ffe-system-message-react/src/SystemInfoMessage.js
@@ -1,14 +1,8 @@
 import React from 'react';
-import InfoIkon from '@sb1/ffe-icons-react/lib/info-ikon';
+import { InfoIkon } from '@sb1/ffe-icons-react';
 
 import SystemMessage from './SystemMessage';
 
 export default function SystemInfoMessage(props) {
-    return (
-        <SystemMessage
-            modifier="info"
-            icon={<InfoIkon />}
-            {...props}
-        />
-    );
+    return <SystemMessage modifier="info" icon={<InfoIkon />} {...props} />;
 }

--- a/packages/ffe-system-message-react/src/SystemMessage.js
+++ b/packages/ffe-system-message-react/src/SystemMessage.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import { func, string, number, node, oneOf, bool } from 'prop-types';
 import classNames from 'classnames';
-import KryssIkon from '@sb1/ffe-icons-react/lib/kryss-ikon';
+import { KryssIkon } from '@sb1/ffe-icons-react';
 
 class SystemMessage extends Component {
     constructor() {

--- a/packages/ffe-system-message-react/src/SystemNewsMessage.js
+++ b/packages/ffe-system-message-react/src/SystemNewsMessage.js
@@ -1,14 +1,8 @@
 import React from 'react';
-import InfoIkon from '@sb1/ffe-icons-react/lib/info-ikon';
+import { InfoIkon } from '@sb1/ffe-icons-react';
 
 import SystemMessage from './SystemMessage';
 
 export default function SystemNewsMessage(props) {
-    return (
-        <SystemMessage
-            modifier="news"
-            icon={<InfoIkon />}
-            {...props}
-        />
-    );
+    return <SystemMessage modifier="news" icon={<InfoIkon />} {...props} />;
 }

--- a/packages/ffe-system-message-react/src/SystemSuccessMessage.js
+++ b/packages/ffe-system-message-react/src/SystemSuccessMessage.js
@@ -1,14 +1,8 @@
 import React from 'react';
-import HakeIkon from '@sb1/ffe-icons-react/lib/hake-ikon';
+import { HakeIkon } from '@sb1/ffe-icons-react';
 
 import SystemMessage from './SystemMessage';
 
 export default function SystemSuccessMessage(props) {
-    return (
-        <SystemMessage
-            modifier="success"
-            icon={<HakeIkon />}
-            {...props}
-        />
-    );
+    return <SystemMessage modifier="success" icon={<HakeIkon />} {...props} />;
 }

--- a/packages/ffe-tables-react/src/SortableTable/SortableTable.js
+++ b/packages/ffe-tables-react/src/SortableTable/SortableTable.js
@@ -1,4 +1,4 @@
-import PilNedIkon from '@sb1/ffe-icons-react/lib/pil-ned-ikon';
+import { PilNedIkon } from '@sb1/ffe-icons-react';
 import classNames from 'classnames';
 import equal from 'deep-equal';
 import PropTypes from 'prop-types';

--- a/packages/ffe-tables-react/src/TableParts/TableRowExpandable.js
+++ b/packages/ffe-tables-react/src/TableParts/TableRowExpandable.js
@@ -1,4 +1,4 @@
-import ChevronIkon from '@sb1/ffe-icons-react/lib/chevron-ikon';
+import { ChevronIkon } from '@sb1/ffe-icons-react';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';


### PR DESCRIPTION
Mekker med babel-bygget slik at babel endrer hvor ffe-icons blir importert fra, avhengig av om den bygger til commonjs eller es modules.

F.eks denne _named import_ i kildekoden:

```js
import { AtvIkon, BamseIkon as MyIcon } from '@sb1/ffe-icons-react'
```
blir til denne _default import_ i es-moduler (legg merke til `/es` som import path):

```js
import AtvIkon from '@sb1/ffe-icons-react/es/atv-ikon';
import MyIcon from '@sb1/ffe-icons-react/es/bamse-ikon';
```

eller til disse commonjs-requires fra `/lib`:

```js
const AtvIkon = require('@sb1/ffe-icons-react/lib/atv-ikon');
const MyIcon = require('@sb1/ffe-icons-react/lib/bamse-ikon');
```
Denne endring gjør at ffe-pakkene som bruker ffe-icons-react ikke krever _tree shaking_, og de inkluderer ikonene i samme module-format som man importerer, dvs. esm eller commonjs. Det virker som noe transpiler ble forvirret av når es-kode importerte et ikon i commonjs.