### PR TITLE
fix(ffe-context-message-react): icon override not possible anymore

### DIFF
--- a/packages/ffe-context-message-react/src/ContextErrorMessage.js
+++ b/packages/ffe-context-message-react/src/ContextErrorMessage.js
@@ -1,14 +1,5 @@
 import React from 'react';
-import {
-    number,
-    node,
-    string,
-    bool,
-    element,
-    oneOf,
-    func,
-    object,
-} from 'prop-types';
+import { number, node, string, bool, oneOf, func, object } from 'prop-types';
 import acceptedLocales from './locale/accepted-locales';
 import ContextMessage from './ContextMessage';
 import UtropstegnIkon from '@sb1/ffe-icons-react/lib/utropstegn-ikon';
@@ -18,10 +9,10 @@ const ContextErrorMessage = props => {
 
     return (
         <ContextMessage
+            {...rest}
             messageType="error"
             role={alert ? 'alert' : false}
             icon={<UtropstegnIkon />}
-            {...rest}
         />
     );
 };
@@ -39,7 +30,6 @@ ContextErrorMessage.propTypes = {
     header: string,
     /** ID for the header container */
     headerElementId: string,
-    icon: element,
     /** Decides the language of the aria-label for the close icon */
     locale: oneOf(acceptedLocales),
     /** Provided by the wrapper component */

--- a/packages/ffe-context-message-react/src/ContextInfoMessage.js
+++ b/packages/ffe-context-message-react/src/ContextInfoMessage.js
@@ -3,7 +3,7 @@ import ContextMessage from './ContextMessage';
 import InfoIkon from '@sb1/ffe-icons-react/lib/info-ikon';
 
 const ContextInfoMessage = props => (
-    <ContextMessage messageType="info" icon={<InfoIkon />} {...props} />
+    <ContextMessage {...props} messageType="info" icon={<InfoIkon />} />
 );
 
 export default ContextInfoMessage;

--- a/packages/ffe-context-message-react/src/ContextSuccessMessage.js
+++ b/packages/ffe-context-message-react/src/ContextSuccessMessage.js
@@ -3,7 +3,7 @@ import ContextMessage from './ContextMessage';
 import HakeIkon from '@sb1/ffe-icons-react/lib/hake-ikon';
 
 const ContextSuccessMessage = props => (
-    <ContextMessage messageType="success" icon={<HakeIkon />} {...props} />
+    <ContextMessage {...props} messageType="success" icon={<HakeIkon />} />
 );
 
 export default ContextSuccessMessage;

--- a/packages/ffe-context-message-react/src/ContextTipMessage.js
+++ b/packages/ffe-context-message-react/src/ContextTipMessage.js
@@ -3,7 +3,7 @@ import ContextMessage from './ContextMessage';
 import LyspareIkon from '@sb1/ffe-icons-react/lib/lyspare-ikon';
 
 const ContextTipMessage = props => (
-    <ContextMessage messageType="tip" icon={<LyspareIkon />} {...props} />
+    <ContextMessage {...props} messageType="tip" icon={<LyspareIkon />} />
 );
 
 export default ContextTipMessage;

--- a/packages/ffe-context-message-react/src/index.d.ts
+++ b/packages/ffe-context-message-react/src/index.d.ts
@@ -10,7 +10,6 @@ export interface ContextMessageProps
     headerText?: string;
     headerElementId?: string;
     headerElement?: string;
-    icon?: React.ReactNode;
     locale?: 'nb' | 'nn' | 'en';
     onClose?: (event: React.MouseEvent) => void;
     showCloseButton?: boolean;


### PR DESCRIPTION
Jag vet ikke om dere vill ha dette men jag synes man burde gjøre disse tiltaken da BREAKING CHANGE 6.0.0 allrede er på plats. Eller kommer det en til BREAKING CHANGE når muligheten att sende in ikon fjernes på riktigt?