### PR TITLE
Justeringer etter meldinger endringer

### DIFF
--- a/component-overview/examples/context-message/ContextErrorMessage-coloredbg.jsx
+++ b/component-overview/examples/context-message/ContextErrorMessage-coloredbg.jsx
@@ -1,12 +1,7 @@
 import { ContextErrorMessage } from '@sb1/ffe-context-message-react';
-import { Grid, GridRow, GridCol } from '@sb1/ffe-grid-react';
 
-<Grid>
-    <GridRow background="frost-30" style={{ paddingTop: '8px' }}>
-        <GridCol sm={12} lg={{ cols: 6, offset: 3 }}>
-            <ContextErrorMessage onColoredBg={true}>
-                Dette gikk ikke som forventet i det hele tatt!
-            </ContextErrorMessage>
-        </GridCol>
-    </GridRow>
-</Grid>;
+<div style={{ backgroundColor: 'var(--ffe-farge-frost-30)', padding: '8px' }}>
+    <ContextErrorMessage onColoredBg={true}>
+        Dette gikk ikke som forventet i det hele tatt!
+    </ContextErrorMessage>
+</div>;

--- a/component-overview/examples/context-message/ContextInfoMessage-coloredbg.jsx
+++ b/component-overview/examples/context-message/ContextInfoMessage-coloredbg.jsx
@@ -1,12 +1,7 @@
 import { ContextInfoMessage } from '@sb1/ffe-context-message-react';
-import { Grid, GridRow, GridCol } from '@sb1/ffe-grid-react';
 
-<Grid>
-    <GridRow background="frost-30" style={{ paddingTop: '8px' }}>
-        <GridCol sm={12} lg={{ cols: 6, offset: 3 }}>
-            <ContextInfoMessage onColoredBg={true}>
-                Dette gikk ikke som forventet i det hele tatt!
-            </ContextInfoMessage>
-        </GridCol>
-    </GridRow>
-</Grid>;
+<div style={{ backgroundColor: 'var(--ffe-farge-frost-30)', padding: '8px' }}>
+    <ContextInfoMessage onColoredBg={true}>
+        Dette gikk ikke som forventet i det hele tatt!
+    </ContextInfoMessage>
+</div>;

--- a/component-overview/examples/context-message/ContextInfoMessage-header-link.jsx
+++ b/component-overview/examples/context-message/ContextInfoMessage-header-link.jsx
@@ -1,0 +1,9 @@
+import { ContextInfoMessage } from '@sb1/ffe-context-message-react';
+import { Paragraph, LinkText } from '@sb1/ffe-core-react';
+
+<ContextInfoMessage headerText="Til info">
+    <Paragraph>
+        Nå har det kommet noe nytt og spennende fra SpareBank 1!
+    </Paragraph>
+    <LinkText href="#">Les mer om spennende nyhet</LinkText>
+</ContextInfoMessage>;

--- a/component-overview/examples/context-message/ContextSuccessMessage-coloredbg.jsx
+++ b/component-overview/examples/context-message/ContextSuccessMessage-coloredbg.jsx
@@ -1,12 +1,7 @@
 import { ContextSuccessMessage } from '@sb1/ffe-context-message-react';
-import { Grid, GridRow, GridCol } from '@sb1/ffe-grid-react';
 
-<Grid>
-    <GridRow background="frost-30" style={{ paddingTop: '8px' }}>
-        <GridCol sm={12} lg={{ cols: 6, offset: 3 }}>
-            <ContextSuccessMessage onColoredBg={true}>
-                Dette gikk ikke som forventet i det hele tatt!
-            </ContextSuccessMessage>
-        </GridCol>
-    </GridRow>
-</Grid>;
+<div style={{ backgroundColor: 'var(--ffe-farge-frost-30)', padding: '8px' }}>
+    <ContextSuccessMessage onColoredBg={true}>
+        Dette gikk ikke som forventet i det hele tatt!
+    </ContextSuccessMessage>
+</div>;

--- a/component-overview/examples/context-message/ContextTipMessage-coloredbg.jsx
+++ b/component-overview/examples/context-message/ContextTipMessage-coloredbg.jsx
@@ -1,12 +1,7 @@
 import { ContextTipMessage } from '@sb1/ffe-context-message-react';
-import { Grid, GridRow, GridCol } from '@sb1/ffe-grid-react';
 
-<Grid>
-    <GridRow background="frost-30" style={{ paddingTop: '8px' }}>
-        <GridCol sm={12} lg={{ cols: 6, offset: 3 }}>
-            <ContextTipMessage onColoredBg={true}>
-                Dette gikk ikke som forventet i det hele tatt!
-            </ContextTipMessage>
-        </GridCol>
-    </GridRow>
-</Grid>;
+<div style={{ backgroundColor: 'var(--ffe-farge-frost-30)', padding: '8px' }}>
+    <ContextTipMessage onColoredBg={true}>
+        Dette gikk ikke som forventet i det hele tatt!
+    </ContextTipMessage>
+</div>;

--- a/component-overview/examples/message-box/InfoMessage-coloredbg.jsx
+++ b/component-overview/examples/message-box/InfoMessage-coloredbg.jsx
@@ -1,16 +1,11 @@
 import { InfoMessage } from '@sb1/ffe-message-box-react';
 import { Paragraph } from '@sb1/ffe-core-react';
-import { Grid, GridRow, GridCol } from '@sb1/ffe-grid-react';
 
-<Grid>
-    <GridRow background="frost-30">
-        <GridCol sm={12} lg={{ cols: 6, offset: 3 }}>
-            <InfoMessage title="Du har ingen kort" onColoredBg={true}>
-                <Paragraph>
-                    Denne tjenesten er kun tilgjengelig for deg med et debitkort
-                    eller kredittkort fra SpareBank 1.
-                </Paragraph>
-            </InfoMessage>
-        </GridCol>
-    </GridRow>
-</Grid>;
+<div style={{ backgroundColor: 'var(--ffe-farge-frost-30)', padding: '8px' }}>
+    <InfoMessage title="Du har ingen kort" onColoredBg={true}>
+        <Paragraph>
+            Denne tjenesten er kun tilgjengelig for deg med et debitkort eller
+            kredittkort fra SpareBank 1.
+        </Paragraph>
+    </InfoMessage>
+</div>;

--- a/component-overview/examples/message-box/TipsMessage-with-link.jsx
+++ b/component-overview/examples/message-box/TipsMessage-with-link.jsx
@@ -1,0 +1,9 @@
+import { TipsMessage } from '@sb1/ffe-message-box-react';
+import { Paragraph, LinkText } from '@sb1/ffe-core-react';
+
+<TipsMessage title="Reiseforsikringen dekker alt utenfor hjemmet!">
+    <Paragraph>
+        Reiseforsikringen gjelder ikke bare når du er på ferie.
+    </Paragraph>
+    <LinkText href="#">Les mer om hva som dekkes i vilkårene.</LinkText>
+</TipsMessage>;

--- a/component-overview/examples/system-message/SystemInfoMessage-coloredbg.jsx
+++ b/component-overview/examples/system-message/SystemInfoMessage-coloredbg.jsx
@@ -1,13 +1,7 @@
 import { SystemInfoMessage } from '@sb1/ffe-system-message-react';
-import { Grid, GridRow, GridCol } from '@sb1/ffe-grid-react';
 
-<Grid>
-    <GridRow background="frost-30">
-        <GridCol sm={12} lg={{ cols: 6, offset: 3 }}>
-            <SystemInfoMessage onColoredBg={true}>
-                Mobilbanken vil være utilgjengelig førstkommende fredag kl
-                19-20.
-            </SystemInfoMessage>
-        </GridCol>
-    </GridRow>
-</Grid>;
+<div style={{ backgroundColor: 'var(--ffe-farge-frost-30)', padding: '8px' }}>
+    <SystemInfoMessage onColoredBg={true}>
+        Mobilbanken vil være utilgjengelig førstkommende fredag kl 19-20.
+    </SystemInfoMessage>
+</div>;

--- a/packages/ffe-context-message/less/ffe-context-message.less
+++ b/packages/ffe-context-message/less/ffe-context-message.less
@@ -99,7 +99,6 @@
     &__icon-svg {
         height: 2em;
         width: 2em;
-        padding: @ffe-spacing-2xs;
         fill: @ffe-farge-hvit;
     }
 
@@ -162,9 +161,8 @@
         }
 
         .ffe-context-message-content__icon-svg {
-            height: 1.5em;
-            width: 1.5em;
-            padding: @ffe-spacing-2xs;
+            height: 1rem;
+            width: 1rem;
         }
     }
 

--- a/packages/ffe-message-box-react/src/BaseMessage.js
+++ b/packages/ffe-message-box-react/src/BaseMessage.js
@@ -3,8 +3,8 @@ import { bool, node, oneOf, string } from 'prop-types';
 import classNames from 'classnames';
 
 const iconStyles = {
-    width: '40px',
-    height: '40px',
+    width: '32px',
+    height: '32px',
 };
 
 const BaseMessage = props => {
@@ -33,9 +33,7 @@ const BaseMessage = props => {
                 {React.cloneElement(icon, { style: iconStyles, ...icon.props })}
             </span>
             <div className="ffe-message-box__box">
-                {title && (
-                    <div className="ffe-h4 ffe-message-box__title">{title}</div>
-                )}
+                {title && <div className="ffe-message-box__title">{title}</div>}
                 {content && <p>{content}</p>}
                 {!content && children}
             </div>

--- a/packages/ffe-message-box-react/src/BaseMessage.spec.js
+++ b/packages/ffe-message-box-react/src/BaseMessage.spec.js
@@ -35,7 +35,9 @@ describe('<BaseMessage />', () => {
     });
     it('renders a title if specified', () => {
         const wrapper = getWrapper({ title: 'test title' });
-        expect(wrapper.find('.ffe-h4').text()).toBe('test title');
+        expect(wrapper.find('.ffe-message-box__title').text()).toBe(
+            'test title',
+        );
     });
     it('renders children if specified', () => {
         const wrapper = getWrapper({ children: <p>children</p> });

--- a/packages/ffe-message-box/less/ffe-message-box.less
+++ b/packages/ffe-message-box/less/ffe-message-box.less
@@ -181,15 +181,4 @@
             margin-bottom: -33.5px;
         }
     }
-
-    &__link {
-        color: inherit;
-        text-decoration: underline;
-
-        &:hover,
-        &:focus {
-            font-family: 'SpareBank1-medium', 'MuseoSansRounded-700', arial,
-                sans-serif;
-        }
-    }
 }


### PR DESCRIPTION
## Beskrivelse
Noen små endringer på ikon størrelser og eksemplene relatert til meldingsbokser.
Denne endringer sikrer at ikonene har samme størrelser som i figma, og eksemplene ser mer riktig og ryddere ut. 

Legger også til eksempler for bruk av lenker i meldingsbokser da det var etterspurt. 

## Testing
Kjørt opp og testet lokalt
