### PR TITLE
fix(ffe-account-selector-react): Only show AccountDetails if accountN…

### DIFF
--- a/packages/ffe-account-selector-react/src/components/account-selector/AccountSelector.js
+++ b/packages/ffe-account-selector-react/src/components/account-selector/AccountSelector.js
@@ -126,12 +126,17 @@ const AccountSelector = ({
           })
         : accounts;
 
+    const showAccountDetails = !!(
+        selectedAccount &&
+        (selectedAccount.accountNumber || selectedAccount.balance)
+    );
+
     return (
         <div className="ffe-account-selector-single-container">
             <div
                 className={classNames('ffe-account-selector-single', {
                     'ffe-account-selector-single--with-space-for-details':
-                        !selectedAccount && withSpaceForDetails,
+                        !showAccountDetails && withSpaceForDetails,
                     className,
                 })}
                 id={`${id}-account-selector-container`}
@@ -158,7 +163,7 @@ const AccountSelector = ({
                     onOpen={onOpen}
                     onClose={onClose}
                 />
-                {selectedAccount && (
+                {showAccountDetails && (
                     <AccountDetails
                         account={selectedAccount}
                         locale={locale}

--- a/packages/ffe-account-selector-react/src/components/account-selector/AccountSelector.spec.js
+++ b/packages/ffe-account-selector-react/src/components/account-selector/AccountSelector.spec.js
@@ -48,6 +48,24 @@ describe('AccountSelector', () => {
             currencyCode: 'NOK',
             balance: 0,
         },
+        {
+            accountNumber: '',
+            name: 'Alle',
+            currencyCode: 'NOK',
+            balance: 0,
+        },
+        {
+            accountNumber: '',
+            name: 'Alle',
+            currencyCode: 'NOK',
+            balance: 123,
+        },
+        {
+            accountNumber: '3123 23 4311',
+            name: 'Alle',
+            currencyCode: 'NOK',
+            balance: 0,
+        },
     ];
 
     let selectedAccount;
@@ -64,441 +82,576 @@ describe('AccountSelector', () => {
         selectedAccount = undefined;
     });
 
-    it('should show filtered result', () => {
-        render(
-            <AccountSelector
-                id="id"
-                labelId="labelId"
-                accounts={accounts}
-                locale="nb"
-                onAccountSelected={onAccountSelected}
-                onReset={onReset}
-                ariaInvalid={false}
-            />,
-        );
+    describe('filtering', () => {
+        it('should ignore spaces, periods and case when filtering', () => {
+            render(
+                <AccountSelector
+                    id="id"
+                    labelId="labelId"
+                    accounts={accounts.concat([
+                        {
+                            accountNumber: '3485.42.80352',
+                            name: 'Hopps.ann heisann',
+                            currencyCode: 'NOK',
+                            balance: 7488,
+                        },
+                    ])}
+                    locale="nb"
+                    onAccountSelected={onAccountSelected}
+                    onReset={onReset}
+                    ariaInvalid={false}
+                />,
+            );
 
-        const input = screen.getByRole('combobox');
+            const input = screen.getByRole('combobox');
 
-        fireEvent.click(input);
+            fireEvent.click(input);
 
-        expect(screen.getByText('Brukskonto')).toBeInTheDocument();
-        expect(screen.getByText('1234 56 789101')).toBeInTheDocument();
-        expect(screen.getByText('Jeg er en konto')).toBeInTheDocument();
-        expect(screen.getByText('1234 56 789102')).toBeInTheDocument();
-        expect(screen.getByText('Sparekonto')).toBeInTheDocument();
-        expect(screen.getByText('2234 56 789102')).toBeInTheDocument();
-        expect(screen.getByText('Gris')).toBeInTheDocument();
-        expect(screen.getByText('1253 47 789102')).toBeInTheDocument();
+            expect(screen.getByText('Brukskonto')).toBeInTheDocument();
+            expect(screen.getByText('1234 56 789101')).toBeInTheDocument();
+            expect(screen.getByText('Jeg er en konto')).toBeInTheDocument();
+            expect(screen.getByText('1234 56 789102')).toBeInTheDocument();
+            expect(screen.getByText('Sparekonto')).toBeInTheDocument();
+            expect(screen.getByText('2234 56 789102')).toBeInTheDocument();
+            expect(screen.getByText('Gris')).toBeInTheDocument();
+            expect(screen.getByText('1253 47 789102')).toBeInTheDocument();
+            expect(screen.getByText('Hopps.ann heisann')).toBeInTheDocument();
+            expect(screen.getByText('3485.42.80352')).toBeInTheDocument();
 
-        fireEvent.change(input, { target: { value: 'konto' } });
+            fireEvent.change(input, { target: { value: 'JeG.eRe.n Kont o' } });
 
-        expect(screen.getByText('Brukskonto')).toBeInTheDocument();
-        expect(screen.getByText('1234 56 789101')).toBeInTheDocument();
-        expect(screen.getByText('Jeg er en konto')).toBeInTheDocument();
-        expect(screen.getByText('1234 56 789102')).toBeInTheDocument();
-        expect(screen.getByText('Sparekonto')).toBeInTheDocument();
-        expect(screen.getByText('2234 56 789102')).toBeInTheDocument();
-        expect(screen.queryByText('Gris')).toBeNull();
-        expect(screen.queryByText('1253 47 789102')).toBeNull();
+            expect(screen.queryByText('Brukskonto')).toBeNull();
+            expect(screen.queryByText('1234 56 789101')).toBeNull();
+            expect(screen.getByText('Jeg er en konto')).toBeInTheDocument();
+            expect(screen.getByText('1234 56 789102')).toBeInTheDocument();
+            expect(screen.queryByText('Sparekonto')).toBeNull();
+            expect(screen.queryByText('2234 56 789102')).toBeNull();
+            expect(screen.queryByText('Gris')).toBeNull();
+            expect(screen.queryByText('1253 47 789102')).toBeNull();
+            expect(screen.queryByText('Hopps.ann heisann')).toBeNull();
+            expect(screen.queryByText('3485.42.80352')).toBeNull();
+
+            fireEvent.change(input, { target: { value: '3485 4280352' } });
+
+            expect(screen.queryByText('Brukskonto')).toBeNull();
+            expect(screen.queryByText('1234 56 789101')).toBeNull();
+            expect(screen.queryByText('Jeg er en konto')).toBeNull();
+            expect(screen.queryByText('1234 56 789102')).toBeNull();
+            expect(screen.queryByText('Sparekonto')).toBeNull();
+            expect(screen.queryByText('2234 56 789102')).toBeNull();
+            expect(screen.queryByText('Gris')).toBeNull();
+            expect(screen.queryByText('1253 47 789102')).toBeNull();
+            expect(screen.getByText('Hopps.ann heisann')).toBeInTheDocument();
+            expect(screen.getByText('3485.42.80352')).toBeInTheDocument();
+        });
     });
 
-    it('should ignore spaces, periods and case when filtering', () => {
-        render(
-            <AccountSelector
-                id="id"
-                labelId="labelId"
-                accounts={accounts.concat([
-                    {
-                        accountNumber: '3485.42.80352',
-                        name: 'Hopps.ann heisann',
+    describe('display', () => {
+        it('should show filtered result', () => {
+            render(
+                <AccountSelector
+                    id="id"
+                    labelId="labelId"
+                    accounts={accounts}
+                    locale="nb"
+                    onAccountSelected={onAccountSelected}
+                    onReset={onReset}
+                    ariaInvalid={false}
+                />,
+            );
+
+            const input = screen.getByRole('combobox');
+
+            fireEvent.click(input);
+
+            expect(screen.getByText('Brukskonto')).toBeInTheDocument();
+            expect(screen.getByText('1234 56 789101')).toBeInTheDocument();
+            expect(screen.getByText('Jeg er en konto')).toBeInTheDocument();
+            expect(screen.getByText('1234 56 789102')).toBeInTheDocument();
+            expect(screen.getByText('Sparekonto')).toBeInTheDocument();
+            expect(screen.getByText('2234 56 789102')).toBeInTheDocument();
+            expect(screen.getByText('Gris')).toBeInTheDocument();
+            expect(screen.getByText('1253 47 789102')).toBeInTheDocument();
+
+            fireEvent.change(input, { target: { value: 'konto' } });
+
+            expect(screen.getByText('Brukskonto')).toBeInTheDocument();
+            expect(screen.getByText('1234 56 789101')).toBeInTheDocument();
+            expect(screen.getByText('Jeg er en konto')).toBeInTheDocument();
+            expect(screen.getByText('1234 56 789102')).toBeInTheDocument();
+            expect(screen.getByText('Sparekonto')).toBeInTheDocument();
+            expect(screen.getByText('2234 56 789102')).toBeInTheDocument();
+            expect(screen.queryByText('Gris')).toBeNull();
+            expect(screen.queryByText('1253 47 789102')).toBeNull();
+        });
+
+        it('should display account info after selection', () => {
+            const { rerender } = render(
+                <AccountSelector
+                    id="id"
+                    labelId="labelId"
+                    accounts={accounts}
+                    locale="nb"
+                    onAccountSelected={onAccountSelected}
+                    onReset={onReset}
+                    selectedAccount={selectedAccount}
+                    ariaInvalid={false}
+                />,
+            );
+            expect(screen.queryByText('1234 56 789102')).toBeNull();
+
+            const input = screen.getByRole('combobox');
+
+            fireEvent.click(input);
+            fireEvent.click(screen.getByText('Jeg er en konto'));
+
+            rerender(
+                <AccountSelector
+                    id="id"
+                    labelId="labelId"
+                    accounts={accounts}
+                    locale="nb"
+                    onAccountSelected={onAccountSelected}
+                    onReset={onReset}
+                    selectedAccount={selectedAccount}
+                    ariaInvalid={false}
+                />,
+            );
+
+            expect(screen.getByText('1234 56 789102')).toBeInTheDocument();
+        });
+
+        it('should display balance when specified', () => {
+            const { rerender } = render(
+                <AccountSelector
+                    id="id"
+                    labelId="labelId"
+                    accounts={accounts}
+                    locale="nb"
+                    onAccountSelected={onAccountSelected}
+                    onReset={onReset}
+                    selectedAccount={selectedAccount}
+                    showBalance={true}
+                    ariaInvalid={false}
+                />,
+            );
+
+            const input = screen.getByRole('combobox');
+
+            fireEvent.click(input);
+            expect(screen.getByText('1 337,00 kr')).toBeInTheDocument();
+            fireEvent.click(screen.getByText('Brukskonto'));
+
+            rerender(
+                <AccountSelector
+                    id="id"
+                    labelId="labelId"
+                    accounts={accounts}
+                    locale="nb"
+                    onAccountSelected={onAccountSelected}
+                    onReset={onReset}
+                    selectedAccount={selectedAccount}
+                    showBalance={true}
+                    ariaInvalid={false}
+                />,
+            );
+
+            expect(screen.getByText('1 337,00 kr')).toBeInTheDocument();
+            expect(screen.getByText('1234 56 789101')).toBeInTheDocument();
+
+            rerender(
+                <AccountSelector
+                    id="id"
+                    labelId="labelId"
+                    accounts={accounts}
+                    locale="nb"
+                    onAccountSelected={onAccountSelected}
+                    onReset={onReset}
+                    selectedAccount={selectedAccount}
+                    showBalance={false}
+                    ariaInvalid={false}
+                />,
+            );
+
+            expect(screen.queryByText('1 337,00 kr')).toBeNull();
+            expect(screen.getByText('1234 56 789101')).toBeInTheDocument();
+
+            fireEvent.click(input);
+            expect(screen.queryByText('1 337,00 kr')).toBeNull();
+        });
+    });
+
+    describe('custom account', () => {
+        it('should allow selecting custom account when specified', () => {
+            const { rerender } = render(
+                <AccountSelector
+                    id="id"
+                    labelId="labelId"
+                    accounts={accounts}
+                    locale="nb"
+                    onAccountSelected={onAccountSelected}
+                    onReset={onReset}
+                    selectedAccount={selectedAccount}
+                    allowCustomAccount={true}
+                    ariaInvalid={false}
+                />,
+            );
+
+            const input = screen.getByRole('combobox');
+
+            fireEvent.click(input);
+
+            expect(screen.getByText('Brukskonto')).toBeInTheDocument();
+            expect(screen.queryByText('BrukskoABC')).toBeNull();
+
+            fireEvent.change(input, { target: { value: 'BrukskoABC' } });
+
+            expect(screen.queryByText('Brukskonto')).toBeNull();
+            expect(screen.getByText('BrukskoABC')).toBeInTheDocument();
+
+            fireEvent.click(screen.getByText('BrukskoABC'));
+
+            rerender(
+                <AccountSelector
+                    id="id"
+                    labelId="labelId"
+                    accounts={accounts}
+                    locale="nb"
+                    onAccountSelected={onAccountSelected}
+                    onReset={onReset}
+                    selectedAccount={selectedAccount}
+                    allowCustomAccount={true}
+                    ariaInvalid={false}
+                />,
+            );
+
+            expect(screen.getByText('BrukskoABC')).toBeInTheDocument();
+        });
+
+        it('should allow passing custom selected account when specified', () => {
+            render(
+                <AccountSelector
+                    id="id"
+                    labelId="labelId"
+                    accounts={accounts}
+                    locale="nb"
+                    onAccountSelected={onAccountSelected}
+                    onReset={onReset}
+                    selectedAccount={{
+                        accountNumber: '2234 56 789101',
+                        name: 'Brukskonto 9',
                         currencyCode: 'NOK',
-                        balance: 7488,
-                    },
-                ])}
-                locale="nb"
-                onAccountSelected={onAccountSelected}
-                onReset={onReset}
-                ariaInvalid={false}
-            />,
-        );
+                        balance: 133,
+                    }}
+                    allowCustomAccount={true}
+                    ariaInvalid={false}
+                />,
+            );
 
-        const input = screen.getByRole('combobox');
+            const input = screen.getByRole('combobox');
 
-        fireEvent.click(input);
+            expect(input.getAttribute('value')).toEqual('Brukskonto 9');
+            expect(screen.getByText('2234 56 789101')).toBeInTheDocument();
+        });
 
-        expect(screen.getByText('Brukskonto')).toBeInTheDocument();
-        expect(screen.getByText('1234 56 789101')).toBeInTheDocument();
-        expect(screen.getByText('Jeg er en konto')).toBeInTheDocument();
-        expect(screen.getByText('1234 56 789102')).toBeInTheDocument();
-        expect(screen.getByText('Sparekonto')).toBeInTheDocument();
-        expect(screen.getByText('2234 56 789102')).toBeInTheDocument();
-        expect(screen.getByText('Gris')).toBeInTheDocument();
-        expect(screen.getByText('1253 47 789102')).toBeInTheDocument();
-        expect(screen.getByText('Hopps.ann heisann')).toBeInTheDocument();
-        expect(screen.getByText('3485.42.80352')).toBeInTheDocument();
+        it('should not show custom account when some account matches search', () => {
+            render(
+                <AccountSelector
+                    id="id"
+                    labelId="labelId"
+                    accounts={accounts}
+                    locale="nb"
+                    onAccountSelected={onAccountSelected}
+                    onReset={onReset}
+                    selectedAccount={selectedAccount}
+                    allowCustomAccount={true}
+                    ariaInvalid={false}
+                />,
+            );
 
-        fireEvent.change(input, { target: { value: 'JeG.eRe.n Kont o' } });
+            const input = screen.getByRole('combobox');
 
-        expect(screen.queryByText('Brukskonto')).toBeNull();
-        expect(screen.queryByText('1234 56 789101')).toBeNull();
-        expect(screen.getByText('Jeg er en konto')).toBeInTheDocument();
-        expect(screen.getByText('1234 56 789102')).toBeInTheDocument();
-        expect(screen.queryByText('Sparekonto')).toBeNull();
-        expect(screen.queryByText('2234 56 789102')).toBeNull();
-        expect(screen.queryByText('Gris')).toBeNull();
-        expect(screen.queryByText('1253 47 789102')).toBeNull();
-        expect(screen.queryByText('Hopps.ann heisann')).toBeNull();
-        expect(screen.queryByText('3485.42.80352')).toBeNull();
+            fireEvent.click(input);
 
-        fireEvent.change(input, { target: { value: '3485 4280352' } });
+            expect(screen.getByText('Brukskonto')).toBeInTheDocument();
+            expect(screen.queryByText('BrukskoABC')).toBeNull();
 
-        expect(screen.queryByText('Brukskonto')).toBeNull();
-        expect(screen.queryByText('1234 56 789101')).toBeNull();
-        expect(screen.queryByText('Jeg er en konto')).toBeNull();
-        expect(screen.queryByText('1234 56 789102')).toBeNull();
-        expect(screen.queryByText('Sparekonto')).toBeNull();
-        expect(screen.queryByText('2234 56 789102')).toBeNull();
-        expect(screen.queryByText('Gris')).toBeNull();
-        expect(screen.queryByText('1253 47 789102')).toBeNull();
-        expect(screen.getByText('Hopps.ann heisann')).toBeInTheDocument();
-        expect(screen.getByText('3485.42.80352')).toBeInTheDocument();
+            fireEvent.change(input, { target: { value: 'Bruksko' } });
+
+            expect(
+                screen.getAllByText('Bruksko', { exact: false }),
+            ).toHaveLength(1);
+        });
+
+        it('should be able to render custom list items', () => {
+            const CustomListItemBody = ({
+                // eslint-disable-next-line react/prop-types
+                item: { accountNumber, name, balance, currencyCode },
+            }) => (
+                <div>
+                    <span>{accountNumber}</span>
+                    <span>FOR et navn! {name}</span>
+                    <span>Litt av en saldo! {balance}</span>
+                    <span>{currencyCode}</span>
+                </div>
+            );
+
+            render(
+                <AccountSelector
+                    id="id"
+                    labelId="labelId"
+                    accounts={accounts}
+                    locale="nb"
+                    onAccountSelected={onAccountSelected}
+                    onReset={onReset}
+                    listElementBody={CustomListItemBody}
+                    ariaInvalid={false}
+                />,
+            );
+
+            const input = screen.getByRole('combobox');
+
+            fireEvent.click(input);
+
+            expect(
+                screen.getByText('FOR et navn! Jeg er en konto'),
+            ).toBeInTheDocument();
+            expect(
+                screen.getByText('Litt av en saldo! 13337'),
+            ).toBeInTheDocument();
+        });
     });
 
-    it('should display account info after selection', () => {
-        const { rerender } = render(
-            <AccountSelector
-                id="id"
-                labelId="labelId"
-                accounts={accounts}
-                locale="nb"
-                onAccountSelected={onAccountSelected}
-                onReset={onReset}
-                selectedAccount={selectedAccount}
-                ariaInvalid={false}
-            />,
-        );
-        expect(screen.queryByText('1234 56 789102')).toBeNull();
+    describe('formatting', () => {
+        it('should format input field while typing if value only contains digits and/or spaces', () => {
+            render(
+                <AccountSelector
+                    id="id"
+                    labelId="labelId"
+                    accounts={accounts}
+                    locale="nb"
+                    onAccountSelected={onAccountSelected}
+                    onReset={onReset}
+                    ariaInvalid={false}
+                />,
+            );
 
-        const input = screen.getByRole('combobox');
+            const input = screen.getByRole('combobox');
 
-        fireEvent.click(input);
-        fireEvent.click(screen.getByText('Jeg er en konto'));
+            fireEvent.change(input, { target: { value: 'ab1de' } });
+            expect(input.getAttribute('value')).toEqual('ab1de');
 
-        rerender(
-            <AccountSelector
-                id="id"
-                labelId="labelId"
-                accounts={accounts}
-                locale="nb"
-                onAccountSelected={onAccountSelected}
-                onReset={onReset}
-                selectedAccount={selectedAccount}
-                ariaInvalid={false}
-            />,
-        );
+            fireEvent.change(input, { target: { value: 'ab1de ' } });
+            expect(input.getAttribute('value')).toEqual('ab1de ');
 
-        expect(screen.getByText('1234 56 789102')).toBeInTheDocument();
+            fireEvent.change(input, { target: { value: '1234.' } });
+            expect(input.getAttribute('value')).toEqual('1234.');
+
+            fireEvent.change(input, { target: { value: '1234.5' } });
+            expect(input.getAttribute('value')).toEqual('1234.5');
+
+            fireEvent.change(input, { target: { value: '4321' } });
+            expect(input.getAttribute('value')).toEqual('4321');
+
+            fireEvent.change(input, { target: { value: '54321' } });
+            expect(input.getAttribute('value')).toEqual('5432 1');
+
+            fireEvent.change(input, { target: { value: '5432 1 ' } });
+            expect(input.getAttribute('value')).toEqual('5432 1');
+
+            fireEvent.change(input, { target: { value: '543216789101' } });
+            expect(input.getAttribute('value')).toEqual('5432 16 789101');
+        });
+
+        it('should not format input field when formatAccountNumber is false', () => {
+            render(
+                <AccountSelector
+                    id="id"
+                    labelId="labelId"
+                    accounts={accounts}
+                    locale="nb"
+                    onAccountSelected={onAccountSelected}
+                    onReset={onReset}
+                    formatAccountNumber={false}
+                    ariaInvalid={false}
+                />,
+            );
+
+            const input = screen.getByRole('combobox');
+
+            fireEvent.change(input, { target: { value: '54321' } });
+            expect(input.getAttribute('value')).toEqual('54321');
+
+            fireEvent.change(input, { target: { value: '543216789101' } });
+            expect(input.getAttribute('value')).toEqual('543216789101');
+        });
     });
 
-    it('should display balance when specified', () => {
-        const { rerender } = render(
-            <AccountSelector
-                id="id"
-                labelId="labelId"
-                accounts={accounts}
-                locale="nb"
-                onAccountSelected={onAccountSelected}
-                onReset={onReset}
-                selectedAccount={selectedAccount}
-                showBalance={true}
-                ariaInvalid={false}
-            />,
-        );
+    describe('default selectedAccount', () => {
+        it('should allow changing selectedAccount even if selectedAccount is defined on first render (initial value)', () => {
+            selectedAccount = accounts[2];
 
-        const input = screen.getByRole('combobox');
+            const { rerender } = render(
+                <AccountSelector
+                    id="id"
+                    labelId="labelId"
+                    accounts={accounts}
+                    locale="nb"
+                    onAccountSelected={onAccountSelected}
+                    onReset={onReset}
+                    selectedAccount={selectedAccount}
+                    ariaInvalid={false}
+                />,
+            );
 
-        fireEvent.click(input);
-        expect(screen.getByText('1 337,00 kr')).toBeInTheDocument();
-        fireEvent.click(screen.getByText('Brukskonto'));
+            const input = screen.getByRole('combobox');
 
-        rerender(
-            <AccountSelector
-                id="id"
-                labelId="labelId"
-                accounts={accounts}
-                locale="nb"
-                onAccountSelected={onAccountSelected}
-                onReset={onReset}
-                selectedAccount={selectedAccount}
-                showBalance={true}
-                ariaInvalid={false}
-            />,
-        );
+            expect(screen.getByText('2234 56 789102')).toBeInTheDocument();
+            expect(screen.queryByText('1234 56 789102')).toBeNull();
+            expect(input.value).toBe('Sparekonto');
 
-        expect(screen.getByText('1 337,00 kr')).toBeInTheDocument();
-        expect(screen.getByText('1234 56 789101')).toBeInTheDocument();
+            fireEvent.click(input);
+            fireEvent.click(screen.getByText('Jeg er en konto'));
 
-        rerender(
-            <AccountSelector
-                id="id"
-                labelId="labelId"
-                accounts={accounts}
-                locale="nb"
-                onAccountSelected={onAccountSelected}
-                onReset={onReset}
-                selectedAccount={selectedAccount}
-                showBalance={false}
-                ariaInvalid={false}
-            />,
-        );
+            rerender(
+                <AccountSelector
+                    id="id"
+                    labelId="labelId"
+                    accounts={accounts}
+                    locale="nb"
+                    onAccountSelected={onAccountSelected}
+                    onReset={onReset}
+                    selectedAccount={selectedAccount}
+                    ariaInvalid={false}
+                />,
+            );
 
-        expect(screen.queryByText('1 337,00 kr')).toBeNull();
-        expect(screen.getByText('1234 56 789101')).toBeInTheDocument();
-
-        fireEvent.click(input);
-        expect(screen.queryByText('1 337,00 kr')).toBeNull();
+            expect(screen.queryByText('2234 56 789102')).toBeNull();
+            expect(screen.getByText('1234 56 789102')).toBeInTheDocument();
+            expect(input.value).toBe('Jeg er en konto');
+        });
     });
 
-    it('should allow selecting custom account when specified', () => {
-        const { rerender } = render(
-            <AccountSelector
-                id="id"
-                labelId="labelId"
-                accounts={accounts}
-                locale="nb"
-                onAccountSelected={onAccountSelected}
-                onReset={onReset}
-                selectedAccount={selectedAccount}
-                allowCustomAccount={true}
-                ariaInvalid={false}
-            />,
-        );
+    describe('whitespace', () => {
+        it('should add whitespace for details if no account is selected', () => {
+            selectedAccount = undefined;
+            const { container } = render(
+                <AccountSelector
+                    id="id"
+                    labelId="labelId"
+                    accounts={accounts}
+                    locale="nb"
+                    onAccountSelected={onAccountSelected}
+                    onReset={onReset}
+                    selectedAccount={selectedAccount}
+                    ariaInvalid={false}
+                />,
+            );
+            const accountSelectorWithWhiteSpaceForDetals = container.querySelector(
+                '.ffe-account-selector-single--with-space-for-details',
+            );
+            expect(accountSelectorWithWhiteSpaceForDetals).toBeInTheDocument();
+        });
 
-        const input = screen.getByRole('combobox');
+        it('should add whitespace for details if account is selected but has no balance or no accountNumber', () => {
+            selectedAccount = accounts[4];
+            const { container } = render(
+                <AccountSelector
+                    id="id"
+                    labelId="labelId"
+                    accounts={accounts}
+                    locale="nb"
+                    onAccountSelected={onAccountSelected}
+                    onReset={onReset}
+                    selectedAccount={selectedAccount}
+                    ariaInvalid={false}
+                />,
+            );
+            const accountSelectorWithWhiteSpaceForDetals = container.querySelector(
+                '.ffe-account-selector-single--with-space-for-details',
+            );
+            expect(accountSelectorWithWhiteSpaceForDetals).toBeInTheDocument();
+        });
 
-        fireEvent.click(input);
+        it('should not add whitespace for details if account is selected with balance but no accountNumber', () => {
+            selectedAccount = accounts[5];
+            const { container } = render(
+                <AccountSelector
+                    id="id"
+                    labelId="labelId"
+                    accounts={accounts}
+                    locale="nb"
+                    onAccountSelected={onAccountSelected}
+                    onReset={onReset}
+                    selectedAccount={selectedAccount}
+                    ariaInvalid={false}
+                />,
+            );
+            const accountSelectorWithWhiteSpaceForDetals = container.querySelector(
+                '.ffe-account-selector-single--with-space-for-details',
+            );
+            expect(accountSelectorWithWhiteSpaceForDetals).toBeNull();
+        });
 
-        expect(screen.getByText('Brukskonto')).toBeInTheDocument();
-        expect(screen.queryByText('BrukskoABC')).toBeNull();
+        it('should not add whitespace for details if account is selected with accountNumber but no balance', () => {
+            selectedAccount = accounts[6];
+            const { container } = render(
+                <AccountSelector
+                    id="id"
+                    labelId="labelId"
+                    accounts={accounts}
+                    locale="nb"
+                    onAccountSelected={onAccountSelected}
+                    onReset={onReset}
+                    selectedAccount={selectedAccount}
+                    ariaInvalid={false}
+                />,
+            );
+            const accountSelectorWithWhiteSpaceForDetals = container.querySelector(
+                '.ffe-account-selector-single--with-space-for-details',
+            );
+            expect(accountSelectorWithWhiteSpaceForDetals).toBeNull();
+        });
 
-        fireEvent.change(input, { target: { value: 'BrukskoABC' } });
+        it('should not add whitespace for details if account is selected', () => {
+            selectedAccount = accounts[1];
+            const { container } = render(
+                <AccountSelector
+                    id="id"
+                    labelId="labelId"
+                    accounts={accounts}
+                    locale="nb"
+                    onAccountSelected={onAccountSelected}
+                    onReset={onReset}
+                    selectedAccount={selectedAccount}
+                    ariaInvalid={false}
+                />,
+            );
+            const accountSelectorWithWhiteSpaceForDetals = container.querySelector(
+                '.ffe-account-selector-single--with-space-for-details',
+            );
+            expect(accountSelectorWithWhiteSpaceForDetals).toBeNull();
+        });
 
-        expect(screen.queryByText('Brukskonto')).toBeNull();
-        expect(screen.getByText('BrukskoABC')).toBeInTheDocument();
-
-        fireEvent.click(screen.getByText('BrukskoABC'));
-
-        rerender(
-            <AccountSelector
-                id="id"
-                labelId="labelId"
-                accounts={accounts}
-                locale="nb"
-                onAccountSelected={onAccountSelected}
-                onReset={onReset}
-                selectedAccount={selectedAccount}
-                allowCustomAccount={true}
-                ariaInvalid={false}
-            />,
-        );
-
-        expect(screen.getByText('BrukskoABC')).toBeInTheDocument();
-    });
-
-    it('should allow passing custom selected account when specified', () => {
-        render(
-            <AccountSelector
-                id="id"
-                labelId="labelId"
-                accounts={accounts}
-                locale="nb"
-                onAccountSelected={onAccountSelected}
-                onReset={onReset}
-                selectedAccount={{
-                    accountNumber: '2234 56 789101',
-                    name: 'Brukskonto 9',
-                    currencyCode: 'NOK',
-                    balance: 133,
-                }}
-                allowCustomAccount={true}
-                ariaInvalid={false}
-            />,
-        );
-
-        const input = screen.getByRole('combobox');
-
-        expect(input.getAttribute('value')).toEqual('Brukskonto 9');
-        expect(screen.getByText('2234 56 789101')).toBeInTheDocument();
-    });
-
-    it('should not show custom account when some account matches search', () => {
-        render(
-            <AccountSelector
-                id="id"
-                labelId="labelId"
-                accounts={accounts}
-                locale="nb"
-                onAccountSelected={onAccountSelected}
-                onReset={onReset}
-                selectedAccount={selectedAccount}
-                allowCustomAccount={true}
-                ariaInvalid={false}
-            />,
-        );
-
-        const input = screen.getByRole('combobox');
-
-        fireEvent.click(input);
-
-        expect(screen.getByText('Brukskonto')).toBeInTheDocument();
-        expect(screen.queryByText('BrukskoABC')).toBeNull();
-
-        fireEvent.change(input, { target: { value: 'Bruksko' } });
-
-        expect(screen.getAllByText('Bruksko', { exact: false })).toHaveLength(
-            1,
-        );
-    });
-
-    it('should be able to render custom list items', () => {
-        const CustomListItemBody = ({
-            // eslint-disable-next-line react/prop-types
-            item: { accountNumber, name, balance, currencyCode },
-        }) => (
-            <div>
-                <span>{accountNumber}</span>
-                <span>FOR et navn! {name}</span>
-                <span>Litt av en saldo! {balance}</span>
-                <span>{currencyCode}</span>
-            </div>
-        );
-
-        render(
-            <AccountSelector
-                id="id"
-                labelId="labelId"
-                accounts={accounts}
-                locale="nb"
-                onAccountSelected={onAccountSelected}
-                onReset={onReset}
-                listElementBody={CustomListItemBody}
-                ariaInvalid={false}
-            />,
-        );
-
-        const input = screen.getByRole('combobox');
-
-        fireEvent.click(input);
-
-        expect(
-            screen.getByText('FOR et navn! Jeg er en konto'),
-        ).toBeInTheDocument();
-        expect(screen.getByText('Litt av en saldo! 13337')).toBeInTheDocument();
-    });
-
-    it('should format input field while typing if value only contains digits and/or spaces', () => {
-        render(
-            <AccountSelector
-                id="id"
-                labelId="labelId"
-                accounts={accounts}
-                locale="nb"
-                onAccountSelected={onAccountSelected}
-                onReset={onReset}
-                ariaInvalid={false}
-            />,
-        );
-
-        const input = screen.getByRole('combobox');
-
-        fireEvent.change(input, { target: { value: 'ab1de' } });
-        expect(input.getAttribute('value')).toEqual('ab1de');
-
-        fireEvent.change(input, { target: { value: 'ab1de ' } });
-        expect(input.getAttribute('value')).toEqual('ab1de ');
-
-        fireEvent.change(input, { target: { value: '1234.' } });
-        expect(input.getAttribute('value')).toEqual('1234.');
-
-        fireEvent.change(input, { target: { value: '1234.5' } });
-        expect(input.getAttribute('value')).toEqual('1234.5');
-
-        fireEvent.change(input, { target: { value: '4321' } });
-        expect(input.getAttribute('value')).toEqual('4321');
-
-        fireEvent.change(input, { target: { value: '54321' } });
-        expect(input.getAttribute('value')).toEqual('5432 1');
-
-        fireEvent.change(input, { target: { value: '5432 1 ' } });
-        expect(input.getAttribute('value')).toEqual('5432 1');
-
-        fireEvent.change(input, { target: { value: '543216789101' } });
-        expect(input.getAttribute('value')).toEqual('5432 16 789101');
-    });
-
-    it('should not format input field when formatAccountNumber is false', () => {
-        render(
-            <AccountSelector
-                id="id"
-                labelId="labelId"
-                accounts={accounts}
-                locale="nb"
-                onAccountSelected={onAccountSelected}
-                onReset={onReset}
-                formatAccountNumber={false}
-                ariaInvalid={false}
-            />,
-        );
-
-        const input = screen.getByRole('combobox');
-
-        fireEvent.change(input, { target: { value: '54321' } });
-        expect(input.getAttribute('value')).toEqual('54321');
-
-        fireEvent.change(input, { target: { value: '543216789101' } });
-        expect(input.getAttribute('value')).toEqual('543216789101');
-    });
-
-    it('should allow changing selectedAccount even if selectedAccount is defined on first render (initial value)', () => {
-        selectedAccount = accounts[2];
-
-        const { rerender } = render(
-            <AccountSelector
-                id="id"
-                labelId="labelId"
-                accounts={accounts}
-                locale="nb"
-                onAccountSelected={onAccountSelected}
-                onReset={onReset}
-                selectedAccount={selectedAccount}
-                ariaInvalid={false}
-            />,
-        );
-
-        const input = screen.getByRole('combobox');
-
-        expect(screen.getByText('2234 56 789102')).toBeInTheDocument();
-        expect(screen.queryByText('1234 56 789102')).toBeNull();
-        expect(input.value).toBe('Sparekonto');
-
-        fireEvent.click(input);
-        fireEvent.click(screen.getByText('Jeg er en konto'));
-
-        rerender(
-            <AccountSelector
-                id="id"
-                labelId="labelId"
-                accounts={accounts}
-                locale="nb"
-                onAccountSelected={onAccountSelected}
-                onReset={onReset}
-                selectedAccount={selectedAccount}
-                ariaInvalid={false}
-            />,
-        );
-
-        expect(screen.queryByText('2234 56 789102')).toBeNull();
-        expect(screen.getByText('1234 56 789102')).toBeInTheDocument();
-        expect(input.value).toBe('Jeg er en konto');
+        it('should not add whitespace for details when specified', () => {
+            selectedAccount = undefined;
+            const { container } = render(
+                <AccountSelector
+                    id="id"
+                    labelId="labelId"
+                    accounts={accounts}
+                    locale="nb"
+                    onAccountSelected={onAccountSelected}
+                    onReset={onReset}
+                    selectedAccount={selectedAccount}
+                    ariaInvalid={false}
+                    withSpaceForDetails={false}
+                />,
+            );
+            const accountSelectorWithWhiteSpaceForDetals = container.querySelector(
+                '.ffe-account-selector-single--with-space-for-details',
+            );
+            expect(accountSelectorWithWhiteSpaceForDetals).toBeNull();
+        });
     });
 });


### PR DESCRIPTION
…umber or balance is defined

## Beskrivelse

Nå viser vi fortsatt komponenten med høyde selv om den ikke inneholder noe data. Dette er ikke nødvendig.

## Motivasjon og kontekst

Når vi i betaling har lagt inn en "konto" som vi har kalt "Alle" uten noe kontonummer eller balance, og man da viser en feilmelding får den et mellomrom mellom kontovelgeren og feilmeldingen.

Mulig dette egentlig ikke er et tilfelle vi burde ta hensyn til her. :thinking: 

## Testing

Testet lokalt på desktop. Har også skrevet noen ekstra tester.

La inn noen describes i test-fila i samme slengen så det er litt mer oversiktlig. Eneste nytt i test-fila er det i describen "whitespace" og noen nye kontoer i accounts-lista.
![Skjermbilde fra 2022-02-07 15-04-52](https://user-images.githubusercontent.com/58166609/152803900-f7fdfcfc-f9b5-41a8-b14e-59a28c682217.png)
