### PR TITLE
fix(ffe-message-box): legg til ffe-strong-text styling på tittel

### DIFF
--- a/packages/ffe-message-box/less/ffe-message-box.less
+++ b/packages/ffe-message-box/less/ffe-message-box.less
@@ -108,6 +108,7 @@
                 color: @ffe-farge-svart;
             }
         }
+        .ffe-strong-text();
     }
 
     &__list {


### PR DESCRIPTION
Legger til riktig font og weight på tittel i meldingsboks. 