### PR TITLE
fix(ffe-context-message): gjør ikon mindre på mobil

### DIFF
--- a/packages/ffe-context-message/less/ffe-context-message.less
+++ b/packages/ffe-context-message/less/ffe-context-message.less
@@ -97,9 +97,14 @@
     }
 
     &__icon-svg {
-        height: 2em;
-        width: 2em;
+        height: 1em;
+        width: 1em;
         fill: @ffe-farge-hvit;
+
+        @media (min-width: @breakpoint-sm) {
+            height: 2em;
+            width: 2em;
+        }
     }
 
     &__close-button {


### PR DESCRIPTION
## Beskrivelse
Ikonet i ContextMessage var for stort på mobil. Så gjør ikonet mindre, og legger til styling for å få riktig størrelse på større skjermer.

## Testing
Kjørt opp lokalt 
