### PR TITLE
feat(ffe-buttons-react): remove react-router to attribute

### DIFF
--- a/packages/ffe-buttons-react/src/index.d.ts
+++ b/packages/ffe-buttons-react/src/index.d.ts
@@ -1,22 +1,14 @@
 import * as React from 'react';
 
-type To =
-    | string
-    | {
-          pathname: string;
-          search?: string;
-          hash?: string;
-          state?: { [key: string]: any };
-      };
+export type MinimalBaseButtonProps<ExtraProps> = React.HTMLProps<HTMLElement> &
+    ExtraProps & {
+        className?: string;
+        element?: HTMLElement | string | React.ElementType;
+        innerRef?: React.Ref<HTMLElement>;
+    };
 
-export interface MinimalBaseButtonProps extends React.HTMLProps<HTMLElement> {
-    className?: string;
-    element?: HTMLElement | string | React.ElementType;
-    innerRef?: React.Ref<HTMLElement>;
-    to?: To; //used in order to make buttons work with react-router functionality in typescript-files.
-}
-
-export interface BaseButtonProps extends MinimalBaseButtonProps {
+export interface BaseButtonProps<ExtraProps>
+    extends MinimalBaseButtonProps<ExtraProps> {
     children?: React.ReactNode;
     ariaLoadingMessage?: string;
     condensed?: boolean;
@@ -26,11 +18,13 @@ export interface BaseButtonProps extends MinimalBaseButtonProps {
     rightIcon?: React.ReactNode;
 }
 
-export interface ActionButtonProps extends BaseButtonProps {
+export interface ActionButtonProps<ExtraProps>
+    extends BaseButtonProps<ExtraProps> {
     ghost?: boolean;
 }
 
-export interface BackButtonProps extends MinimalBaseButtonProps {
+export interface BackButtonProps<ExtraProps>
+    extends MinimalBaseButtonProps<ExtraProps> {
     children?: React.ReactNode;
 }
 
@@ -40,7 +34,8 @@ export interface ButtonGroupProps {
     inline?: boolean;
 }
 
-export interface ExpandButtonProps extends MinimalBaseButtonProps {
+export interface ExpandButtonProps<ExtraProps>
+    extends MinimalBaseButtonProps<ExtraProps> {
     children: React.ReactNode;
     closeLabel?: string;
     leftIcon?: React.ReactNode;
@@ -49,56 +44,77 @@ export interface ExpandButtonProps extends MinimalBaseButtonProps {
     onClick: (e: React.MouseEvent | undefined) => void;
 }
 
-export interface InlineExpandButtonProps extends MinimalBaseButtonProps {
+export interface InlineExpandButtonProps<ExtraProps>
+    extends MinimalBaseButtonProps<ExtraProps> {
     children?: React.ReactNode;
     innerRef?: React.Ref<HTMLElement>;
     isExpanded: boolean;
     onClick: (e: React.MouseEvent | undefined) => void;
 }
 
-export interface PrimaryButtonProps extends BaseButtonProps {}
+export interface PrimaryButtonProps<ExtraProps>
+    extends BaseButtonProps<ExtraProps> {}
 
-export interface SecondaryButtonProps extends BaseButtonProps {}
+export interface SecondaryButtonProps<ExtraProps>
+    extends BaseButtonProps<ExtraProps> {}
 
-export interface ShortcutButtonProps extends MinimalBaseButtonProps {
+export interface ShortcutButtonProps<ExtraProps>
+    extends MinimalBaseButtonProps<ExtraProps> {
     children?: React.ReactNode;
     condensed?: boolean;
     disabled?: boolean;
     leftIcon?: React.ReactNode;
 }
 
-export interface TaskButtonProps extends MinimalBaseButtonProps {
+export interface TaskButtonProps<ExtraProps>
+    extends MinimalBaseButtonProps<ExtraProps> {
     children?: React.ReactNode;
     condensed?: boolean;
     disabled?: boolean;
     icon: React.ReactNode;
 }
 
-export interface TertiaryButtonProps extends MinimalBaseButtonProps {
+export interface TertiaryButtonProps<ExtraProps>
+    extends MinimalBaseButtonProps<ExtraProps> {
     children?: React.ReactNode;
     leftIcon?: React.ReactNode;
     rightIcon?: React.ReactNode;
 }
 
-declare class ActionButton extends React.Component<ActionButtonProps, any> {}
-declare class BackButton extends React.Component<BackButtonProps, any> {}
+declare class ActionButton<ExtraProps> extends React.Component<
+    ActionButtonProps<ExtraProps>,
+    any
+> {}
+declare class BackButton<ExtraProps> extends React.Component<
+    BackButtonProps<ExtraProps>,
+    any
+> {}
 declare class ButtonGroup extends React.Component<ButtonGroupProps, any> {}
-declare class ExpandButton extends React.Component<ExpandButtonProps, any> {}
-declare class InlineExpandButton extends React.Component<
-    InlineExpandButtonProps,
+declare class ExpandButton<ExtraProps> extends React.Component<
+    ExpandButtonProps<ExtraProps>,
     any
 > {}
-declare class PrimaryButton extends React.Component<PrimaryButtonProps, any> {}
-declare class SecondaryButton extends React.Component<
-    SecondaryButtonProps,
+declare class InlineExpandButton<ExtraProps> extends React.Component<
+    InlineExpandButtonProps<ExtraProps>,
     any
 > {}
-declare class ShortcutButton extends React.Component<
-    ShortcutButtonProps,
+declare class PrimaryButton<ExtraProps> extends React.Component<
+    PrimaryButtonProps<ExtraProps>,
     any
 > {}
-declare class TaskButton extends React.Component<TaskButtonProps, any> {}
-declare class TertiaryButton extends React.Component<
-    TertiaryButtonProps,
+declare class SecondaryButton<ExtraProps> extends React.Component<
+    SecondaryButtonProps<ExtraProps>,
+    any
+> {}
+declare class ShortcutButton<ExtraProps> extends React.Component<
+    ShortcutButtonProps<ExtraProps>,
+    any
+> {}
+declare class TaskButton<ExtraProps> extends React.Component<
+    TaskButtonProps<ExtraProps>,
+    any
+> {}
+declare class TertiaryButton<ExtraProps> extends React.Component<
+    TertiaryButtonProps<ExtraProps>,
     any
 > {}


### PR DESCRIPTION
Det blir ikke noe vidare med react-router-typer i designsystemet. Det blir feks når noen er på version 5 og noen på version 6. Det to objektet ser anledes ut nå i react-router v6. 

Slik har jag testet dette ut selv. 

```
import React from 'react';
import { LinkProps } from "react-router-dom";

export type ButtonProps<ExtraProps> = React.HTMLProps<HTMLElement> & ExtraProps & {
    className?: string;
    element?: HTMLElement | string | React.ElementType;
    innerRef?: React.Ref<HTMLElement>;
}

const Button: <T>(
    p: ButtonProps<T>
) => React.ReactElement<ButtonProps<T>> = ({  ...rest }) => {

    return <button {...rest} >Click me!</button>;
};

const TestTheButton = () => {
    return <Button <LinkProps> to={""}/>
};


```

Breaking change vell da den gamle `to` ikke lenger vill virke