### PR TITLE
Fikse flere package.jsons

### DIFF
--- a/packages/ffe-accordion/package.json
+++ b/packages/ffe-accordion/package.json
@@ -2,14 +2,11 @@
   "name": "@sb1/ffe-accordion",
   "version": "8.0.10",
   "description": "Accordion component for FFE.",
-  "keywords": [
-    "Accordion",
-    "FFE",
-    "SpareBank1"
-  ],
   "license": "MIT",
   "author": "SpareBank 1",
-  "main": "index.js",
+  "files": [
+    "less"
+  ],
   "repository": {
     "type": "git",
     "url": "ssh://git@github.com:SpareBank1/designsystem.git"

--- a/packages/ffe-cards/package.json
+++ b/packages/ffe-cards/package.json
@@ -4,7 +4,9 @@
   "description": "Kort for bruk i oversikter",
   "license": "MIT",
   "author": "SpareBank 1",
-  "main": "index.js",
+  "files": [
+    "less"
+  ],
   "repository": {
     "type": "git",
     "url": "ssh://git@github.com:SpareBank1/designsystem.git"

--- a/packages/ffe-datepicker-react/package.json
+++ b/packages/ffe-datepicker-react/package.json
@@ -2,6 +2,7 @@
   "name": "@sb1/ffe-datepicker-react",
   "version": "5.1.0",
   "license": "MIT",
+  "author": "SpareBank 1",
   "files": [
     "lib",
     "es",

--- a/packages/ffe-datepicker/package.json
+++ b/packages/ffe-datepicker/package.json
@@ -4,7 +4,9 @@
   "description": "FFE Datepicker",
   "license": "MIT",
   "author": "SpareBank 1",
-  "main": "less/datepicker",
+  "files": [
+    "less"
+  ],
   "repository": {
     "type": "git",
     "url": "ssh://git@github.com:SpareBank1/designsystem.git"

--- a/packages/ffe-details-list/package.json
+++ b/packages/ffe-details-list/package.json
@@ -4,7 +4,9 @@
   "description": "Opplisting av attributter i en grid",
   "license": "MIT",
   "author": "SpareBank 1",
-  "main": "less/ffe-details-list.less",
+  "files": [
+    "less"
+  ],
   "repository": {
     "type": "git",
     "url": "ssh://git@github.com:SpareBank1/designsystem.git"

--- a/packages/ffe-dropdown-react/package.json
+++ b/packages/ffe-dropdown-react/package.json
@@ -2,6 +2,7 @@
   "name": "@sb1/ffe-dropdown-react",
   "version": "5.1.13",
   "license": "MIT",
+  "author": "SpareBank 1",
   "files": [
     "lib",
     "es",

--- a/packages/ffe-file-upload/package.json
+++ b/packages/ffe-file-upload/package.json
@@ -4,7 +4,9 @@
   "description": "File upload module",
   "license": "MIT",
   "author": "SpareBank 1",
-  "main": "less/ffe-file-upload.less",
+  "files": [
+    "less"
+  ],
   "repository": {
     "type": "git",
     "url": "ssh://git@github.com:SpareBank1/designsystem.git"

--- a/packages/ffe-form/package.json
+++ b/packages/ffe-form/package.json
@@ -7,7 +7,6 @@
   "files": [
     "less"
   ],
-  "main": "less/form.less",
   "repository": {
     "type": "git",
     "url": "ssh://git@github.com:SpareBank1/designsystem.git"

--- a/packages/ffe-icons-react/package.json
+++ b/packages/ffe-icons-react/package.json
@@ -3,6 +3,7 @@
   "version": "7.3.0",
   "description": "React-komponenter for ffe-icons",
   "license": "MIT",
+  "author": "SpareBank 1",
   "files": [
     "lib",
     "types",

--- a/packages/ffe-lists/package.json
+++ b/packages/ffe-lists/package.json
@@ -7,7 +7,6 @@
   "files": [
     "less"
   ],
-  "main": "less/lists.less",
   "repository": {
     "type": "git",
     "url": "ssh://git@github.com:SpareBank1/designsystem.git"

--- a/packages/ffe-message-box/package.json
+++ b/packages/ffe-message-box/package.json
@@ -4,7 +4,9 @@
   "description": "Meldingsboks",
   "license": "MIT",
   "author": "SpareBank 1",
-  "main": "less/ffe-message-box",
+  "files": [
+    "less"
+  ],
   "repository": {
     "type": "git",
     "url": "ssh://git@github.com:SpareBank1/designsystem.git"

--- a/packages/ffe-spinner/package.json
+++ b/packages/ffe-spinner/package.json
@@ -2,12 +2,10 @@
   "name": "@sb1/ffe-spinner",
   "version": "4.1.3",
   "license": "MIT",
-  "author": "SpareBank1",
+  "author": "SpareBank 1",
   "files": [
-    "less",
-    "example"
+    "less"
   ],
-  "main": "less/spinner.less",
   "repository": {
     "type": "git",
     "url": "ssh://git@github.com:SpareBank1/designsystem.git"

--- a/packages/ffe-system-message-react/package.json
+++ b/packages/ffe-system-message-react/package.json
@@ -6,6 +6,7 @@
   "author": "SpareBank 1",
   "files": [
     "lib",
+    "es",
     "types"
   ],
   "main": "lib/index.js",

--- a/packages/ffe-tables-react/package.json
+++ b/packages/ffe-tables-react/package.json
@@ -3,6 +3,7 @@
   "version": "6.1.0",
   "description": "React implementation of ffe-tables",
   "license": "MIT",
+  "author": "SpareBank 1",
   "files": [
     "lib",
     "es",


### PR DESCRIPTION
Fikser package.json i flere pakker.

* _ffe-system-message_ ble publisert uten ES-module-kode fordi package.json manglet informasjon at pakken skal inkludere den tilsvarende katalog (806afc21a1f2fd11c85038c4e3143f996978d957)
* Flere less-pakker hadde en less-fil som pakkens entry point (`main`). Dette har ingen fordel og kan føre til uforståelige feilmeldinger hvis man ved en feiltakelse importer disse pakker i javascript med `import` eller `require`.
* Legger til riktig `author` på alle pakker.