### PR TITLE
Toggle switch

### DIFF
--- a/component-overview/examples/form/ToggleSwitch-customOnOff.jsx
+++ b/component-overview/examples/form/ToggleSwitch-customOnOff.jsx
@@ -1,0 +1,5 @@
+import { ToggleSwitch } from '@sb1/ffe-form-react';
+
+<ToggleSwitch hideOnOff={false} onText="Aktiv" offText="Inaktiv">
+    Helautomatisk reklameutsending
+</ToggleSwitch>;

--- a/component-overview/examples/form/ToggleSwitch-description.jsx
+++ b/component-overview/examples/form/ToggleSwitch-description.jsx
@@ -1,0 +1,5 @@
+import { ToggleSwitch } from '@sb1/ffe-form-react';
+
+<ToggleSwitch description="Send meg spam">
+    Jeg vil gjerne ha reklame
+</ToggleSwitch>;

--- a/component-overview/examples/form/ToggleSwitch-hideOnOff.jsx
+++ b/component-overview/examples/form/ToggleSwitch-hideOnOff.jsx
@@ -1,0 +1,3 @@
+import { ToggleSwitch } from '@sb1/ffe-form-react';
+
+<ToggleSwitch hideOnOff={true}>Jeg vil gjerne ha reklame</ToggleSwitch>;

--- a/component-overview/examples/form/ToggleSwitch.jsx
+++ b/component-overview/examples/form/ToggleSwitch.jsx
@@ -1,0 +1,3 @@
+import { ToggleSwitch } from '@sb1/ffe-form-react';
+
+<ToggleSwitch>Jeg vil gjerne ha reklame</ToggleSwitch>;

--- a/component-overview/package.json
+++ b/component-overview/package.json
@@ -20,9 +20,12 @@
   "publishConfig": {
     "access": "public"
   },
+  "alias": {
+    "buffer": false
+  },
   "scripts": {
     "build": "make all",
-    "start": "parcel webapp/index.html --no-cache --open",
+    "start": "parcel webapp/index.html --no-cache --no-autoinstall --no-source-maps --open",
     "watch": "run-p watch:es watch:less watch:examples",
     "watch:es": "chokidar \"node_modules/@sb1/ffe-*/es/**/*.js\" --follow-symlinks -c \"touch package.json\"",
     "watch:less": "chokidar \"node_modules/@sb1/ffe-*/less/**/*.less\" --follow-symlinks -c \"make -B lib/style.css\"",

--- a/component-overview/package.json
+++ b/component-overview/package.json
@@ -20,12 +20,9 @@
   "publishConfig": {
     "access": "public"
   },
-  "alias": {
-    "buffer": false
-  },
   "scripts": {
     "build": "make all",
-    "start": "parcel webapp/index.html --no-cache --no-autoinstall --no-source-maps --open",
+    "start": "parcel webapp/index.html --no-cache --open",
     "watch": "run-p watch:es watch:less watch:examples",
     "watch:es": "chokidar \"node_modules/@sb1/ffe-*/es/**/*.js\" --follow-symlinks -c \"touch package.json\"",
     "watch:less": "chokidar \"node_modules/@sb1/ffe-*/less/**/*.less\" --follow-symlinks -c \"make -B lib/style.css\"",

--- a/packages/ffe-form-react/src/ToggleSwitch.js
+++ b/packages/ffe-form-react/src/ToggleSwitch.js
@@ -1,0 +1,99 @@
+import React from 'react';
+import { bool, node, string } from 'prop-types';
+import { v4 as uuidv4 } from 'uuid';
+import classNames from 'classnames';
+
+class ToggleSwitch extends React.Component {
+    id = `toggle-${uuidv4()}`;
+
+    render() {
+        const {
+            children,
+            className,
+            description,
+            hideOnOff,
+            onText,
+            offText,
+            id,
+            ...rest
+        } = this.props;
+
+        return (
+            <div
+                className={classNames(
+                    'ffe-toggle-switch',
+                    { 'ffe-toggle-switch--hide-on-off': hideOnOff },
+                    className,
+                )}
+            >
+                <input
+                    className="ffe-toggle-switch__input"
+                    type="checkbox"
+                    id={id || this.id}
+                    {...rest}
+                />
+                <label
+                    className="ffe-toggle-switch__label"
+                    htmlFor={id || this.id}
+                >
+                    <span className="ffe-toggle-switch__label-text">
+                        {children}
+                        {description && (
+                            <span className="ffe-toggle-switch__label-description">
+                                {description}
+                            </span>
+                        )}
+                    </span>
+                    {!hideOnOff && (
+                        <span
+                            className="ffe-toggle-switch__label-off"
+                            aria-hidden="true"
+                        >
+                            {offText}
+                        </span>
+                    )}
+                    <span
+                        className="ffe-toggle-switch__switch"
+                        aria-hidden="true"
+                    />
+                    {!hideOnOff && (
+                        <span
+                            className="ffe-toggle-switch__label-on"
+                            aria-hidden="true"
+                        >
+                            {onText}
+                        </span>
+                    )}
+                </label>
+            </div>
+        );
+    }
+}
+
+ToggleSwitch.propTypes = {
+    /** The label text */
+    children: node.isRequired,
+    /** Any extra classes */
+    className: string,
+    /** A second line of text in the label */
+    description: string,
+    /** Custom text to specify the on-option */
+    onText: string,
+    /** Custom text to specify the off-option */
+    offText: string,
+    /** Hide On & Off labels next to switch */
+    hideOnOff: bool,
+    /** Override the generated id with a custom one */
+    id: string,
+    /** Override the value attribute of the input with a custom one */
+    value: string,
+};
+
+ToggleSwitch.defaultProps = {
+    value: 'on',
+    hideOnOff: false,
+    onText: 'På',
+    offText: 'Av',
+};
+
+export default ToggleSwitch;

--- a/packages/ffe-form-react/src/ToggleSwitch.js
+++ b/packages/ffe-form-react/src/ToggleSwitch.js
@@ -2,7 +2,6 @@ import React from 'react';
 import { bool, node, string } from 'prop-types';
 import { v4 as uuidv4 } from 'uuid';
 import classNames from 'classnames';
-import i18n from './i18n/i18n';
 
 class ToggleSwitch extends React.Component {
     id = `toggle-${uuidv4()}`;
@@ -11,7 +10,6 @@ class ToggleSwitch extends React.Component {
         const {
             children,
             className,
-            locale,
             description,
             hideOnOff,
             onText,
@@ -19,14 +17,6 @@ class ToggleSwitch extends React.Component {
             id,
             ...rest
         } = this.props;
-
-        const supportedLocales = ['nb', 'nn', 'en'];
-        const text =
-            i18n[
-                supportedLocales.indexOf(this.props.locale) !== -1
-                    ? this.props.locale
-                    : 'nb'
-            ];
 
         return (
             <div
@@ -59,7 +49,7 @@ class ToggleSwitch extends React.Component {
                             className="ffe-toggle-switch__label-off"
                             aria-hidden="true"
                         >
-                            {offText ? offText : text.OFF}
+                            {offText}
                         </span>
                     )}
                     <span
@@ -69,10 +59,9 @@ class ToggleSwitch extends React.Component {
                     {!hideOnOff && (
                         <span
                             className="ffe-toggle-switch__label-on"
-                            id="test"
                             aria-hidden="true"
                         >
-                            {onText ? onText : text.ON}
+                            {onText}
                         </span>
                     )}
                 </label>
@@ -87,8 +76,6 @@ ToggleSwitch.propTypes = {
     /** Any extra classes */
     className: string,
     /** A second line of text in the label */
-    locale: string,
-    /** On/Off text language */
     description: string,
     /** Custom text to specify the on-option */
     onText: string,
@@ -104,8 +91,9 @@ ToggleSwitch.propTypes = {
 
 ToggleSwitch.defaultProps = {
     value: 'on',
-    locale: 'nb',
     hideOnOff: false,
+    onText: 'På',
+    offText: 'Av',
 };
 
 export default ToggleSwitch;

--- a/packages/ffe-form-react/src/ToggleSwitch.js
+++ b/packages/ffe-form-react/src/ToggleSwitch.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { bool, node, string } from 'prop-types';
 import { v4 as uuidv4 } from 'uuid';
 import classNames from 'classnames';
+import i18n from './i18n/i18n';
 
 class ToggleSwitch extends React.Component {
     id = `toggle-${uuidv4()}`;
@@ -10,6 +11,7 @@ class ToggleSwitch extends React.Component {
         const {
             children,
             className,
+            locale,
             description,
             hideOnOff,
             onText,
@@ -17,6 +19,14 @@ class ToggleSwitch extends React.Component {
             id,
             ...rest
         } = this.props;
+
+        const supportedLocales = ['nb', 'nn', 'en'];
+        const text =
+            i18n[
+                supportedLocales.indexOf(this.props.locale) !== -1
+                    ? this.props.locale
+                    : 'nb'
+            ];
 
         return (
             <div
@@ -49,7 +59,7 @@ class ToggleSwitch extends React.Component {
                             className="ffe-toggle-switch__label-off"
                             aria-hidden="true"
                         >
-                            {offText}
+                            {offText ? offText : text.OFF}
                         </span>
                     )}
                     <span
@@ -59,9 +69,10 @@ class ToggleSwitch extends React.Component {
                     {!hideOnOff && (
                         <span
                             className="ffe-toggle-switch__label-on"
+                            id="test"
                             aria-hidden="true"
                         >
-                            {onText}
+                            {onText ? onText : text.ON}
                         </span>
                     )}
                 </label>
@@ -76,6 +87,8 @@ ToggleSwitch.propTypes = {
     /** Any extra classes */
     className: string,
     /** A second line of text in the label */
+    locale: string,
+    /** On/Off text language */
     description: string,
     /** Custom text to specify the on-option */
     onText: string,
@@ -91,9 +104,8 @@ ToggleSwitch.propTypes = {
 
 ToggleSwitch.defaultProps = {
     value: 'on',
+    locale: 'nb',
     hideOnOff: false,
-    onText: 'På',
-    offText: 'Av',
 };
 
 export default ToggleSwitch;

--- a/packages/ffe-form-react/src/ToggleSwitch.js
+++ b/packages/ffe-form-react/src/ToggleSwitch.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { bool, node, string } from 'prop-types';
 import { v4 as uuidv4 } from 'uuid';
 import classNames from 'classnames';
+import i18n from './i18n/i18n';
 
 class ToggleSwitch extends React.Component {
     id = `toggle-${uuidv4()}`;
@@ -17,6 +18,14 @@ class ToggleSwitch extends React.Component {
             id,
             ...rest
         } = this.props;
+
+        const supportedLocales = ['nb', 'nn', 'en'];
+        const text =
+            i18n[
+                supportedLocales.indexOf(this.props.locale) !== -1
+                    ? this.props.locale
+                    : 'nb'
+            ];
 
         return (
             <div
@@ -49,7 +58,7 @@ class ToggleSwitch extends React.Component {
                             className="ffe-toggle-switch__label-off"
                             aria-hidden="true"
                         >
-                            {offText}
+                            {offText ? offText : text.OFF}
                         </span>
                     )}
                     <span
@@ -59,9 +68,10 @@ class ToggleSwitch extends React.Component {
                     {!hideOnOff && (
                         <span
                             className="ffe-toggle-switch__label-on"
+                            id="test"
                             aria-hidden="true"
                         >
-                            {onText}
+                            {onText ? onText : text.ON}
                         </span>
                     )}
                 </label>
@@ -76,6 +86,8 @@ ToggleSwitch.propTypes = {
     /** Any extra classes */
     className: string,
     /** A second line of text in the label */
+    locale: string,
+    /** On/Off text language */
     description: string,
     /** Custom text to specify the on-option */
     onText: string,
@@ -91,9 +103,8 @@ ToggleSwitch.propTypes = {
 
 ToggleSwitch.defaultProps = {
     value: 'on',
+    locale: 'nb',
     hideOnOff: false,
-    onText: 'På',
-    offText: 'Av',
 };
 
 export default ToggleSwitch;

--- a/packages/ffe-form-react/src/ToggleSwitch.spec.js
+++ b/packages/ffe-form-react/src/ToggleSwitch.spec.js
@@ -1,0 +1,113 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import ToggleSwitch from './ToggleSwitch';
+
+const getWrapper = props =>
+    shallow(<ToggleSwitch {...props}>Hello world</ToggleSwitch>);
+
+describe('<ToggleSwitch />', () => {
+    it('should render a checkbox', () => {
+        const wrapper = getWrapper();
+        expect(wrapper.find('input[type="checkbox"]').exists()).toBe(true);
+    });
+
+    it('should render a default value if passed', () => {
+        let wrapper = getWrapper();
+
+        expect(wrapper.find('input').prop('checked')).toBe(undefined);
+
+        wrapper = getWrapper({ checked: true });
+
+        expect(wrapper.find('input').prop('checked')).toBe(true);
+    });
+
+    it('should apply the same id to <label> and <input>', () => {
+        const wrapper = getWrapper({ name: 'Some text goes here' });
+
+        expect(wrapper.find('label').prop('htmlFor')).toBe(
+            wrapper.find('input').prop('id'),
+        );
+    });
+
+    it('should apply a unique id for each instance', () => {
+        const wrapper1 = getWrapper({ name: 'Some text goes here' });
+        const wrapper2 = getWrapper({ name: 'Some other text goes here' });
+
+        expect(wrapper1.find('input').prop('id')).not.toBe(
+            wrapper2.find('input').prop('id'),
+        );
+    });
+
+    it('should not change id when re-rendering an instance', () => {
+        const wrapper = getWrapper({ name: 'Some text goes here' });
+        const id = wrapper.find('input').prop('id');
+
+        // ShallowWrapper.update() alone does not force a re-render, it seems.
+        wrapper.instance().forceUpdate();
+        wrapper.update();
+        wrapper.setProps({});
+
+        expect(wrapper.find('input').prop('id')).toBe(id);
+    });
+
+    it('should allow to override the id', () => {
+        const id = 'this-is-not-a-generated-id';
+        const wrapper = getWrapper({ id, name: 'Some text goes here' });
+
+        expect(wrapper.find('label').prop('htmlFor')).toBe(id);
+        expect(wrapper.find('input').prop('id')).toBe(id);
+    });
+
+    it('should set arbitrary props (rest) on input', () => {
+        const wrapper = getWrapper({
+            name: 'toggle',
+            randomProp: 'false',
+            tabIndex: -1,
+        });
+
+        expect(wrapper.find('input').prop('name')).toBe('toggle');
+        expect(wrapper.find('input').prop('randomProp')).toBe('false');
+        expect(wrapper.find('input').prop('tabIndex')).toBe(-1);
+    });
+
+    it('should render additional props if passed', () => {
+        const wrapper = getWrapper({
+            onText: 'ooon',
+            offText: 'offf',
+            description: 'hei',
+        });
+
+        expect(wrapper.find('.ffe-toggle-switch__label-on').text()).toMatch(
+            /ooon/,
+        );
+        expect(wrapper.find('.ffe-toggle-switch__label-off').text()).toMatch(
+            /offf/,
+        );
+        expect(
+            wrapper.find('.ffe-toggle-switch__label-description').text(),
+        ).toMatch(/hei/);
+    });
+
+    it('should hide on/off text if specified', () => {
+        const wrapper = getWrapper({
+            hideOnOff: true,
+        });
+
+        expect(wrapper.hasClass('ffe-toggle-switch--hide-on-off')).toBe(true);
+        expect(wrapper.find('.ffe-toggle-switch__label-on').exists()).toBe(
+            false,
+        );
+        expect(wrapper.find('.ffe-toggle-switch__label-off').exists()).toBe(
+            false,
+        );
+    });
+
+    it('should render children', () => {
+        const wrapper = getWrapper();
+
+        expect(
+            wrapper.find('.ffe-toggle-switch__label-text').prop('children'),
+        ).toContain('Hello world');
+    });
+});

--- a/packages/ffe-form-react/src/i18n/en.js
+++ b/packages/ffe-form-react/src/i18n/en.js
@@ -1,4 +1,6 @@
 export default {
     COUNTRY_CODE: 'Country code',
-    PHONE_NUMBER: 'Phone number'
+    PHONE_NUMBER: 'Phone number',
+    ON: 'On',
+    OFF: 'Off',
 };

--- a/packages/ffe-form-react/src/i18n/en.js
+++ b/packages/ffe-form-react/src/i18n/en.js
@@ -1,4 +1,6 @@
 export default {
     COUNTRY_CODE: 'Country code',
-    PHONE_NUMBER: 'Phone number'
+    PHONE_NUMBER: 'Phone number',
+    OFF: 'Off',
+    ON: 'On',
 };

--- a/packages/ffe-form-react/src/i18n/en.js
+++ b/packages/ffe-form-react/src/i18n/en.js
@@ -1,6 +1,4 @@
 export default {
     COUNTRY_CODE: 'Country code',
-    PHONE_NUMBER: 'Phone number',
-    OFF: 'Off',
-    ON: 'On',
+    PHONE_NUMBER: 'Phone number'
 };

--- a/packages/ffe-form-react/src/i18n/nb.js
+++ b/packages/ffe-form-react/src/i18n/nb.js
@@ -1,4 +1,6 @@
 export default {
     COUNTRY_CODE: 'Landskode',
-    PHONE_NUMBER: 'Telefonnummer'
+    PHONE_NUMBER: 'Telefonnummer',
+    ON: 'På',
+    OFF: 'Av',
 };

--- a/packages/ffe-form-react/src/i18n/nb.js
+++ b/packages/ffe-form-react/src/i18n/nb.js
@@ -1,6 +1,4 @@
 export default {
     COUNTRY_CODE: 'Landskode',
-    PHONE_NUMBER: 'Telefonnummer',
-    OFF: 'Av',
-    ON: 'På',
+    PHONE_NUMBER: 'Telefonnummer'
 };

--- a/packages/ffe-form-react/src/i18n/nb.js
+++ b/packages/ffe-form-react/src/i18n/nb.js
@@ -1,4 +1,6 @@
 export default {
     COUNTRY_CODE: 'Landskode',
-    PHONE_NUMBER: 'Telefonnummer'
+    PHONE_NUMBER: 'Telefonnummer',
+    OFF: 'Av',
+    ON: 'På',
 };

--- a/packages/ffe-form-react/src/i18n/nn.js
+++ b/packages/ffe-form-react/src/i18n/nn.js
@@ -1,4 +1,6 @@
 export default {
     COUNTRY_CODE: 'Landskode',
-    PHONE_NUMBER: 'Telefonnummer'
+    PHONE_NUMBER: 'Telefonnummer',
+    ON: 'På',
+    OFF: 'Av',
 };

--- a/packages/ffe-form-react/src/i18n/nn.js
+++ b/packages/ffe-form-react/src/i18n/nn.js
@@ -1,6 +1,4 @@
 export default {
     COUNTRY_CODE: 'Landskode',
-    PHONE_NUMBER: 'Telefonnummer',
-    OFF: 'Av',
-    ON: 'På',
+    PHONE_NUMBER: 'Telefonnummer'
 };

--- a/packages/ffe-form-react/src/i18n/nn.js
+++ b/packages/ffe-form-react/src/i18n/nn.js
@@ -1,4 +1,6 @@
 export default {
     COUNTRY_CODE: 'Landskode',
-    PHONE_NUMBER: 'Telefonnummer'
+    PHONE_NUMBER: 'Telefonnummer',
+    OFF: 'Av',
+    ON: 'På',
 };

--- a/packages/ffe-form-react/src/index.d.ts
+++ b/packages/ffe-form-react/src/index.d.ts
@@ -150,6 +150,18 @@ export interface TextAreaProps
     className?: string;
 }
 
+export interface ToggleSwitchProps
+    extends React.InputHTMLAttributes<HTMLInputElement> {
+    children: React.ReactNode;
+    className: string;
+    id: string;
+    description: string;
+    onText: string;
+    offText: string;
+    hideOnOff: boolean;
+    value: string;
+}
+
 declare class Checkbox extends React.Component<CheckboxProps, any> {}
 declare class ErrorFieldMessage extends React.Component<
     BaseFieldMessageProps,
@@ -168,6 +180,7 @@ declare class PhoneNumber extends React.Component<PhoneNumberProps, any> {}
 declare class Label extends React.Component<LabelProps, any> {}
 declare class InputGroup extends React.Component<InputGroupProps, any> {}
 declare class Tooltip extends React.Component<TooltipProps, any> {}
+declare class ToggleSwitch extends React.Component<ToggleSwitchProps, any> {}
 declare class RadioBlock extends React.Component<RadioBlockProps, any> {}
 declare class RadioButton extends React.Component<RadioButtonProps, any> {}
 declare class RadioButtonInputGroup extends React.Component<

--- a/packages/ffe-form-react/src/index.js
+++ b/packages/ffe-form-react/src/index.js
@@ -12,6 +12,7 @@ import RadioButtonInputGroup from './RadioButtonInputGroup';
 import RadioSwitch from './RadioSwitch';
 import TextArea from './TextArea';
 import Tooltip from './Tooltip';
+import ToggleSwitch from './ToggleSwitch';
 
 export {
     Checkbox,
@@ -28,4 +29,5 @@ export {
     RadioSwitch,
     TextArea,
     Tooltip,
+    ToggleSwitch,
 };

--- a/packages/ffe-form/less/form.less
+++ b/packages/ffe-form/less/form.less
@@ -11,6 +11,7 @@
 @import 'radio-switch';
 @import 'radio-block';
 @import 'phone-number';
+@import 'toggle-switch';
 
 /* Form Layout */
 @import 'input-group';

--- a/packages/ffe-form/less/toggle-switch.less
+++ b/packages/ffe-form/less/toggle-switch.less
@@ -66,7 +66,7 @@
             content: '';
             width: 56px;
             height: 30px;
-            background: @ffe-farge-graa;
+            background: @ffe-farge-graa-wcag;
             border-radius: 15px;
             z-index: 1;
             left: auto;
@@ -76,7 +76,7 @@
 
             .native & {
                 @media (prefers-color-scheme: dark) {
-                    background: @ffe-farge-varmgraa;
+                    background: @ffe-farge-graa;
                 }
             }
         }

--- a/packages/ffe-form/less/toggle-switch.less
+++ b/packages/ffe-form/less/toggle-switch.less
@@ -1,0 +1,160 @@
+// Toggle switch
+//
+// Markup:
+// <div class="ffe-toggle-switch ffe-toggle-switch{{modifier_class}}">
+//     <input type="checkbox" class="ffe-toggle-switch__input" id="toggle{{modifier_class}}" name="toggle{{modifier_class}}" value="on">
+//     <label class="ffe-toggle-switch__label" for="toggle{{modifier_class}}">
+//         Send meg spam
+//     </label>
+// </div>
+//
+// --align-right - Aligns the switch to the right
+//
+// Styleguide ffe-form.toggle-switch
+
+.ffe-toggle-switch {
+    &__input {
+        position: absolute;
+        opacity: 0;
+        cursor: pointer;
+    }
+
+    &__label {
+        display: flex;
+        align-items: center;
+        position: relative;
+        cursor: pointer;
+        color: @ffe-farge-fjell;
+        font-family: 'SpareBank1-regular', 'MuseoSans-500', arial, sans-serif;
+        min-height: 44px;
+        transition: color @ffe-transition-duration @ffe-ease;
+        .ffe-fontsize-h6();
+
+        .native & {
+            @media (prefers-color-scheme: dark) {
+                color: @ffe-farge-vann-70;
+            }
+        }
+    }
+
+    &__label-text {
+        margin-right: auto;
+        padding-right: @ffe-spacing-sm;
+    }
+
+    &__label-on,
+    &__label-off {
+        .ffe-small-text();
+    }
+
+    &__label-description {
+        display: block;
+        margin-top: @ffe-spacing-2xs;
+        .ffe-small-text();
+    }
+
+    &__switch {
+        position: relative;
+        margin: 0 @ffe-spacing-sm;
+
+        .ffe-toggle-switch--hide-on-off & {
+            margin: 0;
+        }
+
+        &::before {
+            display: inline-block;
+            content: '';
+            width: 56px;
+            height: 30px;
+            background: @ffe-farge-graa;
+            border-radius: 15px;
+            z-index: 1;
+            left: auto;
+            right: 0;
+            transition: background 0.4s @ffe-ease,
+                box-shadow @ffe-transition-duration @ffe-ease;
+
+            .native & {
+                @media (prefers-color-scheme: dark) {
+                    background: @ffe-farge-varmgraa;
+                }
+            }
+        }
+
+        &::after {
+            display: inline-block;
+            content: '';
+            width: 24px;
+            height: 24px;
+            background: @ffe-farge-hvit;
+            border-radius: 13px;
+            position: absolute;
+            z-index: 2;
+            left: auto;
+            right: 29px;
+            top: 3px;
+            transition: transform @ffe-transition-duration @ffe-ease-in-out-back;
+
+            .native & {
+                @media (prefers-color-scheme: dark) {
+                    background: @ffe-farge-svart;
+                }
+            }
+        }
+
+        .ffe-toggle-switch__label:hover &::before {
+            background: @ffe-farge-moerkgraa;
+
+            .native & {
+                @media (prefers-color-scheme: dark) {
+                    background: @ffe-farge-lysgraa;
+                }
+            }
+        }
+    }
+
+    &__input:checked + &__label &__switch::after {
+        transform: translateX(26px);
+    }
+
+    &__input:checked + &__label &__switch::before {
+        background: @ffe-farge-vann;
+
+        .native & {
+            @media (prefers-color-scheme: dark) {
+                background: @ffe-farge-vann-70;
+            }
+        }
+    }
+
+    &__input:checked + &__label:hover &__switch::before {
+        background: @ffe-farge-fjell;
+
+        .native & {
+            @media (prefers-color-scheme: dark) {
+                background: @ffe-farge-vann-30;
+            }
+        }
+    }
+
+    &__input:focus:not(:focus-visible) + &__label &__switch::before {
+        box-shadow: none;
+
+        .native & {
+            @media (prefers-color-scheme: dark) {
+                box-shadow: none;
+            }
+        }
+    }
+
+    &__input:focus + &__label &__switch::before {
+        box-shadow: 0 0 0 3px @ffe-farge-hvit, 0 0 0 5px @ffe-farge-vann;
+
+        .native & {
+            @media (prefers-color-scheme: dark) {
+                box-shadow: 0 0 0 3px @ffe-farge-svart,
+                    0 0 0 5px @ffe-farge-hvit;
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse

Ny komponent som passer for valg som kan skrus av eller på, med umiddelbar respons. Under panseret er dette en checkbox.

### Skjermskudd

#### Default visning, light mode:

![image](https://user-images.githubusercontent.com/463847/156554389-c086ee63-a6bb-407f-9607-cbd578385ef8.png)

#### Default visning, dark mode:

![image](https://user-images.githubusercontent.com/463847/156554739-46a73595-a6d4-4de8-86be-808aa677441b.png)

#### Hover/aktiv/fokus, light mode:

![image](https://i.imgur.com/sZEd7xe.gif)

#### Hover/aktiv/fokus, dark mode:

![image](https://i.imgur.com/7XsboVr.gif)

#### Egendefinert av/på-tekst (`onText`/`offText`):

![image](https://user-images.githubusercontent.com/463847/156555303-05ccfcac-f0a3-4031-bf82-5eddd3c69e62.png)

#### Skjult av/på-tekst (`hideOnOff`):

![image](https://user-images.githubusercontent.com/463847/156555569-458042ab-a844-4846-9d02-b677b40b6f70.png)

#### Med `description` i label-tekst:

![image](https://user-images.githubusercontent.com/463847/156555482-7038b68b-d617-4532-a3d0-da9c2b74a752.png)


## Motivasjon og kontekst

Dette er en gjenoppliving av en gammel PR (https://github.com/SpareBank1/designsystem/pull/527) for ny ToggleSwitch-komponent. I etterkant av at den forrige ble lagt på is har behovet blitt revurdert og vi har kommet frem til at vi likevel ønsker en slik komponent. PR-en er skrevet om og redesignet lett etter et tidligere forsøk - se #1299.

## Testing

Testet lokalt med `component-overview` i alle browsere jeg har tilgjengelig.
