### PR TITLE
fix(ffe-tabs): fikse bug på desktop

### DIFF
--- a/packages/ffe-tabs/less/tab.less
+++ b/packages/ffe-tabs/less/tab.less
@@ -100,18 +100,18 @@
             }
         }
     }
-}
 
-@media (min-width: @breakpoint-sm) {
-    display: inline-block;
-    width: auto;
-    margin-right: @ffe-spacing-xs;
+    @media (min-width: @breakpoint-sm) {
+        display: inline-block;
+        width: auto;
+        margin-right: @ffe-spacing-xs;
 
-    &:not(:first-child) {
-        margin-left: -2px;
-    }
+        &:not(:first-child) {
+            margin-left: -2px;
+        }
 
-    &:last-child {
-        margin-right: @ffe-spacing-2xs;
+        &:last-child {
+            margin-right: @ffe-spacing-2xs;
+        }
     }
 }


### PR DESCRIPTION
Skulle ta i bruk tabs i nettbanken og oppdaget at hele hovedmenyen la seg til høyre.

<!-- Detaljert beskrivelse av endringene dine. Skjermskudd er lov. -->

![Screenshot from 2022-03-03 16-09-16](https://user-images.githubusercontent.com/69858000/156592514-0601863a-3c32-4f80-8c07-22d50205ed11.png)


<!-- Hvorfor trengs denne endringen, og hva løser den? -->

Den fikser forhåpentligvis at hovedmenyen i nettbanken ikke legger seg helt til høyre. Må testes når komponenten tas i bruk, men menyen så fin ut da jeg fjernet i css i inspect på desktop.

![Screenshot from 2022-03-03 16-12-32](https://user-images.githubusercontent.com/69858000/156593136-65c2a4f7-41b5-42f2-9711-e38a0361aad4.png)

<!-- Hvordan har du har testet endringene dine? Ta gjerne med systeminfo o.l -->

<!--

Helt til slutt, har du ..

.. lest retningslinjene våre for bidrag?
.. tatt en siste sjekk for kode og skrivefeil, debug informasjon o.l?
.. kjørt og eventuelt oppdatert testene?
.. kommentert og dokumentert det som trengs?
.. knyttet denne opp til relaterte issues?

-->
