### PR TITLE
fix(ffe-form): fiks for oval tooltip i ios

### DIFF
--- a/packages/ffe-form/less/tooltip.less
+++ b/packages/ffe-form/less/tooltip.less
@@ -23,6 +23,7 @@
         cursor: help;
         height: @ffe-tooltip-size;
         margin: 0 0 @ffe-spacing-2xs @ffe-spacing-sm;
+        padding: 0;
         transition: border-color @ffe-transition-duration @ffe-ease;
         width: @ffe-tooltip-size;
         display: inline-flex;


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse

Fikser en bug der tooltip rendres ovalt i stedet for sirkulært i iOS. Bugen kommer av at knappen får default padding fra browseren, ettersom det ikke er spesifisert i css.

## Motivasjon og kontekst

Fixes #1327 

## Testing

Testet lokalt og med Safari web inspector på mobil