### PR TITLE
Refactoring i kortkomponentene ffe-card og -react.

### DIFF
--- a/packages/ffe-cards-react/src/IconCard/IconCard.js
+++ b/packages/ffe-cards-react/src/IconCard/IconCard.js
@@ -2,7 +2,6 @@ import React from 'react';
 import classNames from 'classnames';
 import { node, string, bool, func, oneOfType, elementType } from 'prop-types';
 
-import CardBase from '../CardBase';
 import * as components from '../components';
 
 const IconCard = props => {
@@ -11,12 +10,13 @@ const IconCard = props => {
         icon,
         condensed,
         greyCharcoal,
+        element: Element,
         children,
         ...rest
     } = props;
 
     return (
-        <CardBase
+        <Element
             className={classNames(
                 'ffe-icon-card',
                 { 'ffe-icon-card--condensed': condensed },
@@ -36,8 +36,12 @@ const IconCard = props => {
                     ? children(components)
                     : children}
             </div>
-        </CardBase>
+        </Element>
     );
+};
+
+IconCard.defaultProps = {
+    element: 'div',
 };
 
 IconCard.propTypes = {

--- a/packages/ffe-cards-react/src/ImageCard/ImageCard.js
+++ b/packages/ffe-cards-react/src/ImageCard/ImageCard.js
@@ -10,9 +10,14 @@ const ImageCard = props => {
 
     return (
         <CardBase className={classNames('ffe-image-card', className)} {...rest}>
-            <div className="ffe-image-card__image">
+            <div className="ffe-image-card__image-container">
                 <div className="ffe-image-card__image-overlay" />
-                {image}
+                {React.cloneElement(image, {
+                    className: classNames(
+                        'ffe-image-card__image',
+                        image.props.className,
+                    ),
+                })}
             </div>
             <div className="ffe-image-card__body">
                 {typeof children === 'function'

--- a/packages/ffe-cards-react/src/ImageCard/ImageCard.js
+++ b/packages/ffe-cards-react/src/ImageCard/ImageCard.js
@@ -2,14 +2,13 @@ import React from 'react';
 import classNames from 'classnames';
 import { node, string, func, oneOfType, elementType } from 'prop-types';
 
-import CardBase from '../CardBase';
 import * as components from '../components';
 
 const ImageCard = props => {
-    const { className, image, children, ...rest } = props;
+    const { className, image, element: Element, children, ...rest } = props;
 
     return (
-        <CardBase className={classNames('ffe-image-card', className)} {...rest}>
+        <Element className={classNames('ffe-image-card', className)} {...rest}>
             <div className="ffe-image-card__image-container">
                 <div className="ffe-image-card__image-overlay" />
                 {React.cloneElement(image, {
@@ -24,8 +23,12 @@ const ImageCard = props => {
                     ? children(components)
                     : children}
             </div>
-        </CardBase>
+        </Element>
     );
+};
+
+ImageCard.defaultProps = {
+    element: 'div',
 };
 
 ImageCard.propTypes = {

--- a/packages/ffe-cards-react/src/ImageCard/ImageCard.js
+++ b/packages/ffe-cards-react/src/ImageCard/ImageCard.js
@@ -11,7 +11,7 @@ const ImageCard = props => {
     return (
         <CardBase className={classNames('ffe-image-card', className)} {...rest}>
             <div className="ffe-image-card__image">
-                <div className="ffe-image-card__image__overlay" />
+                <div className="ffe-image-card__image-overlay" />
                 {image}
             </div>
             <div className="ffe-image-card__body">

--- a/packages/ffe-cards-react/src/ImageCard/ImageCard.spec.js
+++ b/packages/ffe-cards-react/src/ImageCard/ImageCard.spec.js
@@ -3,7 +3,7 @@ import React from 'react';
 import ImageCard from './ImageCard';
 import { Text } from '../components';
 
-const image = <img alt="" />;
+const image = <img alt="" className="my-custom-image" />;
 const getWrapper = props => shallow(<ImageCard {...props} image={image} />);
 const children = <div>Hello world</div>;
 
@@ -12,25 +12,35 @@ describe('ImageCard', () => {
         const wrapper = getWrapper();
 
         expect(wrapper.hasClass('ffe-image-card')).toBe(true);
-        expect(wrapper.find('div.ffe-image-card__image').exists()).toBe(true);
+        expect(
+            wrapper.find('div.ffe-image-card__image-container').exists(),
+        ).toBe(true);
     });
 
     it('should render image and overlay alongside each other', () => {
         const wrapper = getWrapper();
 
-        const imageEl = wrapper.find('.ffe-image-card__image');
+        const imageEl = wrapper.find('.ffe-image-card__image-container');
         expect(
             imageEl
                 .children()
                 .first()
                 .hasClass('ffe-image-card__image-overlay'),
         ).toBe(true);
+
         expect(
             imageEl
                 .children()
                 .last()
-                .getElement(),
-        ).toEqual(image);
+                .hasClass('my-custom-image'),
+        ).toBe(true);
+
+        expect(
+            imageEl
+                .children()
+                .last()
+                .hasClass('ffe-image-card__image'),
+        ).toBe(true);
     });
 
     it('should render children inside a div with body class', () => {

--- a/packages/ffe-cards-react/src/ImageCard/ImageCard.spec.js
+++ b/packages/ffe-cards-react/src/ImageCard/ImageCard.spec.js
@@ -23,7 +23,7 @@ describe('ImageCard', () => {
             imageEl
                 .children()
                 .first()
-                .hasClass('ffe-image-card__image__overlay'),
+                .hasClass('ffe-image-card__image-overlay'),
         ).toBe(true);
         expect(
             imageEl

--- a/packages/ffe-cards-react/src/TextCard/TextCard.js
+++ b/packages/ffe-cards-react/src/TextCard/TextCard.js
@@ -2,14 +2,13 @@ import React from 'react';
 import classNames from 'classnames';
 import { string, func, node, oneOfType, bool, elementType } from 'prop-types';
 
-import CardBase from '../CardBase';
 import * as components from '../components';
 
 const TextCard = props => {
-    const { className, leftAlign, children, ...rest } = props;
+    const { className, leftAlign, element: Element, children, ...rest } = props;
 
     return (
-        <CardBase
+        <Element
             className={classNames(
                 'ffe-text-card',
                 { 'ffe-text-card--left-align': leftAlign },
@@ -18,8 +17,12 @@ const TextCard = props => {
             {...rest}
         >
             {typeof children === 'function' ? children(components) : children}
-        </CardBase>
+        </Element>
     );
+};
+
+TextCard.defaultProps = {
+    element: 'div',
 };
 
 TextCard.propTypes = {

--- a/packages/ffe-cards-react/src/components/CardName.js
+++ b/packages/ffe-cards-react/src/components/CardName.js
@@ -6,7 +6,7 @@ import ComponentBase from './ComponentBase';
 
 const CardName = ({ className, ...rest }) => (
     <ComponentBase
-        className={classNames('ffe-card-component--card-name', className)}
+        className={classNames('ffe-card-body__card-name', className)}
         {...rest}
     />
 );

--- a/packages/ffe-cards-react/src/components/ComponentBase.js
+++ b/packages/ffe-cards-react/src/components/ComponentBase.js
@@ -3,10 +3,7 @@ import classNames from 'classnames';
 import { string, node, oneOfType, func, elementType } from 'prop-types';
 
 const ComponentBase = ({ className, element: Element, ...rest }) => (
-    <Element
-        className={classNames('ffe-card-component', className)}
-        {...rest}
-    />
+    <Element className={classNames(className)} {...rest} />
 );
 
 ComponentBase.defaultProps = { element: 'p' };

--- a/packages/ffe-cards-react/src/components/Subtext.js
+++ b/packages/ffe-cards-react/src/components/Subtext.js
@@ -6,7 +6,7 @@ import ComponentBase from './ComponentBase';
 
 const Subtext = ({ className, ...rest }) => (
     <ComponentBase
-        className={classNames('ffe-card-component--subtext', className)}
+        className={classNames('ffe-card-body__subtext', className)}
         {...rest}
     />
 );

--- a/packages/ffe-cards-react/src/components/Text.js
+++ b/packages/ffe-cards-react/src/components/Text.js
@@ -6,7 +6,7 @@ import ComponentBase from './ComponentBase';
 
 const Text = ({ className, ...rest }) => (
     <ComponentBase
-        className={classNames('ffe-card-component--text', className)}
+        className={classNames('ffe-card-body__text', className)}
         {...rest}
     />
 );

--- a/packages/ffe-cards-react/src/components/Title.js
+++ b/packages/ffe-cards-react/src/components/Title.js
@@ -7,9 +7,9 @@ import ComponentBase from './ComponentBase';
 const Title = ({ className, overflowEllipsis, ...rest }) => (
     <ComponentBase
         className={classNames(
-            'ffe-card-component--title',
+            'ffe-card-body__title',
             {
-                'ffe-card-component--title--overflow-ellipsis': overflowEllipsis,
+                'ffe-card-body__title--overflow-ellipsis': overflowEllipsis,
             },
             className,
         )}

--- a/packages/ffe-cards/less/card-base.less
+++ b/packages/ffe-cards/less/card-base.less
@@ -1,48 +1,6 @@
 .ffe-card-base {
-    &:extend(.ffe-body-text);
+    .common-card-styling();
 
-    background: @ffe-farge-hvit;
-    box-shadow: 0 1px 4px 0 rgba(38, 38, 38, 0.3);
     display: block;
-    margin: 0 0 @ffe-spacing-xs;
     padding: 0;
-    border: 2px solid transparent;
-    border-radius: 5px;
-    transition: border-color 0.2s;
-    outline: none;
-    cursor: pointer;
-    width: 100%;
-    text-decoration: none;
-    .native & {
-        @media (prefers-color-scheme: dark) {
-            box-shadow: 0 0 0 1px @ffe-farge-moerkgraa;
-            background: @ffe-farge-svart;
-            color: @ffe-farge-hvit;
-        }
-    }
-
-    &:focus {
-        box-shadow: 0 0 0 2px @ffe-farge-vann;
-
-        .native & {
-            @media (prefers-color-scheme: dark) {
-                box-shadow: 0 0 0 2px @ffe-farge-vann-70;
-            }
-        }
-    }
-
-    &:focus,
-    &:active,
-    &:hover {
-        border-color: @ffe-farge-vann;
-        .native & {
-            @media (prefers-color-scheme: dark) {
-                border-color: @ffe-farge-vann-70;
-            }
-        }
-    }
-
-    @media (min-width: @breakpoint-md) {
-        margin-bottom: @ffe-spacing-md;
-    }
 }

--- a/packages/ffe-cards/less/cards.less
+++ b/packages/ffe-cards/less/cards.less
@@ -1,3 +1,4 @@
+@import 'common-card-styling';
 @import 'card-base';
 @import 'components';
 @import 'text-card';

--- a/packages/ffe-cards/less/common-card-styling.less
+++ b/packages/ffe-cards/less/common-card-styling.less
@@ -1,0 +1,46 @@
+.common-card-styling() {
+    &:extend(.ffe-body-text);
+
+    background: @ffe-farge-hvit;
+    box-shadow: 0 1px 4px 0 rgba(38, 38, 38, 0.3);
+    margin: 0 0 @ffe-spacing-xs;
+    border: 2px solid transparent;
+    border-radius: 5px;
+    transition: border-color 0.2s;
+    outline: none;
+    cursor: pointer;
+    width: 100%;
+    text-decoration: none;
+    .native & {
+        @media (prefers-color-scheme: dark) {
+            box-shadow: 0 0 0 1px @ffe-farge-moerkgraa;
+            background: @ffe-farge-svart;
+            color: @ffe-farge-hvit;
+        }
+    }
+
+    &:focus {
+        box-shadow: 0 0 0 2px @ffe-farge-vann;
+
+        .native & {
+            @media (prefers-color-scheme: dark) {
+                box-shadow: 0 0 0 2px @ffe-farge-vann-70;
+            }
+        }
+    }
+
+    &:focus,
+    &:active,
+    &:hover {
+        border-color: @ffe-farge-vann;
+        .native & {
+            @media (prefers-color-scheme: dark) {
+                border-color: @ffe-farge-vann-70;
+            }
+        }
+    }
+
+    @media (min-width: @breakpoint-md) {
+        margin-bottom: @ffe-spacing-md;
+    }
+}

--- a/packages/ffe-cards/less/components.less
+++ b/packages/ffe-cards/less/components.less
@@ -1,13 +1,13 @@
-.ffe-card-component {
-    &--card-name {
+.ffe-card-body {
+    &__card-name {
         margin: 0 0 @ffe-spacing-2xs 0;
     }
 
-    &--text {
+    &__text {
         margin: @ffe-spacing-2xs 0 0 0;
     }
 
-    &--subtext {
+    &__subtext {
         &:extend(.ffe-small-text);
 
         color: @ffe-farge-moerkgraa;
@@ -20,7 +20,7 @@
         margin: @ffe-spacing-2xs 0 0 0;
     }
 
-    &--title {
+    &__title {
         &:extend(.ffe-h5);
         margin: 0;
 

--- a/packages/ffe-cards/less/components.less
+++ b/packages/ffe-cards/less/components.less
@@ -22,6 +22,7 @@
 
     &__title {
         &:extend(.ffe-h5);
+
         margin: 0;
 
         &--overflow-ellipsis {

--- a/packages/ffe-cards/less/components.less
+++ b/packages/ffe-cards/less/components.less
@@ -22,12 +22,6 @@
 
     &--title {
         &:extend(.ffe-h5);
-        .native & {
-            @media (prefers-color-scheme: dark) {
-                color: @ffe-farge-vann-70;
-            }
-        }
-
         margin: 0;
 
         &--overflow-ellipsis {

--- a/packages/ffe-cards/less/icon-card.less
+++ b/packages/ffe-cards/less/icon-card.less
@@ -1,8 +1,10 @@
 .ffe-icon-card {
+    .common-card-styling();
+
+    display: flex;
+    padding: @ffe-spacing-md;
     max-width: 440px;
     min-height: 130px;
-    padding: @ffe-spacing-md;
-    display: flex;
     flex-flow: row nowrap;
 
     &__icon {

--- a/packages/ffe-cards/less/icon-card.less
+++ b/packages/ffe-cards/less/icon-card.less
@@ -52,7 +52,7 @@
         margin: 0 @ffe-spacing-sm 0 0;
     }
 
-    .ffe-card-component--subtext {
+    .ffe-card-body__subtext {
         margin: 0;
 
         @media (min-width: @breakpoint-md) {
@@ -71,7 +71,7 @@
         }
     }
 
-    .ffe-card-component--title,
+    .ffe-card-body__title,
     .ffe-icon-card__body {
         color: @ffe-farge-moerkgraa;
         .native & {

--- a/packages/ffe-cards/less/icon-card.less
+++ b/packages/ffe-cards/less/icon-card.less
@@ -52,11 +52,7 @@
         margin: 0 @ffe-spacing-sm 0 0;
     }
 
-    .ffe-icon-component--card-name {
-        margin: 0 0 @ffe-spacing-2xs;
-    }
-
-    .ffe-icon-component--subtext {
+    .ffe-card-component--subtext {
         margin: 0;
 
         @media (min-width: @breakpoint-md) {

--- a/packages/ffe-cards/less/image-card.less
+++ b/packages/ffe-cards/less/image-card.less
@@ -1,8 +1,10 @@
 .ffe-image-card {
-    max-width: 290px;
-    padding: 0;
-    border: 0;
+    .common-card-styling();
+
     display: flex;
+    padding: 0;
+    max-width: 290px;
+    border: 0;
     flex-flow: column nowrap;
 
     &:focus,

--- a/packages/ffe-cards/less/image-card.less
+++ b/packages/ffe-cards/less/image-card.less
@@ -8,7 +8,7 @@
     &:focus,
     &:active,
     &:hover {
-        .ffe-image-card__image__overlay,
+        .ffe-image-card__image-overlay,
         .ffe-image-card__body {
             border-color: @ffe-farge-vann;
         }
@@ -22,7 +22,7 @@
         border-top-right-radius: 5px;
     }
 
-    &__image__overlay,
+    &__image-overlay,
     &__body {
         width: 100%;
         overflow: hidden;
@@ -30,7 +30,7 @@
         transition: border-color @ffe-transition-duration;
     }
 
-    &__image__overlay {
+    &__image-overlay {
         z-index: 10;
         height: 100%;
         border-bottom: 0;

--- a/packages/ffe-cards/less/image-card.less
+++ b/packages/ffe-cards/less/image-card.less
@@ -14,12 +14,16 @@
         }
     }
 
-    &__image {
+    &__image-container {
         max-height: 160px;
         position: relative;
         overflow: hidden;
         border-top-left-radius: 5px;
         border-top-right-radius: 5px;
+    }
+
+    &__image {
+        max-width: 100%;
     }
 
     &__image-overlay,

--- a/packages/ffe-cards/less/text-card.less
+++ b/packages/ffe-cards/less/text-card.less
@@ -1,6 +1,8 @@
 .ffe-text-card {
-    padding: @ffe-spacing-sm @ffe-spacing-lg;
+    .common-card-styling();
+
     display: flex;
+    padding: @ffe-spacing-sm @ffe-spacing-lg;
     flex-flow: column nowrap;
     text-align: center;
     overflow: hidden;


### PR DESCRIPTION
Rydder i styling av kortkomponentene i ffe-card og ffe-card-react.

* fjerner kobling av `ffe-card-base` til de andre kortklassene slik at rekkefølge import ikke har noe å si (#1333, 5036082505159f9463f02254f360f741bc83b1a7, f6c092758db19a6bf4b5ed6d97a49b667c561076)
* legger til max-width på bildet i ImageCard (ed0e540dd8c0efd18a8d9915479f5a5d14202c84, 49a2f6a1365b97b1533285f8ead1cec143843e41)
* litt småpirk som gjør klassenavnene mer BEM
