### PR TITLE
fix(ffe-tabs-react): add type button to tab

### DIFF
--- a/packages/ffe-tabs-react/src/Tab.js
+++ b/packages/ffe-tabs-react/src/Tab.js
@@ -6,6 +6,7 @@ export default function Tab(props) {
     const { className, selected, ...rest } = props;
     return (
         <button
+            type="button"
             role="tab"
             aria-selected={selected}
             className={classNames(


### PR DESCRIPTION
```
type="button"
```

var på komponenten som ble sletta. Jag vet ikke helt om det ger mening men har kjørt koden i en HTML validator med dette attributet på og det er gyldig HTML iaf.  

Alternativet er vell og ikke bruke ett knapp., Problemet er iaf att `type=submit` er default og det blri problematsikt hvis denne ligger i et form. Da sendes formen hvis man velger en tab. 