### PR TITLE
Remove ghost

### DIFF
--- a/packages/ffe-buttons-react/src/ActionButton.js
+++ b/packages/ffe-buttons-react/src/ActionButton.js
@@ -14,14 +14,12 @@ import classNames from 'classnames';
 import Button from './BaseButton';
 
 export default function ActionButton(props) {
-    const { className, ghost, ...rest } = props;
+    const { className, ...rest } = props;
 
     return (
         <Button
             buttonType="action"
-            className={classNames(className, {
-                'ffe-button--ghost': ghost,
-            })}
+            className={classNames(className)}
             {...rest}
         />
     );
@@ -40,8 +38,6 @@ ActionButton.propTypes = {
     disabled: bool,
     /** The rendered element, like an `<a />` or `<Link />` */
     element: oneOfType([func, string, elementType]),
-    /** Applies the ghost modifier if true. */
-    ghost: bool,
     /** Ref-setting function, or ref created by useRef, passed to the button element */
     innerRef: oneOfType([func, shape({ current: object })]),
     /** Shows a loader if true */
@@ -50,8 +46,4 @@ ActionButton.propTypes = {
     leftIcon: node,
     /** Icon shown to the right of the label */
     rightIcon: node,
-};
-
-ActionButton.defaultProps = {
-    ghost: false,
 };

--- a/packages/ffe-buttons-react/src/ActionButton.spec.js
+++ b/packages/ffe-buttons-react/src/ActionButton.spec.js
@@ -17,10 +17,4 @@ describe('<ActionButton />', () => {
         });
         expect(wrapper.props()).toHaveProperty('aria-label', 'some label');
     });
-    it('sets correct class when ghost prop is true', () => {
-        const wrapper = getWrapper({
-            ghost: true,
-        });
-        expect(wrapper.hasClass('ffe-button--ghost')).toBe(true);
-    });
 });

--- a/packages/ffe-buttons-react/src/index.d.ts
+++ b/packages/ffe-buttons-react/src/index.d.ts
@@ -26,9 +26,7 @@ export interface BaseButtonProps extends MinimalBaseButtonProps {
     rightIcon?: React.ReactNode;
 }
 
-export interface ActionButtonProps extends BaseButtonProps {
-    ghost?: boolean;
-}
+export interface ActionButtonProps extends BaseButtonProps {}
 
 export interface BackButtonProps extends MinimalBaseButtonProps {
     children?: React.ReactNode;

--- a/packages/ffe-buttons/less/base-button.less
+++ b/packages/ffe-buttons/less/base-button.less
@@ -119,36 +119,6 @@
     }
 }
 
-.ffe-button--action.ffe-button--ghost {
-    &,
-    &:focus,
-    &:visited {
-        background-color: transparent;
-        border: 2px solid @ffe-farge-nordlys-wcag;
-        color: @ffe-farge-svart;
-        .native & {
-            @media (prefers-color-scheme: dark) {
-                color: @ffe-farge-nordlys-30;
-                border-color: @ffe-farge-nordlys;
-                background-color: transparent;
-            }
-        }
-    }
-
-    &:hover {
-        background-color: @ffe-farge-skog;
-        border-color: @ffe-farge-skog;
-        color: @ffe-farge-hvit;
-        .native & {
-            @media (prefers-color-scheme: dark) {
-                color: @ffe-farge-hvit;
-                border-color: @ffe-farge-nordlys-30;
-                background-color: transparent;
-            }
-        }
-    }
-}
-
 .ffe-button--action {
     background-color: @ffe-farge-nordlys-wcag;
 


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse

Sletter prop og modifier for `ghost`-varianten av `ActionButton`. Denne har vært deprecated en stund og skal ikke brukes.

## Motivasjon og kontekst

Fixes #1142 