### PR TITLE
Fikser noe klassenavn i account selector og datepicker

### DIFF
--- a/packages/ffe-account-selector-react/less/account-suggestion-multi.less
+++ b/packages/ffe-account-selector-react/less/account-suggestion-multi.less
@@ -1,4 +1,4 @@
-.highlighted {
+.highlighted() {
     background: @ffe-farge-vann;
     color: @ffe-farge-hvit;
 

--- a/packages/ffe-datepicker/less/calendar.less
+++ b/packages/ffe-datepicker/less/calendar.less
@@ -43,7 +43,7 @@
 
         &:focus,
         &:hover,
-        &.active {
+        &:active {
             box-shadow: 0 0 0 2px @ffe-farge-hvit, 0 0 0 4px @ffe-farge-vann;
 
             .native & {


### PR DESCRIPTION
Fikser to ugyldige klassenavn i account selector og datepicker som nevnt i #921, dvs. `.highlighted` (i `.ffe-account-selector-multi .highlighted`) og `.active` (i `.ffe-calendar__month-nav.active`). 