### PR TITLE
Fjern condensed buttons

### DIFF
--- a/component-overview/examples/buttons/TaskButton.jsx
+++ b/component-overview/examples/buttons/TaskButton.jsx
@@ -3,7 +3,4 @@ import { PlussIkon } from '@sb1/ffe-icons-react';
 
 <ButtonGroup thin={true}>
     <TaskButton icon={<PlussIkon />}>Legg til bruker</TaskButton>
-    <TaskButton icon={<PlussIkon />} condensed={true}>
-        Legg til bruker
-    </TaskButton>
 </ButtonGroup>;

--- a/packages/ffe-buttons-react/src/ActionButton.js
+++ b/packages/ffe-buttons-react/src/ActionButton.js
@@ -32,8 +32,6 @@ ActionButton.propTypes = {
     children: node,
     /** Extra class names */
     className: string,
-    /** Condensed modifier. Use in condensed designs */
-    condensed: bool,
     /** Disable a button in certain situations */
     disabled: bool,
     /** The rendered element, like an `<a />` or `<Link />` */

--- a/packages/ffe-buttons-react/src/BaseButton.js
+++ b/packages/ffe-buttons-react/src/BaseButton.js
@@ -21,7 +21,6 @@ const BaseButton = props => {
         buttonType,
         children,
         className,
-        condensed,
         element: Element,
         innerRef,
         isLoading,
@@ -41,7 +40,6 @@ const BaseButton = props => {
             className={classNames(
                 'ffe-button',
                 `ffe-button--${buttonType}`,
-                { 'ffe-button--condensed': condensed },
                 { 'ffe-button--loading': isLoading && supportsSpinner },
                 className,
             )}
@@ -90,8 +88,6 @@ BaseButton.propTypes = {
     children: node,
     /** Extra class names */
     className: string,
-    /** Condensed modifier. Use in condensed designs */
-    condensed: bool,
     /** Disable a button in certain situations */
     disabled: bool,
     /** The rendered element, like an `<a />` or `<Link />` */

--- a/packages/ffe-buttons-react/src/PrimaryButton.js
+++ b/packages/ffe-buttons-react/src/PrimaryButton.js
@@ -20,8 +20,6 @@ PrimaryButton.propTypes = {
     children: node,
     /** Extra class names */
     className: string,
-    /** Condensed modifier. Use in condensed designs */
-    condensed: bool,
     /** Disable a button in certain situations */
     disabled: bool,
     /** The rendered element, like an `<a />` or `<Link />` */

--- a/packages/ffe-buttons-react/src/SecondaryButton.js
+++ b/packages/ffe-buttons-react/src/SecondaryButton.js
@@ -20,8 +20,6 @@ SecondaryButton.propTypes = {
     children: node,
     /** Extra class names */
     className: string,
-    /** Condensed modifier. Use in condensed designs */
-    condensed: bool,
     /** Disable a button in certain situations */
     disabled: bool,
     /** The rendered element, like an `<a />` or `<Link />` */

--- a/packages/ffe-buttons-react/src/ShortcutButton.js
+++ b/packages/ffe-buttons-react/src/ShortcutButton.js
@@ -21,8 +21,6 @@ ShortcutButton.propTypes = {
     children: node,
     /** Extra class names */
     className: string,
-    /** Condensed modifier. Use in condensed designs */
-    condensed: bool,
     /** Disable a button in certain situations */
     disabled: bool,
     /** The rendered element, like an `<a />` or `<Link />` */

--- a/packages/ffe-buttons-react/src/TaskButton.js
+++ b/packages/ffe-buttons-react/src/TaskButton.js
@@ -20,8 +20,6 @@ TaskButton.propTypes = {
     children: node,
     /** Extra class names */
     className: string,
-    /** Condensed modifier. Use in condensed designs */
-    condensed: bool,
     /** Disable a button in certain situations */
     disabled: bool,
     /** The rendered element, like an `<a />` or `<Link />` */

--- a/packages/ffe-buttons-react/src/index.d.ts
+++ b/packages/ffe-buttons-react/src/index.d.ts
@@ -19,7 +19,6 @@ export interface MinimalBaseButtonProps extends React.HTMLProps<HTMLElement> {
 export interface BaseButtonProps extends MinimalBaseButtonProps {
     children?: React.ReactNode;
     ariaLoadingMessage?: string;
-    condensed?: boolean;
     disabled?: boolean;
     isLoading?: boolean;
     leftIcon?: React.ReactNode;
@@ -60,14 +59,12 @@ export interface SecondaryButtonProps extends BaseButtonProps {}
 
 export interface ShortcutButtonProps extends MinimalBaseButtonProps {
     children?: React.ReactNode;
-    condensed?: boolean;
     disabled?: boolean;
     leftIcon?: React.ReactNode;
 }
 
 export interface TaskButtonProps extends MinimalBaseButtonProps {
     children?: React.ReactNode;
-    condensed?: boolean;
     disabled?: boolean;
     icon: React.ReactNode;
 }

--- a/packages/ffe-buttons/less/base-button.less
+++ b/packages/ffe-buttons/less/base-button.less
@@ -11,14 +11,6 @@
 //   <span class="ffe-button__label">Click bait</span>
 //   <span class="ffe-button__spinner" aria-hidden="false" aria-label="Vennligst vent"></span>
 // </button>
-// <button class="ffe-button ffe-button{{modifier_class}} ffe-button--condensed">
-//   <span class="ffe-button__label">Click bait</span>
-//   <span class="ffe-button__spinner" aria-hidden="true" aria-label="Vennligst vent"></span>
-// </button>
-// <button class="ffe-button ffe-button{{modifier_class}} ffe-button--condensed ffe-button--loading" disabled>
-//   <span class="ffe-button__label">Click bait</span>
-//   <span class="ffe-button__spinner" aria-hidden="false" aria-label="Vennligst vent"></span>
-// </button>
 //
 // --action    - Action
 // --primary   - Primary
@@ -287,16 +279,6 @@
     }
 }
 
-.ffe-button--condensed {
-    padding: @ffe-spacing-2xs @ffe-spacing-sm;
-    .ffe-fontsize-button-condensed();
-
-    &.ffe-button--task {
-        padding: @ffe-spacing-2xs @ffe-spacing-sm @ffe-spacing-2xs
-            @ffe-spacing-2xs;
-    }
-}
-
 .ffe-button--loading {
     pointer-events: none;
 }
@@ -317,11 +299,6 @@
     height: 16px;
     margin: 0 @ffe-spacing-2xs;
     width: 16px;
-
-    .ffe-button--condensed & {
-        height: 14px;
-        width: 14px;
-    }
 
     .ffe-button--shortcut & {
         transform: rotate(-90deg);
@@ -370,12 +347,6 @@
         }
     }
 
-    .ffe-button--task.ffe-button--condensed & {
-        height: 25px;
-        width: 25px;
-        padding: 5px;
-    }
-
     .ffe-button--task:hover & {
         border-color: @ffe-farge-vann;
         background-color: @ffe-farge-vann;
@@ -405,10 +376,6 @@
         opacity: 1;
         transform: none;
         visibility: visible;
-    }
-
-    .ffe-button--condensed & {
-        top: 6px;
     }
 
     &::after {

--- a/packages/ffe-core/less/font-sizes.less
+++ b/packages/ffe-core/less/font-sizes.less
@@ -80,11 +80,3 @@
 .ffe-fontsize-button() {
     font-size: 1rem;
 }
-
-.ffe-fontsize-button-transparent() {
-    font-size: 1rem;
-}
-
-.ffe-fontsize-button-condensed() {
-    font-size: 0.875rem;
-}


### PR DESCRIPTION
Fjerner `--condensed` fra ffe-buttons og `condensed`-prop'en fra ffe-buttons-react.

Ref #1251 