### PR TITLE
fix(ffe-tabs): fikse at TabGroup går ut til kanten på mobil

### DIFF
--- a/packages/ffe-tabs/less/tab-group.less
+++ b/packages/ffe-tabs/less/tab-group.less
@@ -21,7 +21,6 @@
         flex-direction: row;
         border-radius: 40px;
         align-items: center;
-        max-width: max-content;
     }
 
     .native & {

--- a/packages/ffe-tabs/less/tab.less
+++ b/packages/ffe-tabs/less/tab.less
@@ -20,10 +20,14 @@
     font-family: 'SpareBank1-regular', 'MuseoSans-500', arial, sans-serif;
     align-self: stretch;
     justify-content: center;
+    align-items: center;
     transition: all @ffe-transition-duration @ffe-ease;
     cursor: pointer;
     width: auto;
     position: relative;
+    flex: none;
+    order: 0;
+    flex-grow: 1;
 
     .native & {
         @media (prefers-color-scheme: dark) {


### PR DESCRIPTION
Vil at TabGroup skal gå helt ut til kanten på mobil

## Beskrivelse

I prod ser det slik ut og designeren sa at de ikke passet hirearisk i forhold til knappene under.
![Image from iOS (14)](https://user-images.githubusercontent.com/69858000/158131330-6ea1c804-5f78-4117-a6d9-d0015a3dedaf.png)

FIks
![Screenshot from 2022-03-14 09-08-01](https://user-images.githubusercontent.com/69858000/158131357-5d5b5193-f00b-41f3-ade7-59aaacf49554.png)



## Motivasjon og kontekst

Fikk tilbakemelding fra UX-designer om at det burde gå ut i kantene på mobil.

## Testing

Kjørt opp lokalt.

<!--

Helt til slutt, har du ..

.. lest retningslinjene våre for bidrag?
.. tatt en siste sjekk for kode og skrivefeil, debug informasjon o.l?
.. kjørt og eventuelt oppdatert testene?
.. kommentert og dokumentert det som trengs?
.. knyttet denne opp til relaterte issues?

-->
