### PR TITLE
ffe-cards: Fjern nødvendigheten å importere interne mixins

### DIFF
--- a/packages/ffe-cards/README.md
+++ b/packages/ffe-cards/README.md
@@ -8,9 +8,18 @@ npm install --save @sb1/ffe-core @sb1/ffe-cards
 
 ## Usage
 
+Import styling for all card types:
+
 ```less
-@import 'path/to/node_modules/@sb1/ffe-cards/less/image-card';
+@import 'path/to/node_modules/@sb1/ffe-cards/less/cards';
+```
+
+Or pick just the ones you need from these:
+
+```less
+@import 'path/to/node_modules/@sb1/ffe-cards/less/text-card';
 @import 'path/to/node_modules/@sb1/ffe-cards/less/icon-card';
+@import 'path/to/node_modules/@sb1/ffe-cards/less/image-card';
 ```
 
 See also `@sb1/ffe-cards-react`.

--- a/packages/ffe-cards/less/card-base.less
+++ b/packages/ffe-cards/less/card-base.less
@@ -1,3 +1,5 @@
+@import 'common-card-styling';
+
 .ffe-card-base {
     .common-card-styling();
 

--- a/packages/ffe-cards/less/cards.less
+++ b/packages/ffe-cards/less/cards.less
@@ -1,6 +1,4 @@
-@import 'common-card-styling';
 @import 'card-base';
-@import 'components';
 @import 'text-card';
 @import 'icon-card';
 @import 'image-card';

--- a/packages/ffe-cards/less/icon-card.less
+++ b/packages/ffe-cards/less/icon-card.less
@@ -1,3 +1,6 @@
+@import 'common-card-styling';
+@import 'components';
+
 .ffe-icon-card {
     .common-card-styling();
 

--- a/packages/ffe-cards/less/image-card.less
+++ b/packages/ffe-cards/less/image-card.less
@@ -1,3 +1,6 @@
+@import 'common-card-styling';
+@import 'components';
+
 .ffe-image-card {
     .common-card-styling();
 

--- a/packages/ffe-cards/less/text-card.less
+++ b/packages/ffe-cards/less/text-card.less
@@ -1,3 +1,6 @@
+@import 'common-card-styling';
+@import 'components';
+
 .ffe-text-card {
     .common-card-styling();
 


### PR DESCRIPTION
Med denne endring slipper man å importere de interne filene `common-card-styling` og `componets` i tillegg til den styling man egentlig ønsker.