### PR TITLE
Default font i komponenter

### DIFF
--- a/packages/ffe-accordion/less/ffe-accordion.less
+++ b/packages/ffe-accordion/less/ffe-accordion.less
@@ -1,6 +1,8 @@
 .ffe-accordion {
     width: 100%;
     border: 1px solid transparent;
+    font-family: 'SpareBank1-regular', 'MuseoSans-500', arial, sans-serif;
+
     &--focus {
         border-color: @ffe-farge-vann;
 
@@ -30,7 +32,7 @@
     background: none;
     border: none;
     padding: @ffe-spacing-md;
-    font: inherit;
+    font-family: 'SpareBank1-medium', 'MuseoSansRounded-700', arial, sans-serif;
     cursor: pointer;
     outline: none;
     color: @ffe-farge-vann;
@@ -90,6 +92,13 @@
 
 .ffe-accordion-body {
     padding: @ffe-spacing-xs @ffe-spacing-md @ffe-spacing-md;
+    color: @ffe-farge-svart;
+
+    .native & {
+        @media (prefers-color-scheme: dark) {
+            color: @ffe-farge-hvit;
+        }
+    }
 }
 
 .ffe-accordion-item {

--- a/packages/ffe-account-selector-react/less/base-selector.less
+++ b/packages/ffe-account-selector-react/less/base-selector.less
@@ -75,6 +75,7 @@
         border: @border;
         border-radius: 2px;
         background: @ffe-farge-hvit;
+        font-family: 'SpareBank1-regular', 'MuseoSans-500', arial, sans-serif;
         &-list {
             left: 0;
             width: 100%;

--- a/packages/ffe-account-selector-react/less/ffe-account-selector-multi.less
+++ b/packages/ffe-account-selector-react/less/ffe-account-selector-multi.less
@@ -43,6 +43,7 @@
         width: 100%;
         border-bottom-left-radius: 2px;
         border-bottom-right-radius: 2px;
+        font-family: 'SpareBank1-regular', 'MuseoSans-500', arial, sans-serif;
 
         .native & {
             @media (prefers-color-scheme: dark) {

--- a/packages/ffe-core/less/typography.less
+++ b/packages/ffe-core/less/typography.less
@@ -273,6 +273,7 @@
 }
 
 .ffe-body-paragraph {
+    font-family: 'SpareBank1-regular', 'MuseoSans-500', arial, sans-serif;
     margin-bottom: 1em;
     margin-top: 0;
     line-height: 1.5rem;

--- a/packages/ffe-file-upload/less/file-upload.less
+++ b/packages/ffe-file-upload/less/file-upload.less
@@ -24,6 +24,8 @@
     }
 
     &__info-section {
+        .ffe-body-text();
+
         margin-bottom: @ffe-spacing-md;
         grid-row: 2;
 

--- a/packages/ffe-form/less/checkbox.less
+++ b/packages/ffe-form/less/checkbox.less
@@ -24,6 +24,7 @@
     margin: @ffe-spacing-xs 0;
     cursor: pointer;
     transition: width @ffe-transition-duration @ffe-ease;
+    font-family: 'SpareBank1-regular', 'MuseoSans-500', arial, sans-serif;
     text-align: left;
     padding-left: @ffe-spacing-lg;
     -webkit-tap-highlight-color: fade(@ffe-farge-vann, 15%);

--- a/packages/ffe-form/less/field-error-message.less
+++ b/packages/ffe-form/less/field-error-message.less
@@ -5,19 +5,8 @@
 //
 // Styleguide ffe-form.field-error-message
 
-.ffe-field-error-message:extend(.ffe-field-info-message) {
-    color: @ffe-farge-svart;
-    .native & {
-        @media (prefers-color-scheme: dark) {
-            color: @ffe-farge-hvit;
-        }
-    }
-
-    &[aria-hidden='true'] {
-        display: none;
-    }
-
-    &::before:extend(.ffe-field-info-message::before) {
+.ffe-field-error-message:extend(.ffe-field-info-message all) {
+    &::before {
         content: url('data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" fill="%23ffffff" height="12" width="12" x="1650" y="1200" viewBox="0 0 200 200"%3E%3Cpath d="M99.882.64a16.562 16.562 0 0 0-16.294 16.772v93.863a16.562 16.562 0 1 0 33.102 0V17.412A16.562 16.562 0 0 0 99.882.64zm.257 162.054c-9.145 0-16.55 7.405-16.55 16.55 0 9.147 7.405 16.589 16.55 16.589 9.146 0 16.551-7.442 16.551-16.588s-7.405-16.551-16.55-16.551z"/%3E%3C/svg%3E');
         background-color: @ffe-farge-baer-wcag;
         .native & {

--- a/packages/ffe-form/less/field-info-message.less
+++ b/packages/ffe-form/less/field-info-message.less
@@ -6,6 +6,7 @@
 // Styleguide ffe-form.field-info-message
 
 .ffe-field-info-message {
+    font-family: 'SpareBank1-regular', 'MuseoSans-500', arial, sans-serif;
     color: @ffe-farge-svart;
     margin: @ffe-spacing-2xs 0 @ffe-spacing-xs;
     display: block;

--- a/packages/ffe-form/less/field-success-message.less
+++ b/packages/ffe-form/less/field-success-message.less
@@ -5,20 +5,8 @@
 //
 // Styleguide ffe-form.field-success-message
 
-.ffe-field-success-message:extend(.ffe-field-info-message) {
-    color: @ffe-farge-svart;
-
-    .native & {
-        @media (prefers-color-scheme: dark) {
-            color: @ffe-farge-hvit;
-        }
-    }
-
-    &[aria-hidden='true'] {
-        display: none;
-    }
-
-    &::before:extend(.ffe-field-info-message::before) {
+.ffe-field-success-message:extend(.ffe-field-info-message all) {
+    &::before {
         content: url('data:image/svg+xml,%3Csvg width="11" height="11" fill="none" xmlns="http://www.w3.org/2000/svg"%3E%3Cpath d="M1.5 6l2.72 3.15a.5.5 0 00.804-.065L10 1" stroke="%23ffffff" stroke-width="1.75" stroke-linecap="round"/%3E%3C/svg%3E');
         background-color: @ffe-farge-nordlys-wcag;
 

--- a/packages/ffe-form/less/radio-block.less
+++ b/packages/ffe-form/less/radio-block.less
@@ -30,6 +30,7 @@
 // Styleguide ffe-form.radio-block
 
 .ffe-radio-block {
+    font-family: 'SpareBank1-regular', 'MuseoSans-500', arial, sans-serif;
     margin-top: @ffe-spacing-md;
     width: 100%;
     transition: width @ffe-transition-duration @ffe-ease-in-out-back;

--- a/packages/ffe-form/less/radio-button.less
+++ b/packages/ffe-form/less/radio-button.less
@@ -20,6 +20,7 @@
 // Styleguide ffe-form.radio-button
 
 .ffe-radio-button {
+    font-family: 'SpareBank1-regular', 'MuseoSans-500', arial, sans-serif;
     display: block;
     position: relative;
     color: @ffe-farge-svart;

--- a/packages/ffe-lists/less/regular-lists.less
+++ b/packages/ffe-lists/less/regular-lists.less
@@ -52,6 +52,7 @@
 
 .ffe-numbered-list,
 .ffe-bullet-list {
+    font-family: 'SpareBank1-regular', 'MuseoSans-500', arial, sans-serif;
     padding: 0;
     text-align: left;
     margin: 0 0 @ffe-spacing-sm;
@@ -105,6 +106,7 @@
 
 .ffe-check-list,
 .ffe-stylized-numbered-list {
+    font-family: 'SpareBank1-regular', 'MuseoSans-500', arial, sans-serif;
     padding: 0;
     text-align: left;
     margin: 0 0 @ffe-spacing-sm;

--- a/packages/ffe-message-box/less/ffe-message-box.less
+++ b/packages/ffe-message-box/less/ffe-message-box.less
@@ -23,6 +23,8 @@
 
 .ffe-message-box {
     text-align: center;
+    font-family: 'SpareBank1-regular', 'MuseoSans-500', arial, sans-serif;
+
     .ffe-body-paragraph {
         .native & {
             @media (prefers-color-scheme: dark) {

--- a/packages/ffe-searchable-dropdown-react/less/searchable-dropdown.less
+++ b/packages/ffe-searchable-dropdown-react/less/searchable-dropdown.less
@@ -15,6 +15,8 @@
         border-radius: 2px;
         height: 0;
         overflow: hidden;
+        font-family: 'SpareBank1-regular', 'MuseoSans-500', arial, sans-serif;
+        font-size: 1rem;
 
         &--open {
             display: block;

--- a/packages/ffe-system-message/less/ffe-system-message.less
+++ b/packages/ffe-system-message/less/ffe-system-message.less
@@ -121,6 +121,7 @@
     max-width: @app-width;
     align-items: center;
     padding: @ffe-spacing-xs @app-margin;
+    font-family: 'SpareBank1-regular', 'MuseoSans-500', arial, sans-serif;
     text-align: left;
     display: flex;
 

--- a/packages/ffe-tables/less/table.less
+++ b/packages/ffe-tables/less/table.less
@@ -108,6 +108,7 @@
 // Styleguide ffe-tables.table.2
 
 .ffe-table {
+    font-family: 'SpareBank1-regular', 'MuseoSans-500', arial, sans-serif;
     margin: @ffe-spacing-sm 0;
     min-width: 100%;
     text-align: left;


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse

Legger til riktig font-family som default i en del komponenter der det manglet.

## Motivasjon og kontekst

Komponenter uten font-family arver typografi fra sine respektive parent-elementer. I de fleste tilfeller har dette i praksis vært en body med riktige fonter, men ikke alltid.

Fixes #1354 
