### PR TITLE
ffe-cards: Fikse dark mode-styling for kort-titlene

### DIFF
--- a/packages/ffe-cards/less/components.less
+++ b/packages/ffe-cards/less/components.less
@@ -22,6 +22,9 @@
 
     &__title {
         &:extend(.ffe-h5);
+        /* stylelint-disable-next-line block-no-empty */
+        .native &:extend(.native .ffe-h5) {
+        }
 
         margin: 0;
 


### PR DESCRIPTION
Ser nå sånn ut:

![image](https://user-images.githubusercontent.com/493924/159268137-7e4874a5-4abe-4e64-a584-fa989f130522.png)

![image](https://user-images.githubusercontent.com/493924/159268004-a3108710-84dc-4a64-9e8c-b908513f4624.png)

![image](https://user-images.githubusercontent.com/493924/159268198-2027cb15-3adb-4121-9706-15bdd943f8da.png)

Fixes #1357