### PR TITLE
fix(ffe-core): retter font-size på h5 og h6

### DIFF
--- a/packages/ffe-core/less/font-sizes.less
+++ b/packages/ffe-core/less/font-sizes.less
@@ -58,15 +58,13 @@
 }
 
 .ffe-fontsize-h5() {
-    font-size: 1rem;
+    font-size: 1.0625rem;
 
     .ffe-fontsize(@breakpoint-sm, {font-size: 1.125rem;});
 }
 
 .ffe-fontsize-h6() {
-    font-size: 0.9375rem;
-
-    .ffe-fontsize(@breakpoint-sm, {font-size: 1rem;});
+    font-size: 1rem;
 }
 
 .ffe-fontsize-form-input() {


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse

Endrer font-size på h5 og h6 slik at de følger retningslinjene

## Motivasjon og kontekst

Fixes #1363 

## Testing

Testet lokalt