### PR TITLE
fix(ffe-buttons-react): add children type on ButtonGruop

### DIFF
--- a/packages/ffe-buttons-react/src/index.d.ts
+++ b/packages/ffe-buttons-react/src/index.d.ts
@@ -35,6 +35,7 @@ export interface ButtonGroupProps {
     className?: string;
     thin?: boolean;
     inline?: boolean;
+    children: React.ReactNode;
 }
 
 export interface ExpandButtonProps extends MinimalBaseButtonProps {


### PR DESCRIPTION

## Beskrivelse

Jeg har lagt til en type for "children" på ButtonGroupProps.

## Motivasjon og kontekst

ButtonGroup manglet en type for "children".