### PR TITLE
fix(ffe-cards-react): add children types for render-as-a-child

### DIFF
--- a/packages/ffe-cards-react/src/index.d.ts
+++ b/packages/ffe-cards-react/src/index.d.ts
@@ -13,16 +13,6 @@ export interface CardBaseProps extends ComponentBaseProps {
     to?: string;
 }
 
-export interface IconCardProps extends CardBaseProps {
-    icon: React.ReactNode;
-    condensed?: boolean;
-    greyCharcoal?: boolean;
-}
-
-export interface ImageCardProps extends CardBaseProps {
-    image: React.ReactNode;
-}
-
 export interface TitleProps extends ComponentBaseProps {
     overflowEllipsis?: boolean;
 }
@@ -33,15 +23,28 @@ export interface TextProps extends ComponentBaseProps {}
 
 export interface CardNameProps extends ComponentBaseProps {}
 
-export interface TextCardRenderProps {
-    Title: typeof TitleProps;
-    Subtext: typeof SubtextProps;
-    Text: typeof TextProps;
+export interface CardRenderProps {
+    CardName: React.FC<CardNameProps>;
+    Title: React.FC<TitleProps>;
+    Subtext: React.FC<SubtextProps>;
+    Text: React.FC<TextProps>;
+}
+
+export interface ImageCardProps extends CardBaseProps {
+    image: React.ReactNode;
+    children?: React.ReactNode | ((props: CardRenderProps) => React.ReactNode);
+}
+
+export interface IconCardProps extends CardBaseProps {
+    icon: React.ReactNode;
+    condensed?: boolean;
+    greyCharcoal?: boolean;
+    children?: React.ReactNode | ((props: CardRenderProps) => React.ReactNode);
 }
 
 export interface TextCardProps extends CardBaseProps {
     leftAlign?: boolean;
-    children: React.ReactNode | Function<TextCardRenderProps>;
+    children: React.ReactNode | ((props: CardRenderProps) => React.ReactNode);
 }
 
 declare class CardBase extends React.Component<CardBaseProps, any> {}


### PR DESCRIPTION
## Beskrivelse

* Lagt til typer for render-as-a-child i ImageCard og IconCard.
* Oppdatert den eksisterende typen for children i TextCard til å matche de andre kortene.
* BREAKING CHANGE: Fjernet TextCardRenderProps, erstattet med CardRenderProps - men den skal nå være unødvendig å importere ved bruk.

## Motivasjon og kontekst

Typene for render-as-a-child i ImageCard og IconCard var feil, og det gjør det vanskelig å bruke disse komponentene med TypeScript.


## Testing

Jeg har testet dette manuelt i en eksisterende app som bruker IconCard og TextCard.