### PR TITLE
fix(component-overview): rett feil i radioswitch eksempler

### DIFF
--- a/component-overview/examples/form/RadioSwitch-fieldMessage.jsx
+++ b/component-overview/examples/form/RadioSwitch-fieldMessage.jsx
@@ -12,7 +12,7 @@ import { RadioSwitch, RadioButtonInputGroup } from '@sb1/ffe-form-react';
             name="hasLeasing"
             onChange={e => setSelected(e.target.value)}
             selectedValue={selected}
-            fieldMessage={fieldMessageLeasing}
+            fieldMessage={selected === 'ja' && fieldMessageLeasing}
         >
             {inputProps => (
                 <RadioSwitch

--- a/component-overview/examples/form/RadioSwitch-fieldMessageUnselected.jsx
+++ b/component-overview/examples/form/RadioSwitch-fieldMessageUnselected.jsx
@@ -3,8 +3,6 @@ import { RadioSwitch, RadioButtonInputGroup } from '@sb1/ffe-form-react';
 
 () => {
     const [selected, setSelected] = useState();
-    const fieldMessageLeasing =
-        'Bilen kan ikke være leaset hvis du har billån med pant i bilen.';
 
     return (
         <RadioButtonInputGroup
@@ -13,7 +11,7 @@ import { RadioSwitch, RadioButtonInputGroup } from '@sb1/ffe-form-react';
             name="radioButtonInputGroupWithFieldMessage"
             onChange={e => setSelected(e.target.value)}
             selectedValue={selected}
-            fieldMessage="Du må gjøre et valg"
+            fieldMessage={!selected && 'Du må gjøre et valg'}
         >
             {inputProps => (
                 <RadioSwitch

--- a/component-overview/examples/form/RadioSwitch-selectedValue.jsx
+++ b/component-overview/examples/form/RadioSwitch-selectedValue.jsx
@@ -8,7 +8,7 @@ import { RadioSwitch, RadioButtonInputGroup } from '@sb1/ffe-form-react';
         <RadioButtonInputGroup
             label="Vil bilen bli kjørt av sjåfører under 23 år?"
             tooltip="Unge sjåfører har en statistisk høyere sjanse for å bulke bilen."
-            name="radioButtonInputGroup"
+            name="radioButtonInputGroupSelected"
             onChange={e => setSelected(e.target.value)}
             selectedValue={selected}
         >


### PR DESCRIPTION
## Beskrivelse

To av eksemplene brukte likt `name` i RadioButtonInputGroup, noe som fikk eksemplene til å påvirke hverandre uten at de skulle.

Rettet også Radio Switch eksemplene med `fieldmessage`, da feilmeldingene ble vist hele tiden og ikke dynamisk sånn som de skulle.

## Motivasjon og kontekst
Fikk spørsmål på Slack om hvorfor to av eksemplene påvirket hverandre, og at eksempelene for fieldmessage var litt forvirrende da de ikke viste bruken av feilmeldingene, og hvordan de kan vises/gjemmes. 

## Testing
Kjørt opp lokalt