### PR TITLE
fix(ffe-form-react): remove children prop from RadioSwitch

### DIFF
--- a/packages/ffe-form-react/src/index.d.ts
+++ b/packages/ffe-form-react/src/index.d.ts
@@ -145,7 +145,6 @@ export interface RadioButtonInputGroupProps
 export interface RadioSwitchProps
     extends React.InputHTMLAttributes<HTMLInputElement> {
     checked?: boolean;
-    children: React.ReactNode;
     className?: string;
     labelProps?: {};
     leftLabel: string;


### PR DESCRIPTION
## Beskrivelse
Vi ser at children ikke brukes i RadioSwitch, og denne proppen virker derfor overflødig og gir oss kopileringsfeil i typescript

## Motivasjon og kontekst
Children propen gir oss kopileringsfeil i typescript

