### PR TITLE
fix(ffe-form): legger til line-height

### DIFF
--- a/packages/ffe-form/less/radio-switch.less
+++ b/packages/ffe-form/less/radio-switch.less
@@ -29,6 +29,7 @@
     box-shadow: 0 1px 2px 1px rgba(0, 0, 0, 0.05);
     margin-bottom: @ffe-spacing-2xs;
     margin-top: @ffe-spacing-sm;
+    line-height: 1.5;
     .native & {
         @media (prefers-color-scheme: dark) {
             background-color: @ffe-farge-svart;


### PR DESCRIPTION
spesifiserer line-height for å unngå at det arves fra body eller annet

<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse

line-height arves av og til fra andre elementer, ettersom det ikke er spesifisert. Dette gjør at radio switch rendres feil.

![image](https://user-images.githubusercontent.com/463847/167117918-e5a94475-a9f2-4df3-bd08-c2ead474f24b.png)

Fixes #1373 

## Testing

Testet lokalt