### PR TITLE
fix(ffe-form): definert farge på ffe-phone-number__plus

### DIFF
--- a/packages/ffe-form/less/phone-number.less
+++ b/packages/ffe-form/less/phone-number.less
@@ -50,10 +50,12 @@
         border-radius: 4px 0 0 4px;
         border-right: 0;
         transition: all @ffe-transition-duration @ffe-ease;
+        color: @ffe-farge-svart;
         .native & {
             @media (prefers-color-scheme: dark) {
                 background-color: @ffe-farge-svart;
                 border-color: @ffe-farge-graa;
+                color: @ffe-farge-hvit;
             }
         }
     }


### PR DESCRIPTION
## Beskrivelse

Legger til farge på `.ffe-phone-number__plus` for å unngå at fargen arves fra containere.

Fixes #1372

## Testing

Testet lokalt