### PR TITLE
fix(ffe-buttons-react): fikser #1382 og #1386

### DIFF
--- a/packages/ffe-buttons-react/src/BaseButton.js
+++ b/packages/ffe-buttons-react/src/BaseButton.js
@@ -58,16 +58,17 @@ const BaseButton = props => {
                 {leftIcon &&
                     React.cloneElement(leftIcon, {
                         className: 'ffe-button__icon ffe-button__icon--left',
+                        'aria-hidden': 'true',
                     })}
                 {children}
                 {rightIcon &&
                     React.cloneElement(rightIcon, {
                         className: 'ffe-button__icon ffe-button__icon--right',
+                        'aria-hidden': 'true',
                     })}
             </span>
-            {supportsSpinner && (
+            {supportsSpinner && isLoading && (
                 <span
-                    aria-hidden={!isLoading}
                     aria-label={ariaLoadingMessage}
                     className="ffe-button__spinner"
                 />

--- a/packages/ffe-context-message-react/src/ContextMessage.spec.js
+++ b/packages/ffe-context-message-react/src/ContextMessage.spec.js
@@ -173,9 +173,9 @@ describe('<ContextTipsMessage />', () => {
         </ContextTipsMessage>,
     );
 
-    it('renders ContextInfoMessage', () => {
+    it('renders ContextTipsMessage', () => {
         const component = wrapper.find('.ffe-context-message');
-        expect(component.hasClass('ffe-context-message--tip')).toBe(true);
+        expect(component.hasClass('ffe-context-message--tips')).toBe(true);
     });
 });
 

--- a/packages/ffe-core/package.json
+++ b/packages/ffe-core/package.json
@@ -23,9 +23,10 @@
   },
   "devDependencies": {
     "case": "^1.5.5",
+    "less": "^4.1.2",
     "postcss": "^8.3.6",
     "stylelint": "^13.0.0",
-    "typescript": "^3.7.5"
+    "typescript": "^4.6.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ffe-webfonts/package.json
+++ b/packages/ffe-webfonts/package.json
@@ -24,6 +24,7 @@
     "test": "npm run lint"
   },
   "devDependencies": {
+    "less": "^4.1.2",
     "stylelint": "^13.0.0"
   },
   "publishConfig": {


### PR DESCRIPTION
## Beskrivelse
Fjerner rendring av spinner span når isLoading ikke er satt til true og legger til aria-hidden på leftIcon og rightIcon.


## Motivasjon og kontekst

Små forbedringer i forbindelse med UU testing

## Testing
Testet lokalt og inspisert koden for å se om det rendrer riktig