### PR TITLE
Fikse bygget pga @types/prettier og typescript

### DIFF
--- a/packages/ffe-core/package.json
+++ b/packages/ffe-core/package.json
@@ -23,9 +23,10 @@
   },
   "devDependencies": {
     "case": "^1.5.5",
+    "less": "^4.1.2",
     "postcss": "^8.3.6",
     "stylelint": "^13.0.0",
-    "typescript": "^3.7.5"
+    "typescript": "^4.6.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ffe-webfonts/package.json
+++ b/packages/ffe-webfonts/package.json
@@ -24,6 +24,7 @@
     "test": "npm run lint"
   },
   "devDependencies": {
+    "less": "^4.1.2",
     "stylelint": "^13.0.0"
   },
   "publishConfig": {


### PR DESCRIPTION
Det er noe tull med `@types/prettier` (som blir dratt inn som dependency til jest i `buildtool`) og som gjør at `npm build` brekker i `ffe-core`. Dette skyldes mest sannsynlig typescipt versjonen i `ffe-core`. 