### PR TITLE
Add additional padding bottom when error messages pop up below input fields

### DIFF
--- a/packages/ffe-form/less/fieldset.less
+++ b/packages/ffe-form/less/fieldset.less
@@ -26,7 +26,7 @@
 
     .ffe-field-error-message {
         margin-top: -24px;
-        margin-bottom: 0;
+        margin-bottom: @ffe-spacing-sm;
     }
 
     &--no-extra-margin {


### PR DESCRIPTION
This PR adds 16 px below error messages that pops up under input field groups. 
This is to improve grouping hence improving usability in a form with several field groups.

**Screenshots below show before and after pictures of a form with the new changes**
### OLD :
![Screenshot from 2022-05-13 11-59-10](https://user-images.githubusercontent.com/8249453/169050694-7dcba6fa-4fab-4031-a278-82b4c5e7b238.png)
### NEW (8px underneath, so it will have a bit more spacing than shown below)
![Screenshot from 2022-05-13 12-00-34](https://user-images.githubusercontent.com/8249453/169050758-f7e37c16-3b93-4694-96fb-c926d6432e54.png)


**This PR is related to the slack discussion found here:** 
https://sb1-utvikling.slack.com/archives/CNS68BM1B/p1652436108211179

