### PR TITLE
fix(ffe-form): legger til default farger som mangler

### DIFF
--- a/packages/ffe-form/less/input-field.less
+++ b/packages/ffe-form/less/input-field.less
@@ -17,6 +17,7 @@
     height: 45px;
     padding: 0 @ffe-spacing-sm;
     font-family: 'SpareBank1-regular', 'MuseoSans-500', arial, sans-serif;
+    background-color: @ffe-farge-hvit;
     color: @ffe-farge-svart;
     border-radius: 4px;
     border: 2px solid @ffe-farge-graa-wcag;

--- a/packages/ffe-form/less/textarea.less
+++ b/packages/ffe-form/less/textarea.less
@@ -15,6 +15,8 @@
     font-family: 'SpareBank1-regular', 'MuseoSans-500', arial, sans-serif;
     border-radius: 4px;
     border: 2px solid @ffe-farge-graa-wcag;
+    background-color: @ffe-farge-hvit;
+    color: @ffe-farge-svart;
     transition: all @ffe-transition-duration @ffe-ease;
     .ffe-fontsize-form-input();
     .native & {


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse

Legger til default farge på bakgrunn/tekst i input og textarea.

Input og textarea mangler av en eller annen grunn default bakgrunnsfarge. Textarea mangler i tillegg default tekstfarge. Dette fører i noen tilfeller til at browseren setter sin egen default og komponentene rendres feil. Ser spesielt rart ut i tilfeller der dark mode er aktivert på OS-nivå, og browseren derfor plukker helt feil default.

![Screenshot 2022-05-30 at 10 51 39](https://user-images.githubusercontent.com/463847/170959604-4b6a47d5-9e90-450f-a198-45c1427464b5.png)


## Motivasjon og kontekst

Komponentene bør alltid rendres med riktige farger.

## Testing

Testet lokalt