### PR TITLE
font-variant-numeric i tekst

### DIFF
--- a/packages/ffe-core/less/typography.less
+++ b/packages/ffe-core/less/typography.less
@@ -173,6 +173,7 @@
     color: @ffe-farge-svart;
     font-family: 'SpareBank1-regular', 'MuseoSans-500', arial, sans-serif;
     font-weight: normal;
+    font-variant-numeric: tabular-nums;
     line-height: 1.25rem;
     .ffe-fontsize-small-text();
     .native & {
@@ -186,6 +187,7 @@
     color: @ffe-farge-svart;
     font-family: 'SpareBank1-regular', 'MuseoSans-500', arial, sans-serif;
     font-weight: normal;
+    font-variant-numeric: tabular-nums;
     line-height: 1.25rem;
     .ffe-fontsize-micro-text();
     .native & {
@@ -258,11 +260,13 @@
 .ffe-h5,
 .ffe-h6 {
     font-family: 'SpareBank1-medium', 'MuseoSansRounded-700', arial, sans-serif;
+    font-variant-numeric: tabular-nums;
 }
 
 .ffe-body-text {
     color: @ffe-farge-svart;
     font-family: 'SpareBank1-regular', 'MuseoSans-500', arial, sans-serif;
+    font-variant-numeric: tabular-nums;
     line-height: 1.5rem;
     .ffe-fontsize-body-text();
     .native & {
@@ -274,6 +278,7 @@
 
 .ffe-body-paragraph {
     font-family: 'SpareBank1-regular', 'MuseoSans-500', arial, sans-serif;
+    font-variant-numeric: tabular-nums;
     margin-bottom: 1em;
     margin-top: 0;
     line-height: 1.5rem;
@@ -296,6 +301,7 @@
 .ffe-lead-paragraph,
 .ffe-sub-lead-paragraph {
     font-family: 'SpareBank1-regular', 'MuseoSans-500', arial, sans-serif;
+    font-variant-numeric: tabular-nums;
     margin-top: 0;
 }
 
@@ -399,11 +405,13 @@
 
 .ffe-strong-text {
     font-family: 'SpareBank1-medium', 'MuseoSansRounded-700', arial, sans-serif;
+    font-variant-numeric: tabular-nums;
     font-weight: normal;
 }
 
 .ffe-em-text {
     font-family: 'SpareBank1-italic', 'MuseoSans-500', arial, sans-serif;
+    font-variant-numeric: tabular-nums;
     font-weight: normal;
     font-style: normal;
 }

--- a/packages/ffe-form/less/checkbox.less
+++ b/packages/ffe-form/less/checkbox.less
@@ -25,6 +25,7 @@
     cursor: pointer;
     transition: width @ffe-transition-duration @ffe-ease;
     font-family: 'SpareBank1-regular', 'MuseoSans-500', arial, sans-serif;
+    font-variant-numeric: tabular-nums;
     text-align: left;
     padding-left: @ffe-spacing-lg;
     -webkit-tap-highlight-color: fade(@ffe-farge-vann, 15%);

--- a/packages/ffe-form/less/dropdown.less
+++ b/packages/ffe-form/less/dropdown.less
@@ -35,6 +35,7 @@
     }
 
     font-family: 'SpareBank1-regular', 'MuseoSans-500', arial, sans-serif;
+    font-variant-numeric: tabular-nums;
     height: 45px;
     padding: 0 @ffe-spacing-lg 0 @ffe-spacing-sm;
     line-height: 20px;

--- a/packages/ffe-form/less/form-label.less
+++ b/packages/ffe-form/less/form-label.less
@@ -13,6 +13,7 @@
     display: inline-block;
     position: relative;
     font-family: 'SpareBank1-regular', 'MuseoSans-500', arial, sans-serif;
+    font-variant-numeric: tabular-nums;
     .ffe-fontsize-h6();
 
     font-weight: 500;

--- a/packages/ffe-form/less/input-field.less
+++ b/packages/ffe-form/less/input-field.less
@@ -17,6 +17,7 @@
     height: 45px;
     padding: 0 @ffe-spacing-sm;
     font-family: 'SpareBank1-regular', 'MuseoSans-500', arial, sans-serif;
+    font-variant-numeric: tabular-nums;
     color: @ffe-farge-svart;
     border-radius: 4px;
     border: 2px solid @ffe-farge-graa-wcag;

--- a/packages/ffe-form/less/radio-block.less
+++ b/packages/ffe-form/less/radio-block.less
@@ -31,6 +31,7 @@
 
 .ffe-radio-block {
     font-family: 'SpareBank1-regular', 'MuseoSans-500', arial, sans-serif;
+    font-variant-numeric: tabular-nums;
     margin-top: @ffe-spacing-md;
     width: 100%;
     transition: width @ffe-transition-duration @ffe-ease-in-out-back;

--- a/packages/ffe-form/less/radio-button.less
+++ b/packages/ffe-form/less/radio-button.less
@@ -21,6 +21,7 @@
 
 .ffe-radio-button {
     font-family: 'SpareBank1-regular', 'MuseoSans-500', arial, sans-serif;
+    font-variant-numeric: tabular-nums;
     display: block;
     position: relative;
     color: @ffe-farge-svart;

--- a/packages/ffe-form/less/radio-switch.less
+++ b/packages/ffe-form/less/radio-switch.less
@@ -24,6 +24,7 @@
     text-align: left;
     color: @ffe-farge-vann;
     font-family: 'SpareBank1-medium', 'MuseoSansRounded-700', arial, sans-serif;
+    font-variant-numeric: tabular-nums;
     cursor: pointer;
     transition: all @ffe-transition-duration @ffe-ease;
     box-shadow: 0 1px 2px 1px rgba(0, 0, 0, 0.05);

--- a/packages/ffe-form/less/textarea.less
+++ b/packages/ffe-form/less/textarea.less
@@ -13,6 +13,7 @@
     width: 100%;
     padding: @ffe-spacing-sm;
     font-family: 'SpareBank1-regular', 'MuseoSans-500', arial, sans-serif;
+    font-variant-numeric: tabular-nums;
     border-radius: 4px;
     border: 2px solid @ffe-farge-graa-wcag;
     transition: all @ffe-transition-duration @ffe-ease;

--- a/packages/ffe-form/less/toggle-switch.less
+++ b/packages/ffe-form/less/toggle-switch.less
@@ -26,6 +26,7 @@
         cursor: pointer;
         color: @ffe-farge-fjell;
         font-family: 'SpareBank1-regular', 'MuseoSans-500', arial, sans-serif;
+        font-variant-numeric: tabular-nums;
         min-height: 44px;
         transition: color @ffe-transition-duration @ffe-ease;
         .ffe-fontsize-h6();


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse

Legger til `font-variant-numeric: tabular-nums;` i alle tekstklasser og skjemaelementer. Dette gjør at alle tall tar opp like mye plass.

Obs: Endringen kommer ikke med av seg selv i alle komponenter. Det blir rett og slett i overkant mye duplisert kode, som vi heller bør vurdere å spre ut i komponentene i form av en sentralisert variabel eller mixin.

## Motivasjon og kontekst

`tabular-nums` øker lesbarheten på tall, spesielt der man setter opp tabeller eller lignende med flere verdier.

## Testing

Testet lokalt
