### PR TITLE
DatePicker prøver å gjette århundret bedre

### DIFF
--- a/component-overview/examples/datepicker/Datepicker-birthdate.jsx
+++ b/component-overview/examples/datepicker/Datepicker-birthdate.jsx
@@ -1,0 +1,23 @@
+import { useState } from 'react';
+import Datepicker from '@sb1/ffe-datepicker-react';
+
+() => {
+    const [date, setDate] = useState('');
+    const now = new Date();
+
+    const maxDate = `${now.getDate()}.${now.getMonth()+1}.${now.getFullYear()}`;
+
+    return (
+        <>
+            <p>Skriv inn et fødselsdato med tosifret årstal og se om det blir tolket riktig.</p>
+            <Datepicker
+                inputProps={{ id: 'datepicker-birthday-example' }}
+                label="Fødelsedato"
+                language="nb"
+                maxDate={maxDate}
+                onChange={setDate}
+                value={date}
+            />
+        </>
+    );
+};

--- a/packages/ffe-datepicker-react/src/calendar/ClickableDate.spec.js
+++ b/packages/ffe-datepicker-react/src/calendar/ClickableDate.spec.js
@@ -16,7 +16,7 @@ describe('<ClickableDate />', () => {
             isBlured={false}
             activeRef={activeDateRef}
             month={'Mai'}
-            year={'2016'}
+            year={2016}
             isFocusingHeader={false}
         />
     );

--- a/packages/ffe-datepicker-react/src/datepicker/Datepicker.spec.js
+++ b/packages/ffe-datepicker-react/src/datepicker/Datepicker.spec.js
@@ -553,4 +553,42 @@ describe('<Datepicker />', () => {
             });
         });
     });
+
+    describe('try to be smart in which century to place an input of two digit years', () => {
+        it('defaults to the 20th century', () => {
+            const onChange = jest.fn();
+            const wrapper = getMountedWrapper({ onChange });
+
+            wrapper.setProps({ value: '101099' });
+            wrapper.find('input').simulate('blur');
+
+            expect(onChange).toHaveBeenCalledWith('10.10.2099');
+        });
+
+        it('assumes last century if maxDate is today-ish', () => {
+            const onChange = jest.fn();
+            const wrapper = getMountedWrapper({
+                maxDate: '02.02.2022',
+                onChange,
+            });
+
+            wrapper.setProps({ value: '111199' });
+            wrapper.find('input').simulate('blur');
+
+            expect(onChange).toHaveBeenCalledWith('11.11.1999');
+        });
+
+        it('assumes this century if maxDate is today-ish but input is rather close to it', () => {
+            const onChange = jest.fn();
+            const wrapper = getMountedWrapper({
+                maxDate: '02.02.2022',
+                onChange,
+            });
+
+            wrapper.setProps({ value: '121220' });
+            wrapper.find('input').simulate('blur');
+
+            expect(onChange).toHaveBeenCalledWith('12.12.2020');
+        });
+    });
 });

--- a/packages/ffe-datepicker-react/src/util/dateUtil.js
+++ b/packages/ffe-datepicker-react/src/util/dateUtil.js
@@ -3,3 +3,7 @@ const dateRegex = /^(\d{1,2})(\.| |-|\/)?(\d{0,2})\2?(\d{0,2}(\d{2})?)$/;
 export function validateDate(string) {
     return dateRegex.exec(string);
 }
+
+export function isDateInputWithTwoDigitYear(value) {
+    return validateDate(value)?.[4].length === 2;
+}

--- a/packages/ffe-datepicker-react/src/util/dateUtil.spec.js
+++ b/packages/ffe-datepicker-react/src/util/dateUtil.spec.js
@@ -1,0 +1,17 @@
+import { isDateInputWithTwoDigitYear } from './dateUtil';
+
+describe('dateUtil.isDateInputWithTwoDigitYear', () => {
+    test.each([
+        ['010100', true],
+        ['101010', true],
+        ['31 12 99', true],
+        ['31 12 1999', false],
+        ['22.11.33', true],
+        ['22.11.2033', false],
+        ['22119', false],
+        ['2211333', false],
+        ['ddmmyy', false],
+    ])('test %s = %s', (string, expected) => {
+        expect(isDateInputWithTwoDigitYear(string)).toBe(expected);
+    });
+});


### PR DESCRIPTION
## Beskrivelse

Med denne endring tar DatePicker hensyn til `props.maxDate` når man har skrevet inn et tosifret årstalet og dette årstalet skal dateres i riktig århundret.

## Motivasjon og kontekst

Frem til nå har DatePicker alltid antatt at tosifrete årstal er i 2000-talet, som er en feiltolkning hvis man spør etter fortiden, som f.eks fødelesedato.

Etter denne endring plasserer DatePicker et dato i 1900-talet hvis 2000-tal-tolkingen er etter `maxDate`. Dette burde fang opp det fleste use casene vi har i banken.

## Testing

Se enehetstestene til ffe-datepicker-react, og `/datepicker_Datepicker_birthdate` på component-overview. 