### PR TITLE
fix(ffe-form-react): fikser #1379 og #1380

### DIFF
--- a/packages/ffe-form-react/src/index.d.ts
+++ b/packages/ffe-form-react/src/index.d.ts
@@ -57,7 +57,7 @@ export interface InputGroupProps
         | React.ReactNode
         | ((extraProps: {
               id: string;
-              'aria-invalid': string;
+              'aria-invalid': 'true' | 'false';
               'aria-describedby': string;
           }) => React.ReactNode);
     className?: string;
@@ -88,7 +88,7 @@ export interface RadioBlockProps
     label: string | React.ReactNode;
     labelClass?: string;
     name: string;
-    selectedValue?: string;
+    selectedValue?: boolean | string | number;
     showChildren?: boolean;
     value: string;
 }


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse

Fikser to feil i typedefinisjonene til ffe-form-react

## Motivasjon og kontekst

Bygg feilet etter oppgradering til ffe-form-react 9.1.1

## Testing

Bygger ok nå