### PR TITLE
fix(ffe-core): legg til margin bottom på lead og sub lead

### DIFF
--- a/packages/ffe-core/less/typography.less
+++ b/packages/ffe-core/less/typography.less
@@ -303,6 +303,7 @@
     font-family: 'SpareBank1-regular', 'MuseoSans-500', arial, sans-serif;
     font-variant-numeric: tabular-nums;
     margin-top: 0;
+    margin-bottom: 1em;
 }
 
 .ffe-lead-paragraph {


### PR DESCRIPTION
## Motivasjon og kontekst

Sublead og lead paragrah hadde ikke margin bottom satt i less, så den tok browser standarden. 

## Testing

Gå til paragraph eksempelet i component-overview og se at sublead og lead paragraph komponenten har 1em i margin-bottom. 