### PR TITLE
fix(ffe-form-react): Tillat null som selectedValue når ingen radiobut…

### DIFF
--- a/packages/ffe-form-react/src/index.d.ts
+++ b/packages/ffe-form-react/src/index.d.ts
@@ -93,7 +93,7 @@ export interface RadioBlockProps
     label: string | React.ReactNode;
     labelClass?: string;
     name: string;
-    selectedValue?: boolean | string | number;
+    selectedValue?: boolean | string | number | null;
     showChildren?: boolean;
     value: string;
 }
@@ -112,7 +112,7 @@ export interface RadioButtonProps extends WeakInputAttributes {
     inline?: boolean;
     innerRef?: React.Ref<HTMLElement>;
     name: string;
-    selectedValue?: boolean | string | number;
+    selectedValue?: boolean | string | number | null;
     tooltip?: string;
     tooltipProps?: TooltipProps;
     value: boolean | string | number;
@@ -133,7 +133,7 @@ export interface RadioButtonInputGroupProps
               inline?: boolean;
               name: string;
               onChange: (...args: any) => any;
-              selectedValue?: boolean | string | number;
+              selectedValue?: boolean | string | number | null;
           }) => React.ReactNode);
     className?: string;
     description?: string | React.ReactNode;
@@ -143,7 +143,7 @@ export interface RadioButtonInputGroupProps
     label?: string | React.ReactNode;
     name: string;
     onChange?: React.ChangeEventHandler<HTMLInputElement>;
-    selectedValue?: string | boolean | number;
+    selectedValue?: string | boolean | number | null;
     tooltip?: string | React.ReactNode;
 }
 
@@ -159,7 +159,7 @@ export interface RadioSwitchProps
     rightValue: boolean | string | number;
     rightInnerRef?: React.Ref<HTMLInputElement>;
     name: string;
-    selectedValue?: boolean | string | number;
+    selectedValue?: boolean | string | number | null;
     tooltip?: string;
     tooltipProps?: TooltipProps;
     condensed?: boolean;


### PR DESCRIPTION
Tillat null som selectedValue (i typescript) når ingen radiobutton er valgt, siden undefined gjør at den blir uncontrolled

## Beskrivelse

Bare endring i typedefinisjonene, slik at man kan sende inn null som selectedValue, uten å få feil i typesjekkingen

## Motivasjon og kontekst

Hvis selectedValue er undefined, blir komponenten uncontrolled, og du får warnings

## Testing

Jeg har testet at det funker helt fint med selectedValue = null, og at man da ikke får warnings