### PR TITLE
chore: publish github pages on push

### DIFF
--- a/.github/workflows/publish-ghpages.yml
+++ b/.github/workflows/publish-ghpages.yml
@@ -1,7 +1,9 @@
 name: Publish GitHub pages
 
 on:
-    workflow_dispatch:
+    push:
+        branches:
+            - develop
 
 jobs:
     publish:


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse
Publiser GitHub pages (component overview) ved hver commit til develop-branchen, i stedet for å manuelt trigge publisering.

## Motivasjon og kontekst
Sikre at component overview-siden har de nyeste endringene fra develop-branchen. Det er blant annet viktig ved uu-testing av komponentene.