### PR TITLE
feat(ffe-buttons): legge til spacing mellom ikon og label på knapper

### DIFF
--- a/packages/ffe-buttons/less/base-button.less
+++ b/packages/ffe-buttons/less/base-button.less
@@ -287,6 +287,7 @@
     align-items: center;
     display: flex;
     transition: transform @ffe-transition-duration @ffe-ease;
+    gap: @ffe-spacing-xs;
     .ffe-button--loading & {
         transform: translateY(-32px);
         opacity: 0;
@@ -297,7 +298,6 @@
     display: inline-block;
     fill: currentColor;
     height: 16px;
-    margin: 0 @ffe-spacing-2xs;
     width: 16px;
 
     .ffe-button--shortcut & {


### PR DESCRIPTION
Legge til spacing mellom ikon og label i knapper for å matche designet i Figma 

## Beskrivelse
Dersom man bruker rightIcon eller leftIcon er det ikke noe spacing mellom label og ikon på en knapp. Det ser fint ut i dokumentasjoner for der har bindersikonet spacing, men dersom man bruker et større ikon (i mitt tilfelle ble det oppdaget å bruke blyant-ikonet) så er ikonet helt inntil label teksten. 

Slik ser den ut i dag: 
![image](https://user-images.githubusercontent.com/5803429/177756052-2c2cc002-f473-4696-b5e0-e414eaa9ce71.png)

Slik vil den se ut etter endringen: 
![image](https://user-images.githubusercontent.com/5803429/177756129-fcf689a5-6354-4e0c-bfe0-2cbf911e816d.png)

Og slik ser den ut i Figma: 
![image](https://user-images.githubusercontent.com/5803429/177756305-91f0e559-5a20-4595-bfd6-aa6cd49d51b4.png)

## Motivasjon og kontekst

Fikser mismatch mellom Figma og designsystem. 

## Testing
Sjekket at det ser OK ut i Chrome, men vet at flex gap ikke fungerer i Android WebView under versjon 83 (https://caniuse.com/?search=gap%20property%20for%20Flexbox%20), men da er det forsåvidt ingen forskjell fra hvordan det er implementert i dag. Vet heller ikke hvor langt tilbake vi støtter WebView, så kom gjerne med innspill :+1: 
