### PR TITLE
fix(ffe-searchable-dropdown-react): add more height to dropdown list

### DIFF
--- a/packages/ffe-searchable-dropdown-react/src/HighCapacityResults.js
+++ b/packages/ffe-searchable-dropdown-react/src/HighCapacityResults.js
@@ -71,7 +71,7 @@ export default class HighCapacityResults extends React.PureComponent {
         } = this.props;
         const { optionHeight } = this.state;
 
-        const maxHeight = 300;
+        const maxHeight = 335;
         const heightOfAllOptions =
             optionHeight * listToRender.length +
             (isNoMatch && noMatch.text ? optionHeight : 0);

--- a/packages/ffe-searchable-dropdown-react/src/Results.js
+++ b/packages/ffe-searchable-dropdown-react/src/Results.js
@@ -29,7 +29,7 @@ const Results = ({
     onChange,
 }) => {
     return (
-        <Scrollbars autoHeight={true} autoHeightMax={300}>
+        <Scrollbars autoHeight={true} autoHeightMax={335}>
             {isNoMatch && (
                 <NoMatch
                     noMatch={noMatch}


### PR DESCRIPTION
Signed-off-by: Maria Øverlier Berg <maria.berg@sparebank1.no>

<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse

I account-selector-react bruker vi searchable dropdown. Og der blir max-høyden akkurat samme høyde som 5 kontoer. Da er det flere kunder som tror det er alle kontoene som er der, og tar kontakt med kundesenteret og sier at de mangler kontoer ved betaling/overføring. Ved å gjøre maxhøyden litt høyere, ser man halve neste konto, og skjønner kanskje da at det er mylig å scrolle. 

Camilla har til info laget skisser på redesign av selve kontovelgeren, men det blir i en egen oppgave senere.

## Motivasjon og kontekst

Fått ekstra mye kundehenvendelser på dette i det siste.

## Testing

Testet kun lokalt.
