### PR TITLE
feat(ffe-chart-donut-react): Support setting background for the circle

### DIFF
--- a/packages/ffe-chart-donut-react/src/ChartDonut.js
+++ b/packages/ffe-chart-donut-react/src/ChartDonut.js
@@ -1,12 +1,19 @@
 import React from 'react';
-import { node, number, string } from 'prop-types';
+import { node, number, oneOf, string } from 'prop-types';
 
 const NON_BREAKING_SPACE = '\u00A0';
 
 const RADIUS = 150;
 const CIRCUMFERENCE = 2 * Math.PI * RADIUS;
 
-function ChartDonut({ name, percentage, firstLabel, lastLabel, label }) {
+function ChartDonut({
+    name,
+    percentage,
+    firstLabel,
+    lastLabel,
+    label,
+    background,
+}) {
     const offset = CIRCUMFERENCE - (CIRCUMFERENCE / 100) * percentage;
 
     /*
@@ -32,7 +39,7 @@ function ChartDonut({ name, percentage, firstLabel, lastLabel, label }) {
                 {percentage < 95.7 && (
                     <circle
                         className="ffe-chart-donut--vann"
-                        fill="none"
+                        fill={background}
                         strokeWidth="15"
                         strokeLinecap="round"
                         strokeLinejoin="round"
@@ -57,7 +64,7 @@ function ChartDonut({ name, percentage, firstLabel, lastLabel, label }) {
                 {percentage > 3.2 && (
                     <circle
                         className="ffe-chart-donut--frost"
-                        fill="none"
+                        fill={percentage >= 95.7 ? background : 'none'}
                         strokeWidth="15"
                         strokeLinecap="round"
                         strokeLinejoin="round"
@@ -106,7 +113,13 @@ function ChartDonut({ name, percentage, firstLabel, lastLabel, label }) {
     );
 }
 
+ChartDonut.defaultProps = {
+    background: 'none',
+};
+
 ChartDonut.propTypes = {
+    /** Background color of the donut-circle */
+    background: oneOf(['white', 'none']),
     /** Short text labeling left value, like "empty", "said yes" etc */
     firstLabel: string,
     /** Short text labeling right value, like "full", "said no" etc */

--- a/packages/ffe-chart-donut-react/src/ChartDonut.spec.js
+++ b/packages/ffe-chart-donut-react/src/ChartDonut.spec.js
@@ -26,6 +26,71 @@ describe('ChartDonut', () => {
         expect(el.find('.ffe-chart-donut__name').text()).toBe('Baz');
     });
 
+    it('renders a default background of "none"', () => {
+        const el = renderShallow();
+
+        expect(
+            el
+                .find('circle')
+                .at(0)
+                .prop('fill'),
+        ).toEqual('none');
+        expect(
+            el
+                .find('circle')
+                .at(1)
+                .prop('fill'),
+        ).toEqual('none');
+    });
+
+    it('renders a background of "white" on one circle when two are rendered', () => {
+        const el = renderShallow({
+            background: 'white',
+            percentage: 50,
+        });
+
+        expect(
+            el
+                .find('circle')
+                .at(0)
+                .prop('fill'),
+        ).toEqual('white');
+        expect(
+            el
+                .find('circle')
+                .at(1)
+                .prop('fill'),
+        ).toEqual('none');
+    });
+
+    it('renders a background of "white" on one circle when one is rendered', () => {
+        const el = renderShallow({
+            background: 'white',
+            percentage: 99,
+        });
+
+        expect(
+            el
+                .find('circle')
+                .at(0)
+                .prop('fill'),
+        ).toEqual('white');
+    });
+
+    it('renders a background of "white" on one circle when one is rendered', () => {
+        const el = renderShallow({
+            background: 'white',
+            percentage: 1,
+        });
+
+        expect(
+            el
+                .find('circle')
+                .at(0)
+                .prop('fill'),
+        ).toEqual('white');
+    });
+
     it('renders html for the labels and their percentages', () => {
         const el = renderShallow();
 


### PR DESCRIPTION
Adds support for providing a `background` prop that will be used to decide
the fill of the inner SVG circles in the donut. This defaults to "none" but
"white" can also be used if the donut is rendered on a coloured background.

## Beskrivelse

Legger til støtte for å sette bakgrunnen til donut'en til hvit

## Motivasjon og kontekst

Har et design der denne brukes i en grid-col med bakgrunnsfarge og ønsker leselig kontrast på innholdet

## Testing

Skrevet unit-tester
