### PR TITLE
fix(ffe-buttons-react): legg til aria-hidden på ikoner i knapper

### DIFF
--- a/packages/ffe-buttons-react/src/ExpandButton.js
+++ b/packages/ffe-buttons-react/src/ExpandButton.js
@@ -42,12 +42,14 @@ const ExpandButton = props => {
                 <Fragment>
                     {leftIcon &&
                         React.cloneElement(leftIcon, {
+                            'aria-hidden': true,
                             className:
                                 'ffe-button__icon ffe-button__icon--left',
                         })}
                     {children}
                     {rightIcon &&
                         React.cloneElement(rightIcon, {
+                            'aria-hidden': true,
                             className:
                                 'ffe-button__icon ffe-button__icon--right',
                         })}

--- a/packages/ffe-buttons-react/src/ExpandButton.spec.js
+++ b/packages/ffe-buttons-react/src/ExpandButton.spec.js
@@ -30,6 +30,20 @@ describe('<ExpandButton />', () => {
         expect(wrapper.find(BestikkIkon).exists()).toBe(true);
         expect(wrapper.find(BamseIkon).exists()).toBe(true);
     });
+    it('renders leftIcon and rightIcon with aria-hidden true', () => {
+        const wrapper = getWrapper({
+            leftIcon: <BestikkIkon />,
+            rightIcon: <BamseIkon />,
+        });
+        expect(wrapper.find(BestikkIkon).props()).toHaveProperty(
+            'aria-hidden',
+            true,
+        );
+        expect(wrapper.find(BamseIkon).props()).toHaveProperty(
+            'aria-hidden',
+            true,
+        );
+    });
     it('does not use an aria-label since the button itself has a children acting as label', () => {
         const wrapper = getWrapper();
         expect(wrapper.prop('aria-label')).toBe(undefined);

--- a/packages/ffe-buttons-react/src/InlineExpandButton.js
+++ b/packages/ffe-buttons-react/src/InlineExpandButton.js
@@ -13,6 +13,7 @@ const InlineExpandButton = props => {
             type="button"
             rightIcon={
                 <ChevronIkon
+                    aria-hidden="true"
                     style={{
                         marginLeft: '8px',
                         transform: isExpanded ? 'rotateZ(180deg)' : 'none',

--- a/packages/ffe-buttons-react/src/InlineExpandButton.spec.js
+++ b/packages/ffe-buttons-react/src/InlineExpandButton.spec.js
@@ -24,7 +24,10 @@ describe('<InlineExpandButton />', () => {
         const wrapper = getWrapper();
         expect(wrapper.props()).toHaveProperty(
             'rightIcon',
-            <ChevronIkon style={{ marginLeft: '8px', transform: 'none' }} />,
+            <ChevronIkon
+                aria-hidden="true"
+                style={{ marginLeft: '8px', transform: 'none' }}
+            />,
         );
     });
     it('sends an upside down <ChevronIcon /> as rightIcon if isExpanded prop is true', () => {
@@ -32,6 +35,7 @@ describe('<InlineExpandButton />', () => {
         expect(wrapper.props()).toHaveProperty(
             'rightIcon',
             <ChevronIkon
+                aria-hidden="true"
                 style={{ marginLeft: '8px', transform: 'rotateZ(180deg)' }}
             />,
         );


### PR DESCRIPTION

<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse
Legger til aria-hidden='true' på ikonene i inlineExpandButton og expandButton
<!-- Detaljert beskrivelse av endringene dine. Skjermskudd er lov. -->

## Motivasjon og kontekst
For å oppfylle wcag krav
<!-- Hvorfor trengs denne endringen, og hva løser den? -->

## Testing
Kjørt automatiske tester og sjekket opp mot component-overview
<!-- Hvordan har du har testet endringene dine? Ta gjerne med systeminfo o.l -->

<!--

Helt til slutt, har du ..

.. lest retningslinjene våre for bidrag?
.. tatt en siste sjekk for kode og skrivefeil, debug informasjon o.l?
.. kjørt og eventuelt oppdatert testene?
.. kommentert og dokumentert det som trengs?
.. knyttet denne opp til relaterte issues?

-->
