### PR TITLE
fix(ffe-buttons-react): legg til aria-hidden på kryssikon

### DIFF
--- a/packages/ffe-buttons-react/src/ExpandButton.js
+++ b/packages/ffe-buttons-react/src/ExpandButton.js
@@ -37,7 +37,9 @@ const ExpandButton = props => {
             ref={innerRef}
             {...rest}
         >
-            {isExpanded && <KryssIkon className="ffe-button__icon" />}
+            {isExpanded && (
+                <KryssIkon className="ffe-button__icon" aria-hidden="true" />
+            )}
             {!isExpanded && (
                 <Fragment>
                     {leftIcon &&


### PR DESCRIPTION

## Beskrivelse
Skulle vært med en tidligere PR, men legger til aria-hidden=true på kryssikonet som dukker opp når isExpanded er true!

## Motivasjon og kontekst

<!-- Hvorfor trengs denne endringen, og hva løser den? -->
Dette gjøres for å oppfylle WCAG krav og for å gjøre knappen mer forståelig for brukere av skjermlesere. Nå vil de få lest opp aria-label på knappen istedenfor ikonet inne i knappen i tillegg. 

## Testing
Testet ved å kjøre opp i component overview

<!-- Hvordan har du har testet endringene dine? Ta gjerne med systeminfo o.l -->

<!--

Helt til slutt, har du ..

.. lest retningslinjene våre for bidrag?
.. tatt en siste sjekk for kode og skrivefeil, debug informasjon o.l?
.. kjørt og eventuelt oppdatert testene?
.. kommentert og dokumentert det som trengs?
.. knyttet denne opp til relaterte issues?

-->
