### PR TITLE
fix(ffe-lists-react): grupper elementene med div istedenfor dl

### DIFF
--- a/packages/ffe-lists-react/src/DescriptionListMultiCol.js
+++ b/packages/ffe-lists-react/src/DescriptionListMultiCol.js
@@ -14,20 +14,20 @@ const DescriptionListMultiCol = ({ children, className, ...rest }) => {
     });
 
     return (
-        <div
+        <dl
             className={classNames('ffe-description-list-multicol', className)}
             {...rest}
         >
             {pairs.map((pair, idx) => (
-                <dl
+                <div
                     className="ffe-description-list-multicol__avoid-break"
                     key={idx}
                 >
                     {pair[0]}
                     {pair[1]}
-                </dl>
+                </div>
             ))}
-        </div>
+        </dl>
     );
 };
 

--- a/packages/ffe-lists-react/src/DescriptionListMultiCol.spec.js
+++ b/packages/ffe-lists-react/src/DescriptionListMultiCol.spec.js
@@ -21,7 +21,7 @@ describe('<DescriptionListMultiCol>', () => {
     it('renders without exploding', () => {
         const wrapper = getWrapper();
         expect(wrapper.exists()).toBe(true);
-        expect(wrapper.is('div')).toBe(true);
+        expect(wrapper.is('dl')).toBe(true);
     });
     it('has the correct class', () => {
         const wrapper = getWrapper({ className: 'test-class' });
@@ -33,12 +33,12 @@ describe('<DescriptionListMultiCol>', () => {
         expect(wrapper.prop('id')).toBe('that-id');
         expect(wrapper.html()).toContain('Porsche');
     });
-    it('wraps pairs in `dl`', () => {
+    it('wraps pairs in `div`', () => {
         const wrapper = getWrapper();
         expect(
             wrapper
                 .find('.ffe-description-list-multicol__avoid-break')
-                .every('dl'),
+                .every('div'),
         ).toBe(true);
     });
     it('supports several columns', () => {


### PR DESCRIPTION
## Beskrivelse
Bytter om html-elementene så hele descriptionList er samlet under ett dl-element, og selve elementene er gruppert som div'er

## Motivasjon og kontekst
Løser issue #1415  og gjør det lettere å navigere seg gjennom listene med skjermleser. 

<!-- Hvorfor trengs denne endringen, og hva løser den? -->

## Testing
Testet ved å kjøre opp i component-overview
<!-- Hvordan har du har testet endringene dine? Ta gjerne med systeminfo o.l -->

<!--

Helt til slutt, har du ..

.. lest retningslinjene våre for bidrag?
.. tatt en siste sjekk for kode og skrivefeil, debug informasjon o.l?
.. kjørt og eventuelt oppdatert testene?
.. kommentert og dokumentert det som trengs?
.. knyttet denne opp til relaterte issues?

-->
