### PR TITLE
component-overview: show which version of a dependency is used by the example

### DIFF
--- a/component-overview/webapp/components/CodeEditorPanel.jsx
+++ b/component-overview/webapp/components/CodeEditorPanel.jsx
@@ -2,6 +2,23 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { LiveEditor } from 'react-live';
 import { MicroText } from '@sb1/ffe-core-react';
+import { packages } from '../../lib/esm';
+
+const packageVersions = packages.reduce((acc, pkg) => {
+    // eslint-disable-next-line no-param-reassign
+    acc[pkg.name] = pkg.version;
+    return acc;
+}, {});
+
+const getVersions = deps =>
+    deps.reduce((acc, pkg) => {
+        if (packageVersions[pkg]) {
+            // eslint-disable-next-line no-param-reassign
+            acc.push(`${pkg}@${packageVersions[pkg]}`);
+        }
+
+        return acc;
+    }, []);
 
 export default function CodeEditorPanel({ exampleId, example }) {
     return (
@@ -10,6 +27,11 @@ export default function CodeEditorPanel({ exampleId, example }) {
             <LiveEditor className="sb1ex-live__editor" />
             <div className="sb1ex-live__id">
                 <MicroText>ID: {exampleId}</MicroText>
+            </div>
+            <div>
+                <MicroText>
+                    {getVersions(example.dependencies).join(', ')}
+                </MicroText>
             </div>
         </>
     );


### PR DESCRIPTION
Legger til en linje med versjonene til de imports som eksemplene bruker under kodevisningen. Gjør det enklere å finne ut hvilken versjon man tester.

![image](https://user-images.githubusercontent.com/493924/182116987-2997977c-ba4b-49f5-8773-8804dd0194f9.png)
