### PR TITLE
fix(ffe-searchable-dropdown-react): require .native for darkmode

### DIFF
--- a/packages/ffe-searchable-dropdown-react/less/searchable-dropdown.less
+++ b/packages/ffe-searchable-dropdown-react/less/searchable-dropdown.less
@@ -123,7 +123,7 @@
 }
 
 @media (prefers-color-scheme: dark) {
-    .ffe-searchable-dropdown {
+    .native .ffe-searchable-dropdown {
         &__list {
             background: @ffe-black-darkmode;
             color: @ffe-white-darkmode;


### PR DESCRIPTION
Fixes bug where searchable dropdown used darkmode colors without the enabling class `.native` being used.

Fixes #1420
