### PR TITLE
Feilmeldinger i konsollet hvis alert=false

### DIFF
--- a/packages/ffe-context-message-react/src/ContextErrorMessage.js
+++ b/packages/ffe-context-message-react/src/ContextErrorMessage.js
@@ -11,7 +11,7 @@ const ContextErrorMessage = props => {
         <ContextMessage
             {...rest}
             messageType="error"
-            role={alert ? 'alert' : false}
+            role={alert ? 'alert' : undefined}
             icon={<UtropstegnIkon />}
         />
     );

--- a/packages/ffe-message-box-react/src/ErrorMessage.js
+++ b/packages/ffe-message-box-react/src/ErrorMessage.js
@@ -12,7 +12,7 @@ const ErrorMessage = props => {
         <BaseMessage
             type="error"
             icon={<UtropstegnIkon aria-hidden="true" />}
-            role={alert ? 'alert' : false}
+            role={alert ? 'alert' : undefined}
             {...rest}
         />
     );

--- a/packages/ffe-system-message-react/src/SystemErrorMessage.js
+++ b/packages/ffe-system-message-react/src/SystemErrorMessage.js
@@ -11,7 +11,7 @@ export default function SystemErrorMessage(props) {
         <SystemMessage
             modifier="error"
             icon={<UtropstegnIkon aria-hidden="true" />}
-            role={alert ? 'alert' : false}
+            role={alert ? 'alert' : undefined}
             {...rest}
         />
     );


### PR DESCRIPTION
## Beskrivelse

Gjelder komponentene ContextErrorMessage, SystemErrorMessage og ErrorMessage
Hvis de har prop alert=false, kommer slike feilmeldinger i konsollet: 
Warning: Received `false` for a non-boolean attribute `role`.
If you want to write it to the DOM, pass a string instead: role="false" or role={value.toString()}.
If you used to conditionally omit it with role={condition && value}, pass role={condition ? value : undefined} instead.

## Testing

Testet at feilmeldingen forsvinner og at alert=true funker som før