### PR TITLE
fix(ffe-form-react): PhonNumber: Fjernet defaultProp for countryCode

### DIFF
--- a/component-overview/examples/form/PhoneNumber-uncontrolled-input.jsx
+++ b/component-overview/examples/form/PhoneNumber-uncontrolled-input.jsx
@@ -1,0 +1,3 @@
+import { PhoneNumber } from '@sb1/ffe-form-react';
+
+<PhoneNumber />

--- a/component-overview/examples/form/PhoneNumber.jsx
+++ b/component-overview/examples/form/PhoneNumber.jsx
@@ -1,3 +1,16 @@
 import { PhoneNumber } from '@sb1/ffe-form-react';
+import { useState } from 'react';
 
-<PhoneNumber number="123123123" />
+() => {
+    const [countryCode, setCountryCode] = useState('47');
+    const [number, setNumber] = useState('123123123');
+
+    return (
+        <PhoneNumber
+            countryCode={countryCode}
+            number={number}
+            onCountryCodeChange={(e) => setCountryCode(e.currentTarget.value)}
+            onNumberChange={(e) => setNumber(e.currentTarget.value)}
+        />
+    );
+}

--- a/packages/ffe-form-react/src/PhoneNumber.js
+++ b/packages/ffe-form-react/src/PhoneNumber.js
@@ -185,7 +185,6 @@ PhoneNumber.propTypes = {
 };
 
 PhoneNumber.defaultProps = {
-    countryCode: '47',
     locale: 'nb',
     onCountryCodeChange: noop,
     onNumberChange: noop,


### PR DESCRIPTION
BREAKING CHANGE: Fjernet default verdi for landkode i `PhoneNumber` komponenten
slik at det er mulig å bruke denne som to uncontrolled inputs i stedet for at
det bare er selve nummerfeltet som kan være uncontrolled.

Det betyr at brukere som tidligere har basert seg på at `countryCode` har
default-verdien _47_ nå må sende denne inn for å få samme oppførsel som tidligere.

## Motivasjon og kontekst

For å bruke biblioteker som feks `react-hook-form` er det en fordel å kunne jobbe med uncontrolled inputs. 
Slik komponeten opprinnelig ble laget var det ikke mulig å gjøre det første feltet uncontrolled uten å spesifikt sende inn `null` for prop'en, noe som trigger varsler i console.

## Testing

Kjørt opp lerna lokalt og sjekket eksemplene

