### PR TITLE
fix(ffe-lists-react): legg til aria-label på listelement

### DIFF
--- a/packages/ffe-lists-react/src/CheckList.spec.js
+++ b/packages/ffe-lists-react/src/CheckList.spec.js
@@ -50,4 +50,10 @@ describe('<CheckListItem />', () => {
 
         expect(wrapper.hasClass('ffe-check-list__item--cross')).toBe(true);
     });
+    it('sets correct aria-label based on isCross value', () => {
+        const wrapper = shallow(<CheckListItem>An item</CheckListItem>);
+        expect(wrapper.prop('aria-label')).toBe('hake');
+        wrapper.setProps({ isCross: true });
+        expect(wrapper.prop('aria-label')).toBe('kryss');
+    });
 });

--- a/packages/ffe-lists-react/src/CheckListItem.js
+++ b/packages/ffe-lists-react/src/CheckListItem.js
@@ -11,6 +11,7 @@ const CheckListItem = props => {
                 { 'ffe-check-list__item--cross': isCross },
                 className,
             )}
+            aria-label={isCross ? 'kryss' : 'hake'}
             {...rest}
         />
     );


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse

<!-- Detaljert beskrivelse av endringene dine. Skjermskudd er lov. -->
Legger til aria-label på liste elementet basert på hvilket ikon som står foran. 

## Motivasjon og kontekst
Løser problemet med at brukere av skjermlesere ikke får med seg hvilket ikon som står foran.
<!-- Hvorfor trengs denne endringen, og hva løser den? -->

## Testing
Kjørt opp med component overview, og sjekket at aria-label er satt riktig basert på om isCross er true eller ikke. 
Prøvde også å teste med voiceover på mac men sliter med innstillinger eller noe som gjør at jeg ikke kommer inn på selve komponenten i component-overview. Mistenker dette er issue med voiceover hos meg, enn i selve komponenten.

<!-- Hvordan har du har testet endringene dine? Ta gjerne med systeminfo o.l -->

<!--

Helt til slutt, har du ..

.. lest retningslinjene våre for bidrag?
.. tatt en siste sjekk for kode og skrivefeil, debug informasjon o.l?
.. kjørt og eventuelt oppdatert testene?
.. kommentert og dokumentert det som trengs?
.. knyttet denne opp til relaterte issues?

-->
