### PR TITLE
fix(ffe-buttons-react): legg til role på loading ikon

### DIFF
--- a/packages/ffe-buttons-react/src/BaseButton.js
+++ b/packages/ffe-buttons-react/src/BaseButton.js
@@ -70,6 +70,7 @@ const BaseButton = props => {
             {supportsSpinner && isLoading && (
                 <span
                     aria-label={ariaLoadingMessage}
+                    role="img"
                     className="ffe-button__spinner"
                 />
             )}


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse
Legger til role="img" på span som inneholder loading ikonet på basebutton.
<!-- Detaljert beskrivelse av endringene dine. Skjermskudd er lov. -->

## Motivasjon og kontekst
VI får valideringsfeil i w3c validatoren når vi bruker aria-label på span uten role.
<!-- Hvorfor trengs denne endringen, og hva løser den? -->

## Testing
Kjørt opp i component overview, og validert koden på nytt via w3c HTML validator. 
<!-- Hvordan har du har testet endringene dine? Ta gjerne med systeminfo o.l -->

<!--

Helt til slutt, har du ..

.. lest retningslinjene våre for bidrag?
.. tatt en siste sjekk for kode og skrivefeil, debug informasjon o.l?
.. kjørt og eventuelt oppdatert testene?
.. kommentert og dokumentert det som trengs?
.. knyttet denne opp til relaterte issues?

-->
