### PR TITLE
feat(ffe-chart-donut-react): Colour tweaks

### DIFF
--- a/packages/ffe-chart-donut-react/less/ffe-chart-donut.less
+++ b/packages/ffe-chart-donut-react/less/ffe-chart-donut.less
@@ -4,12 +4,22 @@
     text-align: left;
     width: 200px;
 
-    &--vann {
+    &--first {
         stroke: @ffe-farge-vann;
+        .native & {
+            @media (prefers-color-scheme: dark) {
+                stroke: @ffe-farge-vann-30;
+            }
+        }
     }
 
-    &--frost {
-        stroke: @ffe-farge-frost-70;
+    &--last {
+        stroke: @ffe-farge-fjell;
+        .native & {
+            @media (prefers-color-scheme: dark) {
+                stroke: @ffe-farge-vann-70;
+            }
+        }
     }
 
     &__circle {
@@ -41,7 +51,7 @@
 
         .native & {
             @media (prefers-color-scheme: dark) {
-                color: @ffe-farge-graa;
+                color: @ffe-farge-lysgraa;
             }
         }
     }
@@ -58,7 +68,7 @@
 
             .native & {
                 @media (prefers-color-scheme: dark) {
-                    color: @ffe-farge-graa;
+                    color: @ffe-farge-lysgraa;
                 }
             }
         }
@@ -71,6 +81,12 @@
             > .ffe-chart-donut__amount {
                 border-left: 1px solid @ffe-farge-graa;
                 padding-left: 20px;
+
+                .native & {
+                    @media (prefers-color-scheme: dark) {
+                        color: @ffe-farge-lysgraa;
+                    }
+                }
             }
         }
     }

--- a/packages/ffe-chart-donut-react/src/ChartDonut.js
+++ b/packages/ffe-chart-donut-react/src/ChartDonut.js
@@ -31,7 +31,7 @@ function ChartDonut({ name, percentage, firstLabel, lastLabel, label }) {
             >
                 {percentage < 95.7 && (
                     <circle
-                        className="ffe-chart-donut--vann"
+                        className="ffe-chart-donut--first"
                         fill="none"
                         strokeWidth="15"
                         strokeLinecap="round"
@@ -56,7 +56,7 @@ function ChartDonut({ name, percentage, firstLabel, lastLabel, label }) {
             >
                 {percentage > 3.2 && (
                     <circle
-                        className="ffe-chart-donut--frost"
+                        className="ffe-chart-donut--last"
                         fill="none"
                         strokeWidth="15"
                         strokeLinecap="round"


### PR DESCRIPTION
Colours have been tweaked slightly in order to have acceptable
contrast when used with different backgrounds or in darkmode.


## Beskrivelse

![image](https://user-images.githubusercontent.com/379849/183083276-b8de0a47-3790-4d90-b133-c7b7dd5137ef.png)

## Motivasjon og kontekst

Bruk av komponenten på enkelte bakgrunner fra ffe-grid gjorde kontrasten for dårlig

## Testing

Testet med å kjøre opp designsystemet lokalt og verifisere visuelt

