### PR TITLE
fix(ffe-searchable-dropdown-react): setter border-bottom på highCapacity

### DIFF
--- a/packages/ffe-searchable-dropdown-react/less/searchable-dropdown.less
+++ b/packages/ffe-searchable-dropdown-react/less/searchable-dropdown.less
@@ -41,6 +41,11 @@
         border-bottom: 1px solid @ffe-farge-graa-wcag;
     }
 
+    // Fixes https://github.com/SpareBank1/designsystem/issues/1245
+    &__list-item-high-capacity-container:not(:last-child) {
+        border-bottom: 1px solid @ffe-farge-graa-wcag;
+    }
+
     &__list-item-body {
         padding: @ffe-spacing @ffe-spacing-sm;
         cursor: pointer;

--- a/packages/ffe-searchable-dropdown-react/src/HighCapacityResults.js
+++ b/packages/ffe-searchable-dropdown-react/src/HighCapacityResults.js
@@ -137,7 +137,11 @@ export default class HighCapacityResults extends React.PureComponent {
                 parent={parent}
             >
                 {({ registerChild }) => (
-                    <div ref={registerChild} style={style}>
+                    <div
+                        ref={registerChild}
+                        style={style}
+                        className="ffe-searchable-dropdown__list-item-high-capacity-container"
+                    >
                         <ListItemContainer
                             key={itemKey}
                             ref={refs[index]}


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse
Når highCapacity={true} er satt så legges det til ett ekstra nivå i HTML-strukturen, som gjør at :not(:last-child) stylingen som fungerer for vanlig searchable dropdown slår til på alle elementene. Det gjorde at border-bottom ikke ble vist.

Denne endringen legger til en klasse på div'en som blir lagt til med highCapacity sånn at last-child igjen blir riktig. 
<!-- Detaljert beskrivelse av endringene dine. Skjermskudd er lov. -->

## Motivasjon og kontekst
Retter issue #1245 

## Testing
Kjørt opp lokalt i component-overview og sjekket at border-bottom blir riktig satt
<!-- Hvordan har du har testet endringene dine? Ta gjerne med systeminfo o.l -->

<!--

Helt til slutt, har du ..

.. lest retningslinjene våre for bidrag?
.. tatt en siste sjekk for kode og skrivefeil, debug informasjon o.l?
.. kjørt og eventuelt oppdatert testene?
.. kommentert og dokumentert det som trengs?
.. knyttet denne opp til relaterte issues?

-->
