### PR TITLE
fix(ffe-form-react): fjerner støtte for aria-invalid på radiobtn

### DIFF
--- a/packages/ffe-form-react/src/BaseRadioButton.js
+++ b/packages/ffe-form-react/src/BaseRadioButton.js
@@ -3,7 +3,6 @@ import classNames from 'classnames';
 import {
     bool,
     node,
-    oneOf,
     oneOfType,
     shape,
     string,
@@ -20,7 +19,6 @@ class BaseRadioButton extends Component {
 
     render() {
         const {
-            'aria-invalid': ariaInvalid,
             children,
             checked,
             className,
@@ -34,7 +32,6 @@ class BaseRadioButton extends Component {
         } = this.props;
 
         const labelClasses = classNames(
-            { 'ffe-radio-button--invalid': ariaInvalid === 'true' },
             { 'ffe-radio-button--with-tooltip': tooltip },
             className,
         );
@@ -45,7 +42,6 @@ class BaseRadioButton extends Component {
         return (
             <Fragment>
                 <input
-                    aria-invalid={ariaInvalid}
                     className="ffe-radio-input"
                     id={this.id}
                     ref={innerRef}
@@ -73,8 +69,6 @@ BaseRadioButton.defaultProps = {
 };
 
 BaseRadioButton.propTypes = {
-    /** Indicates whether the radio button is invalid or not */
-    'aria-invalid': oneOf(['true', 'false']),
     /** Whether or not the radio button is selected */
     checked: bool,
     /** The label of the radio button */

--- a/packages/ffe-form-react/src/BaseRadioButton.spec.js
+++ b/packages/ffe-form-react/src/BaseRadioButton.spec.js
@@ -110,18 +110,4 @@ describe('<BaseRadioButton />', () => {
             ).toBe(true);
         });
     });
-    describe('aria-invalid', () => {
-        it('does not add the class if false', () => {
-            const wrapper = getWrapper({ 'aria-invalid': 'false' });
-            expect(wrapper.find('.ffe-radio-button--invalid').exists()).toBe(
-                false,
-            );
-        });
-        it('adds the correct class if true', () => {
-            const wrapper = getWrapper({ 'aria-invalid': 'true' });
-            expect(wrapper.find('.ffe-radio-button--invalid').exists()).toBe(
-                true,
-            );
-        });
-    });
 });

--- a/packages/ffe-form-react/src/RadioButtonInputGroup.js
+++ b/packages/ffe-form-react/src/RadioButtonInputGroup.js
@@ -6,7 +6,6 @@ import Tooltip from './Tooltip';
 
 const RadioButtonInputGroup = props => {
     const {
-        'aria-invalid': ariaInvalid,
         children,
         className,
         extraMargin,
@@ -27,7 +26,6 @@ const RadioButtonInputGroup = props => {
     }
 
     const buttonProps = {
-        'aria-invalid': ariaInvalid || String(!!fieldMessage),
         inline,
         name,
         onChange: /* istanbul ignore next */ f => f,

--- a/packages/ffe-form/less/radio-button.less
+++ b/packages/ffe-form/less/radio-button.less
@@ -112,13 +112,11 @@
         }
     }
 
-    &--invalid {
-        &::after {
-            border-color: @ffe-farge-baer;
-            .native & {
-                @media (prefers-color-scheme: dark) {
-                    border-color: @ffe-farge-baer;
-                }
+    [aria-invalid='true'] &::after {
+        border-color: @ffe-farge-baer;
+        .native & {
+            @media (prefers-color-scheme: dark) {
+                border-color: @ffe-farge-baer;
             }
         }
     }
@@ -168,7 +166,7 @@
         box-shadow: none;
     }
 
-    &:hover + .ffe-radio-button--invalid::after {
+    [aria-invalid='true'] &:hover + .ffe-radio-button::after {
         border-color: @ffe-farge-baer;
         .native & {
             @media (prefers-color-scheme: dark) {
@@ -177,7 +175,7 @@
         }
     }
 
-    &:checked + .ffe-radio-button--invalid::after {
+    [aria-invalid='true'] &:checked + .ffe-radio-button::after {
         border-color: @ffe-farge-baer;
         .native & {
             @media (prefers-color-scheme: dark) {


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse
Fjerner støtte for aria-invalid på BaseRadioButton.
<!-- Detaljert beskrivelse av endringene dine. Skjermskudd er lov. -->

## Motivasjon og kontekst
Det er ikke tillatt med aria-invalid på input type="radio". 

<!-- Hvorfor trengs denne endringen, og hva løser den? -->

## Testing
Kjørt opp lokalt
<!-- Hvordan har du har testet endringene dine? Ta gjerne med systeminfo o.l -->

<!--

Helt til slutt, har du ..

.. lest retningslinjene våre for bidrag?
.. tatt en siste sjekk for kode og skrivefeil, debug informasjon o.l?
.. kjørt og eventuelt oppdatert testene?
.. kommentert og dokumentert det som trengs?
.. knyttet denne opp til relaterte issues?

-->
