### PR TITLE
fix(component-overview): Tweak theme editor

### DIFF
--- a/component-overview/webapp/context/ThemeContext/changeMediaQueryCondition.js
+++ b/component-overview/webapp/context/ThemeContext/changeMediaQueryCondition.js
@@ -9,13 +9,16 @@ const changeMediaQueryCondition = (fromCondition, toCondition) => () =>
                 .filter(
                     rule =>
                         rule.media &&
-                        [rule.conditionText, rule.media.mediaText].includes(
-                            fromCondition,
-                        ),
+                        [rule.conditionText, rule.media.mediaText]
+                            .join(' ')
+                            .includes(fromCondition),
                 )
                 .forEach(rule => {
                     /* eslint-disable-next-line no-param-reassign */
-                    rule.media.mediaText = toCondition;
+                    rule.media.mediaText = rule.media.mediaText.replaceAll(
+                        fromCondition,
+                        toCondition,
+                    );
                 });
         } catch (err) {
             // never mind
@@ -24,10 +27,10 @@ const changeMediaQueryCondition = (fromCondition, toCondition) => () =>
 
 export const turnOnDarkMode = changeMediaQueryCondition(
     '(prefers-color-scheme: dark)',
-    'only screen',
+    '(prefers-color-scheme: light)',
 );
 
 export const turnOffDarkMode = changeMediaQueryCondition(
-    'only screen',
+    '(prefers-color-scheme: light)',
     '(prefers-color-scheme: dark)',
 );


### PR DESCRIPTION
The media-query switcher currently misses some styles, e.g. for
the `ContextTipsMessage` icon which has darkmode styles only applied
for larger screens
`@media (min-width: 480px) and (prefers-color-scheme: dark)`
instead of the more common
`@media (prefers-color-scheme: dark)`

Just toggling between _light_ and _dark_ preference seems to work
better for these cases.

<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Motivasjon og kontekst

I forbindelse jeg tenkte å ~stjele~ låne den komponenten for å gjøre det lettere for testerne
våre å både huske på og teste alt i darkmode også så oppdaget jeg at det var enkelte 
komponenter som ikke så like ut når jeg brukte toggle'n vs endret emulering av preference
i chrome devtools

## Testing

Før endring [(link)](https://sparebank1.github.io/designsystem/messages_context_message_ContextTipsMessage)
![image](https://user-images.githubusercontent.com/379849/184292263-bc39d92e-659b-4b47-a866-f680016fac4d.png)

Etter endring (test lokalt)
![image](https://user-images.githubusercontent.com/379849/184292573-ac92db5e-4cde-41e8-a339-ee30cb53be13.png)

