### PR TITLE
fix(ffe-buttons): fikser fargefeil i expandbutton dark mode

### DIFF
--- a/packages/ffe-buttons/less/base-button.less
+++ b/packages/ffe-buttons/less/base-button.less
@@ -341,8 +341,7 @@
     .ffe-button--expand:hover & {
         .native & {
             @media (prefers-color-scheme: dark) {
-                fill: @ffe-farge-hvit;
-                background-color: @ffe-farge-natt;
+                fill: @ffe-farge-svart;
             }
         }
     }


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse

ExpandButton har feil farge og bakgrunn på hover i dark mode.

## Motivasjon og kontekst

Fixes #1441

## Testing

Testet lokalt
