### PR TITLE
fix(ffe-form-react): fjern tester der aria-invalid blir sendt ned til radiobtn

### DIFF
--- a/packages/ffe-form-react/src/RadioButtonInputGroup.spec.js
+++ b/packages/ffe-form-react/src/RadioButtonInputGroup.spec.js
@@ -38,46 +38,6 @@ describe('<RadioButtonInputGroup />', () => {
                 }),
             );
         });
-        it('passes down aria-invalid as true if fieldMessage is set', () => {
-            const childrenSpy = jest.fn();
-            const wrapper = getWrapper({
-                children: childrenSpy,
-                fieldMessage: undefined,
-            });
-
-            expect(childrenSpy).toHaveBeenCalledWith(
-                expect.objectContaining({
-                    'aria-invalid': 'false',
-                }),
-            );
-
-            wrapper.setProps({ fieldMessage: 'such error' });
-            expect(childrenSpy).toHaveBeenCalledWith(
-                expect.objectContaining({
-                    'aria-invalid': 'true',
-                }),
-            );
-        });
-        it('passes down aria-invalid if aria-invalid is set', () => {
-            const childrenSpy = jest.fn();
-            const wrapper = getWrapper({
-                'aria-invalid': 'false',
-                children: childrenSpy,
-            });
-
-            expect(childrenSpy).toHaveBeenCalledWith(
-                expect.objectContaining({
-                    'aria-invalid': 'false',
-                }),
-            );
-
-            wrapper.setProps({ 'aria-invalid': 'true' });
-            expect(childrenSpy).toHaveBeenCalledWith(
-                expect.objectContaining({
-                    'aria-invalid': 'true',
-                }),
-            );
-        });
         it(`passes down a default noop function to silence intermittent propType
             warnings about the radio buttons being controlled components without
             an onChange listener (which is a lie - the onChange is in RadioButtonInputGroup)`, () => {


### PR DESCRIPTION

<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse
Aria-invalid er ikke gyldig på radiobutton og skal bare brukes på radiobuttongroup.
Dette ble fikset i en annen PR, men jeg glemte å fjerne testene som hører til.
<!-- Detaljert beskrivelse av endringene dine. Skjermskudd er lov. -->

## Motivasjon og kontekst

<!-- Hvorfor trengs denne endringen, og hva løser den? -->

## Testing
kjørt npm run test og sett at testene passerer
<!-- Hvordan har du har testet endringene dine? Ta gjerne med systeminfo o.l -->

<!--

Helt til slutt, har du ..

.. lest retningslinjene våre for bidrag?
.. tatt en siste sjekk for kode og skrivefeil, debug informasjon o.l?
.. kjørt og eventuelt oppdatert testene?
.. kommentert og dokumentert det som trengs?
.. knyttet denne opp til relaterte issues?

-->
