### PR TITLE
AccordionItem - put className prop last

### DIFF
--- a/packages/ffe-accordion-react/src/AccordionItem.js
+++ b/packages/ffe-accordion-react/src/AccordionItem.js
@@ -47,9 +47,9 @@ const AccordionItem = ({
 
     return (
         <div
-            className={classNames(className, 'ffe-accordion-item', {
+            className={classNames('ffe-accordion-item', {
                 'ffe-accordion-item--open': isExpanded,
-            })}
+            }, className)}
             {...rest}
         >
             {React.createElement(


### PR DESCRIPTION
## Beskrivelse

Jeg opplever at det er vanskelig å override default styles på AccordionItem - og jeg tror at det er fordi className man passer inn som prop kan bli overstyrt av `.ffe-accordion-item`.

Så jeg har lagt opp en PR som et forslag - sette className som sendes inn som prop til sist, slik at den det blir lettere å overskrive eksisterende styling.

