### PR TITLE
fix(ffe-core): diverse fiks på bølgen

### DIFF
--- a/component-overview/examples/waves/wave-small-positioning.jsx
+++ b/component-overview/examples/waves/wave-small-positioning.jsx
@@ -10,8 +10,8 @@ import { Grid, GridRow, GridCol } from '@sb1/ffe-grid-react';
     <Wave waveHeight='small' color='vann-30' darkmodeColor='natt'>
         <Grid>
             <GridRow>
-                <GridCol sm="6">Litt innhold til venstre</GridCol>
-                <GridCol sm="6">Litt innhold til høyre</GridCol>
+                <GridCol sm={{ cols: 5, offset: 2 }}>Litt innhold</GridCol>
+                <GridCol sm={{ cols: 5, offset: 0 }}>Litt annet innhold</GridCol>
             </GridRow>
         </Grid>
     </Wave>

--- a/packages/ffe-core-react/src/Wave.js
+++ b/packages/ffe-core-react/src/Wave.js
@@ -19,8 +19,8 @@ export default function Wave(props) {
                 'ffe-wave',
                 `ffe-wave--${waveHeight}`,
                 `ffe-wave--bg-${color}`,
-                `ffe-wave--dm-bg-${darkmodeColor}`,
                 {
+                    [`ffe-wave--dm-bg-${darkmodeColor}`]: darkmodeColor,
                     'ffe-wave--flip': flip,
                 },
             )}
@@ -61,6 +61,6 @@ Wave.propTypes = {
         'fjell',
     ]).isRequired,
     /** Set the background color in darkmode */
-    darkmodeColor: oneOf(['svart', 'natt']).isRequired,
+    darkmodeColor: oneOf(['svart', 'natt']),
     children: node,
 };

--- a/packages/ffe-core-react/src/index.d.ts
+++ b/packages/ffe-core-react/src/index.d.ts
@@ -61,8 +61,8 @@ export interface WaveProps {
         | 'vann'
         | 'vann-30'
         | 'fjell';
-    darkmodeColor: 'svart' | 'natt';
-    children: React.ReactNode;
+    darkmodeColor?: 'svart' | 'natt';
+    children?: React.ReactNode;
 }
 
 declare class DividerLine extends React.Component<DividerLineProps, any> {}

--- a/packages/ffe-core/less/waves.less
+++ b/packages/ffe-core/less/waves.less
@@ -2,10 +2,12 @@
 
 .ffe-wave {
     position: relative;
+    width: 100%;
 
     &__content {
         position: absolute;
         z-index: 1;
+        width: 100%;
     }
 
     &__wave {


### PR DESCRIPTION

<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse
- children og darkmodeColor er nå optional
- wave og wave__content er nå satt til 100% bredde, det skal fikse at bølgen forsvinner når man putter den i en grid, og at innholdet alltid blir venstre justert.
- Endrer eksempel til å vise bruk med grid og offset


## Motivasjon og kontekst
Fikser forhåpentligvis en del feil rapportert av brukere
<!-- Hvorfor trengs denne endringen, og hva løser den? -->

## Testing
kjørt opp og testet i component overview
<!-- Hvordan har du har testet endringene dine? Ta gjerne med systeminfo o.l -->

<!--

Helt til slutt, har du ..

.. lest retningslinjene våre for bidrag?
.. tatt en siste sjekk for kode og skrivefeil, debug informasjon o.l?
.. kjørt og eventuelt oppdatert testene?
.. kommentert og dokumentert det som trengs?
.. knyttet denne opp til relaterte issues?

-->
