### PR TITLE
fix(ffe-file-upload): fikser layout-bug i file upload

### DIFF
--- a/packages/ffe-file-upload/less/file-upload.less
+++ b/packages/ffe-file-upload/less/file-upload.less
@@ -80,8 +80,13 @@
     }
 
     &__upload-section-border {
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        align-items: center;
         height: 140px;
         margin: @ffe-spacing-2xs;
+        padding: 0 @ffe-spacing-lg;
         border: 2px dashed @ffe-farge-vann;
         border-radius: 10px;
         position: relative;
@@ -115,7 +120,6 @@
             }
         }
 
-        margin-top: @ffe-spacing-lg;
         margin-bottom: @ffe-spacing-xs;
         display: none;
 


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse

Endrer intern layout i `.ffe-file-upload` til flex. Dette sørger for at innholdet alltid er sentrert horisontalt.

Før:
![Screenshot 2022-09-28 at 12 38 21](https://user-images.githubusercontent.com/463847/192759135-18858c39-53e1-4fb0-957e-2210aeab50ce.png)

Etter:
![Screenshot 2022-09-28 at 12 38 02](https://user-images.githubusercontent.com/463847/192759170-8183fde0-a1bd-4ab8-b8ce-160920eb6145.png)


## Motivasjon og kontekst

Fixes #1455 

## Testing

Testet lokalt i Chrome, Firefox og Safari