### PR TITLE
Fjerner ffe-farge-graa-wcag

### DIFF
--- a/packages/ffe-account-selector-react/less/base-selector.less
+++ b/packages/ffe-account-selector-react/less/base-selector.less
@@ -67,7 +67,7 @@
     }
 
     &__suggestion-container {
-        @border: 1px solid @ffe-farge-graa-wcag;
+        @border: 1px solid @ffe-farge-varmgraa;
         z-index: 100;
         position: absolute;
         left: 0;

--- a/packages/ffe-account-selector-react/less/ffe-account-selector-multi.less
+++ b/packages/ffe-account-selector-react/less/ffe-account-selector-multi.less
@@ -34,7 +34,7 @@
     }
 
     &__dropdown-statusbar {
-        border: 1px solid @ffe-farge-graa-wcag;
+        border: 1px solid @ffe-farge-varmgraa;
         padding: @ffe-spacing-xs;
         background: @ffe-farge-lysgraa;
         color: @ffe-farge-svart;

--- a/packages/ffe-core/less/colors.less
+++ b/packages/ffe-core/less/colors.less
@@ -110,7 +110,6 @@
 @ffe-farge-koksgraa: #323232;
 @ffe-farge-moerkgraa: #676767;
 @ffe-farge-graa: #adadad;
-@ffe-farge-graa-wcag: #949494;
 @ffe-farge-lysgraa: #d8d8d8;
 @ffe-farge-moerkvarmgraa: #848383;
 @ffe-farge-varmgraa: #9b9797;

--- a/packages/ffe-datepicker/less/calendar.less
+++ b/packages/ffe-datepicker/less/calendar.less
@@ -1,5 +1,5 @@
 .ffe-calendar {
-    border: solid 2px @ffe-farge-graa-wcag;
+    border: solid 2px @ffe-farge-varmgraa;
     border-radius: 4px;
     padding: @ffe-spacing-2xs;
     background: @ffe-farge-hvit;
@@ -138,10 +138,10 @@
         &:extend(.ffe-small-text);
 
         border-bottom: 1px solid @ffe-farge-lysgraa;
-        color: @ffe-farge-graa-wcag;
+        color: @ffe-farge-varmgraa;
         .native & {
             @media (prefers-color-scheme: dark) {
-                border-color: @ffe-farge-graa-wcag;
+                border-color: @ffe-farge-varmgraa;
                 color: @ffe-farge-graa;
             }
         }
@@ -174,7 +174,7 @@
         }
 
         &--today {
-            border: 1px solid @ffe-farge-graa-wcag;
+            border: 1px solid @ffe-farge-varmgraa;
             .native & {
                 @media (prefers-color-scheme: dark) {
                     border-color: @ffe-farge-graa;
@@ -243,7 +243,7 @@
         }
 
         &--disabled {
-            color: @ffe-farge-graa-wcag;
+            color: @ffe-farge-varmgraa;
             .native & {
                 @media (prefers-color-scheme: dark) {
                     color: @ffe-farge-graa;
@@ -252,8 +252,8 @@
 
             &:focus,
             &:hover {
-                border: 2px solid @ffe-farge-graa-wcag;
-                color: @ffe-farge-graa-wcag;
+                border: 2px solid @ffe-farge-varmgraa;
+                color: @ffe-farge-varmgraa;
                 .native & {
                     @media (prefers-color-scheme: dark) {
                         border-color: @ffe-farge-graa;
@@ -264,7 +264,7 @@
         }
 
         &--disabled-focus {
-            border: 2px solid @ffe-farge-graa-wcag;
+            border: 2px solid @ffe-farge-varmgraa;
             .native & {
                 @media (prefers-color-scheme: dark) {
                     border-color: @ffe-farge-graa;

--- a/packages/ffe-form/less/checkbox.less
+++ b/packages/ffe-form/less/checkbox.less
@@ -45,7 +45,7 @@
     }
 
     &::before {
-        border: solid 2px @ffe-farge-graa-wcag;
+        border: solid 2px @ffe-farge-varmgraa;
         border-radius: 4px;
         content: '';
         display: inline-block;

--- a/packages/ffe-form/less/dropdown.less
+++ b/packages/ffe-form/less/dropdown.less
@@ -18,7 +18,7 @@
     background-size: 18px 18px;
     background-repeat: no-repeat;
     background-position: ~'calc(100% - 9px) 50%';
-    border: 2px solid @ffe-farge-graa-wcag;
+    border: 2px solid @ffe-farge-varmgraa;
     border-radius: 4px;
     color: @ffe-farge-svart;
     display: block;

--- a/packages/ffe-form/less/input-field.less
+++ b/packages/ffe-form/less/input-field.less
@@ -21,7 +21,7 @@
     background-color: @ffe-farge-hvit;
     color: @ffe-farge-svart;
     border-radius: 4px;
-    border: 2px solid @ffe-farge-graa-wcag;
+    border: 2px solid @ffe-farge-varmgraa;
     transition: all @ffe-transition-duration @ffe-ease;
     width: 100%;
     .ffe-fontsize-form-input();
@@ -83,7 +83,7 @@
     &--text-like {
         background-color: @ffe-farge-hvit;
         border: none;
-        border-bottom: 2px solid @ffe-farge-graa-wcag;
+        border-bottom: 2px solid @ffe-farge-varmgraa;
         border-radius: 4px 4px 0 0;
         box-shadow: none;
         color: @ffe-farge-svart;

--- a/packages/ffe-form/less/phone-number.less
+++ b/packages/ffe-form/less/phone-number.less
@@ -46,7 +46,7 @@
         line-height: 1;
         padding: 12px @ffe-spacing-xs;
         background-color: @ffe-farge-hvit;
-        border: 2px solid @ffe-farge-graa-wcag;
+        border: 2px solid @ffe-farge-varmgraa;
         border-radius: 4px 0 0 4px;
         border-right: 0;
         transition: all @ffe-transition-duration @ffe-ease;

--- a/packages/ffe-form/less/radio-block.less
+++ b/packages/ffe-form/less/radio-block.less
@@ -39,7 +39,7 @@
     &__content {
         width: 100%;
         position: relative;
-        border: 2px solid @ffe-farge-graa-wcag;
+        border: 2px solid @ffe-farge-varmgraa;
         border-radius: 5px;
         display: inline-block;
         margin-right: @ffe-spacing-xs;
@@ -76,7 +76,7 @@
         display: block;
         padding: @ffe-spacing-xs @ffe-spacing-3xl @ffe-spacing-xs;
         cursor: pointer;
-        border-bottom: thin solid @ffe-farge-graa-wcag;
+        border-bottom: thin solid @ffe-farge-varmgraa;
         transition: background-color @ffe-transition-duration @ffe-ease,
             border-color @ffe-transition-duration @ffe-ease;
 

--- a/packages/ffe-form/less/radio-button.less
+++ b/packages/ffe-form/less/radio-button.less
@@ -96,7 +96,7 @@
 
     &::after {
         content: '';
-        border: 2px solid @ffe-farge-graa-wcag;
+        border: 2px solid @ffe-farge-varmgraa;
         width: 20px;
         height: 20px;
         border-radius: 50%;

--- a/packages/ffe-form/less/radio-switch.less
+++ b/packages/ffe-form/less/radio-switch.less
@@ -17,7 +17,7 @@
     padding: 6px @ffe-spacing-sm 6px @ffe-spacing-2xl;
     position: relative;
     background-color: @ffe-farge-hvit;
-    border: 2px solid @ffe-farge-graa-wcag;
+    border: 2px solid @ffe-farge-varmgraa;
     border-radius: 22px;
     display: inline-block;
     min-width: 100px;

--- a/packages/ffe-form/less/radioblob-mixin.less
+++ b/packages/ffe-form/less/radioblob-mixin.less
@@ -4,7 +4,7 @@
 .ffe-sb1-radioblob() {
     content: '';
     background-color: @ffe-farge-hvit;
-    border: 2px solid @ffe-farge-graa-wcag;
+    border: 2px solid @ffe-farge-varmgraa;
     width: 20px;
     height: 20px;
     border-radius: 50%;

--- a/packages/ffe-form/less/textarea.less
+++ b/packages/ffe-form/less/textarea.less
@@ -15,7 +15,7 @@
     font-family: 'SpareBank1-regular', 'MuseoSans-500', arial, sans-serif;
     font-variant-numeric: tabular-nums;
     border-radius: 4px;
-    border: 2px solid @ffe-farge-graa-wcag;
+    border: 2px solid @ffe-farge-varmgraa;
     background-color: @ffe-farge-hvit;
     color: @ffe-farge-svart;
     transition: all @ffe-transition-duration @ffe-ease;
@@ -23,7 +23,7 @@
     .native & {
         @media (prefers-color-scheme: dark) {
             background-color: @ffe-farge-svart;
-            border-color: @ffe-farge-graa-wcag;
+            border-color: @ffe-farge-varmgraa;
             box-shadow: none;
             color: @ffe-farge-hvit;
         }

--- a/packages/ffe-form/less/toggle-switch.less
+++ b/packages/ffe-form/less/toggle-switch.less
@@ -67,7 +67,7 @@
             content: '';
             width: 56px;
             height: 30px;
-            background: @ffe-farge-graa-wcag;
+            background: @ffe-farge-varmgraa;
             border-radius: 15px;
             z-index: 1;
             left: auto;

--- a/packages/ffe-form/less/tooltip.less
+++ b/packages/ffe-form/less/tooltip.less
@@ -18,7 +18,7 @@
     &__icon {
         background: @ffe-farge-hvit;
         border-radius: 50%;
-        border: 2px solid @ffe-farge-graa-wcag;
+        border: 2px solid @ffe-farge-varmgraa;
         color: @ffe-farge-vann;
         cursor: help;
         height: @ffe-tooltip-size;

--- a/packages/ffe-searchable-dropdown-react/less/searchable-dropdown.less
+++ b/packages/ffe-searchable-dropdown-react/less/searchable-dropdown.less
@@ -21,7 +21,7 @@
         &--open {
             display: block;
             height: auto;
-            border: 1px solid @ffe-farge-graa-wcag;
+            border: 1px solid @ffe-farge-varmgraa;
         }
     }
 
@@ -29,7 +29,7 @@
         padding: @ffe-spacing @ffe-spacing-sm;
 
         & + .ffe-searchable-dropdown__list-item-container {
-            border-top: 1px solid @ffe-farge-graa-wcag;
+            border-top: 1px solid @ffe-farge-varmgraa;
         }
 
         .ffe-body-paragraph {
@@ -38,12 +38,12 @@
     }
 
     &__list-item-container:not(:last-child) {
-        border-bottom: 1px solid @ffe-farge-graa-wcag;
+        border-bottom: 1px solid @ffe-farge-varmgraa;
     }
 
     // Fixes https://github.com/SpareBank1/designsystem/issues/1245
     &__list-item-high-capacity-container:not(:last-child) {
-        border-bottom: 1px solid @ffe-farge-graa-wcag;
+        border-bottom: 1px solid @ffe-farge-varmgraa;
     }
 
     &__list-item-body {

--- a/packages/ffe-tables/less/table.less
+++ b/packages/ffe-tables/less/table.less
@@ -144,7 +144,7 @@
     }
 
     &__row {
-        border-bottom: 1px solid @ffe-farge-graa-wcag;
+        border-bottom: 1px solid @ffe-farge-varmgraa;
         display: block;
         padding: @ffe-spacing-xs 0;
         .native & {


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse

Fargen `@ffe-farge-graa-wcag` fjernes helt fra `ffe-core`, og erstattes med `@ffe-farge-varmgraa` der den har vært i bruk i komponentene.

## Motivasjon og kontekst

Fixes #1449 

## Testing

Testet lokalt