### PR TITLE
fix(ffe-accordion): fix focus and heading styling

### DIFF
--- a/packages/ffe-accordion-react/package.json
+++ b/packages/ffe-accordion-react/package.json
@@ -25,7 +25,6 @@
     },
     "dependencies": {
         "@sb1/ffe-collapse-react": "^1.1.14",
-        "@sb1/ffe-core-react": "^6.0.0",
         "@sb1/ffe-icons-react": "^7.3.3",
         "classnames": "^2.3.1",
         "prop-types": "^15.7.2",

--- a/packages/ffe-accordion-react/src/AccordionItem.js
+++ b/packages/ffe-accordion-react/src/AccordionItem.js
@@ -4,7 +4,6 @@ import { v4 as uuid } from 'uuid';
 import { ChevronIkon } from '@sb1/ffe-icons-react';
 import Collapse from '@sb1/ffe-collapse-react';
 import classNames from 'classnames';
-import { Heading6 } from '@sb1/ffe-core-react';
 
 const AccordionItem = ({
     children,
@@ -41,6 +40,8 @@ const AccordionItem = ({
 
     const collapseHidden = !isExpanded && !isAnimating;
 
+    const H = `h${headingLevel}`;
+
     return (
         <div
             className={classNames(className, 'ffe-accordion-item', {
@@ -49,10 +50,7 @@ const AccordionItem = ({
             })}
             {...rest}
         >
-            <Heading6
-                className="ffe-accordion-item__heading"
-                aria-level={headingLevel}
-            >
+            <H className="ffe-h6 ffe-accordion-item__heading">
                 <button
                     type="button"
                     id={buttonId.current}
@@ -77,7 +75,7 @@ const AccordionItem = ({
                         </span>
                     </span>
                 </button>
-            </Heading6>
+            </H>
             <Collapse
                 isOpen={isExpanded}
                 onRest={() => setIsAnimating(false)}


### PR DESCRIPTION
## Beskrivelse
Endret fra: 
![Skjermbilde 2022-10-11 kl  10 39 08](https://user-images.githubusercontent.com/65295516/195060611-fb2223af-89b9-4133-b8bd-a4b7cbd7d980.png)
til:
![image](https://user-images.githubusercontent.com/65295516/195061041-9d68cd56-57c1-4b68-ab87-0c90d43033ff.png)

En feil som oppstår når accordion elementet tas i bruk. Får ikke reprodusert feilen i designsystemet
