### PR TITLE
Bugfikser i ffe-grid

### DIFF
--- a/component-overview/examples/grid/Grid-modifiers.jsx
+++ b/component-overview/examples/grid/Grid-modifiers.jsx
@@ -1,0 +1,30 @@
+import { Grid, GridRow, GridCol } from '@sb1/ffe-grid-react';
+
+<Grid>
+    <GridRow>
+        <GridCol sm="6" md="6" lg="3" background="frost-30">
+            Litt innhold
+        </GridCol>
+        <GridCol sm="6" md="6" lg="3" background="frost-30" centerText={true}>
+            Sentrert tekst
+        </GridCol>
+        <GridCol sm="6" md="6" lg="3" background="frost-30" center={true}>
+            Sentrert innhold
+        </GridCol>
+        <GridCol sm="6" md="6" lg="3" background="frost-30">
+            Litt mer innhold. Legger til en haug av brødtekst som strekker kolonnen i høyden, for å illustrere hvordan kolonnen til venstre sentreres horisontalt og vertikalt når høyden på alle kolonner øker.
+        </GridCol>
+        <GridCol sm="0" md="4" lg="3" background="frost-30">
+            Denne skjules på mobil
+        </GridCol>
+        <GridCol sm="6" md="0" lg="3" background="frost-30">
+            Denne skjules på tablet
+        </GridCol>
+        <GridCol sm="6" md="4" lg="0" background="frost-30">
+            Denne skjules på desktop
+        </GridCol>
+        <GridCol background="frost-30">
+            Denne har ingen størrelse angitt og tar derfor full bredde på alle skjermstørrelser
+        </GridCol>
+    </GridRow>
+</Grid>

--- a/packages/ffe-grid-react/src/GridCol.js
+++ b/packages/ffe-grid-react/src/GridCol.js
@@ -21,7 +21,7 @@ function camelCaseToDashCase(str) {
         );
 }
 
-const MODIFIER_LIST = ['background', 'centerText'];
+const MODIFIER_LIST = ['background', 'centerText', 'center'];
 
 const sizeClasses = (size, def) => {
     switch (typeof def) {
@@ -86,6 +86,7 @@ export default class GridCol extends Component {
         });
 
         const classes = [
+            'ffe-grid__col',
             className,
             sizeClasses('lg', lg),
             sizeClasses('md', md),
@@ -128,6 +129,8 @@ GridCol.propTypes = {
     element: node,
     /** Center text content horizontally */
     centerText: bool,
+    /** Center content vertically */
+    center: bool,
     /** The content of the column */
     children: node,
     /** Size modifiers for small screen sizes */

--- a/packages/ffe-grid-react/src/index.d.ts
+++ b/packages/ffe-grid-react/src/index.d.ts
@@ -66,6 +66,7 @@ export interface GridColProps extends React.HTMLAttributes<HTMLElement> {
     children?: React.ReactNode;
     className?: string;
     element?: React.ReactNode;
+    center?: boolean;
     centerText?: boolean;
     sm?: ColumnsRange | string | GridColSize;
     md?: ColumnsRange | string | GridColSize;

--- a/packages/ffe-grid/README.md
+++ b/packages/ffe-grid/README.md
@@ -58,6 +58,8 @@ You only have to specify one of these if you want - each column defaults to a 10
 for viewports that are not specified (i.e. `.ffe-grid__col--md-6` will be 100 % wide on small
 devices, and 50 % on medium and large screens).
 
+A column can be hidden entirely on a given breakpoint by setting the value to `0`, e.g. `.ffe-grid__col--sm-0` to hide it on small screens.
+
 ### Offset
 
 The pattern is like so: `.ffe-grid__col--{size}-offset-{num-of-cols}`
@@ -81,6 +83,16 @@ By default, rows have no padding or margin.
 The gutter/gap between columns can be controlled using the `.ffe-grid--gap-{size}` modifier. Available sizes correspond to the [ffe spacing variables](https://design.sparebank1.no/profil/spacing/), however the largest available size is `lg`.
 
 The default gap is 16px, equivalent to `.ffe-grid--gap-sm`.
+
+The gap value is also applied as a padding to the left and right of the grid.
+
+### Center
+
+Contents of a grid column can be centered horizontally and vertically using the `.ffe-grid__col--center` modifier.
+
+### Center text
+
+Text inside a grid column can be centered using the `.ffe-grid__col--center-text` modifier.
 
 ### Background colors
 

--- a/packages/ffe-grid/less/ffe-grid.less
+++ b/packages/ffe-grid/less/ffe-grid.less
@@ -22,61 +22,49 @@
 
 .ffe-grid {
     margin: 0 auto;
-    padding: 0 @ffe-spacing-sm;
     max-width: @app-width;
-
-    &--gap-none {
-        padding: 0;
-    }
-
-    &--gap-2xs {
-        padding: 0 @ffe-spacing-2xs;
-    }
-
-    &--gap-xs {
-        padding: 0 @ffe-spacing-xs;
-    }
-
-    &--gap-sm {
-        padding: 0 @ffe-spacing-sm;
-    }
-
-    &--gap-md {
-        padding: 0 @ffe-spacing-md;
-    }
-
-    &--gap-lg {
-        padding: 0 @ffe-spacing-lg;
-    }
 }
 
 .ffe-grid__row {
     display: grid;
     gap: @ffe-spacing-sm;
+    padding-right: @ffe-spacing-sm;
+    padding-left: @ffe-spacing-sm;
     grid-template-columns: repeat(12, 1fr);
 
     .ffe-grid--gap-none & {
         gap: 0;
+        padding: 0;
     }
 
     .ffe-grid--gap-2xs & {
         gap: @ffe-spacing-2xs;
+        padding-right: @ffe-spacing-2xs;
+        padding-left: @ffe-spacing-2xs;
     }
 
     .ffe-grid--gap-xs & {
         gap: @ffe-spacing-xs;
+        padding-right: @ffe-spacing-xs;
+        padding-left: @ffe-spacing-xs;
     }
 
     .ffe-grid--gap-sm & {
         gap: @ffe-spacing-sm;
+        padding-right: @ffe-spacing-sm;
+        padding-left: @ffe-spacing-sm;
     }
 
     .ffe-grid--gap-md & {
         gap: @ffe-spacing-md;
+        padding-right: @ffe-spacing-md;
+        padding-left: @ffe-spacing-md;
     }
 
     .ffe-grid--gap-lg & {
         gap: @ffe-spacing-lg;
+        padding-right: @ffe-spacing-lg;
+        padding-left: @ffe-spacing-lg;
     }
 
     &--padding-2xs {

--- a/packages/ffe-grid/less/ffe-grid.less
+++ b/packages/ffe-grid/less/ffe-grid.less
@@ -1,7 +1,12 @@
 // Mixins
-.create-column(@size, @total, @current: 1) when (@current <= @total) {
+.create-column(@size, @total, @current: 0) when (@current <= @total) {
     .ffe-grid__col--@{size}-@{current} {
+        display: block;
         grid-column: auto / span (@current);
+
+        & when (@current = 0) {
+            display: none;
+        }
     }
 
     .create-column(@size, @total, @current + 1);
@@ -13,6 +18,36 @@
     }
 
     .create-column-offset(@size, @total, @current + 1);
+}
+
+.ffe-grid {
+    margin: 0 auto;
+    padding: 0 @ffe-spacing-sm;
+    max-width: @app-width;
+
+    &--gap-none {
+        padding: 0;
+    }
+
+    &--gap-2xs {
+        padding: 0 @ffe-spacing-2xs;
+    }
+
+    &--gap-xs {
+        padding: 0 @ffe-spacing-xs;
+    }
+
+    &--gap-sm {
+        padding: 0 @ffe-spacing-sm;
+    }
+
+    &--gap-md {
+        padding: 0 @ffe-spacing-md;
+    }
+
+    &--gap-lg {
+        padding: 0 @ffe-spacing-lg;
+    }
 }
 
 .ffe-grid__row {
@@ -215,6 +250,8 @@
 }
 
 .ffe-grid__col {
+    grid-column: auto / span 12;
+
     &--bg-frost-30 {
         background-color: @ffe-farge-frost-30;
         .native & {
@@ -324,4 +361,10 @@
 @media (min-width: @breakpoint-xl) {
     .create-column(xl, 12);
     .create-column-offset(xl, 12);
+}
+
+.ffe-grid__col--center {
+    display: flex;
+    place-items: center;
+    place-content: center;
 }


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse

Legger tilbake noen savnede modifiere og defaults fra før forrige breaking change.

* Kolonner kan skjules med nullverdi på angitt størrelse i klassenavnet, f.eks `.ffe-grid__col--sm-0`
* Default størrelse på `.ffe-grid__col` er 100%
* Padding til høyre og venstre av griden er lagt tilbake. Størrelsen følger og kan overstyres med modifieren for `gap`. Default padding er 16px, tilsvarende `.ffe-grid--gap-sm`.
* Griden har en `max-width` og er sentrert horisontalt
* Legger til en modifier for å sentrere innhold i en kolonne i begge akser: `.ffe-grid__col--center` 

## Motivasjon og kontekst

Fikser nyoppståtte bugs og andre tilbakemeldinger etter omskriving av ffe-grid

## Testing

<!-- Hvordan har du har testet endringene dine? Ta gjerne med systeminfo o.l -->

Testet lokalt med Chrome, Firefox og Safari på Mac