### PR TITLE
fix(ffe-lists): description list, margin left on sibling dd only on h…

### DIFF
--- a/packages/ffe-lists/less/description-list.less
+++ b/packages/ffe-lists/less/description-list.less
@@ -113,7 +113,7 @@
     }
 }
 
-.ffe-description-list--md {
+.ffe-description-list--horizontal.ffe-description-list--md {
     .ffe-description-list__term {
         flex: 0 0 40%;
     }
@@ -128,7 +128,7 @@
     }
 }
 
-.ffe-description-list--lg {
+.ffe-description-list--horizontal.ffe-description-list--lg {
     .ffe-description-list__term {
         flex: 0 0 50%;
     }


### PR DESCRIPTION
Liten bugg i description list. margin left ble alltid satt også på vertikala listor hvis man hade flere dd. 

før fix;
![image](https://user-images.githubusercontent.com/2248579/196414912-aedbd04b-64a7-43ff-a3a0-649fa2e86522.png)


efter fix: 
![image](https://user-images.githubusercontent.com/2248579/196414984-34dc0d70-dfed-4295-9827-d049aa867c48.png)
