### PR TITLE
Støtte for bakgrunnsfarger i full bredde i GridRow

### DIFF
--- a/packages/ffe-grid-react/src/GridRow.js
+++ b/packages/ffe-grid-react/src/GridRow.js
@@ -13,8 +13,14 @@ export default function GridRow({
     margin,
     ...rest
 }) {
+    let content = children;
+
     const hasBackgroundColor = backgroundColors.includes(background);
     const hasRemovedColor = removedColors.includes(background);
+
+    if (hasBackgroundColor) {
+        content = <div className="ffe-grid__row-wrapper">{children}</div>;
+    }
 
     if (hasRemovedColor) {
         throw new Error(
@@ -35,7 +41,7 @@ export default function GridRow({
             )}
             {...rest}
         >
-            {children}
+            {content}
         </Element>
     );
 }

--- a/packages/ffe-grid-react/src/GridRow.js
+++ b/packages/ffe-grid-react/src/GridRow.js
@@ -13,14 +13,13 @@ export default function GridRow({
     margin,
     ...rest
 }) {
-    let content = children;
-
     const hasBackgroundColor = backgroundColors.includes(background);
     const hasRemovedColor = removedColors.includes(background);
-
-    if (hasBackgroundColor) {
-        content = <div className="ffe-grid__row-wrapper">{children}</div>;
-    }
+    const content = hasBackgroundColor ? (
+        <div className="ffe-grid__row-wrapper">{children}</div>
+    ) : (
+        children
+    );
 
     if (hasRemovedColor) {
         throw new Error(

--- a/packages/ffe-grid-react/src/GridRow.spec.js
+++ b/packages/ffe-grid-react/src/GridRow.spec.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { GridRow } from '.';
+import { GridRow, GridCol } from '.';
 import backgroundColors from './background-colors';
 
 const defaultProps = {
@@ -50,6 +50,20 @@ describe('GridRow', () => {
         expect(() => renderShallow({ background: 'blue-cobalt' })).toThrow(
             'Support for the blue-cobalt background on <GridRow> has been removed, please see the CHANGELOG',
         );
+    });
+
+    it('renders coloured rows with extra wrappers', () => {
+        backgroundColors.forEach(background => {
+            const el = renderShallow({
+                background,
+                children: (
+                    <GridCol lg={12}>
+                        <p>blah</p>
+                    </GridCol>
+                ),
+            });
+            expect(el.childAt(0).hasClass('ffe-grid__row-wrapper')).toBe(true);
+        });
     });
 
     it('preserves other attributes that are passed to it', () => {

--- a/packages/ffe-grid/README.md
+++ b/packages/ffe-grid/README.md
@@ -96,15 +96,17 @@ Text inside a grid column can be centered using the `.ffe-grid__col--center-text
 
 ### Background colors
 
-The background color of rows can be changed using modifiers
+The background color of rows can be changed using modifiers. This requires that the children of `.ffe-grid__row` are wrapped in `.ffe-grid__row-wrapper`.
 
 ```html
 <div class="ffe-grid__row ffe-grid__row--bg-sand">
-    <div class="ffe-grid__col--md-6">
-        <!-- content -->
-    </div>
-    <div class="ffe-grid__col--md-6">
-        <!-- content -->
+    <div class="ffe-grid__row-wrapper">
+        <div class="ffe-grid__col--md-6">
+            <!-- content -->
+        </div>
+        <div class="ffe-grid__col--md-6">
+            <!-- content -->
+        </div>
     </div>
 </div>
 ```

--- a/packages/ffe-grid/less/ffe-grid.less
+++ b/packages/ffe-grid/less/ffe-grid.less
@@ -20,16 +20,14 @@
     .create-column-offset(@size, @total, @current + 1);
 }
 
-.ffe-grid {
-    margin: 0 auto;
-    max-width: @app-width;
-}
-
-.ffe-grid__row {
+.ffe-grid__row,
+.ffe-grid__row-wrapper {
     display: grid;
     gap: @ffe-spacing-sm;
     padding-right: @ffe-spacing-sm;
     padding-left: @ffe-spacing-sm;
+    margin: 0 auto;
+    max-width: @app-width;
     grid-template-columns: repeat(12, 1fr);
 
     .ffe-grid--gap-none & {
@@ -108,43 +106,43 @@
     }
 
     &--margin-2xs {
-        margin: @ffe-spacing-2xs 0;
+        margin: @ffe-spacing-2xs auto;
     }
 
     &--margin-xs {
-        margin: @ffe-spacing-xs 0;
+        margin: @ffe-spacing-xs auto;
     }
 
     &--margin-sm {
-        margin: @ffe-spacing-sm 0;
+        margin: @ffe-spacing-sm auto;
     }
 
     &--margin-md {
-        margin: @ffe-spacing-md 0;
+        margin: @ffe-spacing-md auto;
     }
 
     &--margin-lg {
-        margin: @ffe-spacing-lg 0;
+        margin: @ffe-spacing-lg auto;
     }
 
     &--margin-xl {
-        margin: @ffe-spacing-xl 0;
+        margin: @ffe-spacing-xl auto;
     }
 
     &--margin-2xl {
-        margin: @ffe-spacing-2xl 0;
+        margin: @ffe-spacing-2xl auto;
     }
 
     &--margin-3xl {
-        margin: @ffe-spacing-3xl 0;
+        margin: @ffe-spacing-3xl auto;
     }
 
     &--margin-4xl {
-        margin: @ffe-spacing-4xl 0;
+        margin: @ffe-spacing-4xl auto;
     }
 
     &--margin-5xl {
-        margin: @ffe-spacing-5xl 0;
+        margin: @ffe-spacing-5xl auto;
     }
 
     &--bg-frost-30 {
@@ -235,6 +233,11 @@
             }
         }
     }
+}
+
+[class*='ffe-grid__row--bg-'] {
+    display: block;
+    max-width: none;
 }
 
 .ffe-grid__col {


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse

Gjeninnfører `.ffe-grid__row-wrapper` for å støtte at bakgrunnsfarger på `.ffe-grid__row` strekker seg i hele skjermens bredde. 

## Motivasjon og kontekst

Støtte for bakgrunner i full bredde gikk med i dragsuget i #1450. Legger samme funksjonalitet som før tilbake.

## Testing

Testet med `component-overview` i Chrome, Firefox og Safari på Mac.
