### PR TITLE
Flytt Checkliste ikoner fra CSS til react komponenten.

### DIFF
--- a/packages/ffe-lists-react/package.json
+++ b/packages/ffe-lists-react/package.json
@@ -25,6 +25,7 @@
     "test:watch": "ffe-buildtool jest --watch"
   },
   "dependencies": {
+    "@sb1/ffe-icons-react": "^7.3.3",
     "classnames": "^2.3.1",
     "prop-types": "^15.7.2"
   },

--- a/packages/ffe-lists-react/src/CheckList.spec.js
+++ b/packages/ffe-lists-react/src/CheckList.spec.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import CheckList from './CheckList';
 import CheckListItem from './CheckListItem';
-
+import { HakeIkon, KryssIkon } from '@sb1/ffe-icons-react';
 const getWrapper = props =>
     shallow(
         <CheckList {...props}>
@@ -41,19 +41,10 @@ describe('<CheckList>', () => {
 });
 
 describe('<CheckListItem />', () => {
-    it('sets correct class for isCross flag', () => {
+    it('render correct icon based on isCross value', () => {
         const wrapper = shallow(<CheckListItem>An item</CheckListItem>);
-
-        expect(wrapper.hasClass('ffe-check-list__item--cross')).toBe(false);
-
+        expect(wrapper.find(HakeIkon)).toHaveLength(1);
         wrapper.setProps({ isCross: true });
-
-        expect(wrapper.hasClass('ffe-check-list__item--cross')).toBe(true);
-    });
-    it('sets correct aria-label based on isCross value', () => {
-        const wrapper = shallow(<CheckListItem>An item</CheckListItem>);
-        expect(wrapper.prop('aria-label')).toBe('hake');
-        wrapper.setProps({ isCross: true });
-        expect(wrapper.prop('aria-label')).toBe('kryss');
+        expect(wrapper.find(KryssIkon)).toHaveLength(1);
     });
 });

--- a/packages/ffe-lists-react/src/CheckListItem.js
+++ b/packages/ffe-lists-react/src/CheckListItem.js
@@ -1,19 +1,27 @@
 import React from 'react';
 import { bool, node, string } from 'prop-types';
 import classNames from 'classnames';
+import { HakeIkon, KryssIkon } from '@sb1/ffe-icons-react';
 
 const CheckListItem = props => {
     const { className, isCross, ...rest } = props;
     return (
-        <li
-            className={classNames(
-                'ffe-check-list__item',
-                { 'ffe-check-list__item--cross': isCross },
-                className,
+        <li className={classNames('ffe-check-list__item', className)} {...rest}>
+            {isCross ? (
+                <KryssIkon
+                    className="ffe-check-list__icon ffe-check-list__icon--cross"
+                    role="img"
+                    title="kryss"
+                />
+            ) : (
+                <HakeIkon
+                    className="ffe-check-list__icon ffe-check-list__icon--check"
+                    role="img"
+                    title="hake"
+                />
             )}
-            aria-label={isCross ? 'kryss' : 'hake'}
-            {...rest}
-        />
+            {rest.children}
+        </li>
     );
 };
 

--- a/packages/ffe-lists/less/regular-lists.less
+++ b/packages/ffe-lists/less/regular-lists.less
@@ -112,7 +112,6 @@
     margin: 0 0 @ffe-spacing-sm;
     list-style: none;
 
-    > .ffe-check-list__item,
     > .ffe-stylized-numbered-list__item {
         margin-top: @ffe-spacing-sm;
         margin-left: @ffe-spacing-lg;
@@ -121,12 +120,12 @@
     }
 }
 
-@ffe-farge-nordlys-wcag-fill: escape('@{ffe-farge-nordlys-wcag}');
-@ffe-farge-nordlys-fill: escape('@{ffe-farge-nordlys}');
-@ffe-farge-fjell-fill: escape('@{ffe-farge-fjell}');
-@ffe-farge-baer-fill: escape('@{ffe-farge-baer}');
-
 .ffe-check-list__item {
+    display: block;
+    margin-top: @ffe-spacing-sm;
+    position: relative;
+    line-height: 1.5em;
+
     .native & {
         @media (prefers-color-scheme: dark) {
             color: @ffe-farge-hvit;
@@ -135,84 +134,23 @@
 }
 
 .ffe-check-list {
-    > .ffe-check-list__item {
-        &::before {
-            content: '';
-            display: block;
-            position: absolute;
-            text-indent: -9999px;
-            width: 1em;
-            height: 1em;
-            left: -2em;
-            top: 0.15em;
-            background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 200 200' width='200' height='200'%3E%3Cpath fill='@{ffe-farge-nordlys-wcag-fill}' d='M176.56-8.325E-7c-4.403,0-8.307,2.46595-10.288,5.89248l-90.5448,156.336-42.6109-59.77c-2.46172-2.94562-5.88534-4.89058-9.78806-4.89058h-7.3426c-4.40307,0-8.30704,2.46094-10.2884,6.36839-1.94136,3.94753-1.46102,8.8406,1.0007,12.2671l54.8007,75.963c3.4224,4.89,9.3077,7.834,15.1918,7.834,6.84477,0,12.7076-3.42654,16.13-9.31777l100.827-173.487c2.46172-3.4666,2.46547-7.83618,0.0438-11.3028-1.942-3.94755-5.886-5.8925-10.289-5.8925h-6.84226z'/%3E%3C/svg%3E");
-            background-position: center;
-            background-size: 1em 1em;
-            background-repeat: no-repeat;
+    &__icon {
+        width: 1em;
+        height: 1em;
+        margin-right: @ffe-spacing-sm;
+
+        &--check {
+            fill: @ffe-farge-nordlys-wcag;
+
             .native & {
                 @media (prefers-color-scheme: dark) {
-                    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 200 200' width='200' height='200'%3E%3Cpath fill='@{ffe-farge-nordlys-fill}' d='M176.56-8.325E-7c-4.403,0-8.307,2.46595-10.288,5.89248l-90.5448,156.336-42.6109-59.77c-2.46172-2.94562-5.88534-4.89058-9.78806-4.89058h-7.3426c-4.40307,0-8.30704,2.46094-10.2884,6.36839-1.94136,3.94753-1.46102,8.8406,1.0007,12.2671l54.8007,75.963c3.4224,4.89,9.3077,7.834,15.1918,7.834,6.84477,0,12.7076-3.42654,16.13-9.31777l100.827-173.487c2.46172-3.4666,2.46547-7.83618,0.0438-11.3028-1.942-3.94755-5.886-5.8925-10.289-5.8925h-6.84226z'/%3E%3C/svg%3E");
-                }
-            }
-        }
-    }
-
-    > .ffe-check-list__item--cross {
-        &::before {
-            background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 200 200'%3E%3Cpath fill='@{ffe-farge-baer-fill}' d='M18.77,0c-3.562,0-7.125,1.347-9.834,4.044l-4.429,4.439c-5.381,5.394-5.381,14.25,0,19.68l71.19,71.83-71.66,71.83c-5.381,5.394-5.381,14.25,0,19.68l4.429,4.439c5.381,5.394,14.22,5.394,19.64,0l71.66-71.83,71.65,71.83c5.381,5.394,14.23,5.394,19.65,0l4.429-4.439c5.381-5.394,5.381-14.25,0-19.68l-71.19-71.83,71.66-71.83c5.381-4.914,5.381-13.78,0-19.21l-4.429-4.423c-5.381-5.394-14.22-5.394-19.64,0l-72.13,71.34-71.17-71.83c-2.691-2.697-6.257-4.044-9.819-4.044z'/%3E%3C/svg%3E");
-            color: @ffe-farge-baer;
-            content: '';
-            .native & {
-                @media (prefers-color-scheme: dark) {
-                    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 200 200'%3E%3Cpath fill='@{ffe-farge-baer-fill}' d='M18.77,0c-3.562,0-7.125,1.347-9.834,4.044l-4.429,4.439c-5.381,5.394-5.381,14.25,0,19.68l71.19,71.83-71.66,71.83c-5.381,5.394-5.381,14.25,0,19.68l4.429,4.439c5.381,5.394,14.22,5.394,19.64,0l71.66-71.83,71.65,71.83c5.381,5.394,14.23,5.394,19.65,0l4.429-4.439c5.381-5.394,5.381-14.25,0-19.68l-71.19-71.83,71.66-71.83c5.381-4.914,5.381-13.78,0-19.21l-4.429-4.423c-5.381-5.394-14.22-5.394-19.64,0l-72.13,71.34-71.17-71.83c-2.691-2.697-6.257-4.044-9.819-4.044z'/%3E%3C/svg%3E");
-                    color: @ffe-farge-baer;
-                }
-            }
-        }
-    }
-
-    &--bg-sand {
-        > .ffe-check-list__item {
-            color: @ffe-farge-fjell;
-            background-color: @ffe-farge-sand;
-            padding: @ffe-spacing-sm @ffe-spacing-sm @ffe-spacing-sm
-                @ffe-spacing-2xl;
-            border-radius: 4px;
-            margin-left: 0;
-            margin-top: 1em;
-            .ffe-fontsize-h5();
-            .native & {
-                @media (prefers-color-scheme: dark) {
-                    color: @ffe-farge-hvit;
-                    background-color: @ffe-farge-svart;
-                }
-            }
-
-            &::before {
-                left: 1em;
-                top: 1em;
-                background-size: 0.9em 0.9em;
-                background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 200 200' width='200' height='200'%3E%3Cpath fill='@{ffe-farge-fjell-fill}' d='M176.56-8.325E-7c-4.403,0-8.307,2.46595-10.288,5.89248l-90.5448,156.336-42.6109-59.77c-2.46172-2.94562-5.88534-4.89058-9.78806-4.89058h-7.3426c-4.40307,0-8.30704,2.46094-10.2884,6.36839-1.94136,3.94753-1.46102,8.8406,1.0007,12.2671l54.8007,75.963c3.4224,4.89,9.3077,7.834,15.1918,7.834,6.84477,0,12.7076-3.42654,16.13-9.31777l100.827-173.487c2.46172-3.4666,2.46547-7.83618,0.0438-11.3028-1.942-3.94755-5.886-5.8925-10.289-5.8925h-6.84226z'/%3E%3C/svg%3E");
-                .native & {
-                    @media (prefers-color-scheme: dark) {
-                        background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 200 200' width='200' height='200'%3E%3Cpath fill='%230a91ff' d='M176.56-8.325E-7c-4.403,0-8.307,2.46595-10.288,5.89248l-90.5448,156.336-42.6109-59.77c-2.46172-2.94562-5.88534-4.89058-9.78806-4.89058h-7.3426c-4.40307,0-8.30704,2.46094-10.2884,6.36839-1.94136,3.94753-1.46102,8.8406,1.0007,12.2671l54.8007,75.963c3.4224,4.89,9.3077,7.834,15.1918,7.834,6.84477,0,12.7076-3.42654,16.13-9.31777l100.827-173.487c2.46172-3.4666,2.46547-7.83618,0.0438-11.3028-1.942-3.94755-5.886-5.8925-10.289-5.8925h-6.84226z'/%3E%3C/svg%3E");
-                    }
+                    fill: @ffe-farge-nordlys;
                 }
             }
         }
 
-        > .ffe-check-list__item--cross {
-            &::before {
-                background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 200 200'%3E%3Cpath fill='@{ffe-farge-fjell-fill}' d='M18.77,0c-3.562,0-7.125,1.347-9.834,4.044l-4.429,4.439c-5.381,5.394-5.381,14.25,0,19.68l71.19,71.83-71.66,71.83c-5.381,5.394-5.381,14.25,0,19.68l4.429,4.439c5.381,5.394,14.22,5.394,19.64,0l71.66-71.83,71.65,71.83c5.381,5.394,14.23,5.394,19.65,0l4.429-4.439c5.381-5.394,5.381-14.25,0-19.68l-71.19-71.83,71.66-71.83c5.381-4.914,5.381-13.78,0-19.21l-4.429-4.423c-5.381-5.394-14.22-5.394-19.64,0l-72.13,71.34-71.17-71.83c-2.691-2.697-6.257-4.044-9.819-4.044z'/%3E%3C/svg%3E");
-                color: @ffe-farge-baer;
-                content: '';
-                .native & {
-                    @media (prefers-color-scheme: dark) {
-                        background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 200 200'%3E%3Cpath fill='@{ffe-farge-baer-fill}' d='M18.77,0c-3.562,0-7.125,1.347-9.834,4.044l-4.429,4.439c-5.381,5.394-5.381,14.25,0,19.68l71.19,71.83-71.66,71.83c-5.381,5.394-5.381,14.25,0,19.68l4.429,4.439c5.381,5.394,14.22,5.394,19.64,0l71.66-71.83,71.65,71.83c5.381,5.394,14.23,5.394,19.65,0l4.429-4.439c5.381-5.394,5.381-14.25,0-19.68l-71.19-71.83,71.66-71.83c5.381-4.914,5.381-13.78,0-19.21l-4.429-4.423c-5.381-5.394-14.22-5.394-19.64,0l-72.13,71.34-71.17-71.83c-2.691-2.697-6.257-4.044-9.819-4.044z'/%3E%3C/svg%3E");
-                        color: @ffe-farge-baer;
-                    }
-                }
-            }
+        &--cross {
+            fill: @ffe-farge-baer;
         }
     }
 
@@ -244,6 +182,7 @@
             font-size: 1.1em;
             color: @ffe-farge-fjell;
             &:extend(.ffe-strong-text);
+
             .native & {
                 @media (prefers-color-scheme: dark) {
                     color: @ffe-farge-hvit;


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse
For å oppfylle WCAG-krav flyttes checkliste ikonene  fra bakgrunnsbilde i css til svg-tag i react komponenten.
Fjerner også en ubrukt sand-bg variant som ikke lenger er i bruk. 

<!-- Detaljert beskrivelse av endringene dine. Skjermskudd er lov. -->

## Motivasjon og kontekst
For å oppfylle WCAG krav å løse #1417 
<!-- Hvorfor trengs denne endringen, og hva løser den? -->

## Testing
Kjørt opp i component-overview og sammenlignet med gammel variant. 
<!-- Hvordan har du har testet endringene dine? Ta gjerne med systeminfo o.l -->

<!--

Helt til slutt, har du ..

.. lest retningslinjene våre for bidrag?
.. tatt en siste sjekk for kode og skrivefeil, debug informasjon o.l?
.. kjørt og eventuelt oppdatert testene?
.. kommentert og dokumentert det som trengs?
.. knyttet denne opp til relaterte issues?

-->
