### PR TITLE
fix(ffe-searchable-dropdown-react): setter riktig transition på chevron

### DIFF
--- a/packages/ffe-searchable-dropdown-react/less/searchable-dropdown.less
+++ b/packages/ffe-searchable-dropdown-react/less/searchable-dropdown.less
@@ -115,7 +115,8 @@
                 fill: @ffe-farge-vann;
                 height: 17px;
                 width: 17px;
-                transition: fill @ffe-transition-duration @ffe-ease;
+                transition: fill @ffe-transition-duration @ffe-ease,
+                    transform @ffe-transition-duration @ffe-ease-in-out-back;
             }
 
             &:hover {


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse

Legger til riktig transition på chevron-ikonet i SearchableDropdown

## Motivasjon og kontekst

Chevron-ikonet i SearchableDropdown har feil transition på hover. Det skal være en bevegelse der pila roterer 180 grader på klikk, tilsvarende InlineExpandButton.

Før:

![Image](https://i.imgur.com/wGFEVPc.gif)

Etter:

![Image](https://i.imgur.com/g2Ef977.gif)

## Testing

Testet lokalt med component-overview