### PR TITLE
fix(ffe-core-react): possible to add additional class to wave

### DIFF
--- a/packages/ffe-core-react/src/Wave.js
+++ b/packages/ffe-core-react/src/Wave.js
@@ -11,12 +11,13 @@ export default function Wave(props) {
         bgColor,
         bgDarkmodeColor,
         children,
+        className,
         ...rest
     } = props;
 
     return (
         <div
-            className={classNames('ffe-wave', {
+            className={classNames('ffe-wave', className, {
                 [`ffe-wave--bg-${bgColor}`]: bgColor,
                 [`ffe-wave--dm-bg-${bgDarkmodeColor}`]: bgDarkmodeColor,
             })}
@@ -45,6 +46,8 @@ export default function Wave(props) {
 }
 
 Wave.propTypes = {
+    /** Adds additional class */
+    className: string,
     /** Sets the mask-position property, setting a px/rem value will move the starting position of the wave */
     position: string,
     /** Rotate the wave 180 degrees :*/

--- a/packages/ffe-core-react/src/index.d.ts
+++ b/packages/ffe-core-react/src/index.d.ts
@@ -48,6 +48,7 @@ export interface ParagraphProps
 }
 
 export interface WaveProps {
+    className?: string;
     position?: string;
     flip?: boolean;
     color:


### PR DESCRIPTION
Mulighet for og legge til en egen className på Wave.  Slik det er nå så havner den på ...rest og konsekvensen blir att den skriver over className på den indre diven 

```
<div
                className={classNames(
                    'ffe-wave__wave',
                    `ffe-wave--bg-${color}`,
                    {
                        [`ffe-wave--dm-bg-${darkmodeColor}`]: darkmodeColor,
                        'ffe-wave__wave--flip': flip,
                    },
                )}
                aria-hidden="true"
                style={{
                    maskPosition: position,
                    WebkitMaskPosition: position,
                }}
                {...rest} <-- hvis className kommer med her så skriver den over className høgst op.
            />
  ```          
  
  Eller er det kanske bevist att man ikke skall kuna senda med en className?