### PR TITLE
fix(ffe-grid): overstyrer padding kun vertikalt

### DIFF
--- a/packages/ffe-grid/less/ffe-grid.less
+++ b/packages/ffe-grid/less/ffe-grid.less
@@ -66,43 +66,53 @@
     }
 
     &--padding-2xs {
-        padding: @ffe-spacing-2xs 0;
+        padding-top: @ffe-spacing-2xs;
+        padding-bottom: @ffe-spacing-2xs;
     }
 
     &--padding-xs {
-        padding: @ffe-spacing-xs 0;
+        padding-top: @ffe-spacing-xs;
+        padding-bottom: @ffe-spacing-xs;
     }
 
     &--padding-sm {
-        padding: @ffe-spacing-sm 0;
+        padding-top: @ffe-spacing-sm;
+        padding-bottom: @ffe-spacing-sm;
     }
 
     &--padding-md {
-        padding: @ffe-spacing-md 0;
+        padding-top: @ffe-spacing-md;
+        padding-bottom: @ffe-spacing-md;
     }
 
     &--padding-lg {
-        padding: @ffe-spacing-lg 0;
+        padding-top: @ffe-spacing-lg;
+        padding-bottom: @ffe-spacing-lg;
     }
 
     &--padding-xl {
-        padding: @ffe-spacing-xl 0;
+        padding-top: @ffe-spacing-xl;
+        padding-bottom: @ffe-spacing-xl;
     }
 
     &--padding-2xl {
-        padding: @ffe-spacing-2xl 0;
+        padding-top: @ffe-spacing-2xl;
+        padding-bottom: @ffe-spacing-2xl;
     }
 
     &--padding-3xl {
-        padding: @ffe-spacing-3xl 0;
+        padding-top: @ffe-spacing-3xl;
+        padding-bottom: @ffe-spacing-3xl;
     }
 
     &--padding-4xl {
-        padding: @ffe-spacing-4xl 0;
+        padding-top: @ffe-spacing-4xl;
+        padding-bottom: @ffe-spacing-4xl;
     }
 
     &--padding-5xl {
-        padding: @ffe-spacing-5xl 0;
+        padding-top: @ffe-spacing-5xl;
+        padding-bottom: @ffe-spacing-5xl;
     }
 
     &--margin-2xs {


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse

Padding-modifieren skal i utgangspunktet legge til luft kun over og under en grid row, men fordi verdien angis med shorthand overskriver den også default til høyre og venstre. 

## Motivasjon og kontekst

Endrer verdiene på padding slik at de kun treffer over og under row som planlagt.

## Testing

<!-- Hvordan har du har testet endringene dine? Ta gjerne med systeminfo o.l -->

<!--

Helt til slutt, har du ..

.. lest retningslinjene våre for bidrag?
.. tatt en siste sjekk for kode og skrivefeil, debug informasjon o.l?
.. kjørt og eventuelt oppdatert testene?
.. kommentert og dokumentert det som trengs?
.. knyttet denne opp til relaterte issues?

-->
