### PR TITLE
fix(ffe-lists): fjern display: block fra checklist items

### DIFF
--- a/packages/ffe-lists/less/regular-lists.less
+++ b/packages/ffe-lists/less/regular-lists.less
@@ -121,7 +121,6 @@
 }
 
 .ffe-check-list__item {
-    display: block;
     margin-top: @ffe-spacing-sm;
     position: relative;
     line-height: 1.5em;


### PR DESCRIPTION
## Beskrivelse

Når display er noe annet enn list-item leser ikke enkelte skjermlesere opp listen som liste. Det kan da være vanskelig å forstå at det er en liste for personer som bruker skjermleser. At lister er kodet så skjermlesere og annen hjelpeteknologi kan tolke dem som lister  er også nødvendig for å ivareta kravet 1.3.1 Informasjon og relasjoner (Nivå A).