### PR TITLE
Endrer default element i ffe-cards-react

### DIFF
--- a/component-overview/examples/cards/CardBase.jsx
+++ b/component-overview/examples/cards/CardBase.jsx
@@ -1,3 +1,3 @@
 import { CardBase } from '@sb1/ffe-cards-react';
 
-<CardBase>Dette er basisen for alle kort</CardBase>
+<CardBase href="https://design.sparebank1.no">Dette er basisen for alle kort</CardBase>

--- a/component-overview/examples/cards/IconCard-condensed.jsx
+++ b/component-overview/examples/cards/IconCard-condensed.jsx
@@ -1,7 +1,7 @@
 import { IconCard } from '@sb1/ffe-cards-react';
 import { SparegrisIkon } from '@sb1/ffe-icons-react';
 
-<IconCard icon={<SparegrisIkon />} condensed={true}>
+<IconCard href="https://design.sparebank1.no" icon={<SparegrisIkon />} condensed={true}>
     {({ Title, Subtext }) => (
         <>
             <Title>Sparekonto voksen 25</Title>

--- a/component-overview/examples/cards/IconCard-greyCharcoal.jsx
+++ b/component-overview/examples/cards/IconCard-greyCharcoal.jsx
@@ -2,6 +2,7 @@ import { IconCard } from '@sb1/ffe-cards-react';
 import { KryssSirkelIkon } from '@sb1/ffe-icons-react';
 
 <IconCard
+    href="https://design.sparebank1.no"
     icon={<KryssSirkelIkon style={{ transform: 'rotate(45deg)' }} />}
     greyCharcoal={true}
     condensed={true}

--- a/component-overview/examples/cards/IconCard.jsx
+++ b/component-overview/examples/cards/IconCard.jsx
@@ -1,7 +1,7 @@
 import { IconCard } from '@sb1/ffe-cards-react';
 import { GrafOppIkon } from '@sb1/ffe-icons-react';
 
-<IconCard icon={<GrafOppIkon />}>
+<IconCard href="https://design.sparebank1.no" icon={<GrafOppIkon />}>
     {({ CardName, Title, Subtext, Text }) => (
         <>
             <CardName>Kortnavn</CardName>

--- a/component-overview/examples/cards/ImageCard-titleOnly.jsx
+++ b/component-overview/examples/cards/ImageCard-titleOnly.jsx
@@ -1,6 +1,7 @@
 import { ImageCard } from '@sb1/ffe-cards-react';
 
 <ImageCard
+    href="https://design.sparebank1.no"
     image={
         <img
             src="https://www.sparebank1.no/content/dam/SB1/foto/profilbilder-liggende/ung-i-sofa.jpg.thumb.1280.1280.jpg"

--- a/component-overview/examples/cards/ImageCard.jsx
+++ b/component-overview/examples/cards/ImageCard.jsx
@@ -1,6 +1,7 @@
 import { ImageCard } from '@sb1/ffe-cards-react';
 
 <ImageCard
+    href="https://design.sparebank1.no"
     image={
         <img
             src="https://www.sparebank1.no/content/dam/SB1/foto/profilbilder-liggende/ung-i-sofa.jpg.thumb.1280.1280.jpg"

--- a/component-overview/examples/cards/TextCard.jsx
+++ b/component-overview/examples/cards/TextCard.jsx
@@ -1,6 +1,6 @@
 import { TextCard } from '@sb1/ffe-cards-react';
 
-<TextCard element="div">
+<TextCard href="https://design.sparebank1.no">
     {({ CardName, Title, Subtext, Text }) => (
         <>
             <CardName>Kortnavn</CardName>

--- a/packages/ffe-cards-react/src/CardBase.js
+++ b/packages/ffe-cards-react/src/CardBase.js
@@ -16,7 +16,7 @@ const CardBase = React.forwardRef((props, ref) => {
 });
 
 CardBase.defaultProps = {
-    element: 'div',
+    element: 'a',
 };
 
 CardBase.propTypes = {

--- a/packages/ffe-cards-react/src/CardBase.spec.js
+++ b/packages/ffe-cards-react/src/CardBase.spec.js
@@ -6,10 +6,10 @@ const getWrapper = props => shallow(<CardBase {...props} />);
 const children = <div>Hello world</div>;
 
 describe('CardBase', () => {
-    it('should render a div element with correct class and children inside', () => {
+    it('should render an a element with correct class and children inside', () => {
         const wrapper = getWrapper({ children });
 
-        expect(wrapper.find('div').exists()).toBe(true);
+        expect(wrapper.find('a').exists()).toBe(true);
         expect(wrapper.hasClass('ffe-card-base')).toBe(true);
         expect(
             wrapper

--- a/packages/ffe-cards-react/src/IconCard/IconCard.js
+++ b/packages/ffe-cards-react/src/IconCard/IconCard.js
@@ -41,7 +41,7 @@ const IconCard = props => {
 };
 
 IconCard.defaultProps = {
-    element: 'div',
+    element: 'a',
 };
 
 IconCard.propTypes = {

--- a/packages/ffe-cards-react/src/ImageCard/ImageCard.js
+++ b/packages/ffe-cards-react/src/ImageCard/ImageCard.js
@@ -28,7 +28,7 @@ const ImageCard = props => {
 };
 
 ImageCard.defaultProps = {
-    element: 'div',
+    element: 'a',
 };
 
 ImageCard.propTypes = {

--- a/packages/ffe-cards-react/src/TextCard/TextCard.js
+++ b/packages/ffe-cards-react/src/TextCard/TextCard.js
@@ -22,7 +22,7 @@ const TextCard = props => {
 };
 
 TextCard.defaultProps = {
-    element: 'div',
+    element: 'a',
 };
 
 TextCard.propTypes = {


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse

Endrer default element i ffe-cards-react fra `div` til `a`

## Motivasjon og kontekst

Kort skal iht [retningslinjene](https://design.sparebank1.no/komponenter/kort/) være klikkbare lenker. Derfor gir det mer mening at default element er `a` enn `div`.

Endringen innebærer at alle som bruker default kort per i dag enten må legge til `href` eller overstyre `element`.

## Testing

Testet lokalt med component-overview