### PR TITLE
fix(ffe-lists): legg til role="list" i CheckList og StylizedNumberedList

### DIFF
--- a/packages/ffe-lists-react/src/CheckList.js
+++ b/packages/ffe-lists-react/src/CheckList.js
@@ -4,6 +4,7 @@ import { node, oneOf, string } from 'prop-types';
 
 const CheckList = ({ className, columns, ...rest }) => (
     <ul
+        role="list"
         className={classNames(
             'ffe-check-list',
             { 'ffe-check-list--two-columns': Number(columns) === 2 },

--- a/packages/ffe-lists-react/src/StylizedNumberedList.js
+++ b/packages/ffe-lists-react/src/StylizedNumberedList.js
@@ -4,6 +4,7 @@ import classNames from 'classnames';
 
 const StylizedNumberedList = ({ className, ...rest }) => (
     <ol
+        role="list"
         className={classNames('ffe-stylized-numbered-list', className)}
         {...rest}
     />


### PR DESCRIPTION
## Beskrivelse
Skal løse problemet med at lister som har list-style: none ikke leses opp som lister med skjermleser i Safari.
Se https://developer.mozilla.org/en-US/docs/Web/CSS/list-style#accessibility_concerns

Fikser issue #1479


