### PR TITLE
feat(ffe-buttons): legg til mer theming muligheter i ffe-buttons

### DIFF
--- a/packages/ffe-buttons/less/base-button.less
+++ b/packages/ffe-buttons/less/base-button.less
@@ -185,37 +185,20 @@
     border-radius: 1.75rem;
     border: 2px solid transparent;
     box-shadow: none;
-    color: @ffe-farge-vann;
+    color: var(--ffe-v-button-task-primary-color);
     display: inline-block;
     padding: @ffe-spacing-2xs @ffe-spacing-sm @ffe-spacing-2xs @ffe-spacing-2xs;
     text-align: left;
     transition: all @ffe-transition-duration @ffe-ease;
     width: auto;
-    .native & {
-        @media (prefers-color-scheme: dark) {
-            color: @ffe-farge-vann-30;
-        }
-    }
 
     &:hover {
-        color: @ffe-farge-fjell;
+        color: var(--ffe-v-button-task-text-color-hover);
         box-shadow: none;
-
-        .native & {
-            @media (prefers-color-scheme: dark) {
-                color: @ffe-farge-hvit;
-            }
-        }
     }
 
     &:focus {
-        border-color: @ffe-farge-vann;
-
-        .native & {
-            @media (prefers-color-scheme: dark) {
-                border-color: @ffe-farge-hvit;
-            }
-        }
+        border-color: var(--ffe-v-button-task-border-focus);
 
         &::after {
             display: none;
@@ -260,10 +243,10 @@
     }
 
     .ffe-button--task & {
-        border: 2px solid @ffe-farge-vann;
+        border: 2px solid var(--ffe-v-button-primary-color);
         border-radius: 50%;
         background-color: @ffe-farge-hvit;
-        fill: @ffe-farge-vann;
+        fill: var(--ffe-v-button-task-primary-color);
         height: 45px;
         padding: 13px;
         margin: 0 @ffe-spacing-xs 0 0;
@@ -271,22 +254,16 @@
         transition: all @ffe-transition-duration @ffe-ease;
         .native & {
             @media (prefers-color-scheme: dark) {
-                border-color: @ffe-farge-vann-70;
                 background-color: transparent;
-                fill: @ffe-farge-vann-30;
             }
         }
     }
 
     .ffe-button--expand & {
-        .native & {
-            @media (prefers-color-scheme: dark) {
-                fill: @ffe-farge-vann-30;
-            }
-        }
+        fill: var(--ffe-v-button-task-primary-color);
     }
-
     .ffe-button--expand:hover & {
+        fill: @ffe-farge-hvit;
         .native & {
             @media (prefers-color-scheme: dark) {
                 fill: @ffe-farge-svart;
@@ -295,16 +272,9 @@
     }
 
     .ffe-button--task:hover & {
-        border-color: @ffe-farge-vann;
-        background-color: @ffe-farge-vann;
-        fill: @ffe-farge-hvit;
-        .native & {
-            @media (prefers-color-scheme: dark) {
-                border-color: @ffe-farge-vann-70;
-                background-color: @ffe-farge-vann-70;
-                fill: @ffe-farge-svart;
-            }
-        }
+        border-color: var(--ffe-v-button-primary-color);
+        background-color: var(--ffe-v-button-primary-color);
+        fill: var(--ffe-v-button-primary-color-text);
     }
 }
 

--- a/packages/ffe-buttons/less/theme.less
+++ b/packages/ffe-buttons/less/theme.less
@@ -27,6 +27,11 @@
     --ffe-v-button-tertiary-color-hover: var(--ffe-farge-fjell);
     --ffe-v-button-tertiary-color-text: var(--ffe-farge-hvit);
 
+    /** Task button */
+    --ffe-v-button-task-primary-color: var(--ffe-farge-vann);
+    --ffe-v-button-task-text-color-hover: var(--ffe-farge-fjell);
+    --ffe-v-button-task-border-focus: var(--ffe-farge-vann);
+
     @media (prefers-color-scheme: dark) {
         .native {
             --ffe-v-button-text-color: var(--ffe-farge-svart);
@@ -42,6 +47,9 @@
             --ffe-v-button-tertiary-color: var(--ffe-farge-vann-70);
             --ffe-v-button-tertiary-color-hover: var(--ffe-farge-vann-30);
             --ffe-v-button-tertiary-color-text: var(--ffe-farge-svart);
+            --ffe-v-button-task-text-color-hover: var(--ffe-farge-hvit);
+            --ffe-v-button-task-border-focus: var(--ffe-farge-hvit);
+            --ffe-v-button-task-primary-color: var(--ffe-farge-vann-30);
         }
     }
 }


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse
Går gjennom ffe-buttons less filene og erstatter flere verdier i less med variabler i theme fila.
Endrer også expanded-knapp ikonet til riktig farge i darkmode. 
<!-- Detaljert beskrivelse av endringene dine. Skjermskudd er lov. -->

## Motivasjon og kontekst
Legger til flere theming muligheter i ffe-buttons pakken.
<!-- Hvorfor trengs denne endringen, og hva løser den? -->

## Testing
Kjørt opp lokalt og sammenlignet designet med det som ligger ute på https://sparebank1.github.io/designsystem/

