### PR TITLE
Legg til LinkIcon Komponent

### DIFF
--- a/component-overview/examples/typography/LinkIcon.jsx
+++ b/component-overview/examples/typography/LinkIcon.jsx
@@ -1,0 +1,9 @@
+import { LinkIcon } from '@sb1/ffe-core-react';
+import { SnakkebobleIkon } from '@sb1/ffe-icons-react';
+
+<LinkIcon href="https://www.sparebank1.no">
+    <SnakkebobleIkon
+        title="Snakk med oss"
+        style={{ height: '80px' }}
+    />
+</LinkIcon>

--- a/component-overview/examples/typography/LinkText-icon.jsx
+++ b/component-overview/examples/typography/LinkText-icon.jsx
@@ -1,9 +1,0 @@
-import { LinkText } from '@sb1/ffe-core-react';
-import { SnakkebobleIkon } from '@sb1/ffe-icons-react';
-
-<LinkText href="https://www.sparebank1.no" underline={false}>
-    <SnakkebobleIkon
-        title="Snakk med oss"
-        style={{ fill: 'darkblue', height: '80px' }}
-    />
-</LinkText>

--- a/packages/ffe-core-react/src/index.d.ts
+++ b/packages/ffe-core-react/src/index.d.ts
@@ -27,6 +27,12 @@ export interface LinkTextProps extends React.AnchorHTMLAttributes<HTMLElement> {
     underline?: boolean;
 }
 
+export interface LinkIconProps extends React.AnchorHTMLAttributes<HTMLElement> {
+    children: React.ReactNode;
+    className?: string;
+    element?: HTMLElement | string | React.ElementType;
+}
+
 export interface SimpleElementProps {
     children: React.ReactNode;
     className?: string;
@@ -88,6 +94,7 @@ declare class Heading4 extends React.Component<HeadingProps, any> {}
 declare class Heading5 extends React.Component<HeadingProps, any> {}
 declare class Heading6 extends React.Component<HeadingProps, any> {}
 declare class LinkText extends React.Component<LinkTextProps, any> {}
+declare class LinkIcon extends React.Component<LinkIconProps, any> {}
 declare class MicroText extends React.Component<
     SimpleElementProps & React.HTMLAttributes<HTMLSpanElement>,
     any

--- a/packages/ffe-core-react/src/index.js
+++ b/packages/ffe-core-react/src/index.js
@@ -2,6 +2,7 @@ export { default as DividerLine } from './typography/DividerLine';
 export { default as EmphasizedText } from './typography/EmphasizedText';
 export * from './typography/Heading';
 export { default as LinkText } from './typography/LinkText';
+export { default as LinkIcon } from './typography/LinkIcon';
 export { default as MicroText } from './typography/MicroText';
 export { default as Paragraph } from './typography/Paragraph';
 export { default as PreformattedText } from './typography/PreformattedText';

--- a/packages/ffe-core-react/src/typography/LinkIcon.js
+++ b/packages/ffe-core-react/src/typography/LinkIcon.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import { func, node, oneOfType, string, elementType } from 'prop-types';
+import classNames from 'classnames';
+
+const LinkIcon = props => {
+    const { className, element: Element, ...rest } = props;
+
+    return (
+        <Element className={classNames('ffe-link-icon', className)} {...rest} />
+    );
+};
+
+LinkIcon.defaultProps = {
+    element: 'a',
+};
+
+LinkIcon.propTypes = {
+    children: node.isRequired,
+    className: string,
+    /** The rendered element, like a `react-router` `<Link />` */
+    element: oneOfType([func, string, elementType]),
+};
+
+export default LinkIcon;

--- a/packages/ffe-core-react/src/typography/LinkIcon.spec.js
+++ b/packages/ffe-core-react/src/typography/LinkIcon.spec.js
@@ -1,0 +1,56 @@
+import React from 'react';
+import LinkIcon from './LinkIcon';
+
+const defaultProps = {
+    children: <span>test</span>,
+    href: '/avtale/abc123',
+};
+
+const Link = props => <span {...props} />;
+
+const getWrapper = props => shallow(<LinkIcon {...defaultProps} {...props} />);
+
+describe('<LinkIcon />', () => {
+    it('renders without exploding', () => {
+        const wrapper = getWrapper();
+        expect(wrapper.length).toBe(1);
+    });
+
+    it('renders an anchor tag by default', () => {
+        const wrapper = getWrapper();
+        expect(wrapper.is('a')).toBe(true);
+    });
+    it('renders child element', () => {
+        const wrapper = getWrapper();
+        expect(wrapper.find('span')).toHaveLength(1);
+    });
+
+    it('lets consumers provide an element', () => {
+        const wrapper = getWrapper({
+            element: Link,
+        });
+        expect(wrapper.is('Link')).toBe(true);
+    });
+
+    it('adds ffe-link-icon class', () => {
+        const wrapper = getWrapper();
+        expect(wrapper.hasClass('ffe-link-icon')).toBe(true);
+    });
+
+    it('adds the given className next to the ffe-link-icon classes', () => {
+        const wrapper = getWrapper({
+            className: 'some-other-class',
+        });
+        expect(wrapper.hasClass('ffe-link-icon')).toBe(true);
+        expect(wrapper.hasClass('some-other-class')).toBe(true);
+    });
+
+    it('passes on unrecognized props to the anchor', () => {
+        const wrapper = getWrapper({
+            target: '_blank',
+            rel: 'noopener noreferrer',
+        });
+        expect(wrapper.props().target).toBe('_blank');
+        expect(wrapper.props().rel).toBe('noopener noreferrer');
+    });
+});

--- a/packages/ffe-core/less/theme.less
+++ b/packages/ffe-core/less/theme.less
@@ -143,6 +143,8 @@
     --ffe-g-link-color: var(--ffe-farge-vann);
     --ffe-g-link-color-hover: var(--ffe-farge-fjell);
     --ffe-g-link-color-visited: var(--ffe-farge-lyng);
+    --ffe-g-link-icon-color-hover: var(--ffe-farge-natt);
+    --ffe-g-link-icon-color-focus: var(--ffe-farge-vann);
 
     @media (prefers-color-scheme: dark) {
         .native {
@@ -155,6 +157,8 @@
             --ffe-g-link-color: var(--ffe-farge-vann-70);
             --ffe-g-link-color-hover: var(--ffe-farge-vann-30);
             --ffe-g-link-color-visited: var(--ffe-farge-lyng-70);
+            --ffe-g-link-icon-color-hover: var(--ffe-farge-vann-30);
+            --ffe-g-link-icon-color-focus: var(--ffe-farge-hvit);
         }
     }
 }

--- a/packages/ffe-core/less/typography.less
+++ b/packages/ffe-core/less/typography.less
@@ -328,6 +328,21 @@
     }
 }
 
+.ffe-link-icon {
+    fill: var(--ffe-g-link-color);
+    display: inline-flex;
+    border-radius: 1.5rem;
+    border: 2px solid transparent;
+    outline: 0;
+    padding: @ffe-spacing-2xs;
+    &:hover {
+        fill: var(--ffe-g-link-icon-color-hover);
+    }
+    &:focus {
+        box-shadow: 0 0 0 2px var(--ffe-g-link-icon-color-focus);
+    }
+}
+
 .ffe-divider-line {
     border: none;
     border-bottom: solid 1px @ffe-farge-lysgraa;


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse
Legger til komponent for ikoner som også er lenker.

**Default:**
![default](https://user-images.githubusercontent.com/39946146/198345007-9094b2f7-fb2e-4bc0-ae52-2d77af68c548.png)
![Darkmode](https://user-images.githubusercontent.com/39946146/198344998-c0ecac7f-4410-4c1b-b23e-0752a0106702.png)

**Fokus**
La til ekstra padding mellom ikon og strek da noen av ikonene "klipper" over box-shadow streken. Ett eksempel er f.eks HakeIkon, så usikker på hva beste løsning er der.

![Darkmode_focus](https://user-images.githubusercontent.com/39946146/198345002-1f812014-a15b-4929-91cd-fa990c598d67.png)
![Focus](https://user-images.githubusercontent.com/39946146/198345010-f737264e-2ca7-468e-a8c3-06544f8c3dcd.png)

**Hover**

![Darkmode_hover](https://user-images.githubusercontent.com/39946146/198345005-fe3782db-f5e0-434e-8452-b4c7eb76bd26.png)
![hover](https://user-images.githubusercontent.com/39946146/198345013-dcab4b3b-fae2-481f-80a5-f5644b1e35c3.png)


## Motivasjon og kontekst
Tidligere brukte vi LinkText styling for ikoner som også er lenker, men siden stylingen på de to bruksområdene er veldig forskjellig valgte vi å splitte det i 2 komponenter. 

<!-- Hvorfor trengs denne endringen, og hva løser den? -->

## Testing
Testet lokalt ved å kjøre opp i component-overview. 
<!-- Hvordan har du har testet endringene dine? Ta gjerne med systeminfo o.l -->

<!--

Helt til slutt, har du ..

.. lest retningslinjene våre for bidrag?
.. tatt en siste sjekk for kode og skrivefeil, debug informasjon o.l?
.. kjørt og eventuelt oppdatert testene?
.. kommentert og dokumentert det som trengs?
.. knyttet denne opp til relaterte issues?

-->
