### PR TITLE
fix(component-overview): få in-page nav til å følge siden

### DIFF
--- a/component-overview/webapp/styles/sb1ex-toc.css
+++ b/component-overview/webapp/styles/sb1ex-toc.css
@@ -53,6 +53,8 @@
     list-style-type: none;
     margin: 0;
     padding: 0;
+    top: 1rem;
+    position: sticky;
 }
 
 .sb1ex-inpage-nav__list-item {


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse
Få in-page navigasjonen til å scrolle med siden sånn at den alltid er synlig. 

Før:
![Skjermbilde 2022-10-31 kl  14 43 56](https://user-images.githubusercontent.com/39946146/199022208-501cc015-c93d-431b-822b-9d126d53127e.png)

Etter:
![Skjermbilde 2022-10-31 kl  14 43 23](https://user-images.githubusercontent.com/39946146/199022203-2de6d0f0-38e3-495e-b902-fccdbff2d918.png)

<!-- Detaljert beskrivelse av endringene dine. Skjermskudd er lov. -->

## Motivasjon og kontekst
Ble lei av å scrolle ned på siden for å så måtte scrolle opp igjen hver gang jeg glemmer å bruke søkefeltet.
<!-- Hvorfor trengs denne endringen, og hva løser den? -->

## Testing
Kjørt opp og testet lokalt
<!-- Hvordan har du har testet endringene dine? Ta gjerne med systeminfo o.l -->

<!--

Helt til slutt, har du ..

.. lest retningslinjene våre for bidrag?
.. tatt en siste sjekk for kode og skrivefeil, debug informasjon o.l?
.. kjørt og eventuelt oppdatert testene?
.. kommentert og dokumentert det som trengs?
.. knyttet denne opp til relaterte issues?

-->
