### PR TITLE
fix(ffe-searchable-dropdown-react): add missing uuid dependency

### DIFF
--- a/packages/ffe-searchable-dropdown-react/package.json
+++ b/packages/ffe-searchable-dropdown-react/package.json
@@ -35,7 +35,8 @@
         "lodash.isequal": "^4.5.0",
         "prop-types": "^15.7.2",
         "react-custom-scrollbars": "^4.2.1",
-        "react-virtualized": "^9.22.3"
+        "react-virtualized": "^9.22.3",
+        "uuid": "^9.0.0"
     },
     "devDependencies": {
         "@sb1/ffe-buildtool": "^0.5.0",


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse

uuid blir brukt i searchable dropdown, men det er ikke lagt til i dependencies. Det blir da "hentet" fra et helt annet sted og får da en eldre versjon.

## Motivasjon og kontekst

Vi i kundefront-pm-betaling er avhengig av nyeste versjon av uuid.
