### PR TITLE
fix(ffe-accordion): text should not be centered

### DIFF
--- a/packages/ffe-accordion/less/ffe-accordion.less
+++ b/packages/ffe-accordion/less/ffe-accordion.less
@@ -45,6 +45,7 @@
     }
 
     &__heading-button-content {
+        text-align: start;
         width: 100%;
         display: flex;
         align-items: center;


### PR DESCRIPTION
Fikser texten i accordion

Før fiks:
![image](https://user-images.githubusercontent.com/2248579/199925941-57040d40-9599-4443-8d81-05fa7382a8f2.png)

Efter fiks: 
![image](https://user-images.githubusercontent.com/2248579/199925892-127276d2-d57f-495b-8a62-6dedb86be0bd.png)