### PR TITLE
fix(ffe-accordion): add gap between button and text

### DIFF
--- a/packages/ffe-accordion/less/ffe-accordion.less
+++ b/packages/ffe-accordion/less/ffe-accordion.less
@@ -50,6 +50,7 @@
         display: flex;
         align-items: center;
         justify-content: space-between;
+        gap: @ffe-spacing-xs;
     }
 
     &__heading-icon-wrapper {


### PR DESCRIPTION
Legger til avstand mellom knapp og text slik att det ikke blir som på bilden "Kan jeg tape penger på å spare i fond?" som ligger helt ute vid knappen. Jag kjøre på 8px. Hoper det er greit. 

![image](https://user-images.githubusercontent.com/2248579/200576150-452f3234-914e-45ec-95b1-bc0004b9abc2.png)
