### PR TITLE
Fjern legacy-peer-deps

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,1 @@
 package-lock=false
-legacy-peer-deps=true

--- a/packages/ffe-decorators-react/package.json
+++ b/packages/ffe-decorators-react/package.json
@@ -30,7 +30,6 @@
         "eslint": "^5.9.0",
         "mock-raf": "^1.0.0",
         "react": "^16.9.0",
-        "react-addons-test-utils": "^15.6.2",
         "react-dom": "^16.9.0",
         "sinon": "^7.2.3"
     },

--- a/packages/ffe-dropdown-react/package.json
+++ b/packages/ffe-dropdown-react/package.json
@@ -30,7 +30,6 @@
         "@sb1/ffe-buildtool": "^0.5.0",
         "eslint": "^5.9.0",
         "react": "^16.9.0",
-        "react-addons-test-utils": "^15.6.2",
         "react-dom": "^16.9.0"
     },
     "peerDependencies": {

--- a/packages/ffe-message-box-react/package.json
+++ b/packages/ffe-message-box-react/package.json
@@ -32,7 +32,6 @@
         "eslint": "^5.9.0",
         "prop-types": "^15.7.2",
         "react": "^16.9.0",
-        "react-addons-test-utils": "^15.6.2",
         "react-dom": "^16.9.0"
     },
     "peerDependencies": {


### PR DESCRIPTION
Fjerner unødig avhengighet til `react-addons-test-utils` og som gjør det mulig å slå av `legacy-peer-deps` i npm.
