### PR TITLE
Erstatte react-custom-scrollbars

### DIFF
--- a/packages/ffe-account-selector-react/package.json
+++ b/packages/ffe-account-selector-react/package.json
@@ -37,7 +37,7 @@
         "classnames": "^2.3.1",
         "prop-types": "^15.7.2",
         "react-auto-bind": "^0.4.2",
-        "react-custom-scrollbars": "^4.2.1",
+        "react-custom-scrollbars-2": "^4.3.0",
         "react-window": "^1.8.5"
     },
     "devDependencies": {

--- a/packages/ffe-account-selector-react/src/subcomponents/suggestion-high-capacity/SuggestionListContainer.js
+++ b/packages/ffe-account-selector-react/src/subcomponents/suggestion-high-capacity/SuggestionListContainer.js
@@ -1,7 +1,7 @@
 /* eslint jsx-a11y/no-static-element-interactions:0 */
 import React from 'react';
 import { bool, number } from 'prop-types';
-import { Scrollbars } from 'react-custom-scrollbars';
+import { Scrollbars } from 'react-custom-scrollbars-2';
 
 import SuggestionList from './SuggestionList';
 

--- a/packages/ffe-account-selector-react/src/subcomponents/suggestion/SuggestionListContainer.js
+++ b/packages/ffe-account-selector-react/src/subcomponents/suggestion/SuggestionListContainer.js
@@ -1,7 +1,7 @@
 /* eslint jsx-a11y/no-static-element-interactions:0 */
 import React from 'react';
 import { bool, number } from 'prop-types';
-import { Scrollbars } from 'react-custom-scrollbars';
+import { Scrollbars } from 'react-custom-scrollbars-2';
 
 import SuggestionList from './SuggestionList';
 

--- a/packages/ffe-searchable-dropdown-react/package.json
+++ b/packages/ffe-searchable-dropdown-react/package.json
@@ -34,7 +34,7 @@
         "compute-scroll-into-view": "^1.0.17",
         "lodash.isequal": "^4.5.0",
         "prop-types": "^15.7.2",
-        "react-custom-scrollbars": "^4.2.1",
+        "react-custom-scrollbars-2": "^4.3.0",
         "react-virtualized": "^9.22.3",
         "uuid": "^9.0.0"
     },

--- a/packages/ffe-searchable-dropdown-react/src/HighCapacityResults.js
+++ b/packages/ffe-searchable-dropdown-react/src/HighCapacityResults.js
@@ -5,7 +5,7 @@ import {
     AutoSizer,
 } from 'react-virtualized';
 import React from 'react';
-import { Scrollbars } from 'react-custom-scrollbars';
+import { Scrollbars } from 'react-custom-scrollbars-2';
 import {
     arrayOf,
     any,

--- a/packages/ffe-searchable-dropdown-react/src/Results.js
+++ b/packages/ffe-searchable-dropdown-react/src/Results.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Scrollbars } from 'react-custom-scrollbars';
+import { Scrollbars } from 'react-custom-scrollbars-2';
 import {
     arrayOf,
     any,


### PR DESCRIPTION
Erstatter `react-custom-scrollbars` med `react-custom-scrollbars-2`.

Pakken `react-custom-scrollbars` blir brukt av searchable dropdown og account selector for å få en scrollbar på den dropdown med resultatene. Det virker som `react-custom-scrollbars` ikke blir videreutviklet, og pakken er låst til React 16 som peer dependency. Dette blir et problem når man ønsker å bruke searchable dropdown eller account selector sammen med React 17 eller nyere. Se issue #1511.

Denne PR tar i bruk `react-custom-scrollbars-2` som er en fork av nevnt pakke. Den har samme funksjonalitet og burde fungere som drop in replacement.