### PR TITLE
fix(ffe-file-upload-react): send correct argument to onFileDeleted() and improve type signatures

### DIFF
--- a/component-overview/examples/file-upload/FileUpload-with-xhr.jsx
+++ b/component-overview/examples/file-upload/FileUpload-with-xhr.jsx
@@ -59,11 +59,11 @@ import { InputGroup, Input, Checkbox } from '@sb1/ffe-form-react';
         }
     };
 
-    const deleteAttachement = fileName => {
-        sendDeleteRequest('/delete', fileName);
+    const deleteAttachement = file => {
+        sendDeleteRequest('/delete', file);
         setAttachments(prevState => {
             const { ...nextState } = prevState;
-            delete nextState[fileName];
+            delete nextState[file.name];
             return nextState;
         });
     };
@@ -97,8 +97,8 @@ import { InputGroup, Input, Checkbox } from '@sb1/ffe-form-react';
                         uploadAttachments(dragEvent.dataTransfer.files);
                     }
                 }}
-                onFileDeleted={evt =>
-                    deleteAttachement(evt.target.id)
+                onFileDeleted={file =>
+                    deleteAttachement(file)
                 }
                 multiple={true}
             />

--- a/packages/ffe-file-upload-react/src/FileUpload.js
+++ b/packages/ffe-file-upload-react/src/FileUpload.js
@@ -60,7 +60,6 @@ class FileUpload extends React.Component {
             uploadTitle,
             uploadMicroText,
             uploadSubText,
-            onFileDeleted,
         } = this.props;
 
         return (
@@ -74,7 +73,7 @@ class FileUpload extends React.Component {
                                 file={files[file]}
                                 cancelText={cancelText}
                                 deleteText={deleteText}
-                                onFileDeleted={onFileDeleted}
+                                onFileDeleted={this.onFileDeleted}
                             />
                         ))}
                     </div>

--- a/packages/ffe-file-upload-react/src/index.d.ts
+++ b/packages/ffe-file-upload-react/src/index.d.ts
@@ -1,18 +1,18 @@
 import * as React from 'react';
 
-export interface FileItem {
+export interface FileItem<T> {
     name: string;
-    document?: File;
+    document?: T;
     error?: string;
 }
 
-export interface FileUploadProps {
+export interface FileUploadProps<T> {
     id: string;
     label: string;
-    files: Record<string, FileItem>;
+    files: Record<string, FileItem<T>>;
     onFilesSelected(fileList: FileList): void;
     onFilesDropped(fileList: FileList): void;
-    onFileDeleted(file: File): void;
+    onFileDeleted(file: FileItem<T>): void;
     multiple?: boolean;
     title: string;
     infoText: string;
@@ -23,9 +23,9 @@ export interface FileUploadProps {
     uploadMicroText: string;
     uploadSubText: string;
 }
-declare class FileUpload extends React.Component<FileUploadProps, any> {}
+declare class FileUpload<T> extends React.Component<FileUploadProps<T>, any> {}
 
-declare function getFileContent(file: File): Promise<any>;
+declare function getFileContent(file: File): Promise<string>;
 
 export default FileUpload;
 export { getFileContent };


### PR DESCRIPTION
## Beskrivelse

`onFileDeleted(file)` kalles nå med `FileItem` i stedet for `MouseEvent`. Dette ser ut til å være tiltenkt oppførsel og er mye nærmere den påståtte typedefinisjonen `onFileDeleted(file: File): void` i `index.d.ts`. I tillegg er `FileEvent.document` gjort generisk, slik at eksempelet i `FileUpload-with-xhr.jsx` blir gyldig.

## Motivasjon og kontekst

Oppdaget at `onFileDeleted(file)` ble kalt med `MouseEvent` i stedet for `File` og at det i `FileUpload.js` var en ubrukt `onFileDeleted(event)`. Riktignok mappet den funksjonen om fra `MouseEvent` til `FileItem`, så her var det full forvirring av typer.

## Testing

Har testet lokalt med `FileUpload-with-xhr.jsx` og ved å dra inn ny kode i et annet prosjekt.
