### PR TITLE
feat(ffe-account-selector-react): legger til theming av accountselector

### DIFF
--- a/packages/ffe-account-selector-react/less/account-suggestion-multi.less
+++ b/packages/ffe-account-selector-react/less/account-suggestion-multi.less
@@ -1,10 +1,10 @@
 .highlighted() {
-    background: @ffe-farge-vann;
-    color: @ffe-farge-hvit;
+    background: var(--ffe-g-primary-color);
+    color: var(--ffe-v-accountselector-option-primary-color);
 
     .ffe-account-suggestion-multi__details,
     .ffe-account-suggestion-multi__name {
-        color: @ffe-farge-hvit;
+        color: var(--ffe-v-accountselector-option-primary-color);
     }
 }
 
@@ -16,7 +16,7 @@
 
 .ffe-account-suggestion-multi {
     margin: 0;
-    background: @ffe-farge-hvit;
+    background: var(--ffe-v-accountselector-option-primary-color);
     cursor: pointer;
     padding: @ffe-spacing-xs @ffe-spacing-sm @ffe-spacing-xs @ffe-spacing-xs;
     overflow: hidden;
@@ -28,8 +28,8 @@
     }
 
     &__nomatches {
-        background: @ffe-farge-hvit;
-        color: @ffe-farge-vann;
+        background: var(--ffe-v-accountselector-option-primary-color);
+        color: var(--ffe-g-lead-color);
         padding: @ffe-spacing-sm;
         cursor: default;
     }
@@ -39,11 +39,11 @@
         font-size: 1rem;
         display: block;
         padding-bottom: @ffe-spacing-2xs;
-        color: @ffe-farge-fjell;
+        color: var(--ffe-g-lead-color);
     }
 
     &__details {
-        color: @ffe-farge-svart;
+        color: var(--ffe-g-text-color);
         font-size: 0.9rem;
         display: flex;
         justify-content: space-between;
@@ -77,38 +77,9 @@
 .native & {
     @media (prefers-color-scheme: dark) {
         .ffe-account-suggestion-multi {
-            background: @ffe-black-darkmode;
-
-            &__nomatches {
-                background: @ffe-black-darkmode;
-                color: @ffe-white-darkmode;
-            }
-
             &:hover,
             &--highlighted {
-                background: @ffe-farge-vann;
-                color: @ffe-white-darkmode;
-
-                .ffe-account-suggestion-single__details,
-                .ffe-account-suggestion-single__name {
-                    color: @ffe-white-darkmode;
-                }
-            }
-
-            &__name {
-                color: @ffe-white-darkmode;
-            }
-
-            &__details {
-                color: @ffe-grey-cloud-darkmode;
-            }
-        }
-
-        &__select-all {
-            &:hover,
-            &--highlighted {
-                background: @ffe-farge-vann;
-                color: @ffe-white-darkmode;
+                background: var(--ffe-g-primary-color);
             }
         }
     }

--- a/packages/ffe-account-selector-react/less/account-suggestion-single.less
+++ b/packages/ffe-account-selector-react/less/account-suggestion-single.less
@@ -1,17 +1,17 @@
 .ffe-account-suggestion-single {
     margin: 0;
-    background: @ffe-farge-hvit;
+    background: var(--ffe-v-accountselector-option-primary-color);
     cursor: pointer;
     padding: @ffe-spacing-xs @ffe-spacing-sm @ffe-spacing-xs @ffe-spacing-md;
 
     &:hover,
     &--highlighted {
-        background: @ffe-farge-vann;
-        color: @ffe-farge-hvit;
+        background: var(--ffe-g-primary-color);
+        color: var(--ffe-v-accountselector-option-primary-color);
 
         & .ffe-account-suggestion-single__details,
         & .ffe-account-suggestion-single__name {
-            color: @ffe-farge-hvit;
+            color: var(--ffe-v-accountselector-option-primary-color);
         }
     }
 
@@ -20,11 +20,11 @@
         font-size: 1rem;
         display: block;
         padding-bottom: @ffe-spacing-2xs;
-        color: @ffe-farge-fjell;
+        color: var(--ffe-g-lead-color);
     }
 
     &__details {
-        color: @ffe-farge-svart;
+        color: var(--ffe-g-text-color);
         font-size: 0.9rem;
         display: flex;
         justify-content: space-between;
@@ -32,32 +32,5 @@
 
     &:first-child {
         border-top: none;
-    }
-}
-
-.native & {
-    @media (prefers-color-scheme: dark) {
-        .ffe-account-suggestion-single {
-            background: @ffe-black-darkmode;
-
-            &:hover,
-            &--highlighted {
-                background: @ffe-farge-vann;
-                color: @ffe-white-darkmode;
-
-                .ffe-account-suggestion-single__details,
-                .ffe-account-suggestion-single__name {
-                    color: @ffe-white-darkmode;
-                }
-            }
-
-            &__name {
-                color: @ffe-white-darkmode;
-            }
-
-            &__details {
-                color: @ffe-grey-cloud-darkmode;
-            }
-        }
     }
 }

--- a/packages/ffe-account-selector-react/less/base-selector.less
+++ b/packages/ffe-account-selector-react/less/base-selector.less
@@ -25,26 +25,14 @@
         cursor: pointer;
 
         &-icon {
-            fill: @ffe-farge-vann;
+            fill: var(--ffe-g-primary-color);
             display: block;
             width: 17px;
             height: 17px;
-
-            .native & {
-                @media (prefers-color-scheme: dark) {
-                    fill: @ffe-farge-vann-70;
-                }
-            }
         }
 
         &-icon--invalid {
-            fill: @ffe-farge-baer;
-
-            .native & {
-                @media (prefers-color-scheme: dark) {
-                    fill: @ffe-farge-baer;
-                }
-            }
+            fill: var(--ffe-g-error-color);
         }
     }
 
@@ -56,7 +44,7 @@
         right: 35px;
         background: transparent;
         border: none;
-        fill: @ffe-farge-vann;
+        fill: var(--ffe-g-primary-color);
         cursor: pointer;
 
         &-icon {
@@ -67,15 +55,14 @@
     }
 
     &__suggestion-container {
-        @border: 1px solid @ffe-farge-varmgraa;
         z-index: 100;
         position: absolute;
         left: 0;
         right: 0;
-        border: @border;
+        border: 1px solid var(--ffe-g-border-color);
         border-radius: 2px;
-        background: @ffe-farge-hvit;
-        font-family: 'SpareBank1-regular', 'MuseoSans-500', arial, sans-serif;
+        background: var(--ffe-v-accountselector-option-primary-color);
+        font-family: var(--ffe-g-font);
         &-list {
             left: 0;
             width: 100%;

--- a/packages/ffe-account-selector-react/less/ffe-account-selector-multi.less
+++ b/packages/ffe-account-selector-react/less/ffe-account-selector-multi.less
@@ -21,37 +21,25 @@
 
     &__details {
         padding: @ffe-spacing-2xs;
-        color: @ffe-farge-svart;
+        color: var(--ffe-v-accountselector-text-color);
         min-height: @details-height;
         display: flex;
         justify-content: space-between;
-
-        .native & {
-            @media (prefers-color-scheme: dark) {
-                color: @ffe-white-darkmode;
-            }
-        }
     }
 
     &__dropdown-statusbar {
-        border: 1px solid @ffe-farge-varmgraa;
+        border: 1px solid var(--ffe-g-border-color);
         padding: @ffe-spacing-xs;
-        background: @ffe-farge-lysgraa;
-        color: @ffe-farge-svart;
+        background: var(
+            --ffe-v-accountselector-dropdown-statusbar-background-color
+        );
+        color: var(--ffe-v-accountselector-text-color);
         height: 60px;
         display: table;
         width: 100%;
         border-bottom-left-radius: 2px;
         border-bottom-right-radius: 2px;
-        font-family: 'SpareBank1-regular', 'MuseoSans-500', arial, sans-serif;
-
-        .native & {
-            @media (prefers-color-scheme: dark) {
-                border-color: @ffe-farge-graa;
-                background: @ffe-black-darkmode;
-                color: @ffe-white-darkmode;
-            }
-        }
+        font-family: var(--ffe-g-font);
     }
 
     &__selection-status {

--- a/packages/ffe-account-selector-react/less/ffe-account-selector-single.less
+++ b/packages/ffe-account-selector-react/less/ffe-account-selector-single.less
@@ -20,15 +20,9 @@
 
     &__details {
         padding: @ffe-spacing-2xs;
-        color: @ffe-farge-svart;
+        color: var(--ffe-v-accountselector-text-color);
         min-height: @details-height;
         display: flex;
         justify-content: space-between;
-
-        .native & {
-            @media (prefers-color-scheme: dark) {
-                color: @ffe-white-darkmode;
-            }
-        }
     }
 }

--- a/packages/ffe-account-selector-react/less/ffe-account-selector.less
+++ b/packages/ffe-account-selector-react/less/ffe-account-selector.less
@@ -1,3 +1,4 @@
+@import 'theme';
 @import 'base-selector';
 @import 'ffe-account-selector-single';
 @import 'ffe-account-selector-multi';

--- a/packages/ffe-account-selector-react/less/theme.less
+++ b/packages/ffe-account-selector-react/less/theme.less
@@ -1,0 +1,19 @@
+:root {
+    --ffe-v-accountselector-text-color: var(--ffe-farge-svart);
+    --ffe-v-accountselector-dropdown-statusbar-background-color: var(
+        --ffe-farge-lysgraa
+    );
+    --ffe-v-accountselector-option-primary-color: var(--ffe-farge-hvit);
+
+    @media (prefers-color-scheme: dark) {
+        .native {
+            --ffe-v-accountselector-text-color: var(--ffe-farge-hvit);
+            --ffe-v-accountselector-dropdown-statusbar-background-color: var(
+                --ffe-farge-svart
+            );
+            --ffe-v-accountselector-option-primary-color: var(
+                --ffe-farge-svart
+            );
+        }
+    }
+}


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse
Legger til theming i Accountselector og gjør noen justeringer på farger.
Blant annet blir highlight/hover fargen på options nå Vann-70 med sort tekst sånn som det er i andre komponenter. Har også gått vekk fra utdaterte farger og erstattet de med tilsvarende farger i ny palett. 

Ny: 
![Skjermbilde 2022-11-15 kl  14 42 23](https://user-images.githubusercontent.com/39946146/202137453-a54a4c6d-3d43-4c43-a5bc-166140d3e2c8.png)

Gammel:
![Skjermbilde 2022-11-15 kl  14 42 50](https://user-images.githubusercontent.com/39946146/202137486-a8802529-49e0-444b-9341-47d581276215.png)

<!-- Detaljert beskrivelse av endringene dine. Skjermskudd er lov. -->

## Motivasjon og kontekst

<!-- Hvorfor trengs denne endringen, og hva løser den? -->

## Testing
Kjørt opp lokalt 
<!-- Hvordan har du har testet endringene dine? Ta gjerne med systeminfo o.l -->

<!--

Helt til slutt, har du ..

.. lest retningslinjene våre for bidrag?
.. tatt en siste sjekk for kode og skrivefeil, debug informasjon o.l?
.. kjørt og eventuelt oppdatert testene?
.. kommentert og dokumentert det som trengs?
.. knyttet denne opp til relaterte issues?

-->
