### PR TITLE
fix(ffe-core): spacing-variabler i overskrifter

### DIFF
--- a/packages/ffe-core/less/typography.less
+++ b/packages/ffe-core/less/typography.less
@@ -194,7 +194,7 @@
 .ffe-h6 {
     color: var(--ffe-g-heading-color);
     font-weight: normal;
-    margin-bottom: 10px;
+    margin-bottom: @ffe-spacing-xs;
     margin-top: 0;
 
     &--error {
@@ -211,7 +211,7 @@
 
     &--with-border {
         border-bottom: 1px solid @ffe-farge-lysgraa;
-        padding-bottom: 10px;
+        padding-bottom: @ffe-spacing-xs;
         .native & {
             @media (prefers-color-scheme: dark) {
                 border-color: @ffe-farge-graa;
@@ -416,7 +416,7 @@
     .ffe-h4,
     .ffe-h5,
     .ffe-h6 {
-        margin-bottom: 15px;
+        margin-bottom: @ffe-spacing-sm;
 
         &--no-margin {
             margin: 0;
@@ -452,7 +452,7 @@
     .ffe-h4,
     .ffe-h5,
     .ffe-h6 {
-        margin-bottom: 20px;
+        margin-bottom: @ffe-spacing-md;
 
         &--no-margin {
             margin: 0;


### PR DESCRIPTION
erstatter hardkodet margin og padding i overskriftene med felles spacing-variabler

* 10px --> `@ffe-spacing-xs` (8px)
* 15px --> `@ffe-spacing-sm` (16px)
* 20px --> `@ffe-spacing-md` (24px)
