### PR TITLE
Fjern interne pakker fra peerDependencies

### DIFF
--- a/packages/ffe-accordion-react/package.json
+++ b/packages/ffe-accordion-react/package.json
@@ -24,6 +24,7 @@
         "test:watch": "ffe-buildtool jest --watch"
     },
     "dependencies": {
+        "@sb1/ffe-accordion": "^8.2.0",
         "@sb1/ffe-collapse-react": "^1.1.15",
         "@sb1/ffe-icons-react": "^7.3.4",
         "classnames": "^2.3.1",
@@ -36,7 +37,6 @@
         "react-dom": "^16.9.0"
     },
     "peerDependencies": {
-        "@sb1/ffe-accordion": "*",
         "react": ">=16.9.0"
     },
     "publishConfig": {

--- a/packages/ffe-accordion/package.json
+++ b/packages/ffe-accordion/package.json
@@ -15,12 +15,11 @@
         "lint": "ffe-buildtool stylelint less/*.less",
         "test": "npm run lint"
     },
-    "devDependencies": {
-        "@sb1/ffe-buildtool": "^0.5.0",
+    "dependencies": {
         "@sb1/ffe-core": "^26.1.1"
     },
-    "peerDependencies": {
-        "@sb1/ffe-core": "*"
+    "devDependencies": {
+        "@sb1/ffe-buildtool": "^0.5.0"
     },
     "publishConfig": {
         "access": "public"

--- a/packages/ffe-account-selector-react/package.json
+++ b/packages/ffe-account-selector-react/package.json
@@ -29,6 +29,7 @@
         "test:watch": "ffe-buildtool jest --watch"
     },
     "dependencies": {
+        "@sb1/ffe-form": "^22.0.3",
         "@sb1/ffe-form-react": "^10.1.0",
         "@sb1/ffe-formatters": "^4.0.11",
         "@sb1/ffe-icons-react": "^7.3.4",
@@ -47,8 +48,6 @@
         "react-dom": "^16.9.0"
     },
     "peerDependencies": {
-        "@sb1/ffe-form": "*",
-        "@sb1/ffe-spinner": "*",
         "react": ">=16.9.0"
     },
     "publishConfig": {

--- a/packages/ffe-buttons-react/package.json
+++ b/packages/ffe-buttons-react/package.json
@@ -28,6 +28,7 @@
         "test:watch": "ffe-buildtool jest --watch"
     },
     "dependencies": {
+        "@sb1/ffe-buttons": "^16.1.1",
         "@sb1/ffe-icons-react": "^7.3.4",
         "classnames": "^2.3.1",
         "prop-types": "^15.7.2"
@@ -40,7 +41,6 @@
         "react-dom": "^16.9.0"
     },
     "peerDependencies": {
-        "@sb1/ffe-buttons": "*",
         "react": ">=16.9.0"
     },
     "publishConfig": {

--- a/packages/ffe-buttons/package.json
+++ b/packages/ffe-buttons/package.json
@@ -14,12 +14,11 @@
         "lint": "ffe-buildtool stylelint less/*.less",
         "test": "npm run lint"
     },
-    "devDependencies": {
-        "@sb1/ffe-buildtool": "^0.5.0",
+    "dependencies": {
         "@sb1/ffe-core": "^26.1.1"
     },
-    "peerDependencies": {
-        "@sb1/ffe-core": "*"
+    "devDependencies": {
+        "@sb1/ffe-buildtool": "^0.5.0"
     },
     "publishConfig": {
         "access": "public"

--- a/packages/ffe-cards-react/package.json
+++ b/packages/ffe-cards-react/package.json
@@ -25,6 +25,7 @@
         "test:watch": "ffe-buildtool jest --watch"
     },
     "dependencies": {
+        "@sb1/ffe-cards": "^14.1.0",
         "prop-types": "^15.7.2"
     },
     "devDependencies": {
@@ -34,7 +35,6 @@
         "react-dom": "^16.9.0"
     },
     "peerDependencies": {
-        "@sb1/ffe-cards": "*",
         "react": ">=16.9.0"
     },
     "publishConfig": {

--- a/packages/ffe-cards/package.json
+++ b/packages/ffe-cards/package.json
@@ -15,12 +15,11 @@
         "lint": "ffe-buildtool stylelint less/*.less",
         "test": "npm run lint"
     },
-    "devDependencies": {
-        "@sb1/ffe-buildtool": "^0.5.0",
+    "dependencies": {
         "@sb1/ffe-core": "^26.1.1"
     },
-    "peerDependencies": {
-        "@sb1/ffe-core": "*"
+    "devDependencies": {
+        "@sb1/ffe-buildtool": "^0.5.0"
     },
     "publishConfig": {
         "access": "public"

--- a/packages/ffe-collapse-react/package.json
+++ b/packages/ffe-collapse-react/package.json
@@ -29,6 +29,7 @@
         "test:watch": "ffe-buildtool jest --watch"
     },
     "dependencies": {
+        "@sb1/ffe-core": "^26.1.0",
         "classnames": "^2.3.1"
     },
     "devDependencies": {
@@ -39,7 +40,6 @@
         "react-dom": "^16.9.0"
     },
     "peerDependencies": {
-        "@sb1/ffe-core": "*",
         "react": ">=16.9.0"
     },
     "publishConfig": {

--- a/packages/ffe-context-message-react/package.json
+++ b/packages/ffe-context-message-react/package.json
@@ -28,6 +28,7 @@
         "test:watch": "ffe-buildtool jest --watch"
     },
     "dependencies": {
+        "@sb1/ffe-context-message": "^6.1.1",
         "@sb1/ffe-icons-react": "^7.3.4",
         "classnames": "^2.3.1",
         "prop-types": "^15.7.2",
@@ -39,7 +40,6 @@
         "react-dom": "^16.9.0"
     },
     "peerDependencies": {
-        "@sb1/ffe-context-message": "*",
         "react": ">=16.9.0"
     },
     "publishConfig": {

--- a/packages/ffe-context-message/package.json
+++ b/packages/ffe-context-message/package.json
@@ -18,12 +18,11 @@
         "lint": "ffe-buildtool stylelint less/*.less",
         "test": "npm run lint"
     },
-    "devDependencies": {
-        "@sb1/ffe-buildtool": "^0.5.0",
+    "dependencies": {
         "@sb1/ffe-core": "^26.1.1"
     },
-    "peerDependencies": {
-        "@sb1/ffe-core": "*"
+    "devDependencies": {
+        "@sb1/ffe-buildtool": "^0.5.0"
     },
     "publishConfig": {
         "access": "public"

--- a/packages/ffe-core-react/package.json
+++ b/packages/ffe-core-react/package.json
@@ -28,6 +28,7 @@
         "test:watch": "ffe-buildtool jest --watch"
     },
     "dependencies": {
+        "@sb1/ffe-core": "^26.1.0",
         "classnames": "^2.3.1",
         "prop-types": "^15.7.2"
     },
@@ -38,7 +39,6 @@
         "react-dom": "^16.9.0"
     },
     "peerDependencies": {
-        "@sb1/ffe-core": "*",
         "react": ">=16.9.0"
     },
     "publishConfig": {

--- a/packages/ffe-datepicker-react/package.json
+++ b/packages/ffe-datepicker-react/package.json
@@ -25,6 +25,7 @@
     },
     "dependencies": {
         "@sb1/ffe-datepicker": "^10.1.2",
+        "@sb1/ffe-form": "^22.0.3",
         "@sb1/ffe-icons-react": "^7.3.4",
         "classnames": "^2.3.1",
         "lodash.debounce": "^4.0.8",

--- a/packages/ffe-datepicker/package.json
+++ b/packages/ffe-datepicker/package.json
@@ -15,14 +15,12 @@
         "lint": "ffe-buildtool stylelint less/*.less",
         "test": "npm run lint"
     },
-    "devDependencies": {
-        "@sb1/ffe-buildtool": "^0.5.0",
+    "dependencies": {
         "@sb1/ffe-core": "^26.1.1",
         "@sb1/ffe-form": "^22.0.5"
     },
-    "peerDependencies": {
-        "@sb1/ffe-core": "*",
-        "@sb1/ffe-form": "*"
+    "devDependencies": {
+        "@sb1/ffe-buildtool": "^0.5.0"
     },
     "publishConfig": {
         "access": "public"

--- a/packages/ffe-details-list-react/package.json
+++ b/packages/ffe-details-list-react/package.json
@@ -24,18 +24,16 @@
         "test:watch": "ffe-buildtool jest --watch"
     },
     "dependencies": {
+        "@sb1/ffe-grid": "^13.0.9",
+        "@sb1/ffe-grid-react": "^12.0.3",
         "classnames": "^2.3.1"
     },
     "devDependencies": {
         "@sb1/ffe-buildtool": "^0.5.0",
-        "@sb1/ffe-grid": "^13.0.9",
-        "@sb1/ffe-grid-react": "^12.0.3",
         "react": "^16.9.0",
         "react-dom": "^16.9.0"
     },
     "peerDependencies": {
-        "@sb1/ffe-grid": "*",
-        "@sb1/ffe-grid-react": "*",
         "react": ">=16.9.0"
     },
     "publishConfig": {

--- a/packages/ffe-dropdown-react/package.json
+++ b/packages/ffe-dropdown-react/package.json
@@ -24,6 +24,7 @@
         "test:watch": "ffe-buildtool jest --watch"
     },
     "dependencies": {
+        "@sb1/ffe-form": "^22.0.3",
         "classnames": "^2.3.1"
     },
     "devDependencies": {
@@ -33,7 +34,6 @@
         "react-dom": "^16.9.0"
     },
     "peerDependencies": {
-        "@sb1/ffe-form": "*",
         "react": ">=16.9.0"
     },
     "publishConfig": {

--- a/packages/ffe-file-upload-react/package.json
+++ b/packages/ffe-file-upload-react/package.json
@@ -29,6 +29,8 @@
     },
     "dependencies": {
         "@sb1/ffe-buttons-react": "^16.0.7",
+        "@sb1/ffe-file-upload": "^7.1.0",
+        "@sb1/ffe-form": "^22.0.3",
         "@sb1/ffe-icons-react": "^7.3.4",
         "classnames": "^2.3.1"
     },
@@ -38,8 +40,6 @@
         "react-dom": "^16.9.0"
     },
     "peerDependencies": {
-        "@sb1/ffe-core": "*",
-        "@sb1/ffe-form": "*",
         "react": ">=16.9.0"
     },
     "publishConfig": {

--- a/packages/ffe-file-upload/package.json
+++ b/packages/ffe-file-upload/package.json
@@ -15,13 +15,12 @@
         "lint": "ffe-buildtool stylelint less/*.less",
         "test": "npm run lint"
     },
-    "devDependencies": {
-        "@sb1/ffe-buildtool": "^0.5.0",
-        "@sb1/ffe-core": "^26.1.1"
+    "dependencies": {
+        "@sb1/ffe-core": "^26.1.1",
+        "@sb1/ffe-form": "^22.0.4"
     },
-    "peerDependencies": {
-        "@sb1/ffe-core": "*",
-        "@sb1/ffe-form": "*"
+    "devDependencies": {
+        "@sb1/ffe-buildtool": "^0.5.0"
     },
     "publishConfig": {
         "access": "public"

--- a/packages/ffe-form-react/package.json
+++ b/packages/ffe-form-react/package.json
@@ -26,6 +26,7 @@
     },
     "dependencies": {
         "@sb1/ffe-collapse-react": "^1.1.15",
+        "@sb1/ffe-form": "^22.0.3",
         "classnames": "^2.3.1",
         "uuid": "^9.0.0"
     },
@@ -38,8 +39,6 @@
         "sinon": "^7.2.3"
     },
     "peerDependencies": {
-        "@sb1/ffe-core": "*",
-        "@sb1/ffe-form": "*",
         "react": ">=16.9.0"
     },
     "publishConfig": {

--- a/packages/ffe-form/package.json
+++ b/packages/ffe-form/package.json
@@ -15,14 +15,12 @@
         "lint": "ffe-buildtool stylelint less/*.less",
         "test": "npm run lint"
     },
-    "devDependencies": {
-        "@sb1/ffe-buildtool": "^0.5.0",
+    "dependencies": {
         "@sb1/ffe-buttons": "^16.1.3",
         "@sb1/ffe-core": "^26.1.1"
     },
-    "peerDependencies": {
-        "@sb1/ffe-buttons": "*",
-        "@sb1/ffe-core": "*"
+    "devDependencies": {
+        "@sb1/ffe-buildtool": "^0.5.0"
     },
     "publishConfig": {
         "access": "public"

--- a/packages/ffe-grid-react/package.json
+++ b/packages/ffe-grid-react/package.json
@@ -24,6 +24,7 @@
         "test:watch": "ffe-buildtool jest --watch"
     },
     "dependencies": {
+        "@sb1/ffe-grid": "^13.0.8",
         "classnames": "^2.3.1"
     },
     "devDependencies": {
@@ -32,7 +33,6 @@
         "react-dom": "^16.9.0"
     },
     "peerDependencies": {
-        "@sb1/ffe-grid": "*",
         "react": ">=16.9.0"
     },
     "publishConfig": {

--- a/packages/ffe-grid/package.json
+++ b/packages/ffe-grid/package.json
@@ -18,12 +18,11 @@
         "lint": "ffe-buildtool stylelint less/*.less",
         "test": "npm run lint"
     },
-    "devDependencies": {
-        "@sb1/ffe-buildtool": "^0.5.0",
+    "dependencies": {
         "@sb1/ffe-core": "^26.1.1"
     },
-    "peerDependencies": {
-        "@sb1/ffe-core": "*"
+    "devDependencies": {
+        "@sb1/ffe-buildtool": "^0.5.0"
     },
     "publishConfig": {
         "access": "public"

--- a/packages/ffe-header/package.json
+++ b/packages/ffe-header/package.json
@@ -26,10 +26,6 @@
         "less": "^4.1.2",
         "less-plugin-autoprefix": "^2.0.0"
     },
-    "peerDependencies": {
-        "@sb1/ffe-buttons": "*",
-        "@sb1/ffe-core": "*"
-    },
     "publishConfig": {
         "access": "public"
     }

--- a/packages/ffe-lists-react/package.json
+++ b/packages/ffe-lists-react/package.json
@@ -26,6 +26,7 @@
     },
     "dependencies": {
         "@sb1/ffe-icons-react": "^7.3.4",
+        "@sb1/ffe-lists": "^11.1.0",
         "classnames": "^2.3.1",
         "prop-types": "^15.7.2"
     },
@@ -35,7 +36,6 @@
         "react-dom": "^16.9.0"
     },
     "peerDependencies": {
-        "@sb1/ffe-lists": "*",
         "react": ">=16.9.0"
     },
     "publishConfig": {

--- a/packages/ffe-lists/package.json
+++ b/packages/ffe-lists/package.json
@@ -15,12 +15,11 @@
         "lint": "ffe-buildtool stylelint less/*.less",
         "test": "npm run lint"
     },
-    "devDependencies": {
-        "@sb1/ffe-buildtool": "^0.5.0",
+    "dependencies": {
         "@sb1/ffe-core": "^26.1.1"
     },
-    "peerDependencies": {
-        "@sb1/ffe-core": "*"
+    "devDependencies": {
+        "@sb1/ffe-buildtool": "^0.5.0"
     },
     "publishConfig": {
         "access": "public"

--- a/packages/ffe-message-box-react/package.json
+++ b/packages/ffe-message-box-react/package.json
@@ -25,6 +25,7 @@
     },
     "dependencies": {
         "@sb1/ffe-icons-react": "^7.3.4",
+        "@sb1/ffe-message-box": "^10.2.1",
         "classnames": "^2.3.1"
     },
     "devDependencies": {
@@ -35,7 +36,6 @@
         "react-dom": "^16.9.0"
     },
     "peerDependencies": {
-        "@sb1/ffe-message-box": "*",
         "react": ">=16.9.0"
     },
     "publishConfig": {

--- a/packages/ffe-message-box/package.json
+++ b/packages/ffe-message-box/package.json
@@ -15,11 +15,11 @@
         "lint": "ffe-buildtool stylelint less/*.less",
         "test": "npm run lint"
     },
+    "dependencies": {
+        "@sb1/ffe-core": "^26.1.0"
+    },
     "devDependencies": {
         "@sb1/ffe-buildtool": "^0.5.0"
-    },
-    "peerDependencies": {
-        "@sb1/ffe-core": "*"
     },
     "publishConfig": {
         "access": "public"

--- a/packages/ffe-searchable-dropdown-react/src/SearchableDropdown.js
+++ b/packages/ffe-searchable-dropdown-react/src/SearchableDropdown.js
@@ -169,13 +169,11 @@ const SearchableDropdown = ({
     }, [dropdownList, dispatch]);
 
     useEffect(() => {
-        if (state.isExpanded && typeof onOpen === 'function') {
-            onOpen();
+        const cb = state.isExpanded ? onOpen : onClose;
+        if (cb) {
+            cb();
         }
-        if (!state.isExpanded && typeof onClose === 'function') {
-            onClose();
-        }
-    }, [state.isExpanded]);
+    }, [state.isExpanded, onOpen, onClose]);
 
     /**
      * Because of changes in event handling between react v16 and v17, the check for the

--- a/packages/ffe-spinner-react/package.json
+++ b/packages/ffe-spinner-react/package.json
@@ -24,6 +24,7 @@
         "test:watch": "ffe-buildtool jest --watch"
     },
     "dependencies": {
+        "@sb1/ffe-spinner": "^4.2.0",
         "prop-types": "^15.7.2"
     },
     "devDependencies": {
@@ -32,7 +33,6 @@
         "react-dom": "^16.9.0"
     },
     "peerDependencies": {
-        "@sb1/ffe-spinner": "*",
         "react": ">=16.9.0"
     },
     "publishConfig": {

--- a/packages/ffe-spinner/package.json
+++ b/packages/ffe-spinner/package.json
@@ -14,12 +14,11 @@
         "lint": "ffe-buildtool stylelint less/*.less",
         "test": "npm run lint"
     },
-    "devDependencies": {
-        "@sb1/ffe-buildtool": "^0.5.0",
+    "dependencies": {
         "@sb1/ffe-core": "^26.1.1"
     },
-    "peerDependencies": {
-        "@sb1/ffe-core": "*"
+    "devDependencies": {
+        "@sb1/ffe-buildtool": "^0.5.0"
     },
     "publishConfig": {
         "access": "public"

--- a/packages/ffe-system-message-react/package.json
+++ b/packages/ffe-system-message-react/package.json
@@ -25,6 +25,8 @@
     },
     "dependencies": {
         "@sb1/ffe-grid-react": "^12.0.3",
+        "@sb1/ffe-icons-react": "^7.3.4",
+        "@sb1/ffe-system-message": "^6.3.1",
         "classnames": "^2.3.1",
         "prop-types": "^15.7.2"
     },
@@ -35,8 +37,6 @@
         "react-dom": "^16.9.0"
     },
     "peerDependencies": {
-        "@sb1/ffe-icons-react": "*",
-        "@sb1/ffe-system-message": "*",
         "react": ">=16.9.0"
     },
     "publishConfig": {

--- a/packages/ffe-system-message/package.json
+++ b/packages/ffe-system-message/package.json
@@ -15,12 +15,11 @@
         "lint": "ffe-buildtool stylelint less/*.less",
         "test": "npm run lint"
     },
-    "devDependencies": {
-        "@sb1/ffe-buildtool": "^0.5.0",
+    "dependencies": {
         "@sb1/ffe-core": "^26.1.1"
     },
-    "peerDependencies": {
-        "@sb1/ffe-core": "*"
+    "devDependencies": {
+        "@sb1/ffe-buildtool": "^0.5.0"
     },
     "publishConfig": {
         "access": "public"

--- a/packages/ffe-tables-react/package.json
+++ b/packages/ffe-tables-react/package.json
@@ -26,6 +26,7 @@
     },
     "dependencies": {
         "@sb1/ffe-icons-react": "^7.3.4",
+        "@sb1/ffe-tables": "^12.1.0",
         "classnames": "^2.3.1",
         "deep-equal": "^1.0.1",
         "memoize-one": "^5.0.0",
@@ -40,7 +41,6 @@
         "sinon": "^7.2.3"
     },
     "peerDependencies": {
-        "@sb1/ffe-tables": "*",
         "react": ">=16.9.0"
     },
     "publishConfig": {

--- a/packages/ffe-tables/package.json
+++ b/packages/ffe-tables/package.json
@@ -14,12 +14,11 @@
         "lint": "ffe-buildtool stylelint less/*.less",
         "test": "npm run lint"
     },
-    "devDependencies": {
-        "@sb1/ffe-buildtool": "^0.5.0",
+    "dependencies": {
         "@sb1/ffe-core": "^26.1.1"
     },
-    "peerDependencies": {
-        "@sb1/ffe-core": "*"
+    "devDependencies": {
+        "@sb1/ffe-buildtool": "^0.5.0"
     },
     "publishConfig": {
         "access": "public"

--- a/packages/ffe-tabs-react/package.json
+++ b/packages/ffe-tabs-react/package.json
@@ -24,6 +24,7 @@
         "test:watch": "ffe-buildtool jest --watch"
     },
     "dependencies": {
+        "@sb1/ffe-tabs": "^12.1.0",
         "classnames": "^2.3.1",
         "prop-types": "^15.7.2"
     },
@@ -33,8 +34,6 @@
         "react-dom": "^16.9.0"
     },
     "peerDependencies": {
-        "@sb1/ffe-core": "*",
-        "@sb1/ffe-tabs": "*",
         "react": ">=16.9.0"
     },
     "publishConfig": {

--- a/packages/ffe-tabs/package.json
+++ b/packages/ffe-tabs/package.json
@@ -14,12 +14,11 @@
         "lint": "ffe-buildtool stylelint less/*.less",
         "test": "npm run lint"
     },
-    "devDependencies": {
-        "@sb1/ffe-buildtool": "^0.5.0",
+    "dependencies": {
         "@sb1/ffe-core": "^26.1.1"
     },
-    "peerDependencies": {
-        "@sb1/ffe-core": "*"
+    "devDependencies": {
+        "@sb1/ffe-buildtool": "^0.5.0"
     },
     "publishConfig": {
         "access": "public"


### PR DESCRIPTION
Endrer på _peerDependcies_ slik at interne pakker blir "vanlige" dependencies og konsumenter slipper å tenke på hvilke versjoner av styling-pakkene må installeres manuelt.
