### PR TITLE
Overstyrer lenkefarge i meldingsbokser

### DIFF
--- a/packages/ffe-context-message/less/context-message.less
+++ b/packages/ffe-context-message/less/context-message.less
@@ -60,10 +60,31 @@
                 color: var(--ffe-farge-svart);
             }
         }
+    }
 
-        .ffe-link-text:not(:focus) {
-            color: var(--ffe-farge-fjell);
-            border-color: var(--ffe-farge-fjell);
+    .ffe-link-text {
+        border-bottom: 1px solid var(--ffe-v-context-message-link-color);
+        color: var(--ffe-v-context-message-link-color);
+
+        &:hover {
+            border-bottom-color: var(--ffe-v-context-message-link-color-hover);
+            color: var(--ffe-v-context-message-link-color-hover);
+        }
+
+        &:visited {
+            border-bottom-color: var(
+                --ffe-v-context-message-link-color-visited
+            );
+            color: var(--ffe-v-context-message-link-color-visited);
+        }
+
+        &:focus {
+            border-color: var(
+                --ffe-v-context-message-link-color-focus
+            ) !important;
+            background-color: var(--ffe-v-context-message-link-color);
+            box-shadow: 0 0 0 2px var(--ffe-v-context-message-link-color);
+            color: var(--ffe-v-context-message-link-color-focus) !important;
         }
     }
 

--- a/packages/ffe-context-message/less/theme.less
+++ b/packages/ffe-context-message/less/theme.less
@@ -32,6 +32,12 @@
     --ffe-v-context-message-error-bg-color: var(--ffe-farge-baer-30);
     --ffe-v-context-message-error-icon-color: var(--ffe-farge-baer);
 
+    /** Link colors */
+    --ffe-v-context-message-link-color: var(--ffe-farge-vann);
+    --ffe-v-context-message-link-color-hover: var(--ffe-farge-fjell);
+    --ffe-v-context-message-link-color-visited: var(--ffe-farge-lyng);
+    --ffe-v-context-message-link-color-focus: var(--ffe-farge-hvit);
+
     @media (prefers-color-scheme: dark) {
         .native {
             --ffe-v-context-message-icon-bg-color: var(--ffe-farge-svart);

--- a/packages/ffe-message-box/less/message-box.less
+++ b/packages/ffe-message-box/less/message-box.less
@@ -1,26 +1,3 @@
-// Message box
-//
-// Markup:
-// <div class="ffe-message-box">
-//     <span class="ffe-message-box__icon ffe-message-box__icon{{modifier_class}}">
-//         <svg focusable="false" viewBox="0 0 200 200" height="150" width="150" style="width: 40px; height: 40px;">
-//             <path d="m96.19,199.99h7.846c7.1536,0,11.308-4.398,11.308-11.805v-102.99c0-7.407-4.1537-11.805-11.308-11.805h-7.846c-7.3844,0-11.769,4.3979-11.769,11.805v103c0.227,7.4054,4.38,11.805,11.765,11.805z"></path>
-//             <path d="M116.5,11.805c0-7.4072-4.15-11.805-11.31-11.805h-10.382c-7.1577,0-11.308,4.3978-11.308,11.805v15.045c0,7.407,3.923,11.342,11.308,11.342h10.385c7.3844,0,11.308-3.935,11.308-11.342v-15.045z"></path>
-//         </svg>
-//     </span>
-//     <div class="ffe-message-box__box ffe-message-box__box{{modifier_class}}">
-//         <div class="ffe-h4 ffe-message-box__title{{modifier_class}}">Betalingen ble gjennomført</div>
-//         <p class="ffe-body-paragraph">Nå er du helt gjeldsfri! Hurra!</p>
-//     </div>
-// </div>
-//
-// --tips      - Helpful tips
-// --info      - Generic info
-// --success   - Success message
-// --error     - Error message
-//
-// Styleguide ffe-message-box
-
 .ffe-message-box {
     text-align: center;
     font-family: var(--ffe-g-font);
@@ -30,6 +7,28 @@
             @media (prefers-color-scheme: dark) {
                 color: var(--ffe-farge-svart);
             }
+        }
+    }
+
+    .ffe-link-text {
+        border-bottom: 1px solid var(--ffe-v-message-box-link-color);
+        color: var(--ffe-v-message-box-link-color);
+
+        &:hover {
+            border-bottom-color: var(--ffe-v-message-box-link-color-hover);
+            color: var(--ffe-v-message-box-link-color-hover);
+        }
+
+        &:visited {
+            border-bottom-color: var(--ffe-v-message-box-link-color-visited);
+            color: var(--ffe-v-message-box-link-color-visited);
+        }
+
+        &:focus {
+            border-color: var(--ffe-v-message-box-link-color-focus) !important;
+            background-color: var(--ffe-v-message-box-link-color);
+            box-shadow: 0 0 0 2px var(--ffe-v-message-box-link-color);
+            color: var(--ffe-v-message-box-link-color-focus) !important;
         }
     }
 

--- a/packages/ffe-message-box/less/theme.less
+++ b/packages/ffe-message-box/less/theme.less
@@ -21,6 +21,12 @@
     --ffe-v-message-box-error-bg-color: var(--ffe-farge-baer-30);
     --ffe-v-message-box-error-icon-color: var(--ffe-farge-baer);
 
+    /** Link colors */
+    --ffe-v-message-box-link-color: var(--ffe-farge-vann);
+    --ffe-v-message-box-link-color-hover: var(--ffe-farge-fjell);
+    --ffe-v-message-box-link-color-visited: var(--ffe-farge-lyng);
+    --ffe-v-message-box-link-color-focus: var(--ffe-farge-hvit);
+
     @media (prefers-color-scheme: dark) {
         .native {
             --ffe-v-message-box-info-bg-color: var(--ffe-farge-vann-30);

--- a/packages/ffe-system-message/less/system-message.less
+++ b/packages/ffe-system-message/less/system-message.less
@@ -32,6 +32,36 @@
     overflow: hidden;
     border-radius: @ffe-spacing-xs;
 
+    &:not(&--news) {
+        .ffe-link-text {
+            border-bottom: 1px solid var(--ffe-v-system-message-link-color);
+            color: var(--ffe-v-system-message-link-color);
+
+            &:hover {
+                border-bottom-color: var(
+                    --ffe-v-system-message-link-color-hover
+                );
+                color: var(--ffe-v-system-message-link-color-hover);
+            }
+
+            &:visited {
+                border-bottom-color: var(
+                    --ffe-v-system-message-link-color-visited
+                );
+                color: var(--ffe-v-system-message-link-color-visited);
+            }
+
+            &:focus {
+                border-color: var(
+                    --ffe-v-system-message-link-color-focus
+                ) !important;
+                background-color: var(--ffe-v-system-message-link-color);
+                box-shadow: 0 0 0 2px var(--ffe-v-system-message-link-color);
+                color: var(--ffe-v-system-message-link-color-focus) !important;
+            }
+        }
+    }
+
     &--error&--coloredbg {
         background-color: var(--ffe-v-system-message-variant-bg-color);
         .native & {

--- a/packages/ffe-system-message/less/theme.less
+++ b/packages/ffe-system-message/less/theme.less
@@ -25,6 +25,12 @@
     --ffe-v-system-message-success-bg-color: var(--ffe-farge-nordlys-30);
     --ffe-v-system-message-news-icon-bg-color: var(--ffe-farge-nordlys-wcag);
 
+    /** Link colors */
+    --ffe-v-system-message-link-color: var(--ffe-farge-vann);
+    --ffe-v-system-message-link-color-hover: var(--ffe-farge-fjell);
+    --ffe-v-system-message-link-color-visited: var(--ffe-farge-lyng);
+    --ffe-v-system-message-link-color-focus: var(--ffe-farge-hvit);
+
     @media (prefers-color-scheme: dark) {
         .native {
             --ffe-v-system-message-info-bg-color: var(--ffe-farge-vann-30);


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse

Overstyrer farger på lenker i alle meldingskomponenter, for å unngå at lenker får default farge i dark mode. Meldingsboksene har lyse bakgrunner, kontrasten mellom tekst og bakgrunn blir derfor ikke god nok når lenkene har de vanlige dark mode-fargene. Unntaket er `SystemNewsMessage`, som har mørk bakgrunn.

## Motivasjon og kontekst

Fixes #1528 

## Testing

Testet lokalt med component-overview