### PR TITLE
fix(ffe-tables-react): onSort ble ikke kalt ved initiell sortering

### DIFF
--- a/packages/ffe-tables-react/src/SortableTable/SortableTable.js
+++ b/packages/ffe-tables-react/src/SortableTable/SortableTable.js
@@ -17,8 +17,19 @@ class SortableTable extends Component {
         };
     }
 
+    sort = (columns, data, sortBy, descending) => {
+        const { onSort } = this.props;
+        const tableData = sortData(columns, data, sortBy, descending);
+        onSort({
+            sortBy,
+            descending,
+            tableData,
+        });
+        return tableData;
+    };
+
     sortTableData = memoize((columns, data, sortBy, descending) =>
-        sortBy ? sortData(columns, data, sortBy, descending) : data,
+        sortBy ? this.sort(columns, data, sortBy, descending) : data,
     );
 
     sortStateHasChanged(nextState) {
@@ -35,32 +46,15 @@ class SortableTable extends Component {
     }
 
     tableHeaderClicked(columnKey) {
-        const { columns, data } = this.props;
+        this.setState(prevState => {
+            const descending =
+                columnKey === prevState.sortBy ? !prevState.descending : false;
 
-        this.setState(
-            (prevState, currentProps) => {
-                const descending =
-                    columnKey === prevState.sortBy
-                        ? !prevState.descending
-                        : false;
-
-                return {
-                    sortBy: columnKey,
-                    descending,
-                };
-            },
-            () =>
-                this.props.onSort({
-                    sortBy: columnKey,
-                    descending: this.state.descending,
-                    tableData: this.sortTableData(
-                        columns,
-                        data,
-                        columnKey,
-                        this.state.descending,
-                    ),
-                }),
-        );
+            return {
+                sortBy: columnKey,
+                descending,
+            };
+        });
     }
 
     handleKeyPress(columnKey, event) {

--- a/packages/ffe-tables-react/src/SortableTable/SortableTable.spec.js
+++ b/packages/ffe-tables-react/src/SortableTable/SortableTable.spec.js
@@ -73,6 +73,26 @@ describe('<SortableTable>', () => {
         );
     });
 
+    it('should call onSort after initial sort', () => {
+        const onSort = spy();
+        shallow(
+            <SortableTable
+                columns={columns}
+                data={data}
+                onSort={onSort}
+                sortBy={'name'}
+            />,
+        );
+        assert.calledWith(
+            onSort,
+            match(val => {
+                return (
+                    'sortBy' in val && 'descending' in val && 'tableData' in val
+                );
+            }),
+        );
+    });
+
     describe('condensed', () => {
         it('should by default not be condensed', () =>
             expect(wrapper.find('.ffe-table--condensed')).toHaveLength(0));


### PR DESCRIPTION
onSort ble bare kalt ved klikk på header, ikke ved initiell sortering av prop sortBy
Dette begrenser nytten av onSort sortBy

## Beskrivelse

Kaller sortBy hver gang innholdet sorteres, i stedet for hver gang header klikkes

## Motivasjon og kontekst

Vi ønsker å bruke sortert tabelldata fra en callback

## Testing

Har skrevet en test for caset