### PR TITLE
Gjør Message-box og ContextMessage tittelen h2 på default

### DIFF
--- a/component-overview/examples/messages/message-box/InfoMessage-titleElement.jsx
+++ b/component-overview/examples/messages/message-box/InfoMessage-titleElement.jsx
@@ -1,0 +1,8 @@
+import { InfoMessage } from '@sb1/ffe-message-box-react';
+import { Paragraph } from '@sb1/ffe-core-react';
+
+<InfoMessage title="Tittelen her er h4" titleElement="h4">
+    <Paragraph>
+        Ved å bruke titleElement propertyen kan man endre HTML-elementet på tittelen.
+    </Paragraph>
+</InfoMessage>

--- a/packages/ffe-context-message-react/src/ContextMessage.js
+++ b/packages/ffe-context-message-react/src/ContextMessage.js
@@ -163,7 +163,7 @@ ContextMessage.propTypes = {
 ContextMessage.defaultProps = {
     animationLengthMs: 300,
     compact: false,
-    headerElement: 'div',
+    headerElement: 'h2',
     locale: 'nb',
     onClose: () => {},
     showCloseButton: false,

--- a/packages/ffe-context-message-react/src/ContextMessage.spec.js
+++ b/packages/ffe-context-message-react/src/ContextMessage.spec.js
@@ -39,7 +39,7 @@ describe('<ContextMessage />', () => {
         );
         expect(headerComponent.exists()).toBe(true);
         expect(headerComponent.text()).toBe('header text');
-        expect(headerComponent.type()).toBe('div');
+        expect(headerComponent.type()).toBe('h2');
     });
 
     it('renders with provided header as given tag', () => {

--- a/packages/ffe-context-message/less/context-message.less
+++ b/packages/ffe-context-message/less/context-message.less
@@ -72,6 +72,8 @@
 
         color: var(--ffe-farge-svart);
         margin-bottom: @ffe-spacing-2xs;
+        margin-top: 0;
+        font-size: var(--ffe-fontsize-h6);
     }
 
     &__icon {

--- a/packages/ffe-message-box-react/src/BaseMessage.js
+++ b/packages/ffe-message-box-react/src/BaseMessage.js
@@ -11,6 +11,7 @@ const BaseMessage = props => {
     const {
         type,
         title,
+        titleElement,
         icon,
         content,
         children,
@@ -33,7 +34,14 @@ const BaseMessage = props => {
                 {React.cloneElement(icon, { style: iconStyles, ...icon.props })}
             </span>
             <div className="ffe-message-box__box">
-                {title && <div className="ffe-message-box__title">{title}</div>}
+                {title &&
+                    React.createElement(
+                        titleElement,
+                        {
+                            className: 'ffe-message-box__title',
+                        },
+                        title,
+                    )}
                 {content && <p>{content}</p>}
                 {!content && children}
             </div>
@@ -47,6 +55,8 @@ BaseMessage.propTypes = {
     content: node,
     icon: node.isRequired,
     title: node,
+    /** HTML element for the title */
+    titleElement: string,
     /**
      * Internal type enum for specifying the style of message box. Should not be used directly
      * @ignore
@@ -56,4 +66,8 @@ BaseMessage.propTypes = {
     onColoredBg: bool,
 };
 
+BaseMessage.defaultProps = {
+    titleElement: 'h2',
+    onColoredBg: false,
+};
 export default BaseMessage;

--- a/packages/ffe-message-box/less/message-box.less
+++ b/packages/ffe-message-box/less/message-box.less
@@ -100,6 +100,7 @@
         color: var(--ffe-farge-svart);
         font-size: 18px;
         margin-bottom: @ffe-spacing-sm;
+        margin-top: 0;
         .native & {
             @media (prefers-color-scheme: dark) {
                 color: var(--ffe-farge-svart);


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse
Endrer tittel/header default elementet fra div til h2 i Message-box og contextMessageBox.
I message-box legges det til en property som lar brukerne sette html-elementet på tittelen sånn som man kan på ContextMessage. 

<!-- Detaljert beskrivelse av endringene dine. Skjermskudd er lov. -->

## Motivasjon og kontekst
Retter #1527  og en UU-feil
<!-- Hvorfor trengs denne endringen, og hva løser den? -->

## Testing
Kjørt opp lokalt 
<!-- Hvordan har du har testet endringene dine? Ta gjerne med systeminfo o.l -->

<!--

Helt til slutt, har du ..

.. lest retningslinjene våre for bidrag?
.. tatt en siste sjekk for kode og skrivefeil, debug informasjon o.l?
.. kjørt og eventuelt oppdatert testene?
.. kommentert og dokumentert det som trengs?
.. knyttet denne opp til relaterte issues?

-->
