### PR TITLE
fix(ffe-accordion-react): aria-hidden på ikoner

### DIFF
--- a/packages/ffe-accordion-react/src/AccordionItem.js
+++ b/packages/ffe-accordion-react/src/AccordionItem.js
@@ -71,7 +71,10 @@ const AccordionItem = ({
                     <span className="ffe-accordion-item__heading-button-content">
                         {heading}
                         <span className="ffe-accordion-item__heading-icon-wrapper">
-                            <ChevronIkon className="ffe-accordion-item__heading-icon" />
+                            <ChevronIkon
+                                className="ffe-accordion-item__heading-icon"
+                                aria-hidden="true"
+                            />
                         </span>
                     </span>
                 </button>


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse

skjuler ikonene for skjermlesere med aria-hidden, siden de ikke har noen semantisk betydning

## Motivasjon og kontekst

Fixes #1538 
