### PR TITLE
fix(ffe-form): Setter `min-width: 0` på `.ffe-fieldset`

### DIFF
--- a/packages/ffe-form/less/fieldset.less
+++ b/packages/ffe-form/less/fieldset.less
@@ -2,6 +2,7 @@
     border: 0;
     padding: 0;
     margin: 0;
+    min-width: 0;
 
     > *:nth-last-child(1) {
         margin-bottom: @ffe-spacing-lg;


### PR DESCRIPTION
Dette overstyrer default `min-content` som kan komme som en del av browserens stylesheet og gjøre at feltet blir bredere enn containeren det ligger i

Fixes #1544

