### PR TITLE
fix(ffe-form): max-width på label med tooltip

### DIFF
--- a/packages/ffe-form/less/form-label.less
+++ b/packages/ffe-form/less/form-label.less
@@ -15,4 +15,8 @@
     &--block {
         display: block;
     }
+
+    .ffe-input-group:has(.ffe-tooltip) & {
+        max-width: calc(100% - 42px);
+    }
 }


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse

Legger til `max-width` på `.ffe-form-label` i tilfeller der label inneholder en `.ffe-tooltip`. Dette for å unngå at tooltip bryter over på en egen linje når innholdet i label blir lengre enn en linje.

## Motivasjon og kontekst

Fixes #1277 

## Testing

Testet i component-overview