### PR TITLE
fix(ffe-core): bytter farge på lead paragraph i dark mode

### DIFF
--- a/packages/ffe-core/less/theme.less
+++ b/packages/ffe-core/less/theme.less
@@ -152,7 +152,7 @@
             --ffe-g-secondary-color: var(--ffe-farge-vann-70);
             --ffe-g-border-color: var(--ffe-farge-graa);
             --ffe-g-text-color: var(--ffe-farge-lysgraa);
-            --ffe-g-lead-color: var(--ffe-farge-hvit);
+            --ffe-g-lead-color: var(--ffe-farge-vann-70);
             --ffe-g-heading-color: var(--ffe-farge-vann-70);
             --ffe-g-link-color: var(--ffe-farge-vann-70);
             --ffe-g-link-color-hover: var(--ffe-farge-vann-30);


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse

Bytter farge på Lead Paragraph i dark mode fra hvit (standard tekstfarge) til vann-70, for å utheve Lead på samme måte som den utheves i light mode.

## Motivasjon og kontekst

Fixes #1543 

## Testing

Testet i component-overview