### PR TITLE
fix(ffe-datepicker-react): endre fra aria-selected til aria-current

### DIFF
--- a/packages/ffe-datepicker-react/src/calendar/ClickableDate.js
+++ b/packages/ffe-datepicker-react/src/calendar/ClickableDate.js
@@ -64,7 +64,7 @@ export default class ClickableDate extends Component {
                 role="button"
                 ref={dateButtonRef}
                 aria-disabled={!date.isEnabled}
-                aria-selected={date.isSelected}
+                aria-current={date.isSelected}
                 aria-label={`${date.date}. ${monthName} ${year}`}
                 tabIndex={this.tabIndex()}
                 onClick={() => onClick(date)}

--- a/packages/ffe-datepicker-react/src/calendar/NonClickableDate.js
+++ b/packages/ffe-datepicker-react/src/calendar/NonClickableDate.js
@@ -5,7 +5,7 @@ export default function NonClickableDate(props) {
     return (
         <td
             aria-disabled="true"
-            aria-selected="false"
+            aria-current="false"
             className="ffe-calendar__day"
             key={props.date.timestamp}
             role="button"


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse
Endrer ClickableDate og NonClickableDate knappen til å ha aria-current istedenfor aria-selected
<!-- Detaljert beskrivelse av endringene dine. Skjermskudd er lov. -->

## Motivasjon og kontekst
Retter issue #1534 som er at aria-selected ikke er støttet på role="button" 
<!-- Hvorfor trengs denne endringen, og hva løser den? -->

## Testing
Kjørt opp lokalt og sjekket at aria-current blir satt riktig på datepicker eksempel.
<!-- Hvordan har du har testet endringene dine? Ta gjerne med systeminfo o.l -->

<!--

Helt til slutt, har du ..

.. lest retningslinjene våre for bidrag?
.. tatt en siste sjekk for kode og skrivefeil, debug informasjon o.l?
.. kjørt og eventuelt oppdatert testene?
.. kommentert og dokumentert det som trengs?
.. knyttet denne opp til relaterte issues?

-->
