### PR TITLE
fix(ffe-cards-react): Endre måten man sender med bilde inn i ImageCard

### DIFF
--- a/component-overview/examples/cards/ImageCard-titleOnly.jsx
+++ b/component-overview/examples/cards/ImageCard-titleOnly.jsx
@@ -2,13 +2,8 @@ import { ImageCard } from '@sb1/ffe-cards-react';
 
 <ImageCard
     href="https://design.sparebank1.no"
-    image={
-        <img
-            src="https://www.sparebank1.no/content/dam/SB1/foto/profilbilder-liggende/ung-i-sofa.jpg.thumb.1280.1280.jpg"
-            alt=""
-            style={{ position: 'relative', bottom: '50px' }}
-        />
-    }
+    imageSrc="https://www.sparebank1.no/content/dam/SB1/foto/profilbilder-liggende/ung-i-sofa.jpg.thumb.1280.1280.jpg"
+    imageAltText="To jenter som går å snakker sammen"
 >
     {({ Title }) => <Title>Tittel</Title>}
 </ImageCard>

--- a/component-overview/examples/cards/ImageCard.jsx
+++ b/component-overview/examples/cards/ImageCard.jsx
@@ -2,12 +2,8 @@ import { ImageCard } from '@sb1/ffe-cards-react';
 
 <ImageCard
     href="https://design.sparebank1.no"
-    image={
-        <img
-            src="https://www.sparebank1.no/content/dam/SB1/foto/profilbilder-liggende/ung-i-sofa.jpg.thumb.1280.1280.jpg"
-            alt=""
-        />
-    }
+    imageSrc="https://www.sparebank1.no/content/dam/SB1/foto/profilbilder-liggende/ung-i-sofa.jpg.thumb.1280.1280.jpg"
+    imageAltText="To jenter som går å snakker sammen"
 >
     {({ CardName, Title, Subtext, Text }) => (
         <>

--- a/packages/ffe-cards-react/src/ImageCard/ImageCard.js
+++ b/packages/ffe-cards-react/src/ImageCard/ImageCard.js
@@ -5,18 +5,24 @@ import { node, string, func, oneOfType, elementType } from 'prop-types';
 import * as components from '../components';
 
 const ImageCard = props => {
-    const { className, image, element: Element, children, ...rest } = props;
+    const {
+        className,
+        imageSrc,
+        imageAltText,
+        element: Element,
+        children,
+        ...rest
+    } = props;
 
     return (
         <Element className={classNames('ffe-image-card', className)} {...rest}>
             <div className="ffe-image-card__image-container">
                 <div className="ffe-image-card__image-overlay" />
-                {React.cloneElement(image, {
-                    className: classNames(
-                        'ffe-image-card__image',
-                        image.props.className,
-                    ),
-                })}
+                <img
+                    src={imageSrc}
+                    alt={imageAltText}
+                    className="ffe-image-card__image"
+                />
             </div>
             <div className="ffe-image-card__body">
                 {typeof children === 'function'
@@ -33,8 +39,10 @@ ImageCard.defaultProps = {
 
 ImageCard.propTypes = {
     className: string,
-    /** A rendered image */
-    image: node.isRequired,
+    /** The src for the image */
+    imageSrc: string.isRequired,
+    /** The alt text for the image */
+    imageAltText: string.isRequired,
     /** The element to render the card as */
     element: oneOfType([func, string, elementType]),
     /** Function that's passed available sub-components as arguments, or regular children */

--- a/packages/ffe-cards-react/src/ImageCard/ImageCard.spec.js
+++ b/packages/ffe-cards-react/src/ImageCard/ImageCard.spec.js
@@ -3,8 +3,14 @@ import React from 'react';
 import ImageCard from './ImageCard';
 import { Text } from '../components';
 
-const image = <img alt="" className="my-custom-image" />;
-const getWrapper = props => shallow(<ImageCard {...props} image={image} />);
+const getWrapper = props =>
+    shallow(
+        <ImageCard
+            {...props}
+            imageURL="random/path"
+            imageAltText="Image alt text"
+        />,
+    );
 const children = <div>Hello world</div>;
 
 describe('ImageCard', () => {
@@ -32,17 +38,15 @@ describe('ImageCard', () => {
             imageEl
                 .children()
                 .last()
-                .hasClass('my-custom-image'),
-        ).toBe(true);
-
-        expect(
-            imageEl
-                .children()
-                .last()
                 .hasClass('ffe-image-card__image'),
         ).toBe(true);
     });
 
+    it('should set alt text on image correctly', () => {
+        const wrapper = getWrapper();
+        const imageEl = wrapper.find('.ffe-image-card__image');
+        expect(imageEl.prop('alt')).toBe('Image alt text');
+    });
     it('should render children inside a div with body class', () => {
         const wrapper = getWrapper({ children });
 


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse
Bytter ut image-prop som kunne ta inn element, med imageSrc og imageAltText props som godtar string.

<!-- Detaljert beskrivelse av endringene dine. Skjermskudd er lov. -->

## Motivasjon og kontekst
Retter #1484. Målet er å sikre at man alltid har alt-text på bildene som brukes i imageCard, da dette er ett lovkrav i henhold til WCAG. 

<!-- Hvorfor trengs denne endringen, og hva løser den? -->

## Testing
Kjørt opp lokalt å testet i component-overview. 
<!-- Hvordan har du har testet endringene dine? Ta gjerne med systeminfo o.l -->

<!--

Helt til slutt, har du ..

.. lest retningslinjene våre for bidrag?
.. tatt en siste sjekk for kode og skrivefeil, debug informasjon o.l?
.. kjørt og eventuelt oppdatert testene?
.. kommentert og dokumentert det som trengs?
.. knyttet denne opp til relaterte issues?

-->
