### PR TITLE
feat(ffe-searchable-dropdown-react): remove high capacity prop

### DIFF
--- a/component-overview/examples/account-selector/AccountSelectorHighCapacity.jsx
+++ b/component-overview/examples/account-selector/AccountSelectorHighCapacity.jsx
@@ -1,0 +1,48 @@
+import { useState } from 'react';
+import { AccountSelectorHighCapacity } from '@sb1/ffe-account-selector-react';
+import { InputGroup } from '@sb1/ffe-form-react';
+
+() => {
+    const [selectedAccount, setSelectedAccount] = useState();
+
+    const label1 = 'label1';
+    return (
+        <InputGroup label="Velg konto" extraMargin={false} labelId={label1}>
+            <AccountSelectorHighCapacity
+                accounts={[
+                    {
+                        accountNumber: '1234 56 789101',
+                        name: 'Brukskonto',
+                        currencyCode: 'NOK',
+                        balance: 1337,
+                    },
+                    {
+                        accountNumber: '1234 56 789102',
+                        name: 'Brukskonto2',
+                        currencyCode: 'NOK',
+                        balance: 13337,
+                    },
+                    {
+                        accountNumber: '2234 56 789102',
+                        name: 'Sparekonto1',
+                        currencyCode: 'NOK',
+                        balance: 109236,
+                    },
+                    {
+                        accountNumber: '1253 47 789102',
+                        name: 'Sparekonto2',
+                        currencyCode: 'NOK',
+                        balance: 0,
+                    },
+                ]}
+                id="account-selector-single"
+                locale="nb"
+                labelledById={label1}
+                onAccountSelected={val => setSelectedAccount(val)}
+                onReset={() => setSelectedAccount(null)}
+                selectedAccount={selectedAccount}
+                ariaInvalid={false}
+            />
+        </InputGroup>
+    );
+}

--- a/component-overview/examples/dropdown/SearchableDropdown-2attributes.jsx
+++ b/component-overview/examples/dropdown/SearchableDropdown-2attributes.jsx
@@ -1,5 +1,5 @@
 import { InputGroup } from '@sb1/ffe-form-react';
-import SearchableDropdown from '@sb1/ffe-searchable-dropdown-react';
+import { SearchableDropdown } from '@sb1/ffe-searchable-dropdown-react';
 import { useState } from 'react';
 
 () => {

--- a/component-overview/examples/dropdown/SearchableDropdown-customListElementBody.jsx
+++ b/component-overview/examples/dropdown/SearchableDropdown-customListElementBody.jsx
@@ -1,5 +1,5 @@
 import { InputGroup } from '@sb1/ffe-form-react';
-import SearchableDropdown from '@sb1/ffe-searchable-dropdown-react';
+import { SearchableDropdown } from '@sb1/ffe-searchable-dropdown-react';
 import { useState } from 'react';
 import { SmallText } from '@sb1/ffe-core-react';
 

--- a/component-overview/examples/dropdown/SearchableDropdown-customMatchFunction.jsx
+++ b/component-overview/examples/dropdown/SearchableDropdown-customMatchFunction.jsx
@@ -1,5 +1,5 @@
 import { InputGroup } from '@sb1/ffe-form-react';
-import SearchableDropdown from '@sb1/ffe-searchable-dropdown-react';
+import { SearchableDropdown } from '@sb1/ffe-searchable-dropdown-react';
 import { useState } from 'react';
 
 () => {

--- a/component-overview/examples/dropdown/SearchableDropdown-extraresults.jsx
+++ b/component-overview/examples/dropdown/SearchableDropdown-extraresults.jsx
@@ -1,5 +1,5 @@
 import { InputGroup } from '@sb1/ffe-form-react';
-import SearchableDropdown from '@sb1/ffe-searchable-dropdown-react';
+import { SearchableDropdown } from '@sb1/ffe-searchable-dropdown-react';
 import { useState } from 'react';
 
 () => {

--- a/component-overview/examples/dropdown/SearchableDropdown-highCapacity.jsx
+++ b/component-overview/examples/dropdown/SearchableDropdown-highCapacity.jsx
@@ -1,5 +1,5 @@
 import { InputGroup } from '@sb1/ffe-form-react';
-import SearchableDropdown from '@sb1/ffe-searchable-dropdown-react';
+import { SearchableDropdownHighCapacity } from '@sb1/ffe-searchable-dropdown-react';
 import { useState } from 'react';
 
 () => {
@@ -12,7 +12,7 @@ import { useState } from 'react';
     const [selectedOption, setSelectedOption] = useState(null);
     return (
         <InputGroup label="Velg bedrift" labelId={labelId}>
-            <SearchableDropdown
+            <SearchableDropdownHighCapacity
                 id={id}
                 labelledById={labelId}
                 inputProps={{ placeholder: 'Velg' }}

--- a/component-overview/examples/dropdown/SearchableDropdown-isLoading.jsx
+++ b/component-overview/examples/dropdown/SearchableDropdown-isLoading.jsx
@@ -1,5 +1,5 @@
 import { InputGroup } from '@sb1/ffe-form-react';
-import SearchableDropdown from '@sb1/ffe-searchable-dropdown-react';
+import { SearchableDropdown } from '@sb1/ffe-searchable-dropdown-react';
 import { useState } from 'react';
 
 () => {

--- a/component-overview/examples/dropdown/SearchableDropdown-selectedItem.jsx
+++ b/component-overview/examples/dropdown/SearchableDropdown-selectedItem.jsx
@@ -1,5 +1,5 @@
 import { InputGroup } from '@sb1/ffe-form-react';
-import SearchableDropdown from '@sb1/ffe-searchable-dropdown-react';
+import { SearchableDropdown } from '@sb1/ffe-searchable-dropdown-react';
 import { useState } from 'react';
 
 () => {

--- a/component-overview/examples/dropdown/SearchableDropdown.jsx
+++ b/component-overview/examples/dropdown/SearchableDropdown.jsx
@@ -1,5 +1,5 @@
 import { InputGroup } from '@sb1/ffe-form-react';
-import SearchableDropdown from '@sb1/ffe-searchable-dropdown-react';
+import { SearchableDropdown } from '@sb1/ffe-searchable-dropdown-react';
 import { useState } from 'react';
 
 () => {

--- a/packages/ffe-account-selector-react/src/components/account-selector/AccountSelector.spec.js
+++ b/packages/ffe-account-selector-react/src/components/account-selector/AccountSelector.spec.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render, fireEvent, screen } from '@testing-library/react';
 
-import AccountSelector from './AccountSelector';
+import { AccountSelector } from './AccountSelector';
 
 describe('AccountSelector', () => {
     beforeAll(() => {

--- a/packages/ffe-account-selector-react/src/components/account-selector/AccountSelectorHighCapacity.js
+++ b/packages/ffe-account-selector-react/src/components/account-selector/AccountSelectorHighCapacity.js
@@ -8,11 +8,11 @@ import {
     object,
     oneOfType,
 } from 'prop-types';
-import { SearchableDropdown } from '@sb1/ffe-searchable-dropdown-react';
+import { SearchableDropdownHighCapacity } from '@sb1/ffe-searchable-dropdown-react';
 import { Account, Locale } from '../../util/types';
 import { BaseAccountSelector } from './BaseAccountSelector';
 
-export const AccountSelector = ({
+export const AccountSelectorHighCapacity = ({
     id,
     className,
     locale,
@@ -53,12 +53,12 @@ export const AccountSelector = ({
             formatAccountNumber={formatAccountNumber}
             withSpaceForDetails={withSpaceForDetails}
         >
-            {props => <SearchableDropdown {...props} />}
+            {props => <SearchableDropdownHighCapacity {...props} />}
         </BaseAccountSelector>
     );
 };
 
-AccountSelector.propTypes = {
+AccountSelectorHighCapacity.propTypes = {
     id: string.isRequired,
     className: string,
     /** 'nb', 'nn', or 'en' */

--- a/packages/ffe-account-selector-react/src/components/account-selector/BaseAccountSelector.js
+++ b/packages/ffe-account-selector-react/src/components/account-selector/BaseAccountSelector.js
@@ -1,0 +1,223 @@
+import React, { useState } from 'react';
+import {
+    func,
+    string,
+    arrayOf,
+    bool,
+    shape,
+    object,
+    oneOfType,
+} from 'prop-types';
+import classNames from 'classnames';
+import {
+    AccountDetails,
+    AccountSuggestionSingle,
+} from '../../subcomponents/account-selector-single';
+import { Account, Locale } from '../../util/types';
+import { formatIncompleteAccountNumber } from '../../util/format';
+
+const getAccountsWithCustomAccounts = ({
+    accounts,
+    selectedAccount,
+    inputValue,
+}) => {
+    const shouldAddSelectedAccountNotFoundInList =
+        selectedAccount &&
+        selectedAccount.name === inputValue &&
+        !accounts.find(
+            account => account.accountNumber === selectedAccount.accountNumber,
+        );
+
+    return shouldAddSelectedAccountNotFoundInList
+        ? [...accounts, selectedAccount]
+        : accounts;
+};
+
+export const BaseAccountSelector = ({
+    id,
+    className,
+    locale,
+    selectedAccount,
+    showBalance = false,
+    noMatches,
+    accounts,
+    onAccountSelected,
+    allowCustomAccount = false,
+    labelledById,
+    listElementBody,
+    onReset,
+    inputProps,
+    formatAccountNumber = true,
+    ariaInvalid,
+    withSpaceForDetails = true,
+    onOpen,
+    onClose,
+    children,
+}) => {
+    const [inputValue, setInputValue] = useState(selectedAccount?.name || '');
+
+    const formatter = formatAccountNumber
+        ? formatIncompleteAccountNumber
+        : undefined;
+
+    /*
+     * This matcher function closely resembles the default one of SearchableDropdown,
+     * but it ignores all spaces and periods so that account number formatting won't mess with the search.
+     */
+    const searchMatcherIgnoringAccountNumberFormatting = (
+        searchString,
+        searchAttributes,
+    ) => item => {
+        const cleanString = value =>
+            `${value}`
+                .replace(/(\s|\.)/g, '') // Remove all spaces and periods
+                .toLowerCase();
+        const cleanedSearchString = cleanString(searchString);
+        return searchAttributes.some(searchAttribute =>
+            cleanString(item[searchAttribute]).includes(cleanedSearchString),
+        );
+    };
+    const onInputChange = event => {
+        setInputValue(event.target.value);
+        if (inputProps?.onChange) {
+            inputProps.onChange(event);
+        }
+    };
+
+    const handleAccountSelected = value => {
+        const hasResetSelection = value === null;
+        const hasSelectedCustomAccount = !value?.accountNumber;
+        if (hasResetSelection) {
+            setInputValue('');
+            onReset();
+        } else if (hasSelectedCustomAccount) {
+            onAccountSelected({ name: value.name, accountNumber: value.name });
+            setInputValue(value.name);
+        } else {
+            onAccountSelected(value);
+            setInputValue(value.name);
+        }
+    };
+
+    const customNoMatch =
+        allowCustomAccount && inputValue.trim() !== ''
+            ? {
+                  dropdownList: [
+                      {
+                          name: formatter ? formatter(inputValue) : inputValue,
+                          accountNumber: '',
+                      },
+                  ],
+              }
+            : noMatches;
+
+    const dropdownAttributes = showBalance
+        ? ['name', 'accountNumber', 'balance']
+        : ['name', 'accountNumber'];
+
+    const dropdownList = allowCustomAccount
+        ? getAccountsWithCustomAccounts({
+              selectedAccount,
+              accounts,
+              inputValue,
+          })
+        : accounts;
+
+    return (
+        <div className="ffe-account-selector-single-container">
+            <div
+                className={classNames('ffe-account-selector-single', {
+                    'ffe-account-selector-single--with-space-for-details':
+                        !selectedAccount && withSpaceForDetails,
+                    className,
+                })}
+                id={`${id}-account-selector-container`}
+            >
+                {children({
+                    id,
+                    labelledById,
+                    inputProps: {
+                        ...inputProps,
+                        onChange: onInputChange,
+                    },
+                    dropdownAttributes,
+                    dropdownList,
+                    noMatch: customNoMatch,
+                    formatter,
+                    onChange: handleAccountSelected,
+                    searchAttributes: ['name', 'accountNumber'],
+                    locale,
+                    listElementBody: listElementBody || AccountSuggestionSingle,
+                    ariaInvalid,
+                    searchMatcher: searchMatcherIgnoringAccountNumberFormatting,
+                    selectedItem: selectedAccount,
+                    onOpen,
+                    onClose,
+                })}
+                {selectedAccount && (
+                    <AccountDetails
+                        account={selectedAccount}
+                        locale={locale}
+                        showBalance={
+                            showBalance &&
+                            typeof selectedAccount.balance === 'number'
+                        }
+                    />
+                )}
+            </div>
+        </div>
+    );
+};
+
+BaseAccountSelector.propTypes = {
+    id: string.isRequired,
+    className: string,
+    /** 'nb', 'nn', or 'en' */
+    locale: Locale.isRequired,
+    selectedAccount: Account,
+    /**
+     * Array of objects:
+     *  {
+     *      accountNumber: string.isRequired,
+     *      name: string.isRequired,
+     *      balance: number,
+     *      currencyCode: string,
+     *  }
+     */
+    accounts: arrayOf(Account).isRequired,
+    /** Default false. */
+    showBalance: bool,
+    /** Overrides default string for all locales. */
+    noMatches: shape({
+        text: string.isRequired,
+        dropdownList: arrayOf(object),
+    }),
+    /** Returns the selected account object */
+    onAccountSelected: func.isRequired,
+    /**
+     * Allows selecting the text the user writes even if it does not match anything in the accounts array.
+     * Useful e.g. if you want to pay to account that is not in your recipients list.
+     */
+    allowCustomAccount: bool,
+    /** Id of element that labels input field */
+    labelledById: string,
+    /** Custom element to use for each item in the dropdown list */
+    listElementBody: func,
+    /**
+     * Called when emptying the input field and moving focus away from the account selector
+     * */
+    onReset: func.isRequired,
+    /** Props passed to the input field */
+    inputProps: shape(),
+    /** Sets aria-invalid on input field  */
+    ariaInvalid: oneOfType([string, bool]).isRequired,
+    /** Default true. */
+    formatAccountNumber: bool,
+    /** Defines if you should save space for account details that is shown when an account is selected */
+    withSpaceForDetails: bool,
+    /** Prop passed to the dropdown list */
+    onClose: func,
+    /** Prop passed to the dropdown list */
+    onOpen: func,
+    children: func,
+};

--- a/packages/ffe-account-selector-react/src/components/account-selector/index.js
+++ b/packages/ffe-account-selector-react/src/components/account-selector/index.js
@@ -1,3 +1,2 @@
-import AccountSelector from './AccountSelector';
-
-export default AccountSelector;
+export { AccountSelector } from './AccountSelector';
+export { AccountSelectorHighCapacity } from './AccountSelectorHighCapacity';

--- a/packages/ffe-account-selector-react/src/index.d.ts
+++ b/packages/ffe-account-selector-react/src/index.d.ts
@@ -36,14 +36,20 @@ export interface AccountSelectorProps<T extends Account = Account> {
     listElementBody?: (props: ListElementBodyProps<T>) => React.ReactElement;
     withSpaceForDetails?: boolean;
     ariaInvalid: boolean;
-    highCapacity?: boolean;
     onOpen?: () => void;
     onClose?: () => void;
 }
 
+export interface AccountSelectorHighCapacityProps<T extends Account = Account>
+    extends AccountSelectorProps<T> {}
+
 declare class AccountSelector<
     T extends Account = Account
 > extends React.Component<AccountSelectorProps<T>> {}
+
+declare class AccountSelectorHighCapacity<
+    T extends Account = Account
+> extends React.Component<AccountSelectorHighCapacityProps<T>> {}
 
 export interface AccountSelectorMultiProps<T extends Account = Account> {
     accounts?: Array<T>;

--- a/packages/ffe-account-selector-react/src/index.js
+++ b/packages/ffe-account-selector-react/src/index.js
@@ -1,5 +1,6 @@
-export { default as AccountSelector } from './components/account-selector';
 export {
-    default as AccountSelectorMulti,
-} from './components/account-selector-multi';
+    AccountSelector,
+    AccountSelectorHighCapacity,
+} from './components/account-selector';
+export { default as AccountSelectorMulti } from './components/account-selector-multi';
 export { default as BaseSelector } from './components/base-selector';

--- a/packages/ffe-searchable-dropdown-react/README.md
+++ b/packages/ffe-searchable-dropdown-react/README.md
@@ -11,7 +11,7 @@ npm install --save ffe-searchable-dropdown-react
 ## Usage
 
 ```javascript
-import SearchableDropdown from '@sb1/ffe-searchable-dropdown-react';
+import { SearchableDropdown } from '@sb1/ffe-searchable-dropdown-react';
 ```
 
 styling:

--- a/packages/ffe-searchable-dropdown-react/src/SearchableDropdown.js
+++ b/packages/ffe-searchable-dropdown-react/src/SearchableDropdown.js
@@ -6,27 +6,12 @@ import React, {
     useState,
     useEffect,
 } from 'react';
-import {
-    arrayOf,
-    bool,
-    func,
-    number,
-    object,
-    oneOf,
-    oneOfType,
-    shape,
-    string,
-} from 'prop-types';
+import { propTypes } from './propTypes';
 import classNames from 'classnames';
 import { ChevronIkon } from '@sb1/ffe-icons-react';
 
-import HighCapacityResults from './HighCapacityResults';
 import ListItemBody from './ListItemBody';
-import {
-    getButtonLabelClose,
-    getButtonLabelOpen,
-    locales,
-} from './translations';
+import { getButtonLabelClose, getButtonLabelOpen } from './translations';
 import { v4 as uuid } from 'uuid';
 import { createReducer, stateChangeTypes } from './reducer';
 import { getListToRender } from './getListToRender';
@@ -44,7 +29,7 @@ const ARROW_DOWN = 'ArrowDown';
 const ESCAPE = 'Escape';
 const ENTER = 'Enter';
 
-const SearchableDropdown = ({
+export const SearchableDropdown = ({
     id,
     labelledById,
     className,
@@ -61,10 +46,10 @@ const SearchableDropdown = ({
     formatter = value => value,
     searchMatcher,
     selectedItem,
-    highCapacity = false,
     isLoading = false,
     onOpen,
     onClose,
+    results: ResultsElement = Results,
 }) => {
     const [state, dispatch] = useReducer(
         createReducer({
@@ -261,11 +246,8 @@ const SearchableDropdown = ({
                     listBoxRef.current,
                 );
             }
-            return;
         }
     };
-
-    const ResultsElement = highCapacity ? HighCapacityResults : Results;
 
     return (
         <div // eslint-disable-line jsx-a11y/no-static-element-interactions
@@ -384,81 +366,4 @@ const SearchableDropdown = ({
     );
 };
 
-SearchableDropdown.propTypes = {
-    /** Id of drop down */
-    id: string.isRequired,
-
-    /** Id of element that labels input field */
-    labelledById: string,
-
-    /** Extra class */
-    className: string,
-
-    /** List of objects to be displayed in dropdown */
-    dropdownList: arrayOf(object).isRequired,
-
-    /** The selected item to be displayed in the input field. If not specified, uses internal state to decide. */
-    selectedItem: object,
-
-    /** Array of attributes to be displayed in list */
-    dropdownAttributes: arrayOf(string).isRequired,
-
-    /** Array of attributes used when filtering search */
-    searchAttributes: arrayOf(string).isRequired,
-
-    /** Props used on input field */
-    inputProps: shape({
-        onFocus: func,
-    }),
-
-    /** Limits number of rendered dropdown elements */
-    maxRenderedDropdownElements: number,
-
-    /** Called when a value is selected */
-    onChange: func,
-
-    /** Custom element to use for each item in dropDownList */
-    listElementBody: func,
-
-    /** Message and a dropdownList to use when no match */
-    noMatch: shape({
-        text: string,
-        dropdownList: arrayOf(object),
-    }),
-
-    /** Locale to use for translations */
-    locale: oneOf(Object.values(locales)),
-
-    /** aria-invalid attribute  */
-    ariaInvalid: oneOfType([string, bool]),
-
-    /** Function used to format the input field value */
-    formatter: func,
-
-    /**
-     * Function used to decide if an item matches the input field value
-     * (inputValue: string, searchAttributes: string[]) => (item) => boolean
-     */
-    searchMatcher: func,
-
-    /**
-     * For situations where SearchableDropdown might be populated with hundreds of accounts
-     * uses react-window for performance optimization, default false
-     */
-    highCapacity: bool,
-
-    /**
-     * For situations where the dropdownList prop will be updated at a later point in time.
-     * That is, if the consumer first sends down an initial value before sending down data
-     * that has loaded.
-     */
-    isLoading: bool,
-
-    /** Function used when dropdown opens */
-    onOpen: func,
-
-    /**  Function used when dropdown closes */
-    onClose: func,
-};
-
-export default SearchableDropdown;
+SearchableDropdown.propTypes = propTypes;

--- a/packages/ffe-searchable-dropdown-react/src/SearchableDropdown.spec.js
+++ b/packages/ffe-searchable-dropdown-react/src/SearchableDropdown.spec.js
@@ -3,7 +3,7 @@ import { render, screen, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import 'regenerator-runtime';
 
-import SearchableDropdown from './SearchableDropdown';
+import { SearchableDropdown } from './SearchableDropdown';
 
 describe('SearchableDropdown', () => {
     beforeAll(() => {

--- a/packages/ffe-searchable-dropdown-react/src/SearchableDropdownHighCapacity.js
+++ b/packages/ffe-searchable-dropdown-react/src/SearchableDropdownHighCapacity.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import HighCapacityResults from './HighCapacityResults';
+import { SearchableDropdown } from './SearchableDropdown';
+import { propTypes } from './propTypes';
+
+export const SearchableDropdownHighCapacity = ({ ...rest }) => {
+    return <SearchableDropdown {...rest} results={HighCapacityResults} />;
+};
+
+SearchableDropdownHighCapacity.propTypes = propTypes;

--- a/packages/ffe-searchable-dropdown-react/src/index.d.ts
+++ b/packages/ffe-searchable-dropdown-react/src/index.d.ts
@@ -30,14 +30,20 @@ export interface SearchableDropdownProps<T> {
         inputValue: string,
         searchAttributes: (keyof T)[],
     ) => (item: T) => boolean;
-    highCapacity?: boolean;
     isLoading?: boolean;
     onOpen?: () => void;
     onClose?: () => void;
 }
 
+export interface SearchableDropdownHighCapacityProps<T>
+    extends SearchableDropdownProps<T> {}
+
 declare class SearchableDropdown<T> extends React.Component<
     SearchableDropdownProps<T>
+> {}
+
+declare class SearchableDropdownHighCapacity<T> extends React.Component<
+    SearchableDropdownHighCapacityProps<T>
 > {}
 
 export default SearchableDropdown;

--- a/packages/ffe-searchable-dropdown-react/src/index.js
+++ b/packages/ffe-searchable-dropdown-react/src/index.js
@@ -1,1 +1,2 @@
-export { default } from './SearchableDropdown';
+export { SearchableDropdown } from './SearchableDropdown';
+export { SearchableDropdownHighCapacity } from './SearchableDropdownHighCapacity';

--- a/packages/ffe-searchable-dropdown-react/src/propTypes.js
+++ b/packages/ffe-searchable-dropdown-react/src/propTypes.js
@@ -1,0 +1,87 @@
+import { locales } from './translations';
+import {
+    arrayOf,
+    bool,
+    func,
+    number,
+    object,
+    oneOf,
+    oneOfType,
+    shape,
+    string,
+    element,
+} from 'prop-types';
+
+export const propTypes = {
+    /** Id of drop down */
+    id: string.isRequired,
+
+    /** Id of element that labels input field */
+    labelledById: string,
+
+    /** Extra class */
+    className: string,
+
+    /** List of objects to be displayed in dropdown */
+    dropdownList: arrayOf(object).isRequired,
+
+    /** The selected item to be displayed in the input field. If not specified, uses internal state to decide. */
+    selectedItem: object,
+
+    /** Array of attributes to be displayed in list */
+    dropdownAttributes: arrayOf(string).isRequired,
+
+    /** Array of attributes used when filtering search */
+    searchAttributes: arrayOf(string).isRequired,
+
+    /** Props used on input field */
+    inputProps: shape({
+        onFocus: func,
+    }),
+
+    /** Limits number of rendered dropdown elements */
+    maxRenderedDropdownElements: number,
+
+    /** Called when a value is selected */
+    onChange: func,
+
+    /** Custom element to use for each item in dropDownList */
+    listElementBody: func,
+
+    /** Message and a dropdownList to use when no match */
+    noMatch: shape({
+        text: string,
+        dropdownList: arrayOf(object),
+    }),
+
+    /** Locale to use for translations */
+    locale: oneOf(Object.values(locales)),
+
+    /** aria-invalid attribute  */
+    ariaInvalid: oneOfType([string, bool]),
+
+    /** Function used to format the input field value */
+    formatter: func,
+
+    /**
+     * Function used to decide if an item matches the input field value
+     * (inputValue: string, searchAttributes: string[]) => (item) => boolean
+     */
+    searchMatcher: func,
+
+    /**
+     * For situations where the dropdownList prop will be updated at a later point in time.
+     * That is, if the consumer first sends down an initial value before sending down data
+     * that has loaded.
+     */
+    isLoading: bool,
+
+    /** Function used when dropdown opens */
+    onOpen: func,
+
+    /**  Function used when dropdown closes */
+    onClose: func,
+
+    /**  For internal usage */
+    results: element,
+};


### PR DESCRIPTION
Visst borde man kunna kunna undgå att react-virtualized blir med i bundle slik? Så kan man byte ut `react-virtualized` eftervart? Jag synes ikke man skall vare tvungen att ha react-window i sin bundle egentligen heller

Har alltså laget SearchableDropdownHighCapacity og AccountSelectorHighCapacity i hop om att tree shaking klarer skaka av dom.