### PR TITLE
fix(ffe-grid): fjern padding fra wrapper klasse

### DIFF
--- a/packages/ffe-grid/less/ffe-grid.less
+++ b/packages/ffe-grid/less/ffe-grid.less
@@ -20,12 +20,15 @@
     .create-column-offset(@size, @total, @current + 1);
 }
 
+.ffe-grid__row {
+    padding-right: @ffe-spacing-sm;
+    padding-left: @ffe-spacing-sm;
+}
+
 .ffe-grid__row,
 .ffe-grid__row-wrapper {
     display: grid;
     gap: @ffe-spacing-sm;
-    padding-right: @ffe-spacing-sm;
-    padding-left: @ffe-spacing-sm;
     margin: 0 auto;
     max-width: @app-width;
     grid-template-columns: repeat(12, 1fr);


### PR DESCRIPTION
## Beskrivelse
Fjerner padding fra wrapper klassen som legges til når man setter bakgrunnsfarge
<!-- Detaljert beskrivelse av endringene dine. Skjermskudd er lov. -->

## Motivasjon og kontekst
Retter #1560
<!-- Hvorfor trengs denne endringen, og hva løser den? -->

## Testing
Kjørt opp lokalt å sjekket at teksten ikke lenger flytter på seg når man legger til/fjerner bakgrunnsfarge. 

<!-- Hvordan har du har testet endringene dine? Ta gjerne med systeminfo o.l -->

<!--

Helt til slutt, har du ..

.. lest retningslinjene våre for bidrag?
.. tatt en siste sjekk for kode og skrivefeil, debug informasjon o.l?
.. kjørt og eventuelt oppdatert testene?
.. kommentert og dokumentert det som trengs?
.. knyttet denne opp til relaterte issues?

-->
