### PR TITLE
fix(ffe-form-react): legg til manglende textRightAlign prop i ts

### DIFF
--- a/packages/ffe-form-react/src/index.d.ts
+++ b/packages/ffe-form-react/src/index.d.ts
@@ -26,6 +26,7 @@ export interface InputProps
     className?: string;
     inline?: boolean;
     textLike?: boolean;
+    textRightAlign: boolean;
 }
 
 export interface PhoneNumberProps {


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse
Legger til textRightAlign proptype definisjon i  Inputprops

## Motivasjon og kontekst
Denne manglet og ga feilmelding for brukere. 
<!-- Hvorfor trengs denne endringen, og hva løser den? -->

## Testing

<!-- Hvordan har du har testet endringene dine? Ta gjerne med systeminfo o.l -->

<!--

Helt til slutt, har du ..

.. lest retningslinjene våre for bidrag?
.. tatt en siste sjekk for kode og skrivefeil, debug informasjon o.l?
.. kjørt og eventuelt oppdatert testene?
.. kommentert og dokumentert det som trengs?
.. knyttet denne opp til relaterte issues?

-->
