### PR TITLE
Fix issue 1526

### DIFF
--- a/packages/ffe-message-box-react/src/ErrorMessage.js
+++ b/packages/ffe-message-box-react/src/ErrorMessage.js
@@ -13,7 +13,7 @@ const ErrorMessage = props => {
             type="error"
             aria-label="Feilmelding"
             icon={<UtropstegnIkon title="Utropstegn, ikon" />}
-            role={alert ? 'alert' : undefined}
+            role={alert ? 'alert' : 'group'}
             {...rest}
         />
     );

--- a/packages/ffe-system-message-react/src/SystemErrorMessage.js
+++ b/packages/ffe-system-message-react/src/SystemErrorMessage.js
@@ -12,7 +12,7 @@ export default function SystemErrorMessage(props) {
             modifier="error"
             aria-label="Feilmelding"
             icon={<UtropstegnIkon title="Utropstegn, ikon" />}
-            role={alert ? 'alert' : undefined}
+            role={alert ? 'alert' : 'group'}
             {...rest}
         />
     );


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse
Setter role="group" når alert er satt til false.
<!-- Detaljert beskrivelse av endringene dine. Skjermskudd er lov. -->

## Motivasjon og kontekst
I MessageError og i SystemErrorMessage ble role satt til "undefined" når man sendte med "alert=false" 
dette gjorde at man fjernet "role=group" som kommer fra baseMessage og SystemMessage. 
Dette gjør at man feiler ett UU-krav under testing av eksempelet der alert er satt til false 
<!-- Hvorfor trengs denne endringen, og hva løser den? -->

## Testing
Kjørt opp lokalt og togglet alert mellom true/false i component-overview for å se at role settes riktig 
<!-- Hvordan har du har testet endringene dine? Ta gjerne med systeminfo o.l -->

<!--

Helt til slutt, har du ..

.. lest retningslinjene våre for bidrag?
.. tatt en siste sjekk for kode og skrivefeil, debug informasjon o.l?
.. kjørt og eventuelt oppdatert testene?
.. kommentert og dokumentert det som trengs?
.. knyttet denne opp til relaterte issues?

-->
