### PR TITLE
feat(ffe-account-selector-react): Tillat string som verdi for balance

### DIFF
--- a/packages/ffe-account-selector-react/src/components/account-selector/AccountSelectorHighCapacity.js
+++ b/packages/ffe-account-selector-react/src/components/account-selector/AccountSelectorHighCapacity.js
@@ -69,7 +69,7 @@ AccountSelectorHighCapacity.propTypes = {
      *  {
      *      accountNumber: string.isRequired,
      *      name: string.isRequired,
-     *      balance: number,
+     *      balance: number | string,
      *      currencyCode: string,
      *  }
      */

--- a/packages/ffe-account-selector-react/src/index.d.ts
+++ b/packages/ffe-account-selector-react/src/index.d.ts
@@ -4,7 +4,7 @@ export interface Account {
     accountNumber: string;
     name: string;
     currencyCode?: string;
-    balance?: number;
+    balance?: number | string;
 }
 
 export interface ListElementBodyProps<T extends Account> {

--- a/packages/ffe-account-selector-react/src/util/types.js
+++ b/packages/ffe-account-selector-react/src/util/types.js
@@ -30,7 +30,7 @@ export const Account = shape({
     accountNumber: string.isRequired,
     name: string.isRequired,
     currencyCode: string,
-    balance: number,
+    balance: oneOf([string, number]),
 });
 
 export const Locale = oneOf([nb, nn, en]);


### PR DESCRIPTION
Vi bør kunne bruke string som verdi for balance siden floats kan være litt vanskelig å stole på.