### PR TITLE
fix(ffe-form-react): correct type definitions for onCountryCodeChange and onNumberChange

### DIFF
--- a/packages/ffe-form-react/src/index.d.ts
+++ b/packages/ffe-form-react/src/index.d.ts
@@ -32,8 +32,8 @@ export interface InputProps
 export interface PhoneNumberProps {
     number?: string;
     countryCode?: string;
-    onCountryCodeChange?: React.FormEventHandler<HTMLInputElement>;
-    onNumberChange?: React.FormEventHandler<HTMLInputElement>;
+    onCountryCodeChange?: React.ChangeEventHandler<HTMLInputElement>;
+    onNumberChange?: React.ChangeEventHandler<HTMLInputElement>;
     onCountryCodeBlur?: React.FocusEventHandler<HTMLInputElement>;
     onNumberBlur?: React.FocusEventHandler<HTMLInputElement>;
     locale?: string;


### PR DESCRIPTION
## Beskrivelse

Typedefinisjonene på eventhandlerene er endret fra FormEventHandler til ChangeEventHandler.

## Motivasjon og kontekst

Får feilmelding ved forsøk på å implementere eventhandlerene:
![Screenshot from 2023-02-23 11-29-43](https://user-images.githubusercontent.com/110812287/220882087-cfefda5c-84e0-4fb4-8755-231bf8e101f5.png)

Editoren påpeker at det skulle vært ChangeEvent fremfor FormEvent:
![Screenshot from 2023-02-23 10-23-37](https://user-images.githubusercontent.com/110812287/220881424-387b6d8f-36c9-4d08-af02-821e3481c049.png)

## Testing
