### PR TITLE
fix(ffe-account-selector-react): retter setting av className

### DIFF
--- a/packages/ffe-account-selector-react/src/components/account-selector/AccountSelector.spec.js
+++ b/packages/ffe-account-selector-react/src/components/account-selector/AccountSelector.spec.js
@@ -501,4 +501,22 @@ describe('AccountSelector', () => {
         expect(screen.getByText('1234 56 789102')).toBeInTheDocument();
         expect(input.value).toBe('Jeg er en konto');
     });
+
+    it('should apply the given className prop', () => {
+        const component = shallow(
+            <AccountSelector
+                className="testClass"
+                id="id"
+                labelId="labelId"
+                accounts={accounts}
+                locale="nb"
+                onAccountSelected={onAccountSelected}
+                onReset={onReset}
+                selectedAccount={selectedAccount}
+                ariaInvalid={false}
+            />,
+        );
+
+        expect(component.hasClass('testClass')).toBe(true);
+    });
 });

--- a/packages/ffe-account-selector-react/src/components/account-selector/BaseAccountSelector.js
+++ b/packages/ffe-account-selector-react/src/components/account-selector/BaseAccountSelector.js
@@ -126,11 +126,14 @@ export const BaseAccountSelector = ({
     return (
         <div className="ffe-account-selector-single-container">
             <div
-                className={classNames('ffe-account-selector-single', {
-                    'ffe-account-selector-single--with-space-for-details':
-                        !selectedAccount && withSpaceForDetails,
+                className={classNames(
+                    'ffe-account-selector-single',
+                    {
+                        'ffe-account-selector-single--with-space-for-details':
+                            !selectedAccount && withSpaceForDetails,
+                    },
                     className,
-                })}
+                )}
                 id={`${id}-account-selector-container`}
             >
                 {children({


### PR DESCRIPTION
Retter setting av className på BaseAcountSelector

## Beskrivelse

Retter en feil der className-propen ble sendt som object-shorthand til classNames. Dette gjorde at klassen som ble satt i DOM'en ble 'className' og ikke stringen som ble sendt inn.


## Motivasjon og kontekst

Fikser en bug.

## Testing

Testet lokalt og la til en ny automatisk test.
