### PR TITLE
fix(ffe-account-selector-react): bytt til oneOfType for balance

### DIFF
--- a/packages/ffe-account-selector-react/src/util/types.js
+++ b/packages/ffe-account-selector-react/src/util/types.js
@@ -1,4 +1,4 @@
-import { shape, string, number, oneOf } from 'prop-types';
+import { shape, string, number, oneOf, oneOfType } from 'prop-types';
 
 export const nb = 'nb';
 export const en = 'en';
@@ -30,7 +30,7 @@ export const Account = shape({
     accountNumber: string.isRequired,
     name: string.isRequired,
     currencyCode: string,
-    balance: oneOf([string, number]),
+    balance: oneOfType([string, number]),
 });
 
 export const Locale = oneOf([nb, nn, en]);


### PR DESCRIPTION
## Beskrivelse

Endrer balance til å bruke oneOfType istedenfor oneOf. oneOfType verifiserer prop-types typer, oneOf verifiserer verdier.

## Motivasjon og kontekst

Fikser en bug.

Dokumentasjon for prop-types her: https://reactjs.org/docs/typechecking-with-proptypes.html#proptypes

## Testing

Testet lokalt i kundefront-bm-finansiering med yarn link. Tror man vil få denne feilen i nettleser consolen om man kjører dev bygg av designsystemet.
