### PR TITLE
fix(ffe-lists): fikser tekstbryting ved checklistitem over flere linjer

### DIFF
--- a/packages/ffe-lists/less/regular-lists.less
+++ b/packages/ffe-lists/less/regular-lists.less
@@ -124,6 +124,7 @@
     margin-top: @ffe-spacing-sm;
     position: relative;
     line-height: 1.5em;
+    padding-left: 2em;
 
     .native & {
         @media (prefers-color-scheme: dark) {
@@ -137,6 +138,9 @@
         width: 1em;
         height: 1em;
         margin-right: @ffe-spacing-sm;
+        position: absolute;
+        left: 0;
+        top: 0.15em;
 
         &--check {
             fill: var(--ffe-v-lists-check-list-check-icon-color);


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse

Fikser en bug der CheckListItem rendres feil når teksten bryter over flere linjer

Før:
![Screenshot 2023-03-01 at 14 50 55](https://user-images.githubusercontent.com/463847/222159699-67292e4c-084c-4de1-8a77-93fa6544825b.png)

Etter:
![Screenshot 2023-03-01 at 14 51 47](https://user-images.githubusercontent.com/463847/222159761-013a1bab-e11c-4a06-af3d-cb72a41a3f50.png)


## Motivasjon og kontekst

Fixes #1571 

## Testing

Testet lokalt med component-overview