### PR TITLE
feat(ffe-account-selector-react): lagt til mulighet for å skjule Acco…

### DIFF
--- a/component-overview/examples/account-selector/AccountSelector-doNotshowAccountDetails.jsx
+++ b/component-overview/examples/account-selector/AccountSelector-doNotshowAccountDetails.jsx
@@ -1,0 +1,56 @@
+import { useState } from 'react';
+import { AccountSelector } from '@sb1/ffe-account-selector-react';
+import { InputGroup } from '@sb1/ffe-form-react';
+
+
+
+() => {
+
+    const accounts = [
+    {
+        accountNumber: '1234 56 789101',
+        name: 'Brukskonto',
+        currencyCode: 'NOK',
+        balance: 1337,
+    },
+    {
+        accountNumber: '1234 56 789102',
+        name: 'Brukskonto2',
+        currencyCode: 'NOK',
+        balance: 13337,
+    },
+    {
+        accountNumber: '2234 56 789102',
+        name: 'Sparekonto1',
+        currencyCode: 'EUR',
+        balance: 109236,
+    },
+    {
+        accountNumber: '1253 47 789102',
+        name: 'Sparekonto2',
+        currencyCode: 'NOK',
+        balance: 0,
+    },
+];
+
+const [selectedAccount, setSelectedAccount] = useState(accounts[0]);
+const label2 = 'label2';
+
+
+return (
+<InputGroup label="Velg konto" extraMargin={false} labelId={label2}>
+    <AccountSelector
+        accounts={accounts}
+        id="account-selector-single"
+        locale="nb"
+        onAccountSelected={value => setSelectedAccount(value)}
+        onReset={() => setSelectedAccount(null)}
+        selectedAccount={selectedAccount}
+        hideAccountDetails={true}
+        labelledById={label2}
+        ariaInvalid={false}
+    />
+</InputGroup>
+);
+}
+

--- a/packages/ffe-account-selector-react/src/components/account-selector/AccountSelector.js
+++ b/packages/ffe-account-selector-react/src/components/account-selector/AccountSelector.js
@@ -18,6 +18,7 @@ export const AccountSelector = ({
     className,
     locale,
     selectedAccount,
+    hideAccountDetails,
     showBalance,
     noMatches,
     accounts,
@@ -47,6 +48,7 @@ export const AccountSelector = ({
             selectedAccount={selectedAccount}
             onOpen={onOpen}
             onClose={onClose}
+            hideAccountDetails={hideAccountDetails}
             showBalance={showBalance}
             noMatches={noMatches}
             accounts={accounts}
@@ -77,6 +79,8 @@ AccountSelector.propTypes = {
      *  }
      */
     accounts: arrayOf(Account).isRequired,
+    /** Determines if account details should be shown (balance and account number under the input field) */
+    hideAccountDetails: bool,
     /** Default false. */
     showBalance: bool,
     /** Overrides default string for all locales. */

--- a/packages/ffe-account-selector-react/src/components/account-selector/AccountSelector.spec.js
+++ b/packages/ffe-account-selector-react/src/components/account-selector/AccountSelector.spec.js
@@ -519,4 +519,23 @@ describe('AccountSelector', () => {
 
         expect(component.hasClass('testClass')).toBe(true);
     });
+
+    it.only('Should not show account details when hideAccountDetails is set to false', async () => {
+        const component = render(
+            <AccountSelector
+                className="testClass"
+                id="id"
+                labelId="labelId"
+                accounts={accounts}
+                locale="nb"
+                onAccountSelected={onAccountSelected}
+                onReset={onReset}
+                selectedAccount={accounts[0]}
+                ariaInvalid={false}
+                hideAccountDetails={true}
+            />,
+        );
+
+        expect(component.queryByText(accounts[0].accountNumber)).toBeNull();
+    });
 });

--- a/packages/ffe-account-selector-react/src/components/account-selector/AccountSelectorHighCapacity.js
+++ b/packages/ffe-account-selector-react/src/components/account-selector/AccountSelectorHighCapacity.js
@@ -18,6 +18,7 @@ export const AccountSelectorHighCapacity = ({
     className,
     locale,
     selectedAccount,
+    hideAccountDetails,
     showBalance,
     noMatches,
     accounts,
@@ -47,6 +48,7 @@ export const AccountSelectorHighCapacity = ({
             selectedAccount={selectedAccount}
             onOpen={onOpen}
             onClose={onClose}
+            hideAccountDetails={hideAccountDetails}
             showBalance={showBalance}
             noMatches={noMatches}
             accounts={accounts}
@@ -77,6 +79,8 @@ AccountSelectorHighCapacity.propTypes = {
      *  }
      */
     accounts: arrayOf(Account).isRequired,
+    /** Determines if account details should be shown (balance and account number under the input field) */
+    hideAccountDetails: bool,
     /** Default false. */
     showBalance: bool,
     /** Overrides default string for all locales. */

--- a/packages/ffe-account-selector-react/src/components/account-selector/BaseAccountSelector.js
+++ b/packages/ffe-account-selector-react/src/components/account-selector/BaseAccountSelector.js
@@ -39,6 +39,7 @@ export const BaseAccountSelector = ({
     className,
     locale,
     selectedAccount,
+    hideAccountDetails = false,
     showBalance = false,
     noMatches,
     accounts,
@@ -160,7 +161,7 @@ export const BaseAccountSelector = ({
                     onOpen,
                     onClose,
                 })}
-                {selectedAccount && (
+                {!hideAccountDetails && selectedAccount && (
                     <AccountDetails
                         account={selectedAccount}
                         locale={locale}
@@ -193,6 +194,10 @@ BaseAccountSelector.propTypes = {
      *  }
      */
     accounts: arrayOf(Account).isRequired,
+    /** Determines if account details should be shown (balance and account number under the input field)
+     * @default false
+     */
+    hideAccountDetails: bool,
     /** Default false. */
     showBalance: bool,
     /** Overrides default string for all locales. */

--- a/packages/ffe-account-selector-react/src/index.d.ts
+++ b/packages/ffe-account-selector-react/src/index.d.ts
@@ -29,6 +29,7 @@ export interface AccountSelectorProps<T extends Account = Account> {
     onAccountSelected: (account: T) => void;
     onReset: () => void;
     selectedAccount?: T;
+    hideAccountDetails?: boolean;
     showBalance?: boolean;
     formatAccountNumber?: boolean;
     labelledById?: string;


### PR DESCRIPTION
Lagt til mulighet for å skjule AccountDetails. Trenger dette siden jeg har behov for å få feilmelding fra input group tettere på selve inputet når det er behov for det.

Med hideAccountDetails :
<img width="580" alt="image" src="https://user-images.githubusercontent.com/26740919/224755962-3c0de685-ac9a-4e8f-b8f3-ee078d86cfdd.png">
Uten hideAccountDetails:
<img width="647" alt="image" src="https://user-images.githubusercontent.com/26740919/224756246-57fed042-fbd9-4c22-a3d9-c2a997e30b00.png">

