### PR TITLE
fix(ffe-icons): oppdater svgstore dependency

### DIFF
--- a/packages/ffe-icons/package.json
+++ b/packages/ffe-icons/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "mkdirp": "^1.0.4",
-    "svgstore": "^2.0.3",
+    "svgstore": "^3.0.1",
     "yargs": "^16.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse
Oppdaterer svgstore dependency i ffe-icons.
Til tross for at det er til en ny major versjon skal det ikke være noen breaking changes for oss. 
<!-- Detaljert beskrivelse av endringene dine. Skjermskudd er lov. -->

## Motivasjon og kontekst
Fikser #1588, der det kommer frem at gammel versjon av svgstore har sikkerhetshull.
<!-- Hvorfor trengs denne endringen, og hva løser den? -->

## Testing
Kjørt opp lokalt og sjekket at ikonene forsatt fungerer
<!-- Hvordan har du har testet endringene dine? Ta gjerne med systeminfo o.l -->

<!--

Helt til slutt, har du ..

.. lest retningslinjene våre for bidrag?
.. tatt en siste sjekk for kode og skrivefeil, debug informasjon o.l?
.. kjørt og eventuelt oppdatert testene?
.. kommentert og dokumentert det som trengs?
.. knyttet denne opp til relaterte issues?

-->
