### PR TITLE
fix(ffe-form-react): bytte plassering på span og div i tooltip

### DIFF
--- a/packages/ffe-form-react/src/Tooltip.js
+++ b/packages/ffe-form-react/src/Tooltip.js
@@ -31,7 +31,7 @@ const Tooltip = React.forwardRef(
         };
 
         return (
-            <span
+            <div
                 {...rest}
                 className={classNames('ffe-tooltip', {
                     'ffe-tooltip--open': _isOpen,
@@ -56,15 +56,15 @@ const Tooltip = React.forwardRef(
                         id={tooltipId}
                         isOpen={_isOpen}
                     >
-                        <div
+                        <span
                             className={classNames('ffe-small-text', className)}
                             role={_isOpen ? 'status' : 'none'}
                         >
                             {children}
-                        </div>
+                        </span>
                     </Collapse>
                 )}
-            </span>
+            </div>
         );
     },
 );

--- a/packages/ffe-form-react/src/Tooltip.spec.js
+++ b/packages/ffe-form-react/src/Tooltip.spec.js
@@ -6,10 +6,10 @@ const defaultProps = { children: 'Tooltip text' };
 const getWrapper = props => shallow(<Tooltip {...defaultProps} {...props} />);
 
 describe('<Tooltip>', () => {
-    it('renders a span', () => {
+    it('renders a div', () => {
         const wrapper = getWrapper();
         expect(wrapper.exists()).toBe(true);
-        expect(wrapper.is('span')).toBe(true);
+        expect(wrapper.is('div')).toBe(true);
     });
 
     it('renders a "?" button', () => {

--- a/packages/ffe-form/less/tooltip.less
+++ b/packages/ffe-form/less/tooltip.less
@@ -1,4 +1,5 @@
 .ffe-tooltip {
+    display: inline;
     &__icon {
         background: var(--ffe-v-input-bg-color);
         border-radius: 50%;


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse
Bytter om plassering på div og span, så nå er hele tooltipen pakket inn i en div, og selve teksten som dukker opp på expand er span. 

<!-- Detaljert beskrivelse av endringene dine. Skjermskudd er lov. -->

## Motivasjon og kontekst
Retter valideringsfeil i HTML validator. 
<!-- Hvorfor trengs denne endringen, og hva løser den? -->

## Testing
Kjørt opp lokalt og testet opp mot component-overview.
<!-- Hvordan har du har testet endringene dine? Ta gjerne med systeminfo o.l -->

<!--

Helt til slutt, har du ..

.. lest retningslinjene våre for bidrag?
.. tatt en siste sjekk for kode og skrivefeil, debug informasjon o.l?
.. kjørt og eventuelt oppdatert testene?
.. kommentert og dokumentert det som trengs?
.. knyttet denne opp til relaterte issues?

-->
