### PR TITLE
docs(component-overview): grid-eksempler med offset

### DIFF
--- a/component-overview/examples/grid/Grid-offset.jsx
+++ b/component-overview/examples/grid/Grid-offset.jsx
@@ -1,0 +1,32 @@
+import { Grid, GridRow, GridCol } from '@sb1/ffe-grid-react';
+
+<Grid>
+    <GridRow>
+        <GridCol>
+            <h4>Eksempel med offset på alle skjermstørrelser</h4>
+        </GridCol>
+    </GridRow>
+    <GridRow>
+        <GridCol sm={{ cols: 6, offset: 2 }} md={{ cols: 4, offset: 4 }} lg={{ cols: 4, offset: 2 }}>
+            <ul>
+                <li>Små skjermer: 6 kolonner med 2 kolonner offset</li>
+                <li>Medium skjermer: 4 kolonner med 4 kolonner offset</li>
+                <li>Store skjermer: 4 kolonner med 2 kolonner offset</li>
+            </ul>
+        </GridCol>
+    </GridRow>
+    <GridRow>
+        <GridCol>
+            <h4>Eksempel med offset kun på store skjermer</h4>
+        </GridCol>
+    </GridRow>
+    <GridRow>
+        <GridCol sm={{ cols: 6 }} md={{ cols: 4 }} lg={{ cols: 4, offset: 2 }}>
+            <ul>
+                <li>Små skjermer: 6 kolonner, ingen offset</li>
+                <li>Medium skjermer: 4 kolonner, ingen offset</li>
+                <li>Store skjermer: 4 kolonner med 2 kolonner offset</li>
+            </ul>
+        </GridCol>
+    </GridRow>
+</Grid>


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse

Legger til eksempler på `Grid` med `offset`. Disse skal vises i grid-dokumentasjonen (oppdateres i det andre repoet etter at denne er merget).

## Motivasjon og kontekst

Fixes #1542 