### PR TITLE
bug: Längre text gör att UA styling kickar in och centrerar texten i Accordion Heading.

### DIFF
--- a/packages/ffe-accordion/less/accordion.less
+++ b/packages/ffe-accordion/less/accordion.less
@@ -44,13 +44,12 @@
     }
 
     &__heading-button-content {
-        text-align: start;
+        text-align: left;
         width: 100%;
         display: flex;
         align-items: center;
         justify-content: space-between;
         gap: @ffe-spacing-xs;
-        text-align: left;
     }
 
     &__heading-icon-wrapper {

--- a/packages/ffe-accordion/less/accordion.less
+++ b/packages/ffe-accordion/less/accordion.less
@@ -25,7 +25,7 @@
         cursor: pointer;
         outline: none;
         color: var(--ffe-v-accordion-primary-color);
-
+        
         &:hover {
             .ffe-accordion-item__heading-icon {
                 transition: fill @ffe-transition-duration @ffe-ease;
@@ -50,6 +50,7 @@
         align-items: center;
         justify-content: space-between;
         gap: @ffe-spacing-xs;
+        text-align: left;
     }
 
     &__heading-icon-wrapper {


### PR DESCRIPTION

## Beskrivelse
Det är inte ett problem när texten är kortare eftersom att flexbox är vänster justert.

Så här ser det ut med lång text, utan fix:
<img width="740" alt="Screenshot 2023-04-17 at 10 23 32" src="https://user-images.githubusercontent.com/706565/232427782-1a3b023a-863a-4ba6-aa92-f7ee2d04eee9.png">

Med fix:
<img width="698" alt="Screenshot 2023-04-17 at 10 24 07" src="https://user-images.githubusercontent.com/706565/232427927-e497a6ed-13cb-4bec-b8b1-2fa3c31daa3d.png">

