### PR TITLE
fix(ffe-accordion): venstrejusterer tittel istedenfor sentrert

### DIFF
--- a/packages/ffe-accordion/less/accordion.less
+++ b/packages/ffe-accordion/less/accordion.less
@@ -44,7 +44,7 @@
     }
 
     &__heading-button-content {
-        text-align: start;
+        text-align: left;
         width: 100%;
         display: flex;
         align-items: center;


### PR DESCRIPTION
Retter feil der titler som går over flere linjer blir sentrert.

## Beskrivelse
Bare venstrejusterer titlene i accordion. 
Dette er bare en "republisering" av fiksen til https://github.com/SpareBank1/designsystem/pull/1594
fordi det var noe feil i commitmeldingen og siden det var en fork var det vanskelig å rette. 

<!-- Detaljert beskrivelse av endringene dine. Skjermskudd er lov. -->

## Motivasjon og kontekst

<!-- Hvorfor trengs denne endringen, og hva løser den? -->

## Testing
Testet lokalt 
<!-- Hvordan har du har testet endringene dine? Ta gjerne med systeminfo o.l -->

<!--

Helt til slutt, har du ..

.. lest retningslinjene våre for bidrag?
.. tatt en siste sjekk for kode og skrivefeil, debug informasjon o.l?
.. kjørt og eventuelt oppdatert testene?
.. kommentert og dokumentert det som trengs?
.. knyttet denne opp til relaterte issues?

-->
