### PR TITLE
fix(ffe-context-message): flytt ikon på mindre skjerm til toppen

### DIFF
--- a/packages/ffe-context-message/less/context-message.less
+++ b/packages/ffe-context-message/less/context-message.less
@@ -100,7 +100,7 @@
 
     &__icon {
         align-items: center;
-        align-self: center;
+        align-self: start;
         display: flex;
         flex-shrink: 0;
         justify-content: center;
@@ -111,7 +111,6 @@
         width: 2em;
 
         @media (min-width: @breakpoint-sm) {
-            align-self: flex-start;
             margin-bottom: 0;
             height: 4em;
             width: 4em;


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse
På vanlig ContextMessage så ble ikonet på mindre skjermer plutselig sentrert,
denne endringen gjør at ikonet alltid er plassert på toppen i boksen. Sånn at det blir likt med compact versjonen.
<!-- Detaljert beskrivelse av endringene dine. Skjermskudd er lov. -->

## Motivasjon og kontekst
Denne endringen gjør at ContextMessage på mindre skjermer blir lik som compact versjonen. 
<!-- Hvorfor trengs denne endringen, og hva løser den? -->

## Testing
Testet lokalt
<!-- Hvordan har du har testet endringene dine? Ta gjerne med systeminfo o.l -->

<!--

Helt til slutt, har du ..

.. lest retningslinjene våre for bidrag?
.. tatt en siste sjekk for kode og skrivefeil, debug informasjon o.l?
.. kjørt og eventuelt oppdatert testene?
.. kommentert og dokumentert det som trengs?
.. knyttet denne opp til relaterte issues?

-->
