### PR TITLE
Develop fix types

### DIFF
--- a/packages/ffe-account-selector-react/src/index.d.ts
+++ b/packages/ffe-account-selector-react/src/index.d.ts
@@ -25,7 +25,7 @@ export interface AccountSelectorProps<T extends Account = Account> {
     id: string;
     locale: 'nb' | 'nn' | 'en';
     noMatches?: NoMatch<T>;
-    inputProps?: React.InputHTMLAttributes<HTMLInputElement>;
+    inputProps?: React.ComponentPropsWithoutRef<'input'>;
     onAccountSelected: (account: T) => void;
     onReset: () => void;
     selectedAccount?: T;

--- a/packages/ffe-buttons-react/src/index.d.ts
+++ b/packages/ffe-buttons-react/src/index.d.ts
@@ -9,7 +9,8 @@ type To =
           state?: { [key: string]: any };
       };
 
-export interface MinimalBaseButtonProps extends React.HTMLProps<HTMLElement> {
+export interface MinimalBaseButtonProps
+    extends React.ComponentPropsWithoutRef<'html'> {
     className?: string;
     element?: HTMLElement | string | React.ElementType;
     innerRef?: React.Ref<HTMLElement>;

--- a/packages/ffe-cards-react/src/index.d.ts
+++ b/packages/ffe-cards-react/src/index.d.ts
@@ -1,27 +1,25 @@
 import * as React from 'react';
 
-export interface ComponentBaseProps
-    extends React.HtmlHTMLAttributes<
-        HTMLElement | HTMLButtonElement | HTMLAnchorElement
-    > {
-    className?: string;
-    element?: HTMLElement | string | React.ElementType;
-    children?: React.ReactNode;
-}
+type ComponentBaseProps =
+    | ({
+          className?: string;
+          element?: HTMLElement | string | React.ElementType;
+          children?: React.ReactNode;
+      } & React.ComponentProps<'html'>)
+    | React.ComponentProps<'button'>
+    | React.ComponentProps<'a'>;
 
-export interface CardBaseProps extends ComponentBaseProps {
+type CardBaseProps = {
     to?: string;
-}
+} & ComponentBaseProps;
 
-export interface TitleProps extends ComponentBaseProps {
+type TitleProps = {
     overflowEllipsis?: boolean;
-}
+} & ComponentBaseProps;
 
-export interface SubtextProps extends ComponentBaseProps {}
-
-export interface TextProps extends ComponentBaseProps {}
-
-export interface CardNameProps extends ComponentBaseProps {}
+type SubtextProps = ComponentBaseProps;
+type TextProps = ComponentBaseProps;
+type CardNameProps = ComponentBaseProps;
 
 export interface CardRenderProps {
     CardName: React.FC<CardNameProps>;

--- a/packages/ffe-context-message-react/src/index.d.ts
+++ b/packages/ffe-context-message-react/src/index.d.ts
@@ -1,7 +1,6 @@
 import * as React from 'react';
 
-export interface ContextMessageProps
-    extends React.HTMLAttributes<HTMLDivElement> {
+export interface ContextMessageProps extends React.ComponentProps<'div'> {
     animationLengthMs?: number;
     children: React.ReactNode;
     className?: string;

--- a/packages/ffe-core-react/src/index.d.ts
+++ b/packages/ffe-core-react/src/index.d.ts
@@ -1,15 +1,15 @@
 import * as React from 'react';
 
-export interface DividerLineProps extends React.HTMLAttributes<HTMLHRElement> {
+export interface DividerLineProps extends React.ComponentProps<'hr'> {
     className?: string;
 }
 
-export interface EmphasizedTextProps extends React.HTMLAttributes<HTMLElement> {
+export interface EmphasizedTextProps extends React.ComponentProps<'html'> {
     children: React.ReactNode;
     className?: string;
 }
 
-export interface HeadingProps extends React.HTMLAttributes<HTMLHeadingElement> {
+export interface HeadingProps extends React.ComponentProps<'header'> {
     children: React.ReactNode;
     className?: string;
     error?: boolean;
@@ -20,14 +20,14 @@ export interface HeadingProps extends React.HTMLAttributes<HTMLHeadingElement> {
     textCenter?: boolean;
 }
 
-export interface LinkTextProps extends React.AnchorHTMLAttributes<HTMLElement> {
+export interface LinkTextProps extends React.ComponentProps<'a'> {
     children: React.ReactNode;
     className?: string;
     element?: HTMLElement | string | React.ElementType;
     underline?: boolean;
 }
 
-export interface LinkIconProps extends React.AnchorHTMLAttributes<HTMLElement> {
+export interface LinkIconProps extends React.ComponentProps<'html'> {
     children: React.ReactNode;
     className?: string;
     element?: HTMLElement | string | React.ElementType;
@@ -43,8 +43,7 @@ export interface SmallTextProps {
     className?: string;
 }
 
-export interface ParagraphProps
-    extends React.HTMLAttributes<HTMLParagraphElement> {
+export interface ParagraphProps extends React.ComponentProps<'p'> {
     children: React.ReactNode;
     className?: string;
     lead?: boolean;
@@ -96,20 +95,20 @@ declare class Heading6 extends React.Component<HeadingProps, any> {}
 declare class LinkText extends React.Component<LinkTextProps, any> {}
 declare class LinkIcon extends React.Component<LinkIconProps, any> {}
 declare class MicroText extends React.Component<
-    SimpleElementProps & React.HTMLAttributes<HTMLSpanElement>,
+    SimpleElementProps & React.ComponentProps<'span'>,
     any
 > {}
 declare class Paragraph extends React.Component<ParagraphProps, any> {}
 declare class PreformattedText extends React.Component<
-    SimpleElementProps & React.HTMLAttributes<HTMLPreElement>,
+    SimpleElementProps & React.ComponentProps<'pre'>,
     any
 > {}
 declare class SmallText extends React.Component<
-    SmallTextProps & React.HTMLAttributes<HTMLSpanElement>,
+    SmallTextProps & React.ComponentProps<'span'>,
     any
 > {}
 declare class StrongText extends React.Component<
-    SimpleElementProps & React.HTMLAttributes<HTMLElement>,
+    SimpleElementProps & React.ComponentProps<'strong'>,
     any
 > {}
 declare class Wave extends React.Component<WaveProps, any> {}

--- a/packages/ffe-datepicker-react/src/index.d.ts
+++ b/packages/ffe-datepicker-react/src/index.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-export type InputProps = React.InputHTMLAttributes<HTMLInputElement>;
+export type InputProps = React.ComponentProps<'input'>;
 
 type AriaInvalid = boolean | 'false' | 'true' | 'grammar' | 'spelling';
 

--- a/packages/ffe-dropdown-react/src/index.d.ts
+++ b/packages/ffe-dropdown-react/src/index.d.ts
@@ -1,7 +1,6 @@
 import * as React from 'react';
 
-export interface DropdownProps
-    extends React.SelectHTMLAttributes<HTMLSelectElement> {
+export interface DropdownProps extends React.ComponentProps<'select'> {
     children?: React.ReactNode;
     className?: string;
     inline?: boolean;

--- a/packages/ffe-form-react/src/index.d.ts
+++ b/packages/ffe-form-react/src/index.d.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 export interface CheckboxProps
-    extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'children'> {
+    extends Omit<React.ComponentProps<'input'>, 'children'> {
     noMargins?: boolean;
     hiddenLabel?: boolean;
     id?: string;
@@ -14,15 +14,13 @@ export interface CheckboxProps
           }) => React.ReactNode);
 }
 
-export interface BaseFieldMessageProps
-    extends React.HTMLAttributes<HTMLElement> {
+export interface BaseFieldMessageProps extends React.ComponentProps<'html'> {
     children: React.ReactNode;
     className?: string;
     element?: string;
 }
 
-export interface InputProps
-    extends React.InputHTMLAttributes<HTMLInputElement> {
+export interface InputProps extends React.ComponentProps<'input'> {
     className?: string;
     inline?: boolean;
     textLike?: boolean;
@@ -47,8 +45,7 @@ export interface PhoneNumberProps {
     numberRef?: React.Ref<HTMLInputElement>;
 }
 
-export interface LabelProps
-    extends React.LabelHTMLAttributes<HTMLLabelElement> {
+export interface LabelProps extends React.ComponentProps<'label'> {
     block?: boolean;
     children: React.ReactNode;
     className?: string;
@@ -56,7 +53,7 @@ export interface LabelProps
 }
 
 export interface InputGroupProps
-    extends Omit<React.HTMLAttributes<HTMLDivElement>, 'children'> {
+    extends Omit<React.ComponentProps<'div'>, 'children'> {
     inputId?: string;
     /** Unless you only have one element in your `InputGroup` you will have to use the function-as-a-child pattern. */
     children:
@@ -76,7 +73,7 @@ export interface InputGroupProps
     tooltip?: React.ReactNode;
 }
 
-export interface TooltipProps extends React.HTMLAttributes<HTMLSpanElement> {
+export interface TooltipProps extends React.ComponentProps<'span'> {
     'aria-controls'?: string;
     children?: React.ReactNode;
     className?: string;
@@ -86,8 +83,7 @@ export interface TooltipProps extends React.HTMLAttributes<HTMLSpanElement> {
     ref?: React.ForwardedRef<HTMLButtonElement>;
 }
 
-export interface RadioBlockProps
-    extends React.InputHTMLAttributes<HTMLInputElement> {
+export interface RadioBlockProps extends React.ComponentProps<'input'> {
     checked?: boolean;
     children?: React.ReactNode;
     className?: string;
@@ -101,8 +97,7 @@ export interface RadioBlockProps
 }
 
 // As value has a different type than InputHTMLAttributes<T> we have to weaken it
-interface WeakInputAttributes
-    extends React.InputHTMLAttributes<HTMLInputElement> {
+interface WeakInputAttributes extends React.ComponentProps<'input'> {
     value: any;
 }
 
@@ -121,8 +116,7 @@ export interface RadioButtonProps extends WeakInputAttributes {
 }
 
 // As onChange has a different type than React.FieldsetHTMLAttributes<T> we have to weaken it
-interface WeakFieldSetAttributes
-    extends React.FieldsetHTMLAttributes<HTMLFieldSetElement> {
+interface WeakFieldSetAttributes extends React.ComponentProps<'fieldset'> {
     onChange?: any;
 }
 
@@ -149,8 +143,7 @@ export interface RadioButtonInputGroupProps
     tooltip?: string | React.ReactNode;
 }
 
-export interface RadioSwitchProps
-    extends React.InputHTMLAttributes<HTMLInputElement> {
+export interface RadioSwitchProps extends React.ComponentProps<'input'> {
     checked?: boolean;
     className?: string;
     labelProps?: {};
@@ -167,13 +160,11 @@ export interface RadioSwitchProps
     condensed?: boolean;
 }
 
-export interface TextAreaProps
-    extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {
+export interface TextAreaProps extends React.ComponentProps<'textarea'> {
     className?: string;
 }
 
-export interface ToggleSwitchProps
-    extends React.InputHTMLAttributes<HTMLInputElement> {
+export interface ToggleSwitchProps extends React.ComponentProps<'input'> {
     children: React.ReactNode;
     className?: string;
     locale?: 'nb' | 'nn' | 'en';

--- a/packages/ffe-grid-react/src/index.d.ts
+++ b/packages/ffe-grid-react/src/index.d.ts
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 type Gap = 'none' | '2xs' | 'xs' | 'md' | 'lg';
 
-export interface GridProps extends React.HTMLAttributes<HTMLElement> {
+export interface GridProps extends React.ComponentProps<'html'> {
     children: React.ReactNode;
     className?: string;
     element?: string;
@@ -45,7 +45,7 @@ type Padding =
     | '4xl'
     | '5xl';
 
-export interface GridRowProps extends React.HTMLAttributes<HTMLElement> {
+export interface GridRowProps extends React.ComponentProps<'html'> {
     background?: BackgroundColors;
     children: React.ReactNode;
     className?: string;
@@ -61,7 +61,7 @@ export interface GridColSize {
     offset: ColumnsRange | string;
 }
 
-export interface GridColProps extends React.HTMLAttributes<HTMLElement> {
+export interface GridColProps extends React.ComponentProps<'html'> {
     background?: BackgroundColors;
     children?: React.ReactNode;
     className?: string;

--- a/packages/ffe-lists-react/src/index.d.ts
+++ b/packages/ffe-lists-react/src/index.d.ts
@@ -33,50 +33,50 @@ export interface DescriptionListProps extends BaseListProps {
 }
 
 declare class BulletList extends React.Component<
-    BulletListProps & React.HTMLAttributes<HTMLUListElement>,
+    BulletListProps & React.ComponentProps<'ul'>,
     any
 > {}
 declare class BulletListItem extends React.Component<
-    BaseListItemProps & React.LiHTMLAttributes<HTMLLIElement>,
+    BaseListItemProps & React.ComponentProps<'li'>,
     any
 > {}
 declare class CheckList extends React.Component<
-    CheckListProps & React.HTMLAttributes<HTMLUListElement>,
+    CheckListProps & React.ComponentProps<'ul'>,
     any
 > {}
 declare class CheckListItem extends React.Component<
-    CheckListItemProps & React.LiHTMLAttributes<HTMLLIElement>,
+    CheckListItemProps & React.ComponentProps<'li'>,
     any
 > {}
 declare class NumberedList extends React.Component<
-    NumberedListProps & React.OlHTMLAttributes<HTMLOListElement>,
+    NumberedListProps & React.ComponentProps<'ol'>,
     any
 > {}
 declare class NumberedListItem extends React.Component<
-    BaseListItemProps & React.LiHTMLAttributes<HTMLLIElement>,
+    BaseListItemProps & React.ComponentProps<'li'>,
     any
 > {}
 declare class StylizedNumberedList extends React.Component<
-    BaseListProps & React.OlHTMLAttributes<HTMLOListElement>,
+    BaseListProps & React.ComponentProps<'ol'>,
     any
 > {}
 declare class StylizedNumberedListItem extends React.Component<
-    BaseListItemProps & React.LiHTMLAttributes<HTMLLIElement>,
+    BaseListItemProps & React.ComponentProps<'li'>,
     any
 > {}
 declare class DescriptionList extends React.Component<
-    DescriptionListProps & React.HTMLAttributes<HTMLDListElement>,
+    DescriptionListProps & React.ComponentProps<'dl'>,
     any
 > {}
 declare class DescriptionListMultiCol extends React.Component<
-    BaseListProps & React.HTMLAttributes<HTMLDivElement>,
+    BaseListProps & React.ComponentProps<'div'>,
     any
 > {}
 declare class DescriptionListTerm extends React.Component<
-    BaseListItemProps & React.HTMLAttributes<HTMLElement>,
+    BaseListItemProps & React.ComponentProps<'html'>,
     any
 > {}
 declare class DescriptionListDescription extends React.Component<
-    BaseListItemProps & React.HTMLAttributes<HTMLElement>,
+    BaseListItemProps & React.ComponentProps<'html'>,
     any
 > {}

--- a/packages/ffe-message-box-react/src/index.d.ts
+++ b/packages/ffe-message-box-react/src/index.d.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 export interface MessageBoxProps
-    extends Omit<React.HTMLAttributes<HTMLDivElement>, 'title'> {
+    extends Omit<React.ComponentProps<'div'>, 'title'> {
     children?: React.ReactNode;
     className?: string;
     /**

--- a/packages/ffe-searchable-dropdown-react/src/index.d.ts
+++ b/packages/ffe-searchable-dropdown-react/src/index.d.ts
@@ -17,7 +17,7 @@ export interface SearchableDropdownProps<T> {
     dropdownList: T[];
     dropdownAttributes: (keyof T)[];
     searchAttributes: (keyof T)[];
-    inputProps?: React.InputHTMLAttributes<HTMLInputElement>;
+    inputProps?: React.ComponentProps<'input'>;
     selectedItem?: T;
     maxRenderedDropdownElements?: number;
     onChange?: (dropdownListItem: T) => any;

--- a/packages/ffe-spinner-react/src/index.d.ts
+++ b/packages/ffe-spinner-react/src/index.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-export interface SpinnerProps extends React.HTMLAttributes<HTMLSpanElement> {
+export interface SpinnerProps extends React.ComponentProps<'span'> {
     className?: string;
     immediate?: boolean;
     large?: boolean;

--- a/packages/ffe-tables-react/src/index.d.ts
+++ b/packages/ffe-tables-react/src/index.d.ts
@@ -1,7 +1,6 @@
 import * as React from 'react';
 
-export interface RowRenderTrProps
-    extends React.HTMLAttributes<HTMLTableRowElement> {}
+export interface RowRenderTrProps extends React.ComponentProps<'tr'> {}
 
 export interface TableRowProps {
     cells: Data;

--- a/packages/ffe-tabs-react/src/index.d.ts
+++ b/packages/ffe-tabs-react/src/index.d.ts
@@ -1,12 +1,11 @@
 import * as React from 'react';
 
-export interface TabProps
-    extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+export interface TabProps extends React.ComponentProps<'button'> {
     selected?: boolean;
     className?: string;
 }
 
-export interface TabGroupProps extends React.HTMLAttributes<HTMLDivElement> {
+export interface TabGroupProps extends React.ComponentProps<'div'> {
     children: React.ReactNode;
     className?: string;
     noBreak?: boolean;


### PR DESCRIPTION
Vi sliter mye med typer nå 

feks: 
```
../../libs/frontend/packages/shimmer/src/Shimmer.tsx:19:10 - error TS2322: Type '{ children: Element; className: string; title?: string | undefined; key?: Key | null | undefined; value?: string | number | readonly string[] | undefined; action?: string | undefined; ... 357 more ...; wrap?: string | undefined; }' is not assignable to type 'DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement>'.
  Type '{ children: Element; className: string; title?: string | undefined; key?: Key | null | undefined; value?: string | number | readonly string[] | undefined; action?: string | undefined; ... 357 more ...; wrap?: string | undefined; }' is not assignable to type 'HTMLAttributes<HTMLDivElement>'.
    Types of property 'dangerouslySetInnerHTML' are incompatible.
      Type '{ __html: string | TrustedHTML; } | undefined' is not assignable to type '{ __html: string; } | undefined'.

19         <div {...rest} className={cls}>
            ~~~
 ```

Har gjort disse endringerne lokalt og det ser ut att hjelpa. 

https://stackoverflow.com/questions/48198180/what-is-the-difference-between-react-htmlprops-and-react-htmlattributest