### PR TITLE
Develop fix types

### DIFF
--- a/packages/ffe-buttons-react/src/index.d.ts
+++ b/packages/ffe-buttons-react/src/index.d.ts
@@ -1,25 +1,27 @@
 import * as React from 'react';
 
-export interface MinimalBaseButtonProps extends React.ComponentPropsWithoutRef<'html'> {
-    className?: string;
-    element?: HTMLElement | string | React.ElementType;
-    innerRef?: React.Ref<HTMLElement>;
-}
+export type MinimalBaseButtonProps =
+    | ({
+          className?: string;
+          element?: HTMLElement | string | React.ElementType;
+          innerRef?: React.Ref<HTMLElement>;
+      } & React.ComponentProps<'button'>)
+    | React.ComponentProps<'a'>;
 
-export interface BaseButtonProps extends MinimalBaseButtonProps {
+export type BaseButtonProps = {
     children?: React.ReactNode;
     ariaLoadingMessage?: string;
     disabled?: boolean;
     isLoading?: boolean;
     leftIcon?: React.ReactNode;
     rightIcon?: React.ReactNode;
-}
+} & MinimalBaseButtonProps;
 
-export interface ActionButtonProps extends BaseButtonProps {}
+type ActionButtonProps = BaseButtonProps;
 
-export interface BackButtonProps extends MinimalBaseButtonProps {
+export type BackButtonProps = {
     children?: React.ReactNode;
-}
+} & MinimalBaseButtonProps;
 
 export interface ButtonGroupProps {
     className?: string;
@@ -28,43 +30,43 @@ export interface ButtonGroupProps {
     children: React.ReactNode;
 }
 
-export interface ExpandButtonProps extends MinimalBaseButtonProps {
+export type ExpandButtonProps = {
     children: React.ReactNode;
     closeLabel?: string;
     leftIcon?: React.ReactNode;
     rightIcon?: React.ReactNode;
     isExpanded: boolean;
     onClick: (e: React.MouseEvent | undefined) => void;
-}
+} & MinimalBaseButtonProps;
 
-export interface InlineExpandButtonProps extends MinimalBaseButtonProps {
+export type InlineExpandButtonProps = {
     children?: React.ReactNode;
     innerRef?: React.Ref<HTMLElement>;
     isExpanded: boolean;
     onClick: (e: React.MouseEvent | undefined) => void;
-}
+} & MinimalBaseButtonProps;
 
-export interface PrimaryButtonProps extends BaseButtonProps {}
+export type PrimaryButtonProps = BaseButtonProps;
 
-export interface SecondaryButtonProps extends BaseButtonProps {}
+export type SecondaryButtonProps = BaseButtonProps;
 
-export interface ShortcutButtonProps extends MinimalBaseButtonProps {
+export type ShortcutButtonProps = {
     children?: React.ReactNode;
     disabled?: boolean;
     leftIcon?: React.ReactNode;
-}
+} & MinimalBaseButtonProps;
 
-export interface TaskButtonProps extends MinimalBaseButtonProps {
+export type TaskButtonProps = {
     children?: React.ReactNode;
     disabled?: boolean;
     icon: React.ReactNode;
-}
+} & MinimalBaseButtonProps;
 
-export interface TertiaryButtonProps extends MinimalBaseButtonProps {
+export type TertiaryButtonProps = {
     children?: React.ReactNode;
     leftIcon?: React.ReactNode;
     rightIcon?: React.ReactNode;
-}
+} & MinimalBaseButtonProps;
 
 type NoInfer<T> = [T][T extends any ? 0 : never];
 

--- a/packages/ffe-cards-react/src/index.d.ts
+++ b/packages/ffe-cards-react/src/index.d.ts
@@ -1,12 +1,11 @@
 import * as React from 'react';
 
-type ComponentBaseProps =
+export type ComponentBaseProps =
     | ({
           className?: string;
           element?: HTMLElement | string | React.ElementType;
           children?: React.ReactNode;
-      } & React.ComponentProps<'html'>)
-    | React.ComponentProps<'button'>
+      } & React.ComponentProps<'button'>)
     | React.ComponentProps<'a'>;
 
 type TitleProps = {

--- a/packages/ffe-core-react/src/index.d.ts
+++ b/packages/ffe-core-react/src/index.d.ts
@@ -4,7 +4,7 @@ export interface DividerLineProps extends React.ComponentProps<'hr'> {
     className?: string;
 }
 
-export interface EmphasizedTextProps extends React.ComponentProps<'html'> {
+export interface EmphasizedTextProps extends React.ComponentProps<'em'> {
     children: React.ReactNode;
     className?: string;
 }
@@ -27,7 +27,7 @@ export interface LinkTextProps extends React.ComponentProps<'a'> {
     underline?: boolean;
 }
 
-export interface LinkIconProps extends React.ComponentProps<'html'> {
+export interface LinkIconProps extends React.ComponentProps<'a'> {
     children: React.ReactNode;
     className?: string;
     element?: HTMLElement | string | React.ElementType;

--- a/packages/ffe-form-react/src/index.d.ts
+++ b/packages/ffe-form-react/src/index.d.ts
@@ -14,7 +14,7 @@ export interface CheckboxProps
           }) => React.ReactNode);
 }
 
-export interface BaseFieldMessageProps extends React.ComponentProps<'html'> {
+export interface BaseFieldMessageProps extends React.ComponentProps<'div'> {
     children: React.ReactNode;
     className?: string;
     element?: string;

--- a/packages/ffe-grid-react/src/index.d.ts
+++ b/packages/ffe-grid-react/src/index.d.ts
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 type Gap = 'none' | '2xs' | 'xs' | 'md' | 'lg';
 
-export interface GridProps extends React.ComponentProps<'html'> {
+export interface GridProps extends React.ComponentProps<'div'> {
     children: React.ReactNode;
     className?: string;
     element?: string;
@@ -45,7 +45,7 @@ type Padding =
     | '4xl'
     | '5xl';
 
-export interface GridRowProps extends React.ComponentProps<'html'> {
+export interface GridRowProps extends React.ComponentProps<'div'> {
     background?: BackgroundColors;
     children: React.ReactNode;
     className?: string;
@@ -61,7 +61,7 @@ export interface GridColSize {
     offset: ColumnsRange | string;
 }
 
-export interface GridColProps extends React.ComponentProps<'html'> {
+export interface GridColProps extends React.ComponentProps<'div'> {
     background?: BackgroundColors;
     children?: React.ReactNode;
     className?: string;

--- a/packages/ffe-lists-react/src/index.d.ts
+++ b/packages/ffe-lists-react/src/index.d.ts
@@ -73,10 +73,10 @@ declare class DescriptionListMultiCol extends React.Component<
     any
 > {}
 declare class DescriptionListTerm extends React.Component<
-    BaseListItemProps & React.ComponentProps<'html'>,
+    BaseListItemProps & React.ComponentProps<'dt'>,
     any
 > {}
 declare class DescriptionListDescription extends React.Component<
-    BaseListItemProps & React.ComponentProps<'html'>,
+    BaseListItemProps & React.ComponentProps<'dd'>,
     any
 > {}


### PR DESCRIPTION
Må gå tilbake på dom som brukte `React.ComponentProps<'html'>`. Det bettyde faktiskt ett `<html>`, medan `React.HTMLProps<HTMLElement>` betyr vilket html element som helst. Det er ju ingen vidare typning og tillata alla html attributer men det er ju `element` som er input som er problemet. Så gjør en liten revert på alla som hade  `React.ComponentProps<'html'>` intil/hvis vi finner en løsning på dom. 

```
 interface HTMLProps<T> extends AllHTMLAttributes<T>, ClassAttributes<T> {
    }
```