### PR TITLE
fix(ffe-details-list-react): removed bottomPadding prod from GridCol

### DIFF
--- a/packages/ffe-details-list-react/src/DetailContent.js
+++ b/packages/ffe-details-list-react/src/DetailContent.js
@@ -27,7 +27,6 @@ export default function DetailContent(props) {
             sm={12}
             md={{ cols: 8, offset: 2 }}
             lg={{ cols: getColCount(childCount, index), offset: 0 }}
-            bottomPadding={false}
             {...rest}
         >
             {children}


### PR DESCRIPTION
bottomPadding er vell ikke lenger en prop på GridCol

![image](https://github.com/SpareBank1/designsystem/assets/2248579/42c80004-14e2-46e0-aeed-b486055251a6)
