### PR TITLE
docs(component-overview): legger til separate eksempler med inputgroup

### DIFF
--- a/component-overview/examples/form/InputGroup-checkbox.jsx
+++ b/component-overview/examples/form/InputGroup-checkbox.jsx
@@ -1,0 +1,22 @@
+import { useState } from 'react';
+import Datepicker from '@sb1/ffe-datepicker-react';
+import Dropdown from '@sb1/ffe-dropdown-react';
+import { InputGroup, Checkbox, Input, TextArea } from '@sb1/ffe-form-react';
+import { SecondaryButton } from '@sb1/ffe-buttons-react';
+
+() => {
+    const [showErrors, setShowErrors] = useState(false);
+
+    return (
+        <>
+            <div className="ffe-button-group">
+                <SecondaryButton onClick={() => setShowErrors(!showErrors)}>
+                    Skru feilmeldinger av/på
+                </SecondaryButton>
+            </div>
+            <InputGroup fieldMessage={showErrors ? 'Ooops' : null}>
+                <Checkbox name="check">Kryssboks</Checkbox>
+            </InputGroup>
+        </>
+    );
+}

--- a/component-overview/examples/form/InputGroup-datepicker.jsx
+++ b/component-overview/examples/form/InputGroup-datepicker.jsx
@@ -1,0 +1,31 @@
+import { useState } from 'react';
+import Datepicker from '@sb1/ffe-datepicker-react';
+import Dropdown from '@sb1/ffe-dropdown-react';
+import { InputGroup, Checkbox, Input, TextArea } from '@sb1/ffe-form-react';
+import { SecondaryButton } from '@sb1/ffe-buttons-react';
+
+() => {
+    const [showErrors, setShowErrors] = useState(false);
+
+    return (
+        <>
+            <div className="ffe-button-group">
+                <SecondaryButton onClick={() => setShowErrors(!showErrors)}>
+                    Skru feilmeldinger av/på
+                </SecondaryButton>
+            </div>
+            <InputGroup
+                label="Dato"
+                fieldMessage={showErrors ? 'Feil dato' : null}
+            >
+                <Datepicker
+                    language="nb"
+                    maxDate="31.12.2016"
+                    minDate="01.01.2016"
+                    onChange={f => f}
+                    value={'01.01.2016'}
+                />
+            </InputGroup>
+        </>
+    );
+}

--- a/component-overview/examples/form/InputGroup-dropdown.jsx
+++ b/component-overview/examples/form/InputGroup-dropdown.jsx
@@ -1,0 +1,33 @@
+import { useState } from 'react';
+import Datepicker from '@sb1/ffe-datepicker-react';
+import Dropdown from '@sb1/ffe-dropdown-react';
+import { InputGroup, Checkbox, Input, TextArea } from '@sb1/ffe-form-react';
+import { SecondaryButton } from '@sb1/ffe-buttons-react';
+
+() => {
+    const [showErrors, setShowErrors] = useState(false);
+
+    return (
+        <>
+            <div className="ffe-button-group">
+                <SecondaryButton onClick={() => setShowErrors(!showErrors)}>
+                    Skru feilmeldinger av/på
+                </SecondaryButton>
+            </div>
+            
+            <InputGroup
+                label="Måned"
+                fieldMessage={showErrors ? 'Du må velge måned' : null}
+            >
+                <Dropdown defaultValue="placeholder">
+                    <option value="placeholder" disabled>
+                        Velg måned
+                    </option>
+                    <option value="jan">Januar</option>
+                    <option value="feb">Februar</option>
+                    <option value="mar">Mars</option>
+                </Dropdown>
+            </InputGroup>
+        </>
+    );
+}

--- a/component-overview/examples/form/InputGroup-input.jsx
+++ b/component-overview/examples/form/InputGroup-input.jsx
@@ -1,0 +1,39 @@
+import { useState } from 'react';
+import Datepicker from '@sb1/ffe-datepicker-react';
+import Dropdown from '@sb1/ffe-dropdown-react';
+import { InputGroup, Checkbox, Input, TextArea } from '@sb1/ffe-form-react';
+import { SecondaryButton } from '@sb1/ffe-buttons-react';
+
+() => {
+    const [showErrors, setShowErrors] = useState(false);
+
+    return (
+        <>
+            <div className="ffe-button-group">
+                <SecondaryButton onClick={() => setShowErrors(!showErrors)}>
+                    Skru feilmeldinger av/på
+                </SecondaryButton>
+            </div>
+            <InputGroup
+                label="Telefonnummer"
+                tooltip="Vi bruker telefonnummer for å sende deg kvittering på SMS"
+                fieldMessage={showErrors ? 'Ugyldig telefonnummer' : null}
+            >
+                {inputProps => (
+                    <>
+                        <Input
+                            type="tel"
+                            name="mobile"
+                            onChange={e =>
+                                console.log('onChange', e.target.value)
+                            }
+                            onBlur={e => console.log('onBlur', e.target.value)}
+                            {...inputProps}
+                        />
+                        <p>Ekstra innhold</p>
+                    </>
+                )}
+            </InputGroup>
+        </>
+    );
+}

--- a/component-overview/examples/form/InputGroup-textarea.jsx
+++ b/component-overview/examples/form/InputGroup-textarea.jsx
@@ -1,0 +1,25 @@
+import { useState } from 'react';
+import Datepicker from '@sb1/ffe-datepicker-react';
+import Dropdown from '@sb1/ffe-dropdown-react';
+import { InputGroup, Checkbox, Input, TextArea } from '@sb1/ffe-form-react';
+import { SecondaryButton } from '@sb1/ffe-buttons-react';
+
+() => {
+    const [showErrors, setShowErrors] = useState(false);
+
+    return (
+        <>
+            <div className="ffe-button-group">
+                <SecondaryButton onClick={() => setShowErrors(!showErrors)}>
+                    Skru feilmeldinger av/på
+                </SecondaryButton>
+            </div>
+            <InputGroup
+                label="Fritekst"
+                fieldMessage={showErrors ? 'Du må skrive noe lurt' : null}
+            >
+                <TextArea rows={4} />
+            </InputGroup>
+        </>
+    );
+}


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse

Legger til separate eksempler av InputGroup, som inneholder henholdsvis input, dropdown, textarea, datepicker og checkbox.

## Motivasjon og kontekst

Separate eksempler fremfor alle eksemplene på samme side gjør det lettere å UU-teste komponentene.

## Testing

Testet lokalt med component-overview