### PR TITLE
feat(component-overview): legg til eksempler på RadioButtonInputGroup

### DIFF
--- a/component-overview/examples/form/RadioButton-without-radioinputgroup.jsx
+++ b/component-overview/examples/form/RadioButton-without-radioinputgroup.jsx
@@ -1,0 +1,9 @@
+import { RadioButton } from '@sb1/ffe-form-react';
+
+() => {
+    return (
+        <RadioButton value="bank">
+            Bankkunde
+        </RadioButton>
+    );
+}

--- a/component-overview/examples/form/RadioButtonInputGroup-radioBlock.jsx
+++ b/component-overview/examples/form/RadioButtonInputGroup-radioBlock.jsx
@@ -1,0 +1,40 @@
+import { useState } from 'react';
+import {
+    RadioButtonInputGroup,
+    RadioBlock,
+} from '@sb1/ffe-form-react';
+import { SecondaryButton } from '@sb1/ffe-buttons-react';
+
+() => {
+    const [showErrors, setShowErrors] = useState(false);
+
+    return (
+        <>
+            <div className="ffe-button-group">
+                <SecondaryButton onClick={() => setShowErrors(!showErrors)}>
+                    Skru feilmeldinger av/på
+                </SecondaryButton>
+            </div>
+            <RadioButtonInputGroup
+                label="Velg ja eller nei"
+                name="block1"
+                selectedValue="yes"
+                fieldMessage={showErrors ? 'Feil valg' : null}
+            >
+                {inputProps => (
+                    <>
+                        <RadioBlock {...inputProps} label="Ja" value="yes" />
+                        <RadioBlock
+                            {...inputProps}
+                            label="Nei"
+                            showChildren={true}
+                            value="no"
+                        >
+                            Vil ikke!
+                        </RadioBlock>
+                    </>
+                )}
+            </RadioButtonInputGroup>
+        </>
+    );
+}

--- a/component-overview/examples/form/RadioButtonInputGroup-radioButton.jsx
+++ b/component-overview/examples/form/RadioButtonInputGroup-radioButton.jsx
@@ -1,0 +1,49 @@
+import { useState } from 'react';
+import {
+    RadioButtonInputGroup,
+    RadioButton,
+    Tooltip,
+} from '@sb1/ffe-form-react';
+import { SecondaryButton } from '@sb1/ffe-buttons-react';
+
+() => {
+    const [showErrors, setShowErrors] = useState(false);
+    const [selectedColor, setSelectedColor] = useState('red');
+
+    return (
+        <>
+            <div className="ffe-button-group">
+                <SecondaryButton onClick={() => setShowErrors(!showErrors)}>
+                    Skru feilmeldinger av/på
+                </SecondaryButton>
+            </div>
+            <RadioButtonInputGroup
+                label="Hva er din favorittfarge?"
+                inline={true}
+                name="color"
+                fieldMessage={showErrors ? 'Feil farge.' : null}
+                tooltip={
+                    <Tooltip>
+                        Din favorittfarge er viktig for oss. Vår er blå!
+                    </Tooltip>
+                }
+                selectedValue={selectedColor}
+                onChange={e => setSelectedColor(e.target.value)}
+            >
+                {inputProps => (
+                    <>
+                        <RadioButton {...inputProps} value="red">
+                            Rød
+                        </RadioButton>
+                        <RadioButton {...inputProps} value="blue">
+                            Blå
+                        </RadioButton>
+                        <RadioButton {...inputProps} value="yellow">
+                            Gul
+                        </RadioButton>
+                    </>
+                )}
+            </RadioButtonInputGroup>
+        </>
+    );
+}

--- a/component-overview/examples/form/RadioButtonInputGroup-radioSwitch.jsx
+++ b/component-overview/examples/form/RadioButtonInputGroup-radioSwitch.jsx
@@ -1,0 +1,36 @@
+import { useState } from 'react';
+import {
+    RadioButtonInputGroup,
+    RadioSwitch,
+} from '@sb1/ffe-form-react';
+import { SecondaryButton } from '@sb1/ffe-buttons-react';
+
+() => {
+    const [showErrors, setShowErrors] = useState(false);
+
+    return (
+        <>
+            <div className="ffe-button-group">
+                <SecondaryButton onClick={() => setShowErrors(!showErrors)}>
+                    Skru feilmeldinger av/på
+                </SecondaryButton>
+            </div>
+            <RadioButtonInputGroup
+                description="Du kan ikke velge begge"
+                label="Velg ja eller nei"
+                name="switch"
+                fieldMessage={showErrors ? 'Feil valg' : null}
+            >
+                {inputProps => (
+                    <RadioSwitch
+                        leftLabel="Ja"
+                        leftValue={true}
+                        rightLabel="Nei"
+                        rightValue={false}
+                        {...inputProps}
+                    />
+                )}
+            </RadioButtonInputGroup>
+        </>
+    );
+}


### PR DESCRIPTION
Splitter opp eksempler på RadiobuttonInputGroup og legger til ett med bare RadioButton.
Disse eksemplene brukes til UU testing 