### PR TITLE
fix(ffe-tables-react): fjern div fra expanded table cell

### DIFF
--- a/packages/ffe-tables-react/src/TableParts/TableRowExpandable.js
+++ b/packages/ffe-tables-react/src/TableParts/TableRowExpandable.js
@@ -107,7 +107,7 @@ class TableRowExpandable extends Component {
                         colSpan={columns.length}
                         className="ffe-table__cell-expandable-content"
                     >
-                        <div>{this.state.expanded && children}</div>
+                        <>{this.state.expanded && children}</>
                     </td>
                 </tr>
             </tbody>


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse
Fjerner en div som blir lagt til rundt "exandable-content" i TableRowExpandable.
<!-- Detaljert beskrivelse av endringene dine. Skjermskudd er lov. -->

## Motivasjon og kontekst
Det er ikke alle scenarioer der det gir mening å wrappe innholdet i en div. Innholdet til TableRowExpandable blir også satt av children, og det vil derfor være naturlig for brukerne å wrappe innholdet i en tag fra før. Denne diven blir derfor da veldig fort overflødig. 
<!-- Hvorfor trengs denne endringen, og hva løser den? -->

## Testing
Kjørt opp lokalt 
<!-- Hvordan har du har testet endringene dine? Ta gjerne med systeminfo o.l -->

<!--

Helt til slutt, har du ..

.. lest retningslinjene våre for bidrag?
.. tatt en siste sjekk for kode og skrivefeil, debug informasjon o.l?
.. kjørt og eventuelt oppdatert testene?
.. kommentert og dokumentert det som trengs?
.. knyttet denne opp til relaterte issues?

-->
