### PR TITLE
feat(ffe-form-react): tooltip as node also in Tooltip component in In…

### DIFF
--- a/packages/ffe-form-react/src/InputGroup.js
+++ b/packages/ffe-form-react/src/InputGroup.js
@@ -104,13 +104,11 @@ const InputGroup = ({
                     id: labelId,
                 })}
 
-            {typeof tooltip === 'string' && (
+            {(typeof tooltip === 'string' || React.isValidElement(tooltip)) && (
                 <Tooltip onClick={onTooltipToggle}>{tooltip}</Tooltip>
             )}
 
             {tooltip === true && <Tooltip onClick={onTooltipToggle} />}
-
-            {React.isValidElement(tooltip) && tooltip}
 
             {description && (
                 <div


### PR DESCRIPTION
Når tooltip er noe annet en en `string`(og `boolean` vad det nå brukes til?) så havner den ikke i en `<ToolTip />`. Dvs den blir hele tiden synlig og  ikke expandable. Vad er grunden til det? Burde det ikke vare likt får båda?

![image](https://github.com/SpareBank1/designsystem/assets/2248579/6fd42a30-974c-4fbc-a949-29acee6a62b7)
