### PR TITLE
fix(ffe-form-react): fjern aria-describedBy når element ikke finnes

### DIFF
--- a/packages/ffe-form-react/src/RadioBlock.js
+++ b/packages/ffe-form-react/src/RadioBlock.js
@@ -34,7 +34,9 @@ class RadioBlock extends Component {
                     name={name}
                     value={value}
                     aria-describedby={
-                        children ? `${this.id}-described` : undefined
+                        (children && showChildren) || (children && isSelected)
+                            ? `${this.id}-described`
+                            : undefined
                     }
                     {...inputProps}
                 />


### PR DESCRIPTION

<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse
Fjerner aria-describedBy når child elementet er gjemt eller ikke eksisterer.
<!-- Detaljert beskrivelse av endringene dine. Skjermskudd er lov. -->

## Motivasjon og kontekst
Fikser #1615 
<!-- Hvorfor trengs denne endringen, og hva løser den? -->

## Testing
Testet ved å kjøre opp lokalt, og se at aria-describedBy blir lagt til og fjernet når man gjemmer innholdet.
<!-- Hvordan har du har testet endringene dine? Ta gjerne med systeminfo o.l -->

<!--

Helt til slutt, har du ..

.. lest retningslinjene våre for bidrag?
.. tatt en siste sjekk for kode og skrivefeil, debug informasjon o.l?
.. kjørt og eventuelt oppdatert testene?
.. kommentert og dokumentert det som trengs?
.. knyttet denne opp til relaterte issues?

-->
