### PR TITLE
feat(ffe-file-upload-react): Expose file input property `accept`

### DIFF
--- a/packages/ffe-file-upload-react/src/FileUpload.js
+++ b/packages/ffe-file-upload-react/src/FileUpload.js
@@ -60,6 +60,7 @@ class FileUpload extends React.Component {
             uploadTitle,
             uploadMicroText,
             uploadSubText,
+            accept,
         } = this.props;
 
         return (
@@ -131,6 +132,7 @@ class FileUpload extends React.Component {
                     ref={this.setFileInputElement}
                     onChange={this.onFilesSelected}
                     aria-labelledby={`${id}-label`}
+                    accept={accept || '*'}
                 />
             </div>
         );
@@ -180,6 +182,11 @@ FileUpload.propTypes = {
     uploadMicroText: stringType.isRequired,
     /** SubText on the upload-section */
     uploadSubText: stringType.isRequired,
+    /** Unique file type specifier that describes a type of file that may be selected by the user, e.g. ".pdf"
+     *  See MDN for documentation on
+     *  [Unique file type specifiers](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file#unique_file_type_specifiers)
+     */
+    accept: stringType,
 };
 
 export default FileUpload;

--- a/packages/ffe-file-upload-react/src/index.d.ts
+++ b/packages/ffe-file-upload-react/src/index.d.ts
@@ -22,6 +22,7 @@ export interface FileUploadProps<T> {
     uploadTitle: string;
     uploadMicroText: string;
     uploadSubText: string;
+    accept: string;
 }
 declare class FileUpload<T> extends React.Component<FileUploadProps<T>, any> {}
 


### PR DESCRIPTION
Expose file input property `accept` as property on FileUpload component

<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse

<!-- Detaljert beskrivelse av endringene dine. Skjermskudd er lov. -->

## Motivasjon og kontekst

<!-- Hvorfor trengs denne endringen, og hva løser den? -->

## Testing

<!-- Hvordan har du har testet endringene dine? Ta gjerne med systeminfo o.l -->

<!--

Helt til slutt, har du ..

.. lest retningslinjene våre for bidrag?
.. tatt en siste sjekk for kode og skrivefeil, debug informasjon o.l?
.. kjørt og eventuelt oppdatert testene?
.. kommentert og dokumentert det som trengs?
.. knyttet denne opp til relaterte issues?

-->
