### PR TITLE
fix(ffe-file-upload-react): make accept prop optional

### DIFF
--- a/packages/ffe-file-upload-react/src/index.d.ts
+++ b/packages/ffe-file-upload-react/src/index.d.ts
@@ -22,7 +22,7 @@ export interface FileUploadProps<T> {
     uploadTitle: string;
     uploadMicroText: string;
     uploadSubText: string;
-    accept: string;
+    accept?: string;
 }
 declare class FileUpload<T> extends React.Component<FileUploadProps<T>, any> {}
 


### PR DESCRIPTION
Typescript projects would get an error if bumping its minor version of the component,
since the accept prop was not optional. Now that the prop is optional, it is possible
to update minor version of the component without having to set the prop.

<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse

<!-- Detaljert beskrivelse av endringene dine. Skjermskudd er lov. -->

## Motivasjon og kontekst


## Testing

<!-- Hvordan har du har testet endringene dine? Ta gjerne med systeminfo o.l -->

<!--

Helt til slutt, har du ..

.. lest retningslinjene våre for bidrag?
.. tatt en siste sjekk for kode og skrivefeil, debug informasjon o.l?
.. kjørt og eventuelt oppdatert testene?
.. kommentert og dokumentert det som trengs?
.. knyttet denne opp til relaterte issues?

-->
