### PR TITLE
fix(ffe-file-upload-react)!: make component props compliant with its type definitions

### DIFF
--- a/packages/ffe-file-upload-react/src/FileUpload.js
+++ b/packages/ffe-file-upload-react/src/FileUpload.js
@@ -39,7 +39,7 @@ class FileUpload extends React.Component {
     onFilesDropped(event) {
         event.preventDefault();
         this.setState({ hover: false });
-        this.props.onFilesDropped(event);
+        this.props.onFilesDropped(event.dataTransfer.files);
     }
 
     onFileDeleted(event) {


### PR DESCRIPTION
The `onFilesDropped` callback prop received a drop event as argument, not a `fileList` as described in the type definitions. Typescript clients would have to circumvent the mismatch by casting to the `any` type.

BREAKING CHANGE: The `onFilesDropped` callback prop is now called with a `fileList` instead of the drop event

<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse

Det var ikke mulig å bruke komponenten i typescript uten å caste om onFilesDropped ettersom det var mismatch mellom typedefinisjon og implementasjon. Alle repositories/klienter som benytter komponenten fra før av (i monorepo til sb1) ser ut til å hente ut files med event.dataTransfer.files og ikke ha behov for andre deler av eventen. Klienter som bumber major vil nå kunne bruke files direkte. Dette er også mer konsistent med onFilesSelected som allerede (korrekt) får inn en fileList

## Motivasjon og kontekst

<!-- Hvorfor trengs denne endringen, og hva løser den? -->

## Testing

<!-- Hvordan har du har testet endringene dine? Ta gjerne med systeminfo o.l -->

<!--

Helt til slutt, har du ..

.. lest retningslinjene våre for bidrag?
.. tatt en siste sjekk for kode og skrivefeil, debug informasjon o.l?
.. kjørt og eventuelt oppdatert testene?
.. kommentert og dokumentert det som trengs?
.. knyttet denne opp til relaterte issues?

-->
