### PR TITLE
fix(ffe-buttons-react): fix MinimalBaseButtonProps

### DIFF
--- a/packages/ffe-buttons-react/src/index.d.ts
+++ b/packages/ffe-buttons-react/src/index.d.ts
@@ -4,8 +4,7 @@ export type MinimalBaseButtonProps = {
     className?: string;
     element?: HTMLElement | string | React.ElementType;
     innerRef?: React.Ref<HTMLElement>;
-} & React.ComponentProps<'button'> &
-    React.ComponentProps<'a'>;
+} & (React.ComponentProps<'button'> | React.ComponentProps<'a'>);
 
 export type BaseButtonProps = {
     children?: React.ReactNode;


### PR DESCRIPTION
Feil i typingen. Glemte parantesen første gang. Feilen ble inført her https://github.com/SpareBank1/designsystem/commit/4a2923065f759cafb4a2cf3108b42bfc719a0aba 
Glemte parantesen i førsta førsøket