### PR TITLE
docs(component-overview): radioblock-eksempel uten radiobuttoninputgroup

### DIFF
--- a/component-overview/examples/form/RadioBlock-without-radioinputgroup.jsx
+++ b/component-overview/examples/form/RadioBlock-without-radioinputgroup.jsx
@@ -1,0 +1,10 @@
+import { RadioBlock } from '@sb1/ffe-form-react';
+
+() => {
+    return (
+        <>
+            <RadioBlock label="Du" value="you" name="who" />
+            <RadioBlock label="Jeg" value="me" name="who" />
+        </>
+    );
+}


### PR DESCRIPTION
Legger til et eksempel på RadioBlock som ikke er wrappet med RadioButtonInputGroup, for å forenkle testing av komponenten.