### PR TITLE
docs(component-overview): fieldmessage-eksempel med utskiftbar role

### DIFF
--- a/component-overview/examples/form/InfoFieldMessage-switch-roles.jsx
+++ b/component-overview/examples/form/InfoFieldMessage-switch-roles.jsx
@@ -1,0 +1,39 @@
+import { useState } from 'react';
+import { InfoFieldMessage } from '@sb1/ffe-form-react';
+import { RadioButton, RadioButtonInputGroup } from '@sb1/ffe-form-react';
+
+() => {
+    const [selected, setSelected] = useState();
+
+    return (
+        <>
+            <RadioButtonInputGroup
+                label="Velg Aria-role"
+                name="aria-role"
+                onChange={e => setSelected(e.target.value)}
+                selectedValue={selected}
+            >
+                {inputProps => (
+                    <>
+                        <RadioButton {...inputProps} value="status">
+                            Status
+                        </RadioButton>
+                        <RadioButton {...inputProps} value="alert">
+                            Alert
+                        </RadioButton>
+                        <RadioButton {...inputProps} value="none">
+                            None
+                        </RadioButton>
+                    </>
+                )}
+            </RadioButtonInputGroup>
+            {(() => {
+                return (<div>
+                    <InfoFieldMessage role={selected}>
+                        Aria-role: {selected ? selected : 'status'}
+                    </InfoFieldMessage>
+                </div>)
+            })()}
+        </>
+    );
+}


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse

Eksempelimplementasjon av `InfoFieldMessage` med radiobuttons for å velge aria-role. Relatert til #1632 

## Motivasjon og kontekst

Utskiftbar aria-role er lagt til for å lette UU-testing

## Testing

Testet i component-overview