### PR TITLE
fix(ffe-formatters): formatter kontonummer mens man skriver

### DIFF
--- a/packages/ffe-formatters/src/formatAccountNumber.js
+++ b/packages/ffe-formatters/src/formatAccountNumber.js
@@ -1,12 +1,24 @@
 import { NON_BREAKING_SPACE } from './internal/unicode';
 
 export default function formatAccountNumber(accountNumber) {
-    if (!accountNumber || accountNumber.length !== 11) {
+    if (!accountNumber) {
         return accountNumber;
     }
-    return [
-        accountNumber.substring(0, 4),
-        accountNumber.substring(4, 6),
-        accountNumber.substring(6, 11),
-    ].join(NON_BREAKING_SPACE);
+    let formattedAccountNumber = '';
+
+    if (accountNumber.length > 0) {
+        formattedAccountNumber += accountNumber.substring(0, 4);
+    }
+
+    if (accountNumber.length > 4) {
+        formattedAccountNumber +=
+            NON_BREAKING_SPACE + accountNumber.substring(4, 6);
+    }
+
+    if (accountNumber.length > 6) {
+        formattedAccountNumber +=
+            NON_BREAKING_SPACE + accountNumber.substring(6);
+    }
+
+    return formattedAccountNumber;
 }

--- a/packages/ffe-formatters/src/formatAccountNumber.spec.js
+++ b/packages/ffe-formatters/src/formatAccountNumber.spec.js
@@ -14,8 +14,10 @@ describe('format account number', () => {
         expect(formatAccountNumber('')).toBe('');
     });
 
-    test('returns input when account number length is not 11', () => {
-        expect(formatAccountNumber('1234567890')).toBe('1234567890');
+    test('Formats account number even when less than 11 digits', () => {
+        expect(formatAccountNumber('12345678')).toBe(
+            `1234${NON_BREAKING_SPACE}56${NON_BREAKING_SPACE}78`,
+        );
     });
 
     test('formats account number correctly', () => {


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse
Endrer så kontonummer blir formatert mens man skriver og ikke først når kontonummer er på 11-siffer.
Takk til Jonas Kristoffersen for kodeforslaget! 
<!-- Detaljert beskrivelse av endringene dine. Skjermskudd er lov. -->

## Motivasjon og kontekst
Nå kan man se formatteringen mens man taster inn verdien istedenfor når man først har fått 11-siffer.
<!-- Hvorfor trengs denne endringen, og hva løser den? -->

## Testing
kjørt opp lokalt og testet med å skrive inn tall
<!-- Hvordan har du har testet endringene dine? Ta gjerne med systeminfo o.l -->

<!--

Helt til slutt, har du ..

.. lest retningslinjene våre for bidrag?
.. tatt en siste sjekk for kode og skrivefeil, debug informasjon o.l?
.. kjørt og eventuelt oppdatert testene?
.. kommentert og dokumentert det som trengs?
.. knyttet denne opp til relaterte issues?

-->
