### PR TITLE
Ability to change phonenumber label to mobile

### DIFF
--- a/component-overview/examples/form/PhoneNumber-isMobileNumber.jsx
+++ b/component-overview/examples/form/PhoneNumber-isMobileNumber.jsx
@@ -1,0 +1,3 @@
+import { PhoneNumber } from '@sb1/ffe-form-react';
+
+<PhoneNumber isMobileNumber={true} number="123123123" />

--- a/packages/ffe-form-react/src/PhoneNumber.js
+++ b/packages/ffe-form-react/src/PhoneNumber.js
@@ -27,6 +27,7 @@ export default class PhoneNumber extends React.Component {
             extraMargin,
             countryCodeRef,
             numberRef,
+            isMobileNumber,
         } = this.props;
 
         let fieldMessage;
@@ -106,7 +107,9 @@ export default class PhoneNumber extends React.Component {
                             className="ffe-form-label"
                             htmlFor={this.numberId}
                         >
-                            {text.PHONE_NUMBER}
+                            {isMobileNumber
+                                ? text.MOBILE_NUMBER
+                                : text.PHONE_NUMBER}
                         </label>
                         <input
                             id={this.numberId}
@@ -182,6 +185,8 @@ PhoneNumber.propTypes = {
     countryCodeRef: oneOfType([func, shape({ current: object })]),
     /** Ref-setting function, or ref created by useRef, passed to the number input element */
     numberRef: oneOfType([func, shape({ current: object })]),
+    /** If True label is changed from "Phone number" to "Mobile number" */
+    isMobileNumber: bool,
 };
 
 PhoneNumber.defaultProps = {
@@ -192,4 +197,5 @@ PhoneNumber.defaultProps = {
     onCountryCodeBlur: noop,
     onNumberBlur: noop,
     extraMargin: true,
+    isMobileNumber: false,
 };

--- a/packages/ffe-form-react/src/PhoneNumber.spec.js
+++ b/packages/ffe-form-react/src/PhoneNumber.spec.js
@@ -50,6 +50,26 @@ describe('renders correctly', () => {
         expect(inputs.at(1).prop('aria-invalid')).toBe(false);
     });
 
+    it('should set label to phonenumber by default', function() {
+        const wrapper = getWrapper({});
+        const input = wrapper
+            .find('label')
+            .at(1)
+            .props().children;
+        expect(input).toEqual('Telefonnummer');
+    });
+
+    it('should set label to mobilenumber when isMobileNumber true', function() {
+        const wrapper = getWrapper({
+            isMobileNumber: true,
+        });
+        const input = wrapper
+            .find('label')
+            .at(1)
+            .props().children;
+        expect(input).toEqual('Mobilnummer');
+    });
+
     it('should render using numberFieldMessage prop', function() {
         const wrapper = getWrapper({ numberFieldMessage: 'Denne ble feil' });
         const inputs = wrapper.find('input');

--- a/packages/ffe-form-react/src/i18n/en.js
+++ b/packages/ffe-form-react/src/i18n/en.js
@@ -1,6 +1,7 @@
 export default {
     COUNTRY_CODE: 'Country code',
     PHONE_NUMBER: 'Phone number',
+    MOBILE_NUMBER: 'Mobile number',
     ON: 'On',
     OFF: 'Off',
 };

--- a/packages/ffe-form-react/src/i18n/nb.js
+++ b/packages/ffe-form-react/src/i18n/nb.js
@@ -1,6 +1,7 @@
 export default {
     COUNTRY_CODE: 'Landskode',
     PHONE_NUMBER: 'Telefonnummer',
+    MOBILE_NUMBER: 'Mobilnummer',
     ON: 'På',
     OFF: 'Av',
 };

--- a/packages/ffe-form-react/src/i18n/nn.js
+++ b/packages/ffe-form-react/src/i18n/nn.js
@@ -1,6 +1,7 @@
 export default {
     COUNTRY_CODE: 'Landskode',
     PHONE_NUMBER: 'Telefonnummer',
+    MOBILE_NUMBER: 'Mobilnummer',
     ON: 'På',
     OFF: 'Av',
 };


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse
Legger til isMobileNumber prop på "PhoneNumber" komponenten sånn at man kan endre labelen fra "Telefonnummer" til "Mobilnummer"
<!-- Detaljert beskrivelse av endringene dine. Skjermskudd er lov. -->

## Motivasjon og kontekst
Etterspurt i #1580 
<!-- Hvorfor trengs denne endringen, og hva løser den? -->

## Testing
Testet lokalt og ved å kjøre unittester
<!-- Hvordan har du har testet endringene dine? Ta gjerne med systeminfo o.l -->

<!--

Helt til slutt, har du ..

.. lest retningslinjene våre for bidrag?
.. tatt en siste sjekk for kode og skrivefeil, debug informasjon o.l?
.. kjørt og eventuelt oppdatert testene?
.. kommentert og dokumentert det som trengs?
.. knyttet denne opp til relaterte issues?

-->
