### PR TITLE
fix(ffe-form): retter klassenavn

### DIFF
--- a/packages/ffe-form/less/input-group.less
+++ b/packages/ffe-form/less/input-group.less
@@ -40,7 +40,7 @@
         margin-bottom: @ffe-spacing-xs;
     }
 
-    .ffe-field-error-message {
+    .ffe-field-message--error {
         margin-top: -24px;
         margin-bottom: 0;
     }
@@ -54,7 +54,7 @@
             margin-bottom: auto;
         }
 
-        .ffe-field-error-message {
+        .ffe-field-message--error {
             margin: @ffe-spacing-2xs 0 @ffe-spacing-xs;
         }
     }


### PR DESCRIPTION
Retter opp styling av feilmeldinger i input-group.less, som peker på et klassenavn som nylig har blitt endret.