### PR TITLE
fix(ffe-searchable-dropdown-react): endre placeholder farge til mørk grå

### DIFF
--- a/packages/ffe-searchable-dropdown-react/less/ffe-searchable-dropdown.less
+++ b/packages/ffe-searchable-dropdown-react/less/ffe-searchable-dropdown.less
@@ -4,6 +4,10 @@
 
     .ffe-input-field {
         padding-right: calc(@button-width + 3px);
+
+        &::placeholder {
+            color: var(--ffe-g-farge-moerkgraa);
+        }
     }
 
     &__list {


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse
Endrer fargen på placeholder teksten fra standard lys grå til ffe-farge-moerkgraa
<!-- Detaljert beskrivelse av endringene dine. Skjermskudd er lov. -->

## Motivasjon og kontekst
Påpekt forskjell mellom searchable dropdown og vanlig dropdown av designer
<!-- Hvorfor trengs denne endringen, og hva løser den? -->

## Testing
Kjørt opp lokalt
<!-- Hvordan har du har testet endringene dine? Ta gjerne med systeminfo o.l -->

<!--

Helt til slutt, har du ..

.. lest retningslinjene våre for bidrag?
.. tatt en siste sjekk for kode og skrivefeil, debug informasjon o.l?
.. kjørt og eventuelt oppdatert testene?
.. kommentert og dokumentert det som trengs?
.. knyttet denne opp til relaterte issues?

-->
