### PR TITLE
fix(ffe-form-react): add isMobileNumber to PhoneNumberProps

### DIFF
--- a/packages/ffe-form-react/src/index.d.ts
+++ b/packages/ffe-form-react/src/index.d.ts
@@ -44,6 +44,7 @@ export interface PhoneNumberProps {
     extraMargin?: boolean;
     countryCodeRef?: React.Ref<HTMLInputElement>;
     numberRef?: React.Ref<HTMLInputElement>;
+    isMobileNumber?: boolean;
 }
 
 export interface LabelProps extends React.ComponentProps<'label'> {


### PR DESCRIPTION
## Beskrivelse

Legger til manglende typedefinisjon

## Motivasjon og kontekst

`isMobileNumber` ble lagt til i  #1636 (issue #1580) men det mangler typedefinisjoner. Får derfor ikke brukt funksjonen.

## Testing
