### PR TITLE
Bytter ut hardkodet feilmeldingsikon med ikon fra ffe-icons

### DIFF
--- a/packages/ffe-file-upload-react/src/FileItem.js
+++ b/packages/ffe-file-upload-react/src/FileItem.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { func, shape, object, string as stringType } from 'prop-types';
+import { UtropstegnIkon } from '@sb1/ffe-icons-react';
 
 const FileItem = ({ file, onFileDeleted, cancelText, deleteText }) => (
     <li>
@@ -48,8 +49,10 @@ const FileItem = ({ file, onFileDeleted, cancelText, deleteText }) => (
         )}
         {// File has error
         file.error && (
-            <div className="ffe-file-upload__file-item-error">
-                <div className="ffe-file-upload__file-item-error-icon ffe-field-message ffe-field-message--error" />
+            <div className="ffe-file-upload__file-item-error" role="alert">
+                <div className="ffe-file-upload__file-item-error-icon">
+                    <UtropstegnIkon role="img" title="utropstegn-ikon" />
+                </div>
                 <button
                     type="button"
                     id={file.name}

--- a/packages/ffe-file-upload/less/ffe-file-upload.less
+++ b/packages/ffe-file-upload/less/ffe-file-upload.less
@@ -229,26 +229,23 @@
 
     &__file-item-error-icon {
         background-color: var(--ffe-v-error-message-icon-color);
-        text-align: center;
+        fill: var(--ffe-v-fileupload-error-icon-color);
         border-radius: 50%;
         width: 18px;
         height: 18px;
-        margin-right: 4px;
-        padding: 2px;
+        margin-right: @ffe-spacing-2xs;
+        padding: 3px;
         font-family: arial, sans-serif;
-        line-height: 16px;
-        display: inline-block;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        align-self: center;
         grid-column: 1;
         grid-row: 1;
 
-        &::before {
-            content: url('data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" fill="%23ffffff" height="12" width="12" x="1650" y="1200" viewBox="0 0 200 200"%3E%3Cpath d="M99.882.64a16.562 16.562 0 0 0-16.294 16.772v93.863a16.562 16.562 0 1 0 33.102 0V17.412A16.562 16.562 0 0 0 99.882.64zm.257 162.054c-9.145 0-16.55 7.405-16.55 16.55 0 9.147 7.405 16.589 16.55 16.589 9.146 0 16.551-7.442 16.551-16.588s-7.405-16.551-16.55-16.551z"/%3E%3C/svg%3E');
-
-            .native & {
-                @media (prefers-color-scheme: dark) {
-                    content: url('data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" fill="%23002776" height="12" width="12" x="1650" y="1200" viewBox="0 0 200 200"%3E%3Cpath d="M99.882.64a16.562 16.562 0 0 0-16.294 16.772v93.863a16.562 16.562 0 1 0 33.102 0V17.412A16.562 16.562 0 0 0 99.882.64zm.257 162.054c-9.145 0-16.55 7.405-16.55 16.55 0 9.147 7.405 16.589 16.55 16.589 9.146 0 16.551-7.442 16.551-16.588s-7.405-16.551-16.55-16.551z"/%3E%3C/svg%3E');
-                }
-            }
+        > svg {
+            width: 12px;
+            height: 12px;
         }
     }
 

--- a/packages/ffe-file-upload/less/theme.less
+++ b/packages/ffe-file-upload/less/theme.less
@@ -5,6 +5,7 @@
     --ffe-v-fileupload-btn-delete-color-hover: var(--ffe-g-link-color-hover);
     --ffe-v-fileupload-stencil-bg: var(--ffe-farge-frost-30);
     --ffe-v-fileupload-filename-color: var(--ffe-farge-fjell);
+    --ffe-v-fileupload-error-icon-color: var(--ffe-farge-hvit);
 
     @media (prefers-color-scheme: dark) {
         .native {
@@ -16,6 +17,7 @@
             );
             --ffe-v-fileupload-stencil-bg: var(--ffe-farge-frost-70);
             --ffe-v-fileupload-filename-color: var(--ffe-farge-vann-30);
+            --ffe-v-fileupload-error-icon-color: var(--ffe-farge-fjell);
         }
     }
 }


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse

Bytter ut feilmeldingsikonet i ffe-file-upload fra hardkodet pseudo-element til ikon fra ffe-icons. Dette forbedrer tilgjengeligheten og reduserer behovet for overflødig skreddersøm.

## Motivasjon og kontekst

Fixes #1633 

## Testing

Testet i component-overview