### PR TITLE
fix(ffe-tables): retter farge på table-headinger

### DIFF
--- a/packages/ffe-tables/less/table.less
+++ b/packages/ffe-tables/less/table.less
@@ -108,6 +108,10 @@
         }
     }
 
+    &__heading &__content {
+        color: var(--ffe-v-table-heading-color);
+    }
+
     [data-th]::before {
         content: attr(data-th);
         display: block;


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse

Fikser en bug der table heading i noen tilfeller får feil tekstfarge.

## Motivasjon og kontekst

Fixes #1584 

## Testing

Testet i component-overview