### PR TITLE
Skiller ut textLike input i egen komponent

### DIFF
--- a/component-overview/examples/form/InputTextLike.jsx
+++ b/component-overview/examples/form/InputTextLike.jsx
@@ -1,12 +1,11 @@
-import { Input } from '@sb1/ffe-form-react';
+import { InputTextLike } from '@sb1/ffe-form-react';
 import { Paragraph } from '@sb1/ffe-core-react';
 
 <Paragraph>
     Jeg er{' '}
-    <Input
-        aria-label="Skriv inn alder"
+    <InputTextLike
+        ariaLabel="Skriv inn alder"
         style={{ width: '47px' }}
-        textLike={true}
     />{' '}
     år gammel
 </Paragraph>

--- a/packages/ffe-form-react/src/Input.js
+++ b/packages/ffe-form-react/src/Input.js
@@ -3,13 +3,12 @@ import { bool, string } from 'prop-types';
 import classNames from 'classnames';
 
 const Input = React.forwardRef((props, ref) => {
-    const { className, inline, textLike, textRightAlign, ...rest } = props;
+    const { className, inline, textRightAlign, ...rest } = props;
     return (
         <input
             className={classNames(
                 'ffe-input-field',
                 { 'ffe-input-field--inline': inline },
-                { 'ffe-input-field--text-like': textLike },
                 { 'ffe-input-field--text-right-align': textRightAlign },
                 className,
             )}
@@ -23,8 +22,6 @@ Input.propTypes = {
     className: string,
     /** Input fields default to `display: block;`. Set this to `true` to apply the inline modifier. */
     inline: bool,
-    /** Apply the text-like modifier by setting this to `true`. */
-    textLike: bool,
     /** Make the text right aligned */
     textRightAlign: bool,
 };

--- a/packages/ffe-form-react/src/Input.spec.js
+++ b/packages/ffe-form-react/src/Input.spec.js
@@ -28,12 +28,6 @@ describe('<Input />', () => {
         expect(wrapper.hasClass('ffe-input-field--inline')).toBe(true);
     });
 
-    it('sets the correct class for textLike-modifer', () => {
-        const wrapper = getWrapper();
-        expect(wrapper.hasClass('ffe-input-field--text-like')).toBe(false);
-        wrapper.setProps({ textLike: true });
-        expect(wrapper.hasClass('ffe-input-field--text-like')).toBe(true);
-    });
     it('sets the correct class for textRightAlign', () => {
         const wrapper = getWrapper();
         expect(wrapper.hasClass('ffe-input-field--text-right-align')).toBe(

--- a/packages/ffe-form-react/src/InputTextLike.js
+++ b/packages/ffe-form-react/src/InputTextLike.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import { string } from 'prop-types';
+import classNames from 'classnames';
+
+const InputTextLike = React.forwardRef((props, ref) => {
+    const { className, ariaLabel, ...rest } = props;
+    return (
+        <input
+            className={classNames(
+                'ffe-input-field',
+                'ffe-input-field--text-like',
+                className,
+            )}
+            aria-label={ariaLabel}
+            ref={ref}
+            {...rest}
+        />
+    );
+});
+
+InputTextLike.propTypes = {
+    ariaLabel: string.isRequired,
+    className: string,
+};
+
+export default InputTextLike;

--- a/packages/ffe-form-react/src/InputTextLike.spec.js
+++ b/packages/ffe-form-react/src/InputTextLike.spec.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import InputTextLike from './InputTextLike';
+
+const getWrapper = props => shallow(<InputTextLike {...props} />);
+
+describe('<InputTextLike />', () => {
+    it('renders an input element', () => {
+        const wrapper = getWrapper({
+            ariaLabel: 'aria-label',
+        });
+        expect(wrapper.exists()).toBe(true);
+        expect(wrapper.is('input')).toBe(true);
+        expect(wrapper.hasClass('ffe-input-field')).toBe(true);
+        expect(wrapper.hasClass('ffe-input-field--text-like')).toBe(true);
+    });
+
+    it('passes props', () => {
+        const wrapper = getWrapper({
+            ariaLabel: 'aria-label',
+            className: 'app-input',
+        });
+        expect(wrapper.hasClass('app-input')).toBe(true);
+        expect(wrapper.prop('aria-label')).toBe('aria-label');
+    });
+});

--- a/packages/ffe-form-react/src/index.d.ts
+++ b/packages/ffe-form-react/src/index.d.ts
@@ -24,8 +24,12 @@ export interface BaseFieldMessageProps extends React.ComponentProps<'div'> {
 export interface InputProps extends React.ComponentProps<'input'> {
     className?: string;
     inline?: boolean;
-    textLike?: boolean;
     textRightAlign?: boolean;
+}
+
+export interface InputTextLikeProps extends React.ComponentProps<'input'> {
+    ariaLabel: string;
+    className?: string;
 }
 
 export interface PhoneNumberProps {

--- a/packages/ffe-form-react/src/index.js
+++ b/packages/ffe-form-react/src/index.js
@@ -3,6 +3,7 @@ import ErrorFieldMessage from './ErrorFieldMessage';
 import InfoFieldMessage from './InfoFieldMessage';
 import SuccessFieldMessage from './SuccessFieldMessage';
 import Input from './Input';
+import InputTextLike from './InputTextLike';
 import InputGroup from './InputGroup';
 import Label from './Label';
 import PhoneNumber from './PhoneNumber';
@@ -20,6 +21,7 @@ export {
     InfoFieldMessage,
     SuccessFieldMessage,
     Input,
+    InputTextLike,
     PhoneNumber,
     InputGroup,
     Label,


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse

TextLike Input er designet for å brukes inline i brødtekst, og kommer derfor uten egen `label`. Dette er problematisk med tanke på UU og gjør at `Input`-komponenten med `textLike`-modifier ikke passerer WCAG-krav, med mindre man sender med `aria-label`. Dette er frivillig, siden vanlig input har label og dermed passerer.

Skiller derfor denne varianten ut i en egen komponent, `InputTextLike`, der aria-label (prop: `ariaLabel`) er obligatorisk.

## Motivasjon og kontekst

Fixes #1583 

## Testing

Testet lokalt med jest og component-overview