### PR TITLE
fix(ffe-form-react): definerer proptypes på errorfieldmessage

### DIFF
--- a/packages/ffe-form-react/src/ErrorFieldMessage.js
+++ b/packages/ffe-form-react/src/ErrorFieldMessage.js
@@ -1,8 +1,13 @@
 import React from 'react';
+import { oneOf } from 'prop-types';
 import BaseFieldMessage from './BaseFieldMessage';
 
 const ErrorFieldMessage = props => {
     return <BaseFieldMessage {...props} type="error" />;
+};
+
+ErrorFieldMessage.propTypes = {
+    role: oneOf(['status', 'alert', 'none']),
 };
 
 ErrorFieldMessage.defaultProps = {


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse

Legger til `propTypes`-deklarasjon på `ErrorFieldMessage`, ettersom denne overstyrer en prop fra `BaseFieldMessage` og har `defaultProps` fra før.

## Motivasjon og kontekst

Forsøk på å løse en byggefeil i designsystem-docs:

![image](https://github.com/SpareBank1/designsystem/assets/463847/d29d2540-fa9c-442c-b95d-0f58f0076e89)

