### PR TITLE
fix(ffe-symbols-react): legg til types og module i package.json

### DIFF
--- a/packages/ffe-symbols-react/package.json
+++ b/packages/ffe-symbols-react/package.json
@@ -3,6 +3,8 @@
     "version": "1.1.1",
     "description": "React-komponenter for Material Symbols tilpasset Sb1 sine behov",
     "main": "src/index.js",
+    "module": "es/index.js",
+    "types": "types/index.d.ts",
     "scripts": {
         "build": "ffe-buildtool babel",
         "watch": "ffe-buildtool babel-watch",


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse
Legger til types og modules i package.json
<!-- Detaljert beskrivelse av endringene dine. Skjermskudd er lov. -->

## Motivasjon og kontekst
Håper å løse problemet med "cannot import outside of module" error i docs
<!-- Hvorfor trengs denne endringen, og hva løser den? -->

## Testing

<!-- Hvordan har du har testet endringene dine? Ta gjerne med systeminfo o.l -->

<!--

Helt til slutt, har du ..

.. lest retningslinjene våre for bidrag?
.. tatt en siste sjekk for kode og skrivefeil, debug informasjon o.l?
.. kjørt og eventuelt oppdatert testene?
.. kommentert og dokumentert det som trengs?
.. knyttet denne opp til relaterte issues?

-->
