### PR TITLE
fix(ffe-message-box-react): remove deprecated property 'content' because of typescript errors

### DIFF
--- a/packages/ffe-message-box-react/src/BaseMessage.js
+++ b/packages/ffe-message-box-react/src/BaseMessage.js
@@ -13,7 +13,6 @@ const BaseMessage = props => {
         title,
         titleElement,
         icon,
-        content,
         children,
         className = '',
         onColoredBg,
@@ -47,8 +46,7 @@ const BaseMessage = props => {
                         },
                         title,
                     )}
-                {content && <p>{content}</p>}
-                {!content && children}
+                {children}
             </div>
         </div>
     );
@@ -57,7 +55,6 @@ const BaseMessage = props => {
 BaseMessage.propTypes = {
     children: node,
     className: string,
-    content: node,
     icon: node.isRequired,
     title: node,
     /** HTML element for the title */

--- a/packages/ffe-message-box-react/src/ErrorMessage.js
+++ b/packages/ffe-message-box-react/src/ErrorMessage.js
@@ -28,11 +28,6 @@ ErrorMessage.propTypes = {
     children: node,
     /** Any extra class names to the wrapping DOM node */
     className: string,
-    /**
-     * Deprecated. Use `children` instead.
-     * @deprecated
-     */
-    content: node,
     /** The icon to show. Has a default value, but can be overridden */
     icon: node,
     /** An optional title for the message */

--- a/packages/ffe-message-box-react/src/InfoMessage.js
+++ b/packages/ffe-message-box-react/src/InfoMessage.js
@@ -19,11 +19,6 @@ InfoMessage.propTypes = {
     children: node,
     /** Any extra class names to the wrapping DOM node */
     className: string,
-    /**
-     * Deprecated. Use `children` instead.
-     * @deprecated
-     */
-    content: node,
     /** The icon to show. Has a default value, but can be overridden */
     icon: node,
     /** An optional title for the message */

--- a/packages/ffe-message-box-react/src/SuccessMessage.js
+++ b/packages/ffe-message-box-react/src/SuccessMessage.js
@@ -19,11 +19,6 @@ SuccessMessage.propTypes = {
     children: node,
     /** Any extra class names to the wrapping DOM node */
     className: string,
-    /**
-     * Deprecated. Use `children` instead.
-     * @deprecated
-     */
-    content: node,
     /** The icon to show. Has a default value, but can be overridden */
     icon: node,
     /** An optional title for the message */

--- a/packages/ffe-message-box-react/src/TipsMessage.js
+++ b/packages/ffe-message-box-react/src/TipsMessage.js
@@ -19,11 +19,6 @@ TipsMessage.propTypes = {
     children: node,
     /** Any extra class names to the wrapping DOM node */
     className: string,
-    /**
-     * Deprecated. Use `children` instead.
-     * @deprecated
-     */
-    content: node,
     /** The icon to show. Has a default value, but can be overridden */
     icon: node,
     /** An optional title for the message */

--- a/packages/ffe-message-box-react/src/index.d.ts
+++ b/packages/ffe-message-box-react/src/index.d.ts
@@ -4,11 +4,6 @@ export interface MessageBoxProps
     extends Omit<React.ComponentProps<'div'>, 'title'> {
     children?: React.ReactNode;
     className?: string;
-    /**
-     * Deprecated. Use `children` instead.
-     * @deprecated
-     */
-    content?: React.ReactNode;
     icon?: React.ReactNode;
     title?: React.ReactNode;
     onColoredBg?: boolean;


### PR DESCRIPTION
## Beskrivelse

Fjernet en utdatert property siden denne ga typefeil

## Motivasjon og kontekst

TypeScript rapporterer følgende feil i et prosjekt som bruker `ffe-message-box-react`:

```
node_modules/@sb1/ffe-message-box-react/types/index.d.ts:3:18 - error TS2430: Interface 'MessageBoxProps' incorrectly extends interface 'Omit<DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement>, "title">'.
  Types of property 'content' are incompatible.
    Type 'ReactNode' is not assignable to type 'string | undefined'.
      Type 'null' is not assignable to type 'string | undefined'.

3 export interface MessageBoxProps
                   ~~~~~~~~~~~~~~~
```

## Testing

Har verifisert at TypeScript ikke rapporterer feil når `content` fjernes.
