### PR TITLE
Develop fix breaking text

### DIFF
--- a/packages/ffe-cards-react/src/components/Title.js
+++ b/packages/ffe-cards-react/src/components/Title.js
@@ -17,7 +17,7 @@ const Title = ({ className, overflowEllipsis, ...rest }) => (
     />
 );
 
-Title.defaultProps = { overflowEllipsis: true };
+Title.defaultProps = { overflowEllipsis: false };
 
 Title.propTypes = {
     className: string,

--- a/packages/ffe-cards/less/stippled-card.less
+++ b/packages/ffe-cards/less/stippled-card.less
@@ -34,8 +34,12 @@
     width: 40px;
 }
 
+.ffe-stippled-card--condensed {
+    padding: @ffe-spacing-sm;
+}
+
 .ffe-stippled-card--condensed .ffe-stippled-card__img--icon {
-    margin: 0 @ffe-spacing-xs 0 0;
+    margin: 0 @ffe-spacing-2xs 0 0;
     height: 30px;
     width: 30px;
 }


### PR DESCRIPTION
* Lite mindre padding på condensed `StippeledCard`
* Endra default på  `overflowEllipsis`i `Title`


![image](https://github.com/SpareBank1/designsystem/assets/2248579/2501535f-da22-40cb-b68c-645c4fd49b97)
