### PR TITLE
Updates ffe symbols

### DIFF
--- a/packages/ffe-symbols-react/package.json
+++ b/packages/ffe-symbols-react/package.json
@@ -25,6 +25,7 @@
     "dependencies": {
         "classnames": "^2.3.2",
         "prop-types": "^15.8.1",
+        "@sb1/ffe-symbols": "^1.1.1",
         "react": "^18.2.0"
     },
     "devDependencies": {

--- a/packages/ffe-symbols-react/src/Symbol.js
+++ b/packages/ffe-symbols-react/src/Symbol.js
@@ -25,7 +25,7 @@ const Symbol = props => {
                 fontVariationSettings: `'FILL' ${
                     fill ? 1 : 0
                 }, 'GRAD' 0, 'wght' ${weight}`,
-                color: `var(--${color})`,
+                color: color ? `var(--${color})` : null,
             }}
             aria-label={ariaLabel ? ariaLabel : null}
             aria-hidden={ariaLabel ? false : true}
@@ -40,7 +40,6 @@ Symbol.defaultProps = {
     fill: false,
     size: 'md',
     weight: 400,
-    color: 'ffe-v-symbol-default-color',
 };
 
 Symbol.propTypes = {

--- a/packages/ffe-symbols/theme.less
+++ b/packages/ffe-symbols/theme.less
@@ -1,10 +1,3 @@
 :root {
     --ffe-v-symbol-font: 'Material Symbols Rounded';
-    --ffe-v-symbol-default-color: var(--ffe-farge-vann);
-
-    @media (prefers-color-scheme: dark) {
-        .native {
-            --ffe-v-symbol-default-color: var(--ffe-farge-vann-70);
-        }
-    }
 }


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse
Legger til ffe-symbols som dependency i ffe-symbols-react,
og fjerner default fargen som settes på ikonene + legger til muligheten til å overskrive farge via css.
<!-- Detaljert beskrivelse av endringene dine. Skjermskudd er lov. -->

## Motivasjon og kontekst
I alle situasjoner jeg har kommet over så langt vil vi alltid overskrive fra standardfarge, så det er bedre å ikke ha noe standardfarge satt, sånn at man slipper å sende med color-prop når man ønsker å bare bruke styling fra css. 
<!-- Hvorfor trengs denne endringen, og hva løser den? -->

## Testing
Kjørt opp lokalt. 
<!-- Hvordan har du har testet endringene dine? Ta gjerne med systeminfo o.l -->

<!--

Helt til slutt, har du ..

.. lest retningslinjene våre for bidrag?
.. tatt en siste sjekk for kode og skrivefeil, debug informasjon o.l?
.. kjørt og eventuelt oppdatert testene?
.. kommentert og dokumentert det som trengs?
.. knyttet denne opp til relaterte issues?

-->
