### PR TITLE
fix(ffe-message-box-react): remove content from message box prop

### DIFF
--- a/packages/ffe-message-box-react/src/index.d.ts
+++ b/packages/ffe-message-box-react/src/index.d.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 export interface MessageBoxProps
-    extends Omit<React.ComponentProps<'div'>, 'title'> {
+    extends Omit<React.ComponentProps<'div'>, 'title' | 'content'> {
     children?: React.ReactNode;
     className?: string;
     icon?: React.ReactNode;


### PR DESCRIPTION
Det snek seg in en bug hos oss fordi att `content` er med i `React.ComponentProps<'div'>`