### PR TITLE
fix(ffe-buttons-react): erstatter fragment i expandbutton med span

### DIFF
--- a/packages/ffe-buttons-react/src/ExpandButton.js
+++ b/packages/ffe-buttons-react/src/ExpandButton.js
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react';
+import React from 'react';
 import {
     bool,
     func,
@@ -41,7 +41,7 @@ const ExpandButton = props => {
                 <KryssIkon className="ffe-button__icon" aria-hidden="true" />
             )}
             {!isExpanded && (
-                <Fragment>
+                <span>
                     {leftIcon &&
                         React.cloneElement(leftIcon, {
                             'aria-hidden': true,
@@ -55,7 +55,7 @@ const ExpandButton = props => {
                             className:
                                 'ffe-button__icon ffe-button__icon--right',
                         })}
-                </Fragment>
+                </span>
             )}
         </Element>
     );


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse
Erstatter fragment, med span i expandbutton. 
<!-- Detaljert beskrivelse av endringene dine. Skjermskudd er lov. -->

## Motivasjon og kontekst
Siden fragment ikke blir rendret som en DOM-node, så kan man i enkelte tilfeller få feilmelding om `Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node`.
Ved å sette det til span eller noe annet enn fragment, så håper vi å løse det problemet. 
<!-- Hvorfor trengs denne endringen, og hva løser den? -->

## Testing
Kjørt opp lokalt
<!-- Hvordan har du har testet endringene dine? Ta gjerne med systeminfo o.l -->

<!--

Helt til slutt, har du ..

.. lest retningslinjene våre for bidrag?
.. tatt en siste sjekk for kode og skrivefeil, debug informasjon o.l?
.. kjørt og eventuelt oppdatert testene?
.. kommentert og dokumentert det som trengs?
.. knyttet denne opp til relaterte issues?

-->
