### PR TITLE
feat(ffe-formatters): add foreign account number formating

### DIFF
--- a/packages/ffe-formatters/src/formatAccountNumber.js
+++ b/packages/ffe-formatters/src/formatAccountNumber.js
@@ -1,9 +1,20 @@
 import { NON_BREAKING_SPACE } from './internal/unicode';
 
-export default function formatAccountNumber(accountNumber) {
-    if (!accountNumber) {
-        return accountNumber;
+function foreignAccountNumber(accountNumber) {
+    let formattedAccountNumber = '';
+
+    for (let i = 0; i < accountNumber.length; i++) {
+        const isFourthIteration = (i + 1) % 4 === 0;
+        formattedAccountNumber += accountNumber[i].valueOf();
+
+        if (isFourthIteration && i + 1 < accountNumber.length) {
+            formattedAccountNumber += NON_BREAKING_SPACE;
+        }
     }
+    return formattedAccountNumber;
+}
+
+function domesticAccountNumber(accountNumber) {
     let formattedAccountNumber = '';
 
     if (accountNumber.length > 0) {
@@ -21,4 +32,14 @@ export default function formatAccountNumber(accountNumber) {
     }
 
     return formattedAccountNumber;
+}
+
+export default function formatAccountNumber(accountNumber) {
+    if (!accountNumber) {
+        return accountNumber;
+    }
+    if (accountNumber.length <= 11) {
+        return domesticAccountNumber(accountNumber);
+    }
+    return foreignAccountNumber(accountNumber);
 }

--- a/packages/ffe-formatters/src/formatAccountNumber.spec.js
+++ b/packages/ffe-formatters/src/formatAccountNumber.spec.js
@@ -25,4 +25,10 @@ describe('format account number', () => {
             `1234${NON_BREAKING_SPACE}56${NON_BREAKING_SPACE}78901`,
         );
     });
+
+    test('formats foreign account number correctly', () => {
+        expect(formatAccountNumber('AB12345678901234')).toBe(
+            `AB12${NON_BREAKING_SPACE}3456${NON_BREAKING_SPACE}7890${NON_BREAKING_SPACE}1234`,
+        );
+    });
 });


### PR DESCRIPTION
## Beskrivelse
Legg til formatering for kontonummer som er lenger enn 11, mao utenlandske kontonummer.

## Motivasjon og kontekst

Etter [denne](https://github.com/SpareBank1/designsystem/commit/17be715ea029ae473b9d1eef92049036ea27fc58#diff-a7e9fe958b85178c24640732c4d62ef70c167e939a8d34043fe34fe02d505504R4) endringen ser utenlandske kontonummer litt rart ut
