### PR TITLE
Develop support shadow dom

### DIFF
--- a/packages/ffe-accordion/less/theme.less
+++ b/packages/ffe-accordion/less/theme.less
@@ -1,4 +1,5 @@
-:root {
+:root,
+:host {
     --ffe-v-accordion-primary-color: var(--ffe-farge-vann);
     --ffe-v-accordion-secondary-color: var(--ffe-farge-hvit);
     --ffe-v-accordion-body-text-color: var(--ffe-farge-svart);

--- a/packages/ffe-account-selector-react/less/theme.less
+++ b/packages/ffe-account-selector-react/less/theme.less
@@ -1,4 +1,5 @@
-:root {
+:root,
+:host {
     --ffe-v-accountselector-text-color: var(--ffe-farge-svart);
     --ffe-v-accountselector-dropdown-statusbar-background-color: var(
         --ffe-farge-lysgraa

--- a/packages/ffe-buttons/less/theme.less
+++ b/packages/ffe-buttons/less/theme.less
@@ -1,4 +1,5 @@
-:root {
+:root,
+:host {
     /** Buttons */
 
     /* Common button text color */

--- a/packages/ffe-cards/less/theme.less
+++ b/packages/ffe-cards/less/theme.less
@@ -1,4 +1,5 @@
-:root {
+:root,
+:host {
     --ffe-v-cards-common-card-background-color: var(--ffe-farge-hvit);
     --ffe-v-cards-common-card-box-shadow-color: var(--ffe-farge-graa);
     --ffe-v-cards-common-card-border-radius: 16px;

--- a/packages/ffe-chart-donut-react/less/theme.less
+++ b/packages/ffe-chart-donut-react/less/theme.less
@@ -1,4 +1,5 @@
-:root {
+:root,
+:host {
     --ffe-v-chart-donut-first-color: var(--ffe-farge-vann);
     --ffe-v-chart-donut-last-color: var(--ffe-farge-fjell);
     --ffe-v-chart-donut-text-color: var(--ffe-farge-koksgraa);

--- a/packages/ffe-context-message/less/theme.less
+++ b/packages/ffe-context-message/less/theme.less
@@ -1,4 +1,5 @@
-:root {
+:root,
+:host {
     /** Close button */
     --ffe-v-context-message-close-button-color: var(--ffe-farge-moerkgraa);
     --ffe-v-context-message-close-button-color-hover: var(--ffe-farge-svart);

--- a/packages/ffe-core/less/ffe-normalize.less
+++ b/packages/ffe-core/less/ffe-normalize.less
@@ -1,5 +1,6 @@
 /* GAB: Use border-box: http://www.paulirish.com/2012/box-sizing-border-box-ftw/ */
-html {
+html,
+:host {
     box-sizing: border-box;
     font-size: 100%; /* 16 px base in most browsers */
 }

--- a/packages/ffe-core/less/normalize.css
+++ b/packages/ffe-core/less/normalize.css
@@ -8,7 +8,8 @@
  * 2. Prevent adjustments of font size after orientation changes in iOS.
  */
 
-html {
+html,
+:host {
     line-height: 1.15; /* 1 */
     -webkit-text-size-adjust: 100%; /* 2 */
 }

--- a/packages/ffe-core/less/theme.less
+++ b/packages/ffe-core/less/theme.less
@@ -2,7 +2,8 @@
  * These variables are intended to support theming of components. Override any value to create your own look and feel.
  */
 
-:root {
+:root,
+:host {
     /** Primærpalett */
     --ffe-farge-fjell: @ffe-farge-fjell;
     --ffe-farge-fjell-70: @ffe-farge-fjell-70;

--- a/packages/ffe-datepicker/less/theme.less
+++ b/packages/ffe-datepicker/less/theme.less
@@ -1,4 +1,5 @@
-:root {
+:root,
+:host {
     --ffe-v-datepicker-bg-color: var(--ffe-farge-hvit);
     --ffe-v-datepicker-border-hover-color: var(--ffe-g-primary-color);
     --ffe-v-datepicker-icon-color: var(--ffe-g-primary-color);

--- a/packages/ffe-file-upload/less/theme.less
+++ b/packages/ffe-file-upload/less/theme.less
@@ -1,4 +1,5 @@
-:root {
+:root,
+:host {
     --ffe-v-fileupload-bgcolor: var(--ffe-farge-frost-30);
     --ffe-v-fileupload-bordercolor: var(--ffe-farge-vann);
     --ffe-v-fileupload-btn-delete-color: var(--ffe-g-link-color);

--- a/packages/ffe-form/less/theme.less
+++ b/packages/ffe-form/less/theme.less
@@ -1,4 +1,5 @@
-:root {
+:root,
+:host {
     --ffe-v-input-color: var(--ffe-farge-svart);
     --ffe-v-input-bg-color: var(--ffe-farge-hvit);
     --ffe-v-input-placeholder-color: var(--ffe-farge-moerkgraa);

--- a/packages/ffe-header/less/theme.less
+++ b/packages/ffe-header/less/theme.less
@@ -1,4 +1,5 @@
-:root {
+:root,
+:host {
     --ffe-v-background-color: @ffe-farge-hvit;
     --ffe-v-primary-color: @ffe-farge-fjell;
     --ffe-v-header-border-bottom-color: @ffe-farge-lysgraa;

--- a/packages/ffe-lists/less/theme.less
+++ b/packages/ffe-lists/less/theme.less
@@ -1,4 +1,5 @@
-:root {
+:root,
+:host {
     --ffe-v-lists-title-color: var(--ffe-farge-fjell);
     --ffe-v-lists-description-description-color: var(--ffe-farge-svart);
     --ffe-v-lists-check-list-check-icon-color: var(--ffe-farge-skog);

--- a/packages/ffe-message-box/less/theme.less
+++ b/packages/ffe-message-box/less/theme.less
@@ -1,4 +1,5 @@
-:root {
+:root,
+:host {
     /** Common */
     --ffe-v-message-box-icon-bg-color: var(--ffe-farge-hvit);
 

--- a/packages/ffe-searchable-dropdown-react/less/theme.less
+++ b/packages/ffe-searchable-dropdown-react/less/theme.less
@@ -1,4 +1,5 @@
-:root {
+:root,
+:host {
     --ffe-v-searchable-dropdown-list-background-color: var(--ffe-farge-hvit);
     --ffe-v-searchable-dropdown-arrow-svg-hover-color: var(--ffe-farge-fjell);
 

--- a/packages/ffe-symbols/theme.less
+++ b/packages/ffe-symbols/theme.less
@@ -1,4 +1,5 @@
-:root {
+:root,
+:host {
     --ffe-v-symbol-300-font: 'MaterialSymbolsRounded-300';
     --ffe-v-symbol-400-font: 'MaterialSymbolsRounded-400';
     --ffe-v-symbol-500-font: 'MaterialSymbolsRounded-500';

--- a/packages/ffe-system-message/less/theme.less
+++ b/packages/ffe-system-message/less/theme.less
@@ -1,4 +1,5 @@
-:root {
+:root,
+:host {
     /** Close button */
     --ffe-v-system-message-close-button-color: var(--ffe-farge-moerkgraa);
     --ffe-v-system-message-close-button-color-hover: var(--ffe-farge-svart);

--- a/packages/ffe-tables/less/theme.less
+++ b/packages/ffe-tables/less/theme.less
@@ -1,4 +1,5 @@
-:root {
+:root,
+:host {
     --ffe-v-table-row-bordercolor: var(--ffe-farge-varmgraa);
     --ffe-v-table-heading-color: var(--ffe-farge-fjell);
     --ffe-v-table-content-color: var(--ffe-farge-svart);

--- a/packages/ffe-tabs/less/theme.less
+++ b/packages/ffe-tabs/less/theme.less
@@ -1,4 +1,5 @@
-:root {
+:root,
+:host {
     --ffe-v-tabs-primary-color: var(--ffe-farge-fjell);
     --ffe-v-tabs-secondary-color: var(--ffe-farge-hvit);
     --ffe-v-tabs-tab-focus-color: var(--ffe-farge-vann);


### PR DESCRIPTION
Gjør det mulig att bruke designsystem i en shadow dom. Det er behov før dette feks på opna sidor der team kjører sina appar sammen opne sidor sina appar.  I shadow dom er det ikke html eller :root uten :host. 


Noen team har føreløpig løst det slik. Hade vart fint hvis det bare funket. 
```
  // Styles from ffe targeting html or :root should instead target the shadow root (:host)
    const ffeStyleElement = document.createElement("style");
    ffeStyleElement.innerHTML = ffeStyles.toString()
      .replaceAll("html", ":host")
      .replaceAll(":root", ":host");
```


Jens-Christian Børke Bjerkek og @HeleneKassandra skulle se på dette men når behovet melt seg hos oss også begynnte jag på det. 


Det er ju dette scriptet ovan har gjort (nesten) men darkmode vill ikke  funka va før det er ingen .native innanfør :host Jens-Christian Børke Bjerkek?  Vi hade ju kunnat dropppa native klassen? Det var vel det man ønsket på sikt oansett? Eller kan bruker passa på natve klassen også legges in i shadow dom slik att det blir `:host .native { }`?
```
:root,
:host {
    --ffe-v-tabs-primary-color: var(--ffe-farge-fjell);
    --ffe-v-tabs-secondary-color: var(--ffe-farge-hvit);
    --ffe-v-tabs-tab-focus-color: var(--ffe-farge-vann);
    --ffe-v-tabs-tab-hover-color: var(--ffe-farge-vann);
    --ffe-v-tabs-tab-active-hover-color: var(--ffe-farge-natt);

    @media (prefers-color-scheme: dark) {
        .native {
            --ffe-v-tabs-primary-color: var(--ffe-farge-vann-30);
            --ffe-v-tabs-secondary-color: var(--ffe-farge-svart);
            --ffe-v-tabs-tab-focus-color: var(--ffe-farge-hvit);
            --ffe-v-tabs-tab-hover-color: var(--ffe-farge-vann-70);
            --ffe-v-tabs-tab-active-hover-color: var(--ffe-farge-hvit);
        }
    }
}

```

Det er ju føreløpig opne sidor så darkmode er ikke ett problem der men vem vet vad man har lust att bruke dette til?
