### PR TITLE
Fix fontskalering for iOS

### DIFF
--- a/packages/ffe-core/less/ffe-normalize.less
+++ b/packages/ffe-core/less/ffe-normalize.less
@@ -10,3 +10,11 @@ html,
 *::after {
     box-sizing: inherit;
 }
+
+/* stylelint-disable */
+@supports (font: -apple-system-body) {
+    :root,
+    :host {
+        font: -apple-system-body;
+    }
+}


### PR DESCRIPTION
For å møte wcag krav så må web-views i appen også støtte 200% fontskalering. 
