### PR TITLE
fix(component-overview): endrer fra string til number i eksempel

### DIFF
--- a/component-overview/examples/symbols/Symbol-allweights.jsx
+++ b/component-overview/examples/symbols/Symbol-allweights.jsx
@@ -3,9 +3,9 @@ import Symbol from "@sb1/ffe-symbols-react";
 () => {
     return (
         <>
-            <Symbol weight="300" ariaLabel="hus ikon" size="md">Home</Symbol>
-            <Symbol weight="400" ariaLabel="hus ikon" size="md">Home</Symbol>
-            <Symbol weight="500" ariaLabel="hus ikon" size="md">Home</Symbol>
+            <Symbol weight={300} ariaLabel="hus ikon" size="md">Home</Symbol>
+            <Symbol weight={400} ariaLabel="hus ikon" size="md">Home</Symbol>
+            <Symbol weight={500} ariaLabel="hus ikon" size="md">Home</Symbol>
         </>
 
     )


### PR DESCRIPTION


<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse
Endrer eksempelet for symbol weight til å sende inn number istedenfor string. 
<!-- Detaljert beskrivelse av endringene dine. Skjermskudd er lov. -->

## Motivasjon og kontekst
I proptypes står det at det skal være nummer og ikke string, så endrer det så det blir riktig i forhold til typings
<!-- Hvorfor trengs denne endringen, og hva løser den? -->

## Testing

<!-- Hvordan har du har testet endringene dine? Ta gjerne med systeminfo o.l -->

<!--

Helt til slutt, har du ..

.. lest retningslinjene våre for bidrag?
.. tatt en siste sjekk for kode og skrivefeil, debug informasjon o.l?
.. kjørt og eventuelt oppdatert testene?
.. kommentert og dokumentert det som trengs?
.. knyttet denne opp til relaterte issues?

-->
