### PR TITLE
fix(ffe-tables-react): legg til screenreader-only tekst in th

### DIFF
--- a/packages/ffe-tables-react/src/DefaultTable/DefaultTable.js
+++ b/packages/ffe-tables-react/src/DefaultTable/DefaultTable.js
@@ -37,7 +37,11 @@ class DefaultTable extends Component {
         if (this.props.expandedContentMapper) {
             renderColumns.push({
                 key: 'expandIcon',
-                header: '',
+                header: (
+                    <span className="ffe-screenreader-only">
+                        Valg for raden
+                    </span>
+                ),
                 alignRight: true,
             });
         }


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse
Legger til en span med "ffe-screenreader-only" klassen i tabellheaderen som lages når man bruker "expandedContentMapper".  
<!-- Detaljert beskrivelse av endringene dine. Skjermskudd er lov. -->

## Motivasjon og kontekst
Retter #1672 
<!-- Hvorfor trengs denne endringen, og hva løser den? -->

## Testing
Kjørt opp lokalt
<!-- Hvordan har du har testet endringene dine? Ta gjerne med systeminfo o.l -->

<!--

Helt til slutt, har du ..

.. lest retningslinjene våre for bidrag?
.. tatt en siste sjekk for kode og skrivefeil, debug informasjon o.l?
.. kjørt og eventuelt oppdatert testene?
.. kommentert og dokumentert det som trengs?
.. knyttet denne opp til relaterte issues?

-->
