### PR TITLE
fix(ffe-buttons-react): fjern left/right ikon på ExpandButton

### DIFF
--- a/packages/ffe-buttons-react/src/ExpandButton.js
+++ b/packages/ffe-buttons-react/src/ExpandButton.js
@@ -20,8 +20,6 @@ const ExpandButton = props => {
         element: Element,
         innerRef,
         isExpanded,
-        leftIcon,
-        rightIcon,
         ...rest
     } = props;
     return (
@@ -47,29 +45,7 @@ const ExpandButton = props => {
                     close
                 </Symbol>
             )}
-            {!isExpanded && (
-                <span>
-                    {leftIcon && (
-                        <Symbol
-                            className="ffe-button__icon ffe-button__icon--left"
-                            ariaLabel=""
-                            weight={300}
-                        >
-                            {leftIcon}
-                        </Symbol>
-                    )}
-                    {children}
-                    {rightIcon && (
-                        <Symbol
-                            className="ffe-button__icon ffe-button__icon--right"
-                            ariaLabel=""
-                            weight={300}
-                        >
-                            {rightIcon}
-                        </Symbol>
-                    )}
-                </span>
-            )}
+            {!isExpanded && <span>{children}</span>}
         </Element>
     );
 };
@@ -83,10 +59,6 @@ ExpandButton.propTypes = {
     element: oneOfType([func, string, elementType]),
     /** An accessible label for the close-button, only shown in the "isExpanded" state  */
     closeLabel: string,
-    /** Name of Icon shown to the left of the label */
-    leftIcon: string,
-    /** Name of Icon shown to the right of the label */
-    rightIcon: string,
     /** Ref-setting function, or ref created by useRef, passed to the button element */
     innerRef: oneOfType([func, shape({ current: object })]),
     /** When true the component will render a circle with an X indicating whatever is controlled is in an expanded state. */

--- a/packages/ffe-buttons-react/src/ExpandButton.spec.js
+++ b/packages/ffe-buttons-react/src/ExpandButton.spec.js
@@ -19,14 +19,6 @@ describe('<ExpandButton />', () => {
         const wrapper = getWrapper({ 'aria-label': 'some label' });
         expect(wrapper.props()).toHaveProperty('aria-label', 'some label');
     });
-    it('renders leftIcon and rightIcon', () => {
-        const wrapper = getWrapper({
-            leftIcon: 'check',
-            rightIcon: 'close',
-        });
-        expect(wrapper.find('.ffe-button__icon--left').exists()).toBe(true);
-        expect(wrapper.find('.ffe-button__icon--right').exists()).toBe(true);
-    });
     it('does not use an aria-label since the button itself has a children acting as label', () => {
         const wrapper = getWrapper();
         expect(wrapper.prop('aria-label')).toBe(undefined);
@@ -35,19 +27,6 @@ describe('<ExpandButton />', () => {
         it('does not render children', () => {
             const wrapper = getWrapper({ isExpanded: true });
             expect(wrapper.text()).not.toContain('Click me');
-        });
-        it('does not render leftIcon and rightIcon', () => {
-            const wrapper = getWrapper({
-                leftIcon: 'close',
-                isExpanded: true,
-                rightIcon: 'add',
-            });
-            expect(wrapper.find('.ffe-button__icon--left').exists()).toBe(
-                false,
-            );
-            expect(wrapper.find('.ffe-button__icon--right').exists()).toBe(
-                false,
-            );
         });
         it('sets correct class', () => {
             const wrapper = getWrapper({ isExpanded: true });

--- a/packages/ffe-buttons-react/src/index.d.ts
+++ b/packages/ffe-buttons-react/src/index.d.ts
@@ -31,8 +31,6 @@ export interface ButtonGroupProps {
 export type ExpandButtonProps = {
     children: React.ReactNode;
     closeLabel?: string;
-    leftIcon?: React.ReactNode;
-    rightIcon?: React.ReactNode;
     isExpanded: boolean;
     onClick: (e: React.MouseEvent | undefined) => void;
 } & MinimalBaseButtonProps;


### PR DESCRIPTION
BREAKING CHANGE: fjerner leftIcon og rightIcon prop på ExpandButton

<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse
Fjerner leftIcon og rightIcon props på ExpandButton.
<!-- Detaljert beskrivelse av endringene dine. Skjermskudd er lov. -->

## Motivasjon og kontekst
Er ikke meningen av man skal kunne sette ikon på expandbutton.  Fikser #1659 
<!-- Hvorfor trengs denne endringen, og hva løser den? -->

## Testing
kjørt opp lokalt
<!-- Hvordan har du har testet endringene dine? Ta gjerne med systeminfo o.l -->

<!--

Helt til slutt, har du ..

.. lest retningslinjene våre for bidrag?
.. tatt en siste sjekk for kode og skrivefeil, debug informasjon o.l?
.. kjørt og eventuelt oppdatert testene?
.. kommentert og dokumentert det som trengs?
.. knyttet denne opp til relaterte issues?

-->
