### PR TITLE
fix(component-overview): oppdaterer eksempel-tabell som brukte gamle …

### DIFF
--- a/component-overview/examples/tables/Table-customRender.jsx
+++ b/component-overview/examples/tables/Table-customRender.jsx
@@ -1,15 +1,27 @@
 import Table from '@sb1/ffe-tables-react';
 import { TertiaryButton } from '@sb1/ffe-buttons-react';
-import { HakeIkon, KryssIkon } from '@sb1/ffe-icons-react';
+import Symbol from '@sb1/ffe-symbols-react';
 
 () => {
     const generateCheckbox = value => {
         return (
             <div style={{ width: '100%', textAlign: 'center' }}>
                 {value ? (
-                    <HakeIkon className="ffe-table__expand-icon" />
+                    <Symbol
+                        ariaLabel={null}
+                        size="md"
+                        className="ffe-table__expand-icon"
+                    >
+                        check
+                    </Symbol>
                 ) : (
-                    <KryssIkon className="ffe-table__expand-icon" />
+                    <Symbol
+                        ariaLabel={null}
+                        size="md"
+                        className="ffe-table__expand-icon"
+                    >
+                        close
+                    </Symbol>
                 )}
             </div>
         );


### PR DESCRIPTION
…ikoner

<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse

Et tabell-eksempel i component-overview brukte gamle ikoner men ny styling. Oppdaterer til nye ikoner så det ser rett ut.

## Motivasjon og kontekst

Før:

![image](https://github.com/SpareBank1/designsystem/assets/463847/ab4fb8ce-bc97-41e8-acb6-1f6aeb0cca8b)

Etter:

![image](https://github.com/SpareBank1/designsystem/assets/463847/52dc1a8b-bd01-470c-857a-2b377b233498)


## Testing

Testet lokalt i component-overview