### PR TITLE
fix(component-overview): retter feil i eksempel tooltip-external

### DIFF
--- a/component-overview/examples/form/Tooltip-external.jsx
+++ b/component-overview/examples/form/Tooltip-external.jsx
@@ -9,8 +9,8 @@ import { Tooltip } from '@sb1/ffe-form-react';
                 aria-controls="tooltip-text"
                 onClick={() => setOpen(!open)}
             />
-            <div hidden={open} id="tooltip-text">
-                Titt tei!
+            <div hidden={!open} id="tooltip-text">
+                Husk at Tooltip alltid skal være skjult ved default, men du kan styre visningen gjennom en onClick om du vil!
             </div>
         </>
     );


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse
Gjør at tooltip-external eksempelet er lukket på default
<!-- Detaljert beskrivelse av endringene dine. Skjermskudd er lov. -->

## Motivasjon og kontekst
Retter UU-feil med aria-expanded på tooltip-external.
Feilen skyldes at aria-expanded på tooltip settes basert på at den er lukket ved default. 
<!-- Hvorfor trengs denne endringen, og hva løser den? -->

## Testing
kjørt opp lokalt
<!-- Hvordan har du har testet endringene dine? Ta gjerne med systeminfo o.l -->

<!--

Helt til slutt, har du ..

.. lest retningslinjene våre for bidrag?
.. tatt en siste sjekk for kode og skrivefeil, debug informasjon o.l?
.. kjørt og eventuelt oppdatert testene?
.. kommentert og dokumentert det som trengs?
.. knyttet denne opp til relaterte issues?

-->
