### PR TITLE
fix(ffe-core): added :host to generated css files

### DIFF
--- a/packages/ffe-core/scripts/lib/renderLessVarsToCSSProps.js
+++ b/packages/ffe-core/scripts/lib/renderLessVarsToCSSProps.js
@@ -16,7 +16,7 @@ module.exports = async inputFile => {
     const { css } = await less.render(
         `@import '${inputFile}';` +
             `@props: ${propertyNames.join(', ')};` +
-            `:root { each(@props, { --@{value}: @@value; }); }`,
+            `:root, :host { each(@props, { --@{value}: @@value; }); }`,
     );
 
     return css;


### PR DESCRIPTION
La til `:host` i lessfilerna men dom ble ikke med i css filerna

![image](https://github.com/SpareBank1/designsystem/assets/2248579/522d509f-e34f-452a-9c32-66c03c7e16c5)
