### PR TITLE
fix(ffe-form-react): fix type for ref for tooltip

### DIFF
--- a/packages/ffe-form-react/src/index.d.ts
+++ b/packages/ffe-form-react/src/index.d.ts
@@ -86,7 +86,7 @@ export interface TooltipProps extends React.ComponentProps<'span'> {
     isOpen?: boolean;
     onClick?: (e: React.MouseEvent | undefined) => void;
     tabIndex?: number;
-    ref?: React.ForwardedRef<HTMLButtonElement>;
+    ref?: React.Ref<HTMLButtonElement>;
 }
 
 export interface RadioBlockProps extends React.ComponentProps<'input'> {


### PR DESCRIPTION
#1698 

Vet ikke om man heller skal droppe propen, ser det er gjort det for andre component som bruker forwardRef