### PR TITLE
fix(ffe-spinner-react): legg til loadingText-prop

### DIFF
--- a/component-overview/examples/spinner/Spinner-large.jsx
+++ b/component-overview/examples/spinner/Spinner-large.jsx
@@ -2,6 +2,5 @@ import Spinner from '@sb1/ffe-spinner-react';
 import { Paragraph } from '@sb1/ffe-core-react';
 
 <>
-    <Spinner large={true} />
-    <Paragraph>Vennligst vent litt</Paragraph>
+    <Spinner large={true} loadingText={<Paragraph>Vennligst vent litt</Paragraph>} />
 </>

--- a/component-overview/examples/spinner/Spinner-noLoadingtext.jsx
+++ b/component-overview/examples/spinner/Spinner-noLoadingtext.jsx
@@ -1,0 +1,5 @@
+import Spinner from '@sb1/ffe-spinner-react';
+
+<>
+    <Spinner />
+</>

--- a/component-overview/examples/spinner/Spinner.jsx
+++ b/component-overview/examples/spinner/Spinner.jsx
@@ -1,5 +1,6 @@
 import Spinner from '@sb1/ffe-spinner-react';
+import { Paragraph } from '@sb1/ffe-core-react';
 
 <>
-    <Spinner /> Vennligst vent litt
+    <Spinner loadingText={<Paragraph>Vennligst vent</Paragraph>} />
 </>

--- a/packages/ffe-spinner-react/src/Spinner.js
+++ b/packages/ffe-spinner-react/src/Spinner.js
@@ -1,24 +1,28 @@
 import React from 'react';
-import { bool, string } from 'prop-types';
+import { bool, string, node } from 'prop-types';
 import classNames from 'classnames';
 
-const Spinner = ({ className, immediate, large, ...rest }) => (
-    <span
-        aria-live="assertive"
-        className={classNames(
-            'ffe-loading-spinner',
-            { 'ffe-loading-spinner--immediate': immediate },
-            { 'ffe-loading-spinner--large': large },
-            className,
-        )}
-        {...rest}
-    />
+const Spinner = ({ className, immediate, large, loadingText, ...rest }) => (
+    <div aria-live="assertive" className={className} {...rest}>
+        <span
+            className={classNames(
+                'ffe-loading-spinner',
+                { 'ffe-loading-spinner--immediate': immediate },
+                { 'ffe-loading-spinner--large': large },
+            )}
+            role="img"
+            aria-label="Vennligst vent"
+            aria-hidden={!!loadingText}
+        />
+        {loadingText}
+    </div>
 );
 
 Spinner.propTypes = {
     className: string,
     immediate: bool,
     large: bool,
+    loadingText: node,
 };
 
 Spinner.defaultProps = {

--- a/packages/ffe-spinner-react/src/Spinner.spec.js
+++ b/packages/ffe-spinner-react/src/Spinner.spec.js
@@ -7,20 +7,34 @@ describe('<Spinner />', () => {
     it('renders without exploding', () => {
         const wrapper = getWrapper();
         expect(wrapper.exists()).toBe(true);
-        expect(wrapper.is('span')).toBe(true);
+        expect(wrapper.is('div')).toBe(true);
+        expect(wrapper.find('span').exists()).toBe(true);
     });
     it('renders classes correctly', () => {
         const wrapper = getWrapper({ className: 'test-class' });
-        expect(wrapper.hasClass('ffe-loading-spinner')).toBe(true);
+        expect(wrapper.find('span').hasClass('ffe-loading-spinner')).toBe(true);
         expect(wrapper.hasClass('test-class')).toBe(true);
     });
     it('renders a large spinner', () => {
         const wrapper = getWrapper({ large: true });
-
-        expect(wrapper.hasClass('ffe-loading-spinner--large')).toBe(true);
+        expect(
+            wrapper.find('span').hasClass('ffe-loading-spinner--large'),
+        ).toBe(true);
     });
     it('passes props correctly', () => {
         const wrapper = getWrapper({ id: 'test-id' });
         expect(wrapper.prop('id')).toBe('test-id');
+    });
+    it('aria-hidden is set to false by default', () => {
+        const wrapper = getWrapper();
+        expect(wrapper.find('span').prop('aria-hidden')).toBe(false);
+    });
+    it('aria-hidden set to true when loadingText set', () => {
+        const wrapper = getWrapper({ loadingText: 'test' });
+        expect(wrapper.find('span').prop('aria-hidden')).toBe(true);
+    });
+    it('set loadingText correctly', () => {
+        const wrapper = getWrapper({ loadingText: <p>Text</p> });
+        expect(wrapper.find('p').exists()).toBe(true);
     });
 });

--- a/packages/ffe-spinner-react/src/index.d.ts
+++ b/packages/ffe-spinner-react/src/index.d.ts
@@ -4,6 +4,7 @@ export interface SpinnerProps extends React.ComponentProps<'span'> {
     className?: string;
     immediate?: boolean;
     large?: boolean;
+    loadingText: React.ReactNode;
 }
 
 declare class Spinner extends React.Component<SpinnerProps, any> {}


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse
Wrapper innholdet i komponenten i en div, og legger til en ny property som heter loadingText.
loadingText-prop tar ett react element. 

Dersom loadingText er satt så vil selve spinner ikonet settes til aria-hidden. 

Dersom loadingText ikke er satt vil loading ikonet ha aria-hidden="false".
Legger også til  aria-label="Vennligst vent" og role="img" på spinner ikonet. 

<!-- Detaljert beskrivelse av endringene dine. Skjermskudd er lov. -->

## Motivasjon og kontekst
Løser #1577 
<!-- Hvorfor trengs denne endringen, og hva løser den? -->

## Testing
Kjørt opp lokalt
<!-- Hvordan har du har testet endringene dine? Ta gjerne med systeminfo o.l -->

<!--

Helt til slutt, har du ..

.. lest retningslinjene våre for bidrag?
.. tatt en siste sjekk for kode og skrivefeil, debug informasjon o.l?
.. kjørt og eventuelt oppdatert testene?
.. kommentert og dokumentert det som trengs?
.. knyttet denne opp til relaterte issues?

-->
