### PR TITLE
fix(ffe-file-upload-react): fikse sletting av opplastede filer

### DIFF
--- a/packages/ffe-file-upload-react/src/FileUpload.js
+++ b/packages/ffe-file-upload-react/src/FileUpload.js
@@ -43,7 +43,7 @@ class FileUpload extends React.Component {
     }
 
     onFileDeleted(event) {
-        this.props.onFileDeleted(this.props.files[event.target.id]);
+        this.props.onFileDeleted(this.props.files[event.currentTarget.id]);
     }
 
     render() {

--- a/packages/ffe-file-upload-react/src/FileUpload.spec.js
+++ b/packages/ffe-file-upload-react/src/FileUpload.spec.js
@@ -48,7 +48,7 @@ describe('<FileUpload/>', () => {
         });
 
         it('should extract and return files when user finishes selecting files', () => {
-            component.find('#file-upload').simulate('change', {
+            component.find('input#file-upload').simulate('change', {
                 target: {
                     files: {
                         filename: {
@@ -59,6 +59,36 @@ describe('<FileUpload/>', () => {
             });
 
             expect(onFilesSelected.calledOnce).toBe(true);
+        });
+
+        it('should remove file from files when delete button is clicked', () => {
+            // Component needs to be mounted for this test because we must render children.
+            component = mount(
+                <FileUpload
+                    id="file-upload"
+                    label="label"
+                    title="title"
+                    infoText="infoText"
+                    uploadTitle="uploadTitle"
+                    uploadMicroText="uploadMicroText"
+                    uploadSubText="uploadSubText"
+                    files={{
+                        fileToDelete: {
+                            name: 'fileToDelete',
+                        },
+                    }}
+                    onFilesSelected={onFilesSelected}
+                    onFileDeleted={onFileDeleted}
+                    onFilesDropped={onFilesDropped}
+                />,
+            );
+            // Do click on span inside button with event listener instead of actual button to catch nested clicks.
+            component
+                .find('.ffe-file-upload__file-item-delete-button-text')
+                .simulate('click');
+            expect(onFileDeleted.calledWith({ name: 'fileToDelete' })).toBe(
+                true,
+            );
         });
     });
 });


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->
Knyttet til issue: #1697 
## Beskrivelse
Versjon 10 innførte bug som gjorde at man ikke kunne slette opplastede filer. det skyltes at brukeren sitt klikk blir registrert på et element inni button-elementet som har lytteren for click-eventet, men slettingen baserte seg på id-en som lå på elementet som ble klikket på, ikke selve knappen. denne commiten bytter "target" med "currentTarget" som vil bruke targeten til lytteren, ikke targeten som faktisk ble trykket på.
<!-- Detaljert beskrivelse av endringene dine. Skjermskudd er lov. -->

## Motivasjon og kontekst
Se avsnittet over. Dette er bare en liten bugfix.
<!-- Hvorfor trengs denne endringen, og hva løser den? -->

## Testing
Testet ved å lage ny frontend-test, som sjekker at slette-funksjonen kalles med forventet fileName, som i denne bugen har var "undefined", men som nå er navnet på filen som skal slettes.
<!-- Hvordan har du har testet endringene dine? Ta gjerne med systeminfo o.l -->

<!--

Helt til slutt, har du ..

.. lest retningslinjene våre for bidrag?
.. tatt en siste sjekk for kode og skrivefeil, debug informasjon o.l?
.. kjørt og eventuelt oppdatert testene?
.. kommentert og dokumentert det som trengs?
.. knyttet denne opp til relaterte issues?

-->
