### PR TITLE
fix(ffe-symbols): endre loading strategy font-display

### DIFF
--- a/packages/ffe-symbols/ffe-symbol-font-inline.less
+++ b/packages/ffe-symbols/ffe-symbol-font-inline.less
@@ -4,7 +4,7 @@
 @font-face {
     font-family: 'MaterialSymbolsRounded-300';
     font-style: normal;
-    font-display: fallback;
+    font-display: block;
     src: data-uri('@{icons-data-uri}/MaterialSymbolsRounded300.woff2')
         format('woff2');
 }
@@ -12,7 +12,7 @@
 @font-face {
     font-family: 'MaterialSymbolsRounded-400';
     font-style: normal;
-    font-display: fallback;
+    font-display: block;
     src: data-uri('@{icons-data-uri}/MaterialSymbolsRounded400.woff2')
         format('woff2');
 }
@@ -20,7 +20,7 @@
 @font-face {
     font-family: 'MaterialSymbolsRounded-500';
     font-style: normal;
-    font-display: fallback;
+    font-display: block;
     src: data-uri('@{icons-data-uri}/MaterialSymbolsRounded500.woff2')
         format('woff2');
 }
@@ -30,7 +30,7 @@
 @font-face {
     font-family: 'MaterialSymbolsRoundedFilled-300';
     font-style: normal;
-    font-display: fallback;
+    font-display: block;
     src: data-uri('@{icons-data-uri}/MaterialSymbolsRoundedFilled300.woff2')
         format('woff2');
 }
@@ -38,7 +38,7 @@
 @font-face {
     font-family: 'MaterialSymbolsRoundedFilled-400';
     font-style: normal;
-    font-display: fallback;
+    font-display: block;
     src: data-uri('@{icons-data-uri}/MaterialSymbolsRoundedFilled400.woff2')
         format('woff2');
 }
@@ -46,7 +46,7 @@
 @font-face {
     font-family: 'MaterialSymbolsRoundedFilled-500';
     font-style: normal;
-    font-display: fallback;
+    font-display: block;
     src: data-uri('@{icons-data-uri}/MaterialSymbolsRoundedFilled500.woff2')
         format('woff2');
 }

--- a/packages/ffe-symbols/ffe-symbol.less
+++ b/packages/ffe-symbols/ffe-symbol.less
@@ -4,21 +4,21 @@
 @font-face {
     font-family: 'MaterialSymbolsRounded-300';
     font-style: normal;
-    font-display: fallback;
+    font-display: block;
     src: url('@{icons-url}/MaterialSymbolsRounded300.woff2') format('woff2');
 }
 
 @font-face {
     font-family: 'MaterialSymbolsRounded-400';
     font-style: normal;
-    font-display: fallback;
+    font-display: block;
     src: url('@{icons-url}/MaterialSymbolsRounded400.woff2') format('woff2');
 }
 
 @font-face {
     font-family: 'MaterialSymbolsRounded-500';
     font-style: normal;
-    font-display: fallback;
+    font-display: block;
     src: url('@{icons-url}/MaterialSymbolsRounded500.woff2') format('woff2');
 }
 
@@ -27,7 +27,7 @@
 @font-face {
     font-family: 'MaterialSymbolsRoundedFilled-300';
     font-style: normal;
-    font-display: fallback;
+    font-display: block;
     src: url('@{icons-url}/MaterialSymbolsRoundedFilled300.woff2')
         format('woff2');
 }
@@ -35,7 +35,7 @@
 @font-face {
     font-family: 'MaterialSymbolsRoundedFilled-400';
     font-style: normal;
-    font-display: fallback;
+    font-display: block;
     src: url('@{icons-url}/MaterialSymbolsRoundedFilled400.woff2')
         format('woff2');
 }
@@ -43,7 +43,7 @@
 @font-face {
     font-family: 'MaterialSymbolsRoundedFilled-500';
     font-style: normal;
-    font-display: fallback;
+    font-display: block;
     src: url('@{icons-url}/MaterialSymbolsRoundedFilled500.woff2')
         format('woff2');
 }


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse
Endrer font-display fra `fallback` til `block` i håp om at det gjør at ikonene ikke vises som tekst før ikon-fonten lastes. 
Block er også brukt i webtemplating-framework, så nå blir det likt begge steder.
<!-- Detaljert beskrivelse av endringene dine. Skjermskudd er lov. -->

## Motivasjon og kontekst
Det er noen problemer med at ikonene vises som tekst før ikon-fonten er lastes. 
<!-- Hvorfor trengs denne endringen, og hva løser den? -->

## Testing
Må testes mer for å se om det faktisk løser problemet
<!-- Hvordan har du har testet endringene dine? Ta gjerne med systeminfo o.l -->

<!--

Helt til slutt, har du ..

.. lest retningslinjene våre for bidrag?
.. tatt en siste sjekk for kode og skrivefeil, debug informasjon o.l?
.. kjørt og eventuelt oppdatert testene?
.. kommentert og dokumentert det som trengs?
.. knyttet denne opp til relaterte issues?

-->
