### PR TITLE
fix(ffe-buttons): fikser darkmode tekst farge for primary button

### DIFF
--- a/packages/ffe-buttons/less/base-button.less
+++ b/packages/ffe-buttons/less/base-button.less
@@ -58,7 +58,7 @@
     }
 
     &:visited {
-        color: @ffe-farge-hvit;
+        color: var(--ffe-v-button-text-color);
     }
 
     @media (min-width: @breakpoint-sm) {


### PR DESCRIPTION
--ffe-v-button-text-color får korrekt overstyrt darkmode farge, som @ffe-farge-hvit ikke gjorde

## Beskrivelse

Endrer farge på ffe-button:visisted fra @ffe-farge-hvit til var(--ffe-v-button-text-color), som fikser problemet pga. at css variabelen får overstyrt darkmode farge slik den skal.

## Motivasjon og kontekst

PrimaryButton fikk hvit tekst istedetfor svart tekst i darkmode, pga. den ble overstyrt fra ffe-button:visited

