### PR TITLE
fix(ffe-buttons-react): øker størrelsen på ikoner i knapper

### DIFF
--- a/component-overview/examples/buttons/SecondaryButton-leftIcon.jsx
+++ b/component-overview/examples/buttons/SecondaryButton-leftIcon.jsx
@@ -1,7 +1,7 @@
 import { SecondaryButton, ButtonGroup } from '@sb1/ffe-buttons-react';
 
 <ButtonGroup thin={true}>
-    <SecondaryButton leftIcon="attach_file" onClick={f => f}>
+    <SecondaryButton leftIcon="check" onClick={f => f}>
         Secondary m/ ikon
     </SecondaryButton>
 </ButtonGroup>;

--- a/component-overview/examples/buttons/SecondaryButton-rightIcon.jsx
+++ b/component-overview/examples/buttons/SecondaryButton-rightIcon.jsx
@@ -1,7 +1,7 @@
 import { SecondaryButton, ButtonGroup } from '@sb1/ffe-buttons-react';
 
 <ButtonGroup thin={true}>
-    <SecondaryButton rightIcon="attach_file" onClick={f => f}>
+    <SecondaryButton rightIcon="check" onClick={f => f}>
         Secondary m/ ikon
     </SecondaryButton>
 </ButtonGroup>;

--- a/packages/ffe-buttons-react/src/ActionButton.js
+++ b/packages/ffe-buttons-react/src/ActionButton.js
@@ -21,8 +21,8 @@ export default function ActionButton(props) {
         <Button
             buttonType="action"
             className={classNames(className)}
-            leftIcon={leftIcon && <Symbol icon={leftIcon} size="sm" />}
-            rightIcon={rightIcon && <Symbol icon={rightIcon} size="sm" />}
+            leftIcon={leftIcon && <Symbol icon={leftIcon} size="md" />}
+            rightIcon={rightIcon && <Symbol icon={rightIcon} size="md" />}
             {...rest}
         />
     );

--- a/packages/ffe-buttons-react/src/ExpandButton.js
+++ b/packages/ffe-buttons-react/src/ExpandButton.js
@@ -39,7 +39,7 @@ const ExpandButton = props => {
                 <Symbol
                     className="ffe-button__icon"
                     icon="close"
-                    size="sm"
+                    size="md"
                     weight={300}
                 />
             )}

--- a/packages/ffe-buttons-react/src/PrimaryButton.js
+++ b/packages/ffe-buttons-react/src/PrimaryButton.js
@@ -17,8 +17,8 @@ const PrimaryButton = props => {
     return (
         <Button
             buttonType="primary"
-            leftIcon={leftIcon && <Symbol icon={leftIcon} size="sm" />}
-            rightIcon={rightIcon && <Symbol icon={rightIcon} size="sm" />}
+            leftIcon={leftIcon && <Symbol icon={leftIcon} size="md" />}
+            rightIcon={rightIcon && <Symbol icon={rightIcon} size="md" />}
             {...rest}
         />
     );

--- a/packages/ffe-buttons-react/src/SecondaryButton.js
+++ b/packages/ffe-buttons-react/src/SecondaryButton.js
@@ -17,8 +17,8 @@ const SecondaryButton = props => {
     return (
         <Button
             buttonType="secondary"
-            leftIcon={leftIcon && <Symbol icon={leftIcon} size="sm" />}
-            rightIcon={rightIcon && <Symbol icon={rightIcon} size="sm" />}
+            leftIcon={leftIcon && <Symbol icon={leftIcon} size="md" />}
+            rightIcon={rightIcon && <Symbol icon={rightIcon} size="md" />}
             {...rest}
         />
     );

--- a/packages/ffe-buttons-react/src/TaskButton.js
+++ b/packages/ffe-buttons-react/src/TaskButton.js
@@ -15,7 +15,7 @@ import Symbol from '@sb1/ffe-symbols-react';
 const TaskButton = ({ icon, ...rest }) => (
     <Button
         buttonType="task"
-        leftIcon={<Symbol icon={icon} size="sm" />}
+        leftIcon={<Symbol icon={icon} size="md" />}
         {...rest}
     />
 );

--- a/packages/ffe-buttons-react/src/TaskButton.spec.js
+++ b/packages/ffe-buttons-react/src/TaskButton.spec.js
@@ -20,7 +20,7 @@ describe('<TaskButton />', () => {
         const wrapper = getWrapper({ icon: 'add' });
         expect(wrapper.props()).toHaveProperty(
             'leftIcon',
-            <Symbol icon="add" size="sm" />,
+            <Symbol icon="add" size="md" />,
         );
     });
 });

--- a/packages/ffe-buttons-react/src/TertiaryButton.js
+++ b/packages/ffe-buttons-react/src/TertiaryButton.js
@@ -16,8 +16,8 @@ const TertiaryButton = props => {
     return (
         <InlineButton
             buttonType="tertiary"
-            leftIcon={leftIcon && <Symbol icon={leftIcon} size="sm" />}
-            rightIcon={rightIcon && <Symbol icon={rightIcon} size="sm" />}
+            leftIcon={leftIcon && <Symbol icon={leftIcon} size="md" />}
+            rightIcon={rightIcon && <Symbol icon={rightIcon} size="md" />}
             {...rest}
         />
     );


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse

Øker størrelsen på ikoner i knapper fra `sm` til `md`, ettersom de føltes noe for små etter overgangen til Material Symbols.

## Motivasjon og kontekst

Fixes #1707 

## Testing

Testet lokalt i component-overview