### PR TITLE
Legger til mørk bakgrunnsfarge i GridRow

### DIFF
--- a/component-overview/examples/grid/GridRow-background.jsx
+++ b/component-overview/examples/grid/GridRow-background.jsx
@@ -5,6 +5,7 @@ import { Label } from '@sb1/ffe-form-react';
 
 () => {
     const backgroundColors = [
+        undefined,
         'frost-30',
         'sand',
         'sand-70',
@@ -16,7 +17,14 @@ import { Label } from '@sb1/ffe-form-react';
         'fjell',
         'hvit',
     ];
+    const backgroundDarkColors = [
+        undefined,
+        'svart',
+        'natt',
+        'koksgraa',
+    ];
     const [bgColor, setBgColor] = useState(backgroundColors[0]);
+    const [bgDarkColor, setBgDarkColor] = useState(backgroundDarkColors[0]);
 
     return (
         <Grid>
@@ -32,13 +40,31 @@ import { Label } from '@sb1/ffe-form-react';
                     >
                         {backgroundColors.map(name => (
                             <option key={name} value={name}>
-                                {name}
+                                {name || 'Ingen farge'}
                             </option>
                         ))}
                     </Dropdown>
                 </GridCol>
             </GridRow>
-            <GridRow background={bgColor}>
+            <GridRow padding="sm">
+                <GridCol sm={12} lg={{ cols: 6, offset: 3 }}>
+                    <Label htmlFor="select-gridrow-bg-dark">
+                        Du kan velge bakgrunnsfarge for mørk fargemodus på grid-raden under her:
+                    </Label>
+                    <Dropdown
+                        id="select-gridrow-bg-dark"
+                        onChange={e => setBgDarkColor(e.target.value)}
+                        value={bgDarkColor}
+                    >
+                        {backgroundDarkColors.map(name => (
+                            <option key={name} value={name}>
+                                {name || 'Ingen farge'}
+                            </option>
+                        ))}
+                    </Dropdown>
+                </GridCol>
+            </GridRow>
+            <GridRow background={bgColor} backgroundDark={bgDarkColor} >
                 <GridCol sm={12} lg={{ cols: 6, offset: 3 }}>
                     <p>
                         Lorem ipsum dolor sit amet, consectetur adipiscing elit.

--- a/packages/ffe-grid-react/src/GridCol.js
+++ b/packages/ffe-grid-react/src/GridCol.js
@@ -9,7 +9,7 @@ import {
     string,
 } from 'prop-types';
 import classNames from 'classnames';
-import backgroundColors, { removedColors } from './background-colors';
+import { backgroundColors, removedColors } from './background-colors';
 
 function camelCaseToDashCase(str) {
     return str

--- a/packages/ffe-grid-react/src/GridCol.spec.js
+++ b/packages/ffe-grid-react/src/GridCol.spec.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { GridCol } from '.';
-import backgroundColors from './background-colors';
+import { backgroundColors } from './background-colors';
 
 const defaultProps = {
     children: <p>blah</p>,

--- a/packages/ffe-grid-react/src/GridRow.js
+++ b/packages/ffe-grid-react/src/GridRow.js
@@ -2,10 +2,15 @@ import React from 'react';
 import { node, oneOf, string } from 'prop-types';
 import classNames from 'classnames';
 
-import backgroundColors, { removedColors } from './background-colors';
+import {
+    backgroundColors,
+    backgroundDarkColors,
+    removedColors,
+} from './background-colors';
 
 export default function GridRow({
     background,
+    backgroundDark,
     className,
     children,
     element,
@@ -14,12 +19,16 @@ export default function GridRow({
     ...rest
 }) {
     const hasBackgroundColor = backgroundColors.includes(background);
-    const hasRemovedColor = removedColors.includes(background);
-    const content = hasBackgroundColor ? (
-        <div className="ffe-grid__row-wrapper">{children}</div>
-    ) : (
-        children
+    const hasBackgroundDarkColor = backgroundDarkColors.includes(
+        backgroundDark,
     );
+    const hasRemovedColor = removedColors.includes(background);
+    const content =
+        hasBackgroundColor || hasBackgroundDarkColor ? (
+            <div className="ffe-grid__row-wrapper">{children}</div>
+        ) : (
+            children
+        );
 
     if (hasRemovedColor) {
         throw new Error(
@@ -35,6 +44,9 @@ export default function GridRow({
                 className,
                 'ffe-grid__row',
                 { [`ffe-grid__row--bg-${background}`]: hasBackgroundColor },
+                {
+                    [`ffe-grid__row--bg-dark-${backgroundDark}`]: hasBackgroundDarkColor,
+                },
                 { [`ffe-grid__row--padding-${padding}`]: padding },
                 { [`ffe-grid__row--margin-${margin}`]: margin },
             )}
@@ -47,18 +59,9 @@ export default function GridRow({
 
 GridRow.propTypes = {
     /** Supported background colors */
-    background: oneOf([
-        'frost-30',
-        'sand',
-        'sand-70',
-        'sand-30',
-        'syrin-70',
-        'syrin-30',
-        'vann',
-        'vann-30',
-        'fjell',
-        'hvit',
-    ]),
+    background: oneOf(backgroundColors),
+    /** Supported dark background colors */
+    backgroundDark: oneOf(backgroundDarkColors),
     /** Padding in the top and bottom of the row */
     padding: oneOf([
         '2xs',

--- a/packages/ffe-grid-react/src/GridRow.spec.js
+++ b/packages/ffe-grid-react/src/GridRow.spec.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { GridRow, GridCol } from '.';
-import backgroundColors from './background-colors';
+import { backgroundColors, backgroundDarkColors } from './background-colors';
 
 const defaultProps = {
     children: <p>blah</p>,
@@ -37,6 +37,16 @@ describe('GridRow', () => {
         });
     });
 
+    it('adds correct class for all valid dark background colors', () => {
+        const el = renderShallow();
+        backgroundDarkColors.forEach(backgroundDark => {
+            el.setProps({ backgroundDark });
+            expect(
+                el.hasClass(`ffe-grid__row--bg-dark-${backgroundDark}`),
+            ).toBe(true);
+        });
+    });
+
     it('does not add any background-class for invalid background colors', () => {
         const el = renderShallow();
         console.error = jest.fn();
@@ -46,16 +56,41 @@ describe('GridRow', () => {
         });
     });
 
+    it('does not add any dark background-class for invalid background colors', () => {
+        const el = renderShallow();
+        console.error = jest.fn();
+        ['illegal', 'color values', 'are ignored'].forEach(backgroundDark => {
+            el.setProps({ backgroundDark });
+            expect(
+                el.hasClass(`ffe-grid__row--bg-dark-${backgroundDark}`),
+            ).toBe(false);
+        });
+    });
+
     it('throws for removed background colours', () => {
         expect(() => renderShallow({ background: 'blue-cobalt' })).toThrow(
             'Support for the blue-cobalt background on <GridRow> has been removed, please see the CHANGELOG',
         );
     });
 
-    it('renders coloured rows with extra wrappers', () => {
+    it('renders rows with extra wrappers when background is set', () => {
         backgroundColors.forEach(background => {
             const el = renderShallow({
                 background,
+                children: (
+                    <GridCol lg={12}>
+                        <p>blah</p>
+                    </GridCol>
+                ),
+            });
+            expect(el.childAt(0).hasClass('ffe-grid__row-wrapper')).toBe(true);
+        });
+    });
+
+    it('renders rows with extra wrappers when dark background is set', () => {
+        backgroundDarkColors.forEach(backgroundDark => {
+            const el = renderShallow({
+                backgroundDark,
                 children: (
                     <GridCol lg={12}>
                         <p>blah</p>

--- a/packages/ffe-grid-react/src/background-colors.js
+++ b/packages/ffe-grid-react/src/background-colors.js
@@ -1,4 +1,4 @@
-export default [
+export const backgroundColors = [
     'frost-30',
     'sand',
     'sand-70',
@@ -10,6 +10,8 @@ export default [
     'fjell',
     'hvit',
 ];
+
+export const backgroundDarkColors = ['svart', 'natt', 'koksgraa'];
 
 export const removedColors = [
     'blue-cobalt',

--- a/packages/ffe-grid-react/src/index.d.ts
+++ b/packages/ffe-grid-react/src/index.d.ts
@@ -21,6 +21,8 @@ type BackgroundColors =
     | 'fjell'
     | 'hvit';
 
+type BackgroundDarkColors = 'svart' | 'natt' | 'koksgraa';
+
 type Margin =
     | '2xs'
     | 'xs'
@@ -47,6 +49,7 @@ type Padding =
 
 export interface GridRowProps extends React.ComponentProps<'div'> {
     background?: BackgroundColors;
+    backgroundDark?: BackgroundDarkColors;
     children: React.ReactNode;
     className?: string;
     element?: string;

--- a/packages/ffe-grid/less/ffe-grid.less
+++ b/packages/ffe-grid/less/ffe-grid.less
@@ -246,6 +246,30 @@
             }
         }
     }
+
+    &--bg-dark-svart {
+        .native & {
+            @media (prefers-color-scheme: dark) {
+                background-color: var(--ffe-farge-svart);
+            }
+        }
+    }
+
+    &--bg-dark-natt {
+        .native & {
+            @media (prefers-color-scheme: dark) {
+                background-color: var(--ffe-farge-natt);
+            }
+        }
+    }
+
+    &--bg-dark-koksgraa {
+        .native & {
+            @media (prefers-color-scheme: dark) {
+                background-color: var(--ffe-farge-koksgraa);
+            }
+        }
+    }
 }
 
 [class*='ffe-grid__row--bg-'] {


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse

<!-- Detaljert beskrivelse av endringene dine. Skjermskudd er lov. -->

Legger til en `backgroundDark` prop til `GridRow` for å styre bakgrunnsfarge på native darkmode. Jeg la til eksempel kode for denne funksjonaliteten i `examples/grid/GridRow-background.jsx` fordi det er et samspill i bakgrunnsfarger på lightmode og darkmode. Ser at dette eksempelet også er brukt på https://design.sparebank1.no/komponenter/grid/ . Bare si ifra hvis funksjonaliteten istedet skal splittes ut i eget eksempel.

![image](https://github.com/SpareBank1/designsystem/assets/34199185/c05ac135-afb5-4339-980e-2ef3d8d8cad5)

## Motivasjon og kontekst

<!-- Hvorfor trengs denne endringen, og hva løser den? -->

Man kunne ikke styre bakgrunnsfarge i `GridRow` native darkmode før, den ble satt til `--ffe-farge-svart` som default. Det er designbehov rundt å kunne sette bakgrunnsfarge til f.eks `--ffe-farge-natt` på native darkmode.

## Testing

<!-- Hvordan har du har testet endringene dine? Ta gjerne med systeminfo o.l -->

Testet manuelt i eksempelet nevnt ovenfor. Laget enhetstester tilsvarende det som fantes fra før. Det er noe css specificity i spill her med at `&--bg-dark-` klasser må være definert etter `&--bg-` for å overskrive bakgrunnsfarge hvis både `background` og `backgroundDark` er satt. Skulle gjerne hatt en automatisk test på dette men jest enhetstester er nok ikke riktig sted for det.

<!--

Helt til slutt, har du ..

.. lest retningslinjene våre for bidrag?
.. tatt en siste sjekk for kode og skrivefeil, debug informasjon o.l?
.. kjørt og eventuelt oppdatert testene?
.. kommentert og dokumentert det som trengs?
.. knyttet denne opp til relaterte issues?

-->
