### PR TITLE
Legger til mørk bakgrunnsfarge i GridCol

### DIFF
--- a/component-overview/examples/grid/GridCol-background.jsx
+++ b/component-overview/examples/grid/GridCol-background.jsx
@@ -5,6 +5,7 @@ import { Label } from '@sb1/ffe-form-react';
 
 () => {
     const backgroundColors = [
+        undefined,
         'frost-30',
         'sand',
         'sand-70',
@@ -16,23 +17,48 @@ import { Label } from '@sb1/ffe-form-react';
         'fjell',
         'hvit',
     ];
+    const backgroundDarkColors = [
+        undefined,
+        'svart',
+        'natt',
+        'koksgraa',
+    ];
     const [bgColor, setBgColor] = useState(backgroundColors[0]);
+    const [bgDarkColor, setBgDarkColor] = useState(backgroundDarkColors[0]);
 
     return (
         <Grid>
             <GridRow>
                 <GridCol sm={12} lg={{ cols: 6, offset: 3 }}>
-                    <Label htmlFor="select-gridrow-bg">
+                    <Label htmlFor="select-gridcol-bg">
                         Du kan velge bakgrunnsfarge på grid-kolonnen under her:
                     </Label>
                     <Dropdown
-                        id="select-gridrow-bg"
+                        id="select-gridcol-bg"
                         onChange={e => setBgColor(e.target.value)}
                         value={bgColor}
                     >
                         {backgroundColors.map(name => (
                             <option key={name} value={name}>
-                                {name}
+                                {name || 'Ingen farge'}
+                            </option>
+                        ))}
+                    </Dropdown>
+                </GridCol>
+            </GridRow>
+            <GridRow padding="sm">
+                <GridCol sm={12} lg={{ cols: 6, offset: 3 }}>
+                    <Label htmlFor="select-gridcol-bg-dark">
+                        Du kan velge bakgrunnsfarge for mørk fargemodus på grid-kolonnen under her:
+                    </Label>
+                    <Dropdown
+                        id="select-gridcol-bg-dark"
+                        onChange={e => setBgDarkColor(e.target.value)}
+                        value={bgDarkColor}
+                    >
+                        {backgroundDarkColors.map(name => (
+                            <option key={name} value={name}>
+                                {name || 'Ingen farge'}
                             </option>
                         ))}
                     </Dropdown>
@@ -43,6 +69,7 @@ import { Label } from '@sb1/ffe-form-react';
                     sm={12}
                     lg={{ cols: 6, offset: 3 }}
                     background={bgColor}
+                    backgroundDark={bgDarkColor}
                 >
                     <p>
                         Lorem ipsum dolor sit amet, consectetur adipiscing elit.

--- a/packages/ffe-grid-react/src/GridCol.js
+++ b/packages/ffe-grid-react/src/GridCol.js
@@ -9,19 +9,11 @@ import {
     string,
 } from 'prop-types';
 import classNames from 'classnames';
-import { backgroundColors, removedColors } from './background-colors';
-
-function camelCaseToDashCase(str) {
-    return str
-        .split('')
-        .reduce((previous, current) =>
-            /[A-Z]/.test(current)
-                ? `${previous}-${current.toLowerCase()}`
-                : `${previous}${current}`,
-        );
-}
-
-const MODIFIER_LIST = ['background', 'centerText', 'center'];
+import {
+    backgroundColors,
+    backgroundDarkColors,
+    removedColors,
+} from './background-colors';
 
 const sizeClasses = (size, def) => {
     switch (typeof def) {
@@ -39,13 +31,12 @@ const sizeClasses = (size, def) => {
     }
 };
 
-const modifiers = props =>
-    Object.keys(props)
-        .filter(key => MODIFIER_LIST.indexOf(key) !== -1 && !!props[key])
-        .map(key => `ffe-grid__col--${camelCaseToDashCase(key)}`)
-        .join(' ');
+const centerTextClass = centerText =>
+    centerText ? 'ffe-grid__col--center-text' : null;
 
-const backgroundClass = ({ background }) => {
+const centerClass = center => (center ? 'ffe-grid__col--center' : null);
+
+const backgroundClass = background => {
     if (!background) {
         return null;
     }
@@ -61,6 +52,11 @@ const backgroundClass = ({ background }) => {
         : null;
 };
 
+const backgroundDarkClass = backgroundDark =>
+    backgroundDarkColors.includes(backgroundDark)
+        ? `ffe-grid__col--bg-dark-${backgroundDark}`
+        : null;
+
 export default class GridCol extends Component {
     constructor() {
         super();
@@ -70,20 +66,18 @@ export default class GridCol extends Component {
 
     render() {
         const {
-            children,
+            background,
+            backgroundDark,
             className,
             element: Element,
-            lg,
-            md,
+            centerText,
+            center,
+            children,
             sm,
+            md,
+            lg,
             ...rest
         } = this.props;
-
-        Object.keys(rest).forEach(key => {
-            if (MODIFIER_LIST.includes(key)) {
-                delete rest[key];
-            }
-        });
 
         const classes = [
             'ffe-grid__col',
@@ -91,8 +85,10 @@ export default class GridCol extends Component {
             sizeClasses('lg', lg),
             sizeClasses('md', md),
             sizeClasses('sm', !sm && !lg && !md ? 12 : sm),
-            modifiers(this.props),
-            backgroundClass(this.props),
+            centerTextClass(centerText),
+            centerClass(center),
+            backgroundClass(background),
+            backgroundDarkClass(backgroundDark),
         ]
             .filter(x => x)
             .join(' ');
@@ -111,18 +107,9 @@ GridCol.defaultProps = {
 
 GridCol.propTypes = {
     /** Supported background colors */
-    background: oneOf([
-        'frost-30',
-        'sand',
-        'sand-70',
-        'sand-30',
-        'syrin-70',
-        'syrin-30',
-        'vann',
-        'vann-30',
-        'fjell',
-        'hvit',
-    ]),
+    background: oneOf(backgroundColors),
+    /** Supported dark background colors */
+    backgroundDark: oneOf(backgroundDarkColors),
     /** Any extra classes are attached to the root node, in addition to ffe-grid__col classes */
     className: string,
     /** Specify the DOM element being used to create the GridCol */

--- a/packages/ffe-grid-react/src/GridCol.spec.js
+++ b/packages/ffe-grid-react/src/GridCol.spec.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { GridCol } from '.';
-import { backgroundColors } from './background-colors';
+import { backgroundColors, backgroundDarkColors } from './background-colors';
 
 const defaultProps = {
     children: <p>blah</p>,
@@ -65,11 +65,34 @@ describe('GridCol', () => {
         });
     });
 
+    it('sets dark background color class if valid', () => {
+        backgroundDarkColors.forEach(backgroundDark => {
+            const el = renderShallow({ backgroundDark });
+            expect(
+                el.hasClass(`ffe-grid__col--bg-dark-${backgroundDark}`),
+            ).toBe(true);
+        });
+    });
+
     it('does not set background color class if not valid', () => {
         const illegalBackgroundColors = ['ice-cream', 'log("hack")', '123456'];
         illegalBackgroundColors.forEach(background => {
             const el = renderShallow({ background });
             expect(el.hasClass(`ffe-grid__col--bg-${background}`)).toBe(false);
+        });
+    });
+
+    it('does not set dark background color class if not valid', () => {
+        const illegalBackgroundDarkColors = [
+            'ice-cream',
+            'log("hack")',
+            '123456',
+        ];
+        illegalBackgroundDarkColors.forEach(backgroundDark => {
+            const el = renderShallow({ backgroundDark });
+            expect(
+                el.hasClass(`ffe-grid__col--bg-dark-${backgroundDark}`),
+            ).toBe(false);
         });
     });
 

--- a/packages/ffe-grid-react/src/index.d.ts
+++ b/packages/ffe-grid-react/src/index.d.ts
@@ -66,6 +66,7 @@ export interface GridColSize {
 
 export interface GridColProps extends React.ComponentProps<'div'> {
     background?: BackgroundColors;
+    backgroundDark?: BackgroundDarkColors;
     children?: React.ReactNode;
     className?: string;
     element?: React.ReactNode;

--- a/packages/ffe-grid/less/ffe-grid.less
+++ b/packages/ffe-grid/less/ffe-grid.less
@@ -368,6 +368,30 @@
         }
     }
 
+    &--bg-dark-svart {
+        .native & {
+            @media (prefers-color-scheme: dark) {
+                background-color: var(--ffe-farge-svart);
+            }
+        }
+    }
+
+    &--bg-dark-natt {
+        .native & {
+            @media (prefers-color-scheme: dark) {
+                background-color: var(--ffe-farge-natt);
+            }
+        }
+    }
+
+    &--bg-dark-koksgraa {
+        .native & {
+            @media (prefers-color-scheme: dark) {
+                background-color: var(--ffe-farge-koksgraa);
+            }
+        }
+    }
+
     &--center-text {
         text-align: center;
     }


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse

<!-- Detaljert beskrivelse av endringene dine. Skjermskudd er lov. -->

Legger til en `backgroundDark` prop til `GridCol` for å styre bakgrunnsfarge på native darkmode. Jeg la til eksempel kode for denne funksjonaliteten i `examples/grid/GridCol-background.jsx` fordi det er et samspill i bakgrunnsfarger på lightmode og darkmode. Ser at dette eksempelet også er brukt på https://design.sparebank1.no/komponenter/grid/ . Bare si ifra hvis funksjonaliteten istedet skal splittes ut i eget eksempel.

![image](https://github.com/SpareBank1/designsystem/assets/34199185/31f7c069-99fe-4e6a-be43-1bf976463a06)


## Motivasjon og kontekst

<!-- Hvorfor trengs denne endringen, og hva løser den? -->

Man kunne ikke styre bakgrunnsfarge i `GridCol` native darkmode før, den ble satt til `--ffe-farge-svart` som default. Det er designbehov rundt å kunne sette bakgrunnsfarge til f.eks `--ffe-farge-natt` på native darkmode.

## Testing

<!-- Hvordan har du har testet endringene dine? Ta gjerne med systeminfo o.l -->

Testet manuelt i eksempelet nevnt ovenfor. Laget enhetstester tilsvarende det som fantes fra før. Det er noe css specificity i spill her med at `&--bg-dark-` klasser må være definert etter `&--bg-` for å overskrive bakgrunnsfarge hvis både `background` og `backgroundDark` er satt. Skulle gjerne hatt en automatisk test på dette men jest enhetstester er nok ikke riktig sted for det.

<!--

Helt til slutt, har du ..

.. lest retningslinjene våre for bidrag?
.. tatt en siste sjekk for kode og skrivefeil, debug informasjon o.l?
.. kjørt og eventuelt oppdatert testene?
.. kommentert og dokumentert det som trengs?
.. knyttet denne opp til relaterte issues?

-->
