### PR TITLE
feat(ffe-core): bruk text-wrap balance på paragrapher og heading

### DIFF
--- a/packages/ffe-core/less/typography.less
+++ b/packages/ffe-core/less/typography.less
@@ -196,6 +196,7 @@
     font-weight: normal;
     margin-bottom: @ffe-spacing-xs;
     margin-top: 0;
+    text-wrap: balance;
 
     &--error {
         color: var(--ffe-g-error-color);
@@ -256,6 +257,7 @@
     margin-top: 0;
     line-height: 1.5rem;
     color: var(--ffe-g-text-color);
+    text-wrap: balance;
 
     &--text-center {
         text-align: center;
@@ -272,6 +274,7 @@
     font-variant-numeric: tabular-nums;
     margin-top: 0;
     margin-bottom: 1em;
+    text-wrap: balance;
 }
 
 .ffe-lead-paragraph {


### PR DESCRIPTION
Er dette riktig ting att gjøra? Burde det vart slik? Burde det vart en prop på komponenten istellet for på allt?

[https://caniuse.com/?search=text-wrap#:~:text=CSS%20text%2Dwrap%3A%20balance&text=Allows%20[…]of%20text,more%20readable%20and%20](https://caniuse.com/?search=text-wrap#:~:text=CSS%20text%2Dwrap%3A%20balance&text=Allows%20multiple%20lines%20of%20text,more%20readable%20and%20visually%20appealing)

![image](https://github.com/SpareBank1/designsystem/assets/2248579/b10e8607-405a-4526-99d9-b4d76cb38c35)
