### PR TITLE
fix(ffe-feedback-react): fjerner undefined fra typedefinisjon til onclick

### DIFF
--- a/packages/ffe-feedback-react/src/index.d.ts
+++ b/packages/ffe-feedback-react/src/index.d.ts
@@ -11,7 +11,7 @@ export type bgDarkmodeColors = 'svart' | 'natt';
 export interface ContactLink {
     url?: string;
     linkText?: string;
-    onClick?: (e: React.MouseEvent | undefined) => void;
+    onClick?: (e: React.MouseEvent) => void;
 }
 
 export interface FeedbackProps extends React.ComponentProps<'div'> {


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse
Ryddet i metodesignatur til props til `ffe-feedback`.

<!-- Detaljert beskrivelse av endringene dine. Skjermskudd er lov. -->

## Motivasjon og kontekst
`ffe-feedback` tar `contactLink` som en prop, med metoden `onClick`. Rydder opp i signaturen til denne slik at argumentet ikke kan være udefinert (`undefined`), ettersom dette er et ikke-tilfelle når det tiltenkte scenarioet for `onClick`-metoden er at en bruker klikker (med mus eller fingerbevegelser) på en hyperlenke, og vi ønsker å diktere hva dette klikket skal føre til.

<!-- Hvorfor trengs denne endringen, og hva løser den? -->

## Testing
Oppførsel i `component-overview` er uendret.

<!-- Hvordan har du har testet endringene dine? Ta gjerne med systeminfo o.l -->

<!--

Helt til slutt, har du ..

.. lest retningslinjene våre for bidrag?
.. tatt en siste sjekk for kode og skrivefeil, debug informasjon o.l?
.. kjørt og eventuelt oppdatert testene?
.. kommentert og dokumentert det som trengs?
.. knyttet denne opp til relaterte issues?

-->
