### PR TITLE
fix(component-overview): legg til ffe-icons som bundleddependency

### DIFF
--- a/component-overview/package.json
+++ b/component-overview/package.json
@@ -93,6 +93,9 @@
         "react-live": "^2.2.3",
         "react-router-dom": "^5.2.0"
     },
+    "bundledDependencies": [
+        "@sb1/ffe-icons"
+    ],
     "devDependencies": {
         "@rollup/plugin-json": "^4.1.0",
         "acorn": "^8.6.0",


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse
Legger til ffe-icons pakken som bundleddependency
<!-- Detaljert beskrivelse av endringene dine. Skjermskudd er lov. -->

## Motivasjon og kontekst
Vi får byggfeil i dokumentasjonen, fordi vi i 2 eksempler henter inn ikoner fra component-index pakken sin`node_modules/@sb1/ffe-icons/[..]` denne pathen eksisterer ikke da npm installerer alle dependencys på høyere nivå.  Denne endringen gjør at den installerer sb1-ffe-icons under node_modules i component-index pakken, sånn at pathen eksisterer. 

Håpet er at det retter byggfeilen i docs
<!-- Hvorfor trengs denne endringen, og hva løser den? -->

## Testing
Kjørt npm install
<!-- Hvordan har du har testet endringene dine? Ta gjerne med systeminfo o.l -->

<!--

Helt til slutt, har du ..

.. lest retningslinjene våre for bidrag?
.. tatt en siste sjekk for kode og skrivefeil, debug informasjon o.l?
.. kjørt og eventuelt oppdatert testene?
.. kommentert og dokumentert det som trengs?
.. knyttet denne opp til relaterte issues?

-->
