### PR TITLE
feat(ffe-feedback-react): add headingLevel prop

### DIFF
--- a/component-overview/examples/feedback/Feedback-in-custom-color.jsx
+++ b/component-overview/examples/feedback/Feedback-in-custom-color.jsx
@@ -6,4 +6,5 @@ import Feedback from '@sb1/ffe-feedback-react';
   bgDarkmodeColor="natt"
   onThumbClick={console.log}
   onFeedbackSend={console.log}
+  headingLevel={2}
 />

--- a/component-overview/examples/feedback/Feedback-in-wave.jsx
+++ b/component-overview/examples/feedback/Feedback-in-wave.jsx
@@ -11,6 +11,7 @@ import { Grid, GridCol, GridRow } from '@sb1/ffe-grid-react';
           language="nb"
           onThumbClick={console.log}
           onFeedbackSend={console.log}
+          headingLevel={2}
         />
       </GridCol>
     </GridRow>

--- a/component-overview/examples/feedback/Feedback-with-custom-link.jsx
+++ b/component-overview/examples/feedback/Feedback-with-custom-link.jsx
@@ -8,4 +8,5 @@ import Feedback from '@sb1/ffe-feedback-react';
     linkText: 'spør i chatten.',
     onClick: () => confirm('Denne chatten er ikkje så nyttig, så du kan like godt lukke han.'),
   }}
+  headingLevel={2}
 />

--- a/component-overview/examples/feedback/Feedback-with-default-link.jsx
+++ b/component-overview/examples/feedback/Feedback-with-default-link.jsx
@@ -7,4 +7,5 @@ import Feedback from '@sb1/ffe-feedback-react';
   contactLink={{
     onClick: () => console.log('Contact link clicked'),
   }}
+  headingLevel={2}
 />

--- a/component-overview/examples/feedback/Feedback.jsx
+++ b/component-overview/examples/feedback/Feedback.jsx
@@ -4,4 +4,5 @@ import Feedback from '@sb1/ffe-feedback-react';
   language="nb"
   onThumbClick={console.log}
   onFeedbackSend={console.log}
+  headingLevel={2}
 />

--- a/packages/ffe-feedback-react/src/feedback-thumbs.js
+++ b/packages/ffe-feedback-react/src/feedback-thumbs.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import i18n from './i18n/i18n';
-import { func, oneOf } from 'prop-types';
+import { func, oneOf, string } from 'prop-types';
 import { ThumbUp, ThumbUpFill, ThumbDown, ThumbDownFill } from './icons';
 
 export const Thumbs = {
@@ -8,23 +8,25 @@ export const Thumbs = {
     DOWN: 'THUMB_DOWN',
 };
 
-const FeedbackThumbs = ({ language, onClick }) => {
+const FeedbackThumbs = ({ language, onClick, headingId }) => {
     return (
         <div>
             <button
                 aria-label={i18n[language].ARIA_LABEL_THUMB_UP}
-                aria-describedby="feedback-heading"
+                aria-describedby={headingId}
                 className="ffe-feedback__thumb"
                 onClick={() => onClick(Thumbs.UP)}
+                type="button"
             >
                 <ThumbUp className="ffe-feedback__thumb-icon" />
                 <ThumbUpFill className="ffe-feedback__thumb-icon--fill" />
             </button>
             <button
                 aria-label={i18n[language].ARIA_LABEL_THUMB_DOWN}
-                aria-describedby="feedback-heading"
+                aria-describedby={headingId}
                 className="ffe-feedback__thumb"
                 onClick={() => onClick(Thumbs.DOWN)}
+                type="button"
             >
                 <ThumbDown className="ffe-feedback__thumb-icon" />
                 <ThumbDownFill className="ffe-feedback__thumb-icon--fill" />
@@ -38,6 +40,7 @@ export default FeedbackThumbs;
 FeedbackThumbs.propTypes = {
     language: oneOf(['nb', 'nn', 'en']),
     onClick: func.isRequired,
+    headingId: string.isRequired,
 };
 
 FeedbackThumbs.defaultProps = {

--- a/packages/ffe-feedback-react/src/feedback.js
+++ b/packages/ffe-feedback-react/src/feedback.js
@@ -1,14 +1,15 @@
 import React, { useState, useRef } from 'react';
 import { flushSync } from 'react-dom';
-import { Heading2 } from '@sb1/ffe-core-react';
 import { Animation } from './animation';
 import { func, oneOf, shape, string } from 'prop-types';
 import i18n from './i18n/i18n';
 import FeedbackThumbs, { Thumbs } from './feedback-thumbs';
 import classNames from 'classnames';
 import FeedbackExpanded from './feedback-expanded';
+import { v4 as uuid } from 'uuid';
 
 export const Feedback = ({
+    headingLevel,
     language,
     onThumbClick,
     onFeedbackSend,
@@ -21,6 +22,7 @@ export const Feedback = ({
     const [feedbackThumbClicked, setFeedbackThumbClicked] = useState();
     const [expanded, setExpanded] = useState(false);
     const [feedbackSent, setFeedbackSent] = useState(false);
+    const headingId = useRef(uuid()).current;
 
     const feedbackClassnames = classNames('ffe-feedback', {
         [`ffe-feedback--bg-${bgColor}`]: bgColor,
@@ -48,9 +50,15 @@ export const Feedback = ({
         return (
             <div className={feedbackClassnames}>
                 <div className="ffe-feedback__content">
-                    <Heading2 lookLike={4} ref={feedbackSentRef} tabIndex={-1}>
-                        {i18n[language].FEEDBACK_SENT_HEADING}
-                    </Heading2>
+                    {React.createElement(
+                        `h${headingLevel}`,
+                        {
+                            ref: feedbackSentRef,
+                            tabIndex: -1,
+                            className: 'ffe-h4',
+                        },
+                        i18n[language].FEEDBACK_SENT_HEADING,
+                    )}
                     <Animation />
                 </div>
             </div>
@@ -61,11 +69,13 @@ export const Feedback = ({
         return (
             <div className={feedbackClassnames}>
                 <div className="ffe-feedback__content">
-                    <Heading2 lookLike={5} ref={expandedRef} tabIndex={-1}>
-                        {feedbackThumbClicked === Thumbs.UP
+                    {React.createElement(
+                        `h${headingLevel}`,
+                        { ref: expandedRef, tabIndex: -1, className: 'ffe-h5' },
+                        feedbackThumbClicked === Thumbs.UP
                             ? i18n[language].FEEDBACK_GOOD
-                            : i18n[language].FEEDBACK_IMPROVE}
-                    </Heading2>
+                            : i18n[language].FEEDBACK_IMPROVE,
+                    )}
                     <FeedbackExpanded
                         language={language}
                         onSend={handleFeedbackSent}
@@ -80,12 +90,15 @@ export const Feedback = ({
     return (
         <div className={feedbackClassnames}>
             <div className="ffe-feedback__content">
-                <Heading2 id="feedback-heading" lookLike={4}>
-                    {i18n[language].FEEDBACK_NOT_SENT_HEADING}
-                </Heading2>
+                {React.createElement(
+                    `h${headingLevel}`,
+                    { id: headingId, className: 'ffe-h4' },
+                    i18n[language].FEEDBACK_NOT_SENT_HEADING,
+                )}
                 <FeedbackThumbs
                     onClick={handleThumbClicked}
                     language={language}
+                    headingId={headingId}
                 />
             </div>
         </div>
@@ -95,6 +108,7 @@ export const Feedback = ({
 export default Feedback;
 
 Feedback.propTypes = {
+    headingLevel: oneOf([1, 2, 3, 4, 5, 6]).isRequired,
     language: oneOf(['nb', 'nn', 'en']),
     onThumbClick: func.isRequired,
     onFeedbackSend: func.isRequired,

--- a/packages/ffe-feedback-react/src/icons/thumb-down-fill.js
+++ b/packages/ffe-feedback-react/src/icons/thumb-down-fill.js
@@ -1,6 +1,7 @@
 import * as React from 'react';
 const ThumbDownFill = props => (
     <svg
+        aria-hidden={true}
         xmlns="http://www.w3.org/2000/svg"
         width={48}
         height={48}

--- a/packages/ffe-feedback-react/src/icons/thumb-down.js
+++ b/packages/ffe-feedback-react/src/icons/thumb-down.js
@@ -1,6 +1,7 @@
 import * as React from 'react';
 const ThumbDown = props => (
     <svg
+        aria-hidden={true}
         xmlns="http://www.w3.org/2000/svg"
         width={48}
         height={48}

--- a/packages/ffe-feedback-react/src/icons/thumb-up-fill.js
+++ b/packages/ffe-feedback-react/src/icons/thumb-up-fill.js
@@ -1,6 +1,7 @@
 import * as React from 'react';
 const ThumbUpFill = props => (
     <svg
+        aria-hidden={true}
         xmlns="http://www.w3.org/2000/svg"
         width={48}
         height={48}

--- a/packages/ffe-feedback-react/src/icons/thumb-up.js
+++ b/packages/ffe-feedback-react/src/icons/thumb-up.js
@@ -1,6 +1,7 @@
 import * as React from 'react';
 const ThumbUp = props => (
     <svg
+        aria-hidden={true}
         xmlns="http://www.w3.org/2000/svg"
         width={48}
         height={48}

--- a/packages/ffe-feedback-react/src/index.d.ts
+++ b/packages/ffe-feedback-react/src/index.d.ts
@@ -15,6 +15,7 @@ export interface ContactLink {
 }
 
 export interface FeedbackProps extends React.ComponentProps<'div'> {
+    headingLevel: 1 | 2 | 3 | 4 | 5 | 6;
     language?: 'nb' | 'nn' | 'en';
     onThumbClick: (thumb: ThumbType) => void;
     onFeedbackSend: (feedbackText: string) => void;


### PR DESCRIPTION
Veldig bra jobbet med denne

Det er vel inget som siger att denne alltid er heading på nivå2? Jag gjorde propen required slik att man tvingas ta stilling.  Eller muligens når den alldig snakker om denne sidan og man ikke kan sende spørsmålen selv? Vi har disse tilbakemeldningskomponenterna alla muliga steder og forksjelliga spørsmål. 

Det blir en annen pr hvis jag får tid men annars tror jag focus managment er noe man burde se på. Efter att man gitt tommel op burde fokus på headingen til kommentarfeltet feks. 