### PR TITLE
feat(ffe-core) bruk text-wrap pretty på paragrapher

### DIFF
--- a/packages/ffe-core/less/typography.less
+++ b/packages/ffe-core/less/typography.less
@@ -257,7 +257,7 @@
     margin-top: 0;
     line-height: 1.5rem;
     color: var(--ffe-g-text-color);
-    text-wrap: balance;
+    text-wrap: pretty;
 
     &--text-center {
         text-align: center;
@@ -274,7 +274,7 @@
     font-variant-numeric: tabular-nums;
     margin-top: 0;
     margin-bottom: 1em;
-    text-wrap: balance;
+    text-wrap: pretty;
 }
 
 .ffe-lead-paragraph {


### PR DESCRIPTION
## Beskrivelse

text-wrap:balance ser ikke bra ut for paragrafer. Bruker text-wrap:pretty istedenfor
![image (1)](https://github.com/SpareBank1/designsystem/assets/2089562/cb7dceeb-a9d8-42cd-b0d0-8724d8336a34)
![pretty](https://github.com/SpareBank1/designsystem/assets/2089562/2d4f719f-c5f9-4357-a80c-ef646e51a193)

## Testing

Endret til text-wrap:pretty i devtools for .ffe-body-paragraph  i https://www.eiendomsmegler1.no/selge/9-verdifulle-tips-boligsalg

Eiendomsmegler1 task er EM1-2674