### PR TITLE
feat(datepicker): add innerRef to Datepicker

### DIFF
--- a/component-overview/examples/datepicker/Datepicker.jsx
+++ b/component-overview/examples/datepicker/Datepicker.jsx
@@ -1,8 +1,9 @@
-import { useState } from 'react';
+import { useState, useRef } from 'react';
 import Datepicker from '@sb1/ffe-datepicker-react';
 
 () => {
     const [date, setDate] = useState('01.01.2016');
+    const innerRef = useRef(date); //Optional ref to the input element
 
     return (
         <Datepicker
@@ -13,6 +14,7 @@ import Datepicker from '@sb1/ffe-datepicker-react';
             minDate="01.01.2016"
             onChange={setDate}
             value={date}
+            innerRef={innerRef}
         />
     );
 }

--- a/packages/ffe-datepicker-react/src/datepicker/Datepicker.js
+++ b/packages/ffe-datepicker-react/src/datepicker/Datepicker.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { bool, func, oneOfType, shape, string } from 'prop-types';
+import { bool, func, oneOfType, shape, string, PropTypes } from 'prop-types';
 import classNames from 'classnames';
 import { v4 as uuid } from 'uuid';
 import Calendar from '../calendar';
@@ -292,6 +292,7 @@ export default class Datepicker extends Component {
             onChange,
             value,
             fullWidth,
+            innerRef,
         } = this.props;
         const { minDate, maxDate } = this.state;
 
@@ -349,6 +350,10 @@ export default class Datepicker extends Component {
                             onChange={evt => onChange(evt.target.value)}
                             onKeyDown={this.onInputKeydown}
                             ref={c => {
+                                if (innerRef) {
+                                    innerRef.current = c;
+                                }
+
                                 this.dateInputRef = c;
                             }}
                             value={value}
@@ -399,6 +404,7 @@ Datepicker.defaultProps = {
     keepDisplayStateOnError: false,
     onValidationComplete: () => {},
     fullWidth: false,
+    innerRef: undefined,
 };
 
 Datepicker.propTypes = {
@@ -407,6 +413,9 @@ Datepicker.propTypes = {
     calendarAbove: bool,
     hideErrors: bool,
     onValidationComplete: func,
+    innerRef:
+        PropTypes.oneOfType([func, shape({ current: PropTypes.any })]) ||
+        undefined,
     inputProps: shape({
         className: string,
         id: string,


### PR DESCRIPTION
## Beskrivelse

Datepicker har fått en innerRef man kan sende inn for å bruke ref på komponenten utenifra. 
innerRef er optional og komponenten skal fungere som før ellers. Det er lagt til eksempel på bruk i Datepicker.jsx.

Om koden: 
Fra før av brukte datepicker this.dateInputRef som ref, og det er litt uklart om denne fortsatt må være der for at denne endringen skal fungere. Alternativt ville jeg skrevet ref = { innerRef } på linje 352 i stedet for funksjonen, men da er det mulig mer må endres. Åpen for tilbakemeldinger med bedre måter å gjøre det på, men gitt at det er en gammel komponent føles det som den tryggeste måten å gjøre det på.

## Motivasjon og kontekst

Team kjøretøy bruker ref.focus() for å kunne lenke til feil i skjemaer, og Datepicker har ikke kunne blitt referert til via ref. Denne endringen er laget for å kunne bruke ref.focus() på inputfeltet til Datepicker utenifra, via useRef(). 

Motivasjonen bak oppgaven har blandt annet vært denne kodesnutten, hvor vi ønsker å fjerne den øverste delen: 
`onClick={() => {
                      if ("deliveryDate" === key) {
                        const deliveryDate = document.getElementById(
                          "datepicker-wrapper-deliveryDate"
                        );
                        deliveryDate.getElementsByTagName("input")[0].focus();
                      } else {
                        const errorRef: Ref = get(errors, key).ref;
                        if (errorRef.focus) {
                          errorRef.focus();
                        }
                      }
                    }}`

## Testing

Testet ved å lage en knapp som brukte innerRef.current.focus() i Datepicker.jsx, som beviste at innerRef referer til input-elementet. Ellers var det vanskelig å teste for de spesifikke tilfellene Team Kjøretøy trenger det til. 

Har ikke skrevet eller oppdatert noen tester. Gjorde et forsøk, men klarte ikke å finne en god test på om input-feltet får en ref fra innerRef. 
