### PR TITLE
fix(ffe-form): add word-break in radio-button

### DIFF
--- a/component-overview/examples/form/RadioButton-without-radioinputgroup.jsx
+++ b/component-overview/examples/form/RadioButton-without-radioinputgroup.jsx
@@ -2,8 +2,8 @@ import { RadioButton } from '@sb1/ffe-form-react';
 
 () => {
     return (
-        <RadioButton value="bank">
-            Bankkunde
+        <RadioButton value="lån">
+            Mellomfinansieringslån
         </RadioButton>
     );
 }

--- a/packages/ffe-form/less/radio-button.less
+++ b/packages/ffe-form/less/radio-button.less
@@ -1,4 +1,5 @@
 .ffe-radio-button {
+    word-break: break-all;
     font-family: var(--ffe-g-font);
     font-variant-numeric: tabular-nums;
     display: block;


### PR DESCRIPTION
## Beskrivelse
Løser issue #1762, fikset tekst som overflød skjermen når tekst er forstørret.

![Screenshot 2024-02-06 at 13-24-39 SpareBank 1 Designsystem](https://github.com/SpareBank1/designsystem/assets/70075053/0f7d7ca4-a666-4f20-bfce-8add06f70512)

Endret også tekst i eksempel til et lengre ord for å vise fiksen.

## Testing
Åpne opp instillinger i nettleseren, og sett tekststørrelsen til 200% (32px).

Eksempel: `form/RadioButton-without-radioinputgroup.jsx`
