### PR TITLE
fix(ffe-form): add word-break in label

### DIFF
--- a/component-overview/examples/form/Label.jsx
+++ b/component-overview/examples/form/Label.jsx
@@ -1,3 +1,3 @@
 import { Label } from '@sb1/ffe-form-react';
 
-<Label htmlFor="e-post">E-post</Label>
+<Label htmlFor="lån">Mellomfinansieringslån</Label>

--- a/packages/ffe-form/less/form-label.less
+++ b/packages/ffe-form/less/form-label.less
@@ -1,4 +1,5 @@
 .ffe-form-label {
+    word-break: break-all;
     padding-bottom: @ffe-spacing-xs;
     display: inline-block;
     position: relative;


### PR DESCRIPTION
## Beskrivelse

Fikser issue #1758, gjorde slik at ordet kuttet når skjermen ble forstørret eller skriften var for stor. 

![Screenshot 2024-02-06 at 14-11-47 SpareBank 1 Designsystem](https://github.com/SpareBank1/designsystem/assets/142574795/43324536-9926-407e-b02e-a7dda56f9870)

Gjorde også endring på teksten i eksempelet slik at det hadde en bedre lengde under testen. 

## Testing

Åpne opp instillinger i nettleseren, og sett tekststørrelsen itl 200% (32px).

Eksempel: form/Label.jsx