### PR TITLE
Skalering av lange tekster: setter word-break til break-all

### DIFF
--- a/packages/ffe-accordion/less/accordion.less
+++ b/packages/ffe-accordion/less/accordion.less
@@ -18,7 +18,7 @@
 
     &__heading,
     &__body {
-        word-break: break-word;
+        word-break: break-all;
         hyphens: auto;
     }
 

--- a/packages/ffe-cards/less/components.less
+++ b/packages/ffe-cards/less/components.less
@@ -28,6 +28,6 @@
 }
 
 :where(.ffe-card-body__card-name, .ffe-card-body__text, .ffe-card-body__subtext, .ffe-card-body__title) {
-    word-break: break-word;
+    word-break: break-all;
     hyphens: auto;
 }

--- a/packages/ffe-context-message/less/context-message.less
+++ b/packages/ffe-context-message/less/context-message.less
@@ -58,7 +58,7 @@
     .ffe-small-text,
     .ffe-link-text,
     &__header {
-        word-break: break-word;
+        word-break: break-all;
         hyphens: auto;
     }
 

--- a/packages/ffe-core/less/typography.less
+++ b/packages/ffe-core/less/typography.less
@@ -197,7 +197,7 @@
     margin-bottom: @ffe-spacing-xs;
     margin-top: 0;
     text-wrap: balance;
-    word-break: break-word;
+    word-break: break-all;
     hyphens: auto;
 
     &--error {
@@ -296,7 +296,7 @@
     color: var(--ffe-g-link-color);
     cursor: pointer;
     text-decoration: none;
-    word-wrap: break-word;
+    word-wrap: break-all;
     line-height: 1em;
     transition: all @ffe-transition-duration @ffe-ease;
 
@@ -475,6 +475,6 @@
 .ffe-pre-text,
 .ffe-small-text,
 .ffe-micro-text {
-    word-break: break-word;
+    word-break: break-all;
     hyphens: auto;
 }

--- a/packages/ffe-form/less/form-label.less
+++ b/packages/ffe-form/less/form-label.less
@@ -1,5 +1,6 @@
 .ffe-form-label {
     word-break: break-all;
+    hyphens: auto;
     padding-bottom: @ffe-spacing-xs;
     display: inline-block;
     position: relative;

--- a/packages/ffe-form/less/radio-button.less
+++ b/packages/ffe-form/less/radio-button.less
@@ -1,5 +1,6 @@
 .ffe-radio-button {
     word-break: break-all;
+    hyphens: auto;
     font-family: var(--ffe-g-font);
     font-variant-numeric: tabular-nums;
     display: block;

--- a/packages/ffe-message-box/less/message-box.less
+++ b/packages/ffe-message-box/less/message-box.less
@@ -5,7 +5,7 @@
     .ffe-body-paragraph,
     .ffe-link-text,
     &__title {
-        word-break: break-word;
+        word-break: break-all;
         hyphens: auto;
     }
 

--- a/packages/ffe-system-message/less/system-message.less
+++ b/packages/ffe-system-message/less/system-message.less
@@ -149,7 +149,7 @@
         padding: 0;
         font-size: 0.875rem;
         flex: 1 1 auto;
-        word-break: break-word;
+        word-break: break-all;
         hyphens: auto;
 
         @media (min-width: 600px) {


### PR DESCRIPTION
Endrer `word-break: break-word` til `break-all` fordi `break-word` er deperecated. Og legger til `hyphen: auto` der det mangler.