### PR TITLE
fix(ffe-core): legg til font-family på linktext

### DIFF
--- a/packages/ffe-core/less/typography.less
+++ b/packages/ffe-core/less/typography.less
@@ -293,6 +293,7 @@
 
 .ffe-link-text {
     border-bottom: 1px solid var(--ffe-g-link-color);
+    font-family: var(--ffe-g-font);
     color: var(--ffe-g-link-color);
     cursor: pointer;
     text-decoration: none;


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse
Legger til font-family på LinkText
<!-- Detaljert beskrivelse av endringene dine. Skjermskudd er lov. -->

## Motivasjon og kontekst
Nå har ikke LinkText satt font-family, så i noen tilfeller så får du default font når du prøver å bruke linktext
fiksen gjør det sånn at man alltid får sparebank1 fonten. 
<!-- Hvorfor trengs denne endringen, og hva løser den? -->

## Testing
Kjørt opp lokalt
<!-- Hvordan har du har testet endringene dine? Ta gjerne med systeminfo o.l -->

<!--

Helt til slutt, har du ..

.. lest retningslinjene våre for bidrag?
.. tatt en siste sjekk for kode og skrivefeil, debug informasjon o.l?
.. kjørt og eventuelt oppdatert testene?
.. kommentert og dokumentert det som trengs?
.. knyttet denne opp til relaterte issues?

-->
