### PR TITLE
fix(ffe-context-message): alltid bruk liten ikon på condensed versonen

### DIFF
--- a/packages/ffe-context-message/less/context-message.less
+++ b/packages/ffe-context-message/less/context-message.less
@@ -404,3 +404,12 @@
         display: block;
     }
 }
+
+.ffe-context-message--compact
+    .ffe-icons.ffe-context-message-content__icon-span--small {
+    display: block;
+}
+.ffe-context-message--compact
+    .ffe-icons.ffe-context-message-content__icon-span--large {
+    display: none;
+}


### PR DESCRIPTION
Fikser denne


Før: 
![Screenshot from 2024-02-14 14-29-01](https://github.com/SpareBank1/designsystem/assets/2248579/9584be6d-19f9-48bf-b291-d56f0cc3a1e4)

efter: 
![image](https://github.com/SpareBank1/designsystem/assets/2248579/b181406d-f29d-440d-b248-c600fbefd27b)
