### PR TITLE
fix(ffe-form): zoom tooltip

### DIFF
--- a/packages/ffe-form/less/tooltip.less
+++ b/packages/ffe-form/less/tooltip.less
@@ -6,15 +6,15 @@
         border: 2px solid var(--ffe-v-tooltip-border-color);
         color: var(--ffe-v-tooltip-icon-color);
         cursor: help;
-        height: 25px;
+        height: 1.2rem;
+        aspect-ratio: 1;
         margin: 0 0 @ffe-spacing-2xs @ffe-spacing-sm;
         padding: 0;
         transition: border-color @ffe-transition-duration @ffe-ease;
-        width: 25px;
-        display: inline-flex;
-        justify-content: center;
-        align-items: center;
+        display: grid;
+        place-items: center;
         font-family: sans-serif;
+        line-height: 1;
         font-size: var(--ffe-fontsize-button);
 
         > span {


### PR DESCRIPTION
Hvis man ikke vill ha det slik må man vell byta ut spørsmølstegnet med ett bilde

føre:
![Screenshot from 2024-02-20 13-44-19](https://github.com/SpareBank1/designsystem/assets/2248579/a82168d5-ccd8-4db3-a4ad-762af3e29430)

efter:
![image](https://github.com/SpareBank1/designsystem/assets/2248579/dbe8d63f-7c8f-4e22-b21c-58e43c720bf0)
