### PR TITLE
fix(ffe-spinner-react): make loadingText optional ts types

### DIFF
--- a/packages/ffe-spinner-react/src/index.d.ts
+++ b/packages/ffe-spinner-react/src/index.d.ts
@@ -4,7 +4,7 @@ export interface SpinnerProps extends React.ComponentProps<'span'> {
     className?: string;
     immediate?: boolean;
     large?: boolean;
-    loadingText: React.ReactNode;
+    loadingText?: React.ReactNode;
 }
 
 declare class Spinner extends React.Component<SpinnerProps, any> {}


### PR DESCRIPTION
Det ser ut på Spinner komponenten som att loadinText skall vare optional