### PR TITLE
fix(ffe-buttons): wrap buttons in buttongroup

### DIFF
--- a/packages/ffe-buttons/less/button-group.less
+++ b/packages/ffe-buttons/less/button-group.less
@@ -22,8 +22,7 @@
     .ffe-button,
     .ffe-inline-button {
         justify-content: center;
-        margin: 0 auto @ffe-spacing-xs;
-        align-self: center;
+        margin: 0 0 @ffe-spacing-xs;
     }
 
     &--thin {
@@ -31,11 +30,11 @@
     }
 
     &--inline {
+        align-items: center;
         .ffe-button,
         .ffe-inline-button {
             display: inline;
-            margin: 0 0 @ffe-spacing-xs @ffe-spacing-xs;
-            width: auto;
+            width: fit-content;
         }
     }
 
@@ -43,15 +42,12 @@
         display: inline-flex;
         flex-direction: row;
         width: auto;
+        flex-wrap: wrap;
+        gap: @ffe-spacing-xs @ffe-spacing-sm;
 
         .ffe-button,
         .ffe-inline-button {
-            margin: 0 0 @ffe-spacing-xs @ffe-spacing-sm;
             width: auto;
-
-            &:first-child {
-                margin: 0 0 @ffe-spacing-xs;
-            }
         }
     }
 }


### PR DESCRIPTION
Holder på se på text zoom

Her er vår case. Små containers men full skjerm så media querien som bruker columns slår aldrig in. 
![Screenshot from 2024-02-21 08-44-25](https://github.com/SpareBank1/designsystem/assets/2248579/4ff6ddd2-8670-44a2-a79b-8225b7aaac64)

 begynnte og se på container queries men det funker ikke hvis inneholdet bestemmer bredden på containern vilket det gjør her i mange tillfeller. 
 
 Så jag satt på en flex wrap. 
![Screenshot from 2024-02-21 11-18-41](https://github.com/SpareBank1/designsystem/assets/2248579/1dda83e2-9e25-40ec-bbff-198dd81df036)

