### PR TITLE
fix(ffe-buttons): align icons center inline buttons

### DIFF
--- a/packages/ffe-buttons/less/inline-base-button.less
+++ b/packages/ffe-buttons/less/inline-base-button.less
@@ -25,6 +25,7 @@
     padding: 0 @ffe-spacing-2xs;
     text-decoration: none;
     font-size: var(--ffe-fontsize-body-text);
+    align-items: center;
 
     &:active {
         transform: scale(0.97);


### PR DESCRIPTION
Føre:
![inline-før](https://github.com/SpareBank1/designsystem/assets/2248579/9efc44ad-326d-497a-a08f-fe98559b18a4)

Efter:
![efter](https://github.com/SpareBank1/designsystem/assets/2248579/a4a996c9-a301-4fe0-8b7f-2c237e8ac00b)
