### PR TITLE
fix(ffe-buttons): zoom spinner base button

### DIFF
--- a/packages/ffe-buttons/less/base-button.less
+++ b/packages/ffe-buttons/less/base-button.less
@@ -264,10 +264,12 @@
     opacity: 0;
     position: absolute;
     right: 0;
-    top: 8px;
+    top: 0;
     transform: translateY(24px);
     transition: all @ffe-transition-duration @ffe-ease;
     visibility: hidden;
+    display: grid;
+    place-items: center;
 
     .ffe-button--loading & {
         opacity: 1;
@@ -282,9 +284,8 @@
         border-top-color: transparent;
         content: '';
         display: block;
-        height: 22px;
-        margin: 0 auto;
-        width: 22px;
+        height: 1.375rem;
+        aspect-ratio: 1;
 
         @keyframes button-loading-spin {
             from {


### PR DESCRIPTION
Spinner ser ikke så veldig bra ut med text zoom.

Føre: 
![føre loading](https://github.com/SpareBank1/designsystem/assets/2248579/c335e40f-f036-4e5b-891d-f02437d9a83f)

Efter fix:
![efter](https://github.com/SpareBank1/designsystem/assets/2248579/7703ce15-0025-426c-8870-1e7edd43632b)
