### PR TITLE
Develop align checkbox in top

### DIFF
--- a/packages/ffe-form-react/src/BaseRadioButton.js
+++ b/packages/ffe-form-react/src/BaseRadioButton.js
@@ -55,7 +55,7 @@ class BaseRadioButton extends Component {
                     {...labelProps}
                     className={labelClasses}
                 >
-                    {children}
+                    <span className="ffe-radio-input__content">{children}</span>
                 </label>
                 {tooltip && <Tooltip {...tooltipProps}>{tooltip}</Tooltip>}
             </Fragment>

--- a/packages/ffe-form/less/checkbox.less
+++ b/packages/ffe-form/less/checkbox.less
@@ -1,4 +1,7 @@
 .ffe-checkbox {
+    --line-height: 1.15rem;
+
+    line-height: var(--line-height);
     display: grid;
     grid-column-gap: @ffe-spacing-sm;
     align-items: center;
@@ -12,9 +15,11 @@
     -webkit-tap-highlight-color: fade(@ffe-farge-vann, 15%);
     color: var(--ffe-v-input-color);
     grid-template-columns: auto 1fr;
+    grid-template-rows: var(--line-height) 1fr;
 
     .ffe-checkbox__content {
         grid-column: 2/3;
+        grid-row: 1/-1;
     }
 
     &--no-margin {
@@ -32,7 +37,7 @@
         place-self: center;
         content: '';
         grid-column: 1/2;
-        grid-row: 1/-1;
+        grid-row: 1/2;
     }
 
     &::before {

--- a/packages/ffe-form/less/radio-button.less
+++ b/packages/ffe-form/less/radio-button.less
@@ -1,8 +1,11 @@
 .ffe-radio-button {
+    --line-height: 1.15rem;
+
+    line-height: var(--line-height);
     word-break: break-all;
     font-family: var(--ffe-g-font);
     font-variant-numeric: tabular-nums;
-    display: flex;
+    display: grid;
     align-items: center;
     position: relative;
     color: var(--ffe-g-text-color);
@@ -13,10 +16,13 @@
     padding-left: @ffe-spacing-lg;
     padding-top: 1px;
     -webkit-tap-highlight-color: fade(@ffe-farge-vann, 15%);
+    grid-template-columns: auto 1fr;
+    grid-template-rows: var(--line-height) 1fr;
+    grid-column-gap: @ffe-spacing-sm;
 
     &--inline,
     &--with-tooltip {
-        display: inline-flex;
+        display: inline-grid;
         margin-right: @ffe-spacing-md;
     }
 
@@ -56,8 +62,9 @@
         height: 20px;
         border-radius: 50%;
         pointer-events: none;
-        position: absolute;
         left: 0;
+        grid-column: 1/2;
+        grid-row: 1/2;
     }
 
     &::before {
@@ -126,4 +133,9 @@
     [aria-invalid='true'] &:checked + .ffe-radio-button::after {
         border-color: var(--ffe-g-error-color);
     }
+}
+
+.ffe-radio-input__content {
+    grid-column: 2/3;
+    grid-row: 1/-1;
 }


### PR DESCRIPTION
Legger grafiken til checkbokx/radio i toppen og ikke i center slik det var. Dette vill ju ligna på hvordan det var når disse grafiska elementera var hårdkodade med pixlar fra toppen. 
Føre:
![checkbox-before](https://github.com/SpareBank1/designsystem/assets/2248579/e7bcb162-39f5-46cf-83fa-811efcb5a29f)

Efter:
![efter](https://github.com/SpareBank1/designsystem/assets/2248579/f08737a4-16dc-4493-aa01-47161c66279c)
![efter2](https://github.com/SpareBank1/designsystem/assets/2248579/cfa9a815-880c-4563-a12f-6fe80e77a14c)
