### PR TITLE
fix(ffe-buttons): overflow-wrap anywhere

### DIFF
--- a/packages/ffe-buttons/less/base-button.less
+++ b/packages/ffe-buttons/less/base-button.less
@@ -16,7 +16,8 @@
     text-decoration: none;
     transition: all @ffe-transition-duration @ffe-ease;
     user-select: none;
-    white-space: nowrap;
+    overflow-wrap: anywhere;
+    hyphens: auto;
     width: 100%;
     font-size: var(--ffe-fontsize-button);
 


### PR DESCRIPTION
Med ` white-space: nowrap;` så blir texterna borte uanfor knappen hvis man zzomar og ikke lenger synlig. 