### PR TITLE
fix(ffe-icons-react): add webkit to support android browser

### DIFF
--- a/packages/ffe-icons-react/src/Icon.js
+++ b/packages/ffe-icons-react/src/Icon.js
@@ -11,7 +11,10 @@ const Icon = props => {
             aria-label={ariaLabel}
             aria-hidden={!ariaLabel}
             className={classNames('ffe-icons', `ffe-icons--${size}`, className)}
-            style={{ maskImage: `url(${fileUrl})` }}
+            style={{
+                maskImage: `url(${fileUrl})`,
+                WebkitMaskImage: `url(${fileUrl})`,
+            }}
             {...rest}
         />
     );


### PR DESCRIPTION
OPlever ingen problemer selv men blir slik på emualtorn. Det som er lite kjipt med dette er at inline svgerne blir i markupen 2 ganger men what to do?


![image](https://github.com/SpareBank1/designsystem/assets/2248579/bd2104b5-926a-4dee-8a6b-ef24d8976733)

![image](https://github.com/SpareBank1/designsystem/assets/2248579/44736e91-80f1-4921-9ac7-0d96dadaa0bd)
![image](https://github.com/SpareBank1/designsystem/assets/2248579/8b54137c-72bc-475c-b958-f4c501a01fed)
