### PR TITLE
fix(ffe-form): to much padding-left

### DIFF
--- a/packages/ffe-form/less/checkbox.less
+++ b/packages/ffe-form/less/checkbox.less
@@ -11,7 +11,7 @@
     font-family: var(--ffe-g-font);
     font-variant-numeric: tabular-nums;
     text-align: left;
-    padding-left: @ffe-spacing-lg;
+    padding-left: 0;
     -webkit-tap-highlight-color: fade(@ffe-farge-vann, 15%);
     color: var(--ffe-v-input-color);
     grid-template-columns: auto 1fr;

--- a/packages/ffe-form/less/radio-button.less
+++ b/packages/ffe-form/less/radio-button.less
@@ -14,7 +14,7 @@
     margin: 0 0 @ffe-spacing-xs 0;
     transition: width @ffe-transition-duration @ffe-ease-in-out-back;
     text-align: left;
-    padding-left: @ffe-spacing-lg;
+    padding-left: 0;
     padding-top: 1px;
     -webkit-tap-highlight-color: fade(@ffe-farge-vann, 15%);
     grid-template-columns: auto 1fr;


### PR DESCRIPTION
Fikk tilbakemeldning om att det blitt litt mye padding 
![image](https://github.com/SpareBank1/designsystem/assets/2248579/dd43c0dc-4d61-4fdd-a0b7-68d2dcb68b86)


Ser ut som orsaken er att ikonerna tdiligare var positioned absolute. Dvs som var en del av den paddingen. Nå er dom ikke lenger det utan en del av en grid så skruver ner paddingen. 


@ffe-spacing-lg(23px) - 20px(ikonets bredde) -> 12px burde vare riktig svar på begge disse komponenterna. Vi har ingen sånn men kan ju hårdkoda hvis vi ikke burde bruke en som vi har fra før



Har bett på om tilbakemeldning på om fornuftig verdi er brukt np
![image](https://github.com/SpareBank1/designsystem/assets/2248579/a032a2e5-9c53-40b4-81ca-89d82675dd29)
![image](https://github.com/SpareBank1/designsystem/assets/2248579/7c199641-a9f3-4fe7-aed8-985de85c5d7b)
