### PR TITLE
fix(ffe-datepicker-react): add innerRef to Datepicker Props

### DIFF
--- a/packages/ffe-datepicker-react/src/index.d.ts
+++ b/packages/ffe-datepicker-react/src/index.d.ts
@@ -26,6 +26,7 @@ export interface DatepickerProps {
     value: string;
     keepDisplayStateOnError?: boolean;
     fullWidth?: boolean;
+    innerRef?: React.Ref<HTMLInputElement>;
 }
 
 declare class Datepicker extends React.Component<DatepickerProps, any> {}


### PR DESCRIPTION
Legge til innerRef i datepicker props slik at forrige endring kan fungere ordentlig

## Beskrivelse

En tidligere endring har lagt til innerRef til datepicker. Denne endringen legger det til i props-fila også, slik at den kan brukes utenifra uten feilmelding

## Motivasjon og kontekst

Jeg forsøkte å bruke innerRef externt, men typescript fanger ikke opp at Datepicker har et felt som heter innerRef, fordi det ikke var definert i props. 

## Testing

Får testet etter den blir merget, om det går an å referere til innerRef uten av typescript klager.

