### PR TITLE
Develop break text tabs

### DIFF
--- a/packages/ffe-tabs/less/tab-group.less
+++ b/packages/ffe-tabs/less/tab-group.less
@@ -21,6 +21,10 @@
         flex-direction: row;
         border-radius: 40px;
         align-items: center;
+
+        .ffe-tab {
+            flex-shrink: 1;
+        }
     }
 
     &::after {

--- a/packages/ffe-tabs/less/tab.less
+++ b/packages/ffe-tabs/less/tab.less
@@ -14,7 +14,6 @@
     color: var(--ffe-v-tabs-primary-color);
     padding: @ffe-spacing-xs @ffe-spacing-md;
     border-radius: 40px;
-    white-space: nowrap;
     border: 2px solid transparent;
     margin: @ffe-spacing-2xs;
     font-family: var(--ffe-g-font);
@@ -28,6 +27,7 @@
     flex: none;
     order: 0;
     flex-grow: 1;
+    overflow-wrap: anywhere;
 
     &::after {
         content: '';


### PR DESCRIPTION
Den no break varianten må vell bli slik med flex shrink? Annars blir den bredare en skjermen, ext zoom osv

For justering
![image](https://github.com/SpareBank1/designsystem/assets/2248579/c0b647cd-56cf-4665-8905-50ad819a9979)
![image](https://github.com/SpareBank1/designsystem/assets/2248579/dd942760-7efb-4c2d-9057-b3ff40112101)
![image](https://github.com/SpareBank1/designsystem/assets/2248579/5da6c52c-35c3-4c34-8eca-8b2ad5d4bad4)


Efter justering
![image](https://github.com/SpareBank1/designsystem/assets/2248579/92e45a9d-3c32-4243-8ebf-b1d340c94eb6)
Fjernet også `white-space: nowrap;` fra tabbarna. DOm må ju brekke hvis det ikke er plats. 