### PR TITLE
fix(ffe-form): wrong heigth tooltip

### DIFF
--- a/packages/ffe-form-react/src/index.d.ts
+++ b/packages/ffe-form-react/src/index.d.ts
@@ -86,7 +86,7 @@ export interface TooltipProps extends React.ComponentProps<'span'> {
     isOpen?: boolean;
     onClick?: (e: React.MouseEvent | undefined) => void;
     tabIndex?: number;
-    ref?: React.Ref<HTMLButtonElement>;
+    ref?: React.ForwardedRef<HTMLButtonElement>;
 }
 
 export interface RadioBlockProps extends React.ComponentProps<'input'> {

--- a/packages/ffe-form/less/tooltip.less
+++ b/packages/ffe-form/less/tooltip.less
@@ -6,7 +6,7 @@
         border: 2px solid var(--ffe-v-tooltip-border-color);
         color: var(--ffe-v-tooltip-icon-color);
         cursor: help;
-        height: 1.2rem;
+        height: 1.5625rem;
         aspect-ratio: 1;
         margin: 0 0 @ffe-spacing-2xs @ffe-spacing-sm;
         padding: 0;


### PR DESCRIPTION
Må ha telt feil/ikke telt forste gang? 
Denne var iaf hardkodet til 25px før jag begynnte og fixa så att den skulle tåla  text zoom. 