### PR TITLE
fix(ffe-buttons): tekst-overflow i inline knapper

### DIFF
--- a/packages/ffe-buttons/less/inline-base-button.less
+++ b/packages/ffe-buttons/less/inline-base-button.less
@@ -26,6 +26,7 @@
     text-decoration: none;
     font-size: var(--ffe-fontsize-body-text);
     align-items: center;
+    overflow-wrap: anywhere;
 
     &:active {
         transform: scale(0.97);


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse

Fikser et problem i BackButton, der skalert tekst forsvinner utenfor synsvidde i stedet for å brekke over flere linjer.

Før

![image](https://github.com/SpareBank1/designsystem/assets/463847/bf3a5ae9-3622-4dcc-8d0f-58b9b69013d6)


Etter

![image](https://github.com/SpareBank1/designsystem/assets/463847/08fe83c7-f6ff-463e-9d5c-5f32b42ebdf7)


## Motivasjon og kontekst

Fixes #1726 

## Testing

Testet lokalt med component-overview