### PR TITLE
fix(ffe-lists): tekst-overflow i lister

### DIFF
--- a/packages/ffe-lists/less/regular-lists.less
+++ b/packages/ffe-lists/less/regular-lists.less
@@ -61,6 +61,7 @@
     > .ffe-bullet-list__item {
         margin-top: @ffe-spacing-xs;
         margin-left: @ffe-spacing-sm;
+        overflow-wrap: anywhere;
     }
 }
 
@@ -185,4 +186,5 @@
 .ffe-stylized-numbered-list__item-content {
     grid-column: 2/3;
     grid-row: 1/-1;
+    overflow-wrap: anywhere;
 }


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse

Fikser et problem i listekomponentene, der skalert tekst forsvinner utenfor synsvidde i stedet for å brekke over flere linjer.

Før

![image](https://github.com/SpareBank1/designsystem/assets/463847/7393695f-03c1-4640-8a7d-05c2262dc13a)

Etter

![image](https://github.com/SpareBank1/designsystem/assets/463847/5f7e0c64-1eb7-4add-aebb-85e3d4ce6d5d)


<!-- Detaljert beskrivelse av endringene dine. Skjermskudd er lov. -->

## Motivasjon og kontekst

Fixes #1725 
Fixes #1724 

## Testing

Testet lokalt med component-overview