### PR TITLE
fix(ffe-form): tekst-overflow i fieldmessage

### DIFF
--- a/packages/ffe-form/less/field-message.less
+++ b/packages/ffe-form/less/field-message.less
@@ -6,6 +6,7 @@
     grid-template-columns: auto 1fr;
     grid-column-gap: @ffe-spacing-2xs;
     font-size: var(--ffe-fontsize-body-text);
+    overflow-wrap: anywhere;
 
     &[aria-hidden='true'] {
         display: none;


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse

Fikser et problem i field message, der skalert tekst forsvinner utenfor synsvidde i stedet for å brekke over flere linjer.

Før

![image](https://github.com/SpareBank1/designsystem/assets/463847/e5249f4b-9774-467c-8e6e-6cda7c203bab)

Etter

![image](https://github.com/SpareBank1/designsystem/assets/463847/845c628c-d85c-4a87-b1d8-465a6e7deb25)


## Motivasjon og kontekst

Fixes #1739 

## Testing

Testet lokalt med component-overview