### PR TITLE
fix(ffe-core): add missing css custom props to theme.less

### DIFF
--- a/packages/ffe-core/less/theme.less
+++ b/packages/ffe-core/less/theme.less
@@ -75,6 +75,35 @@
     --ffe-fontsize-form-dropdown: 1rem;
     --ffe-fontsize-button: 1rem;
 
+    /** Breakpoints */
+    --breakpoint-sm: @breakpoint-sm;
+    --breakpoint-md: @breakpoint-md;
+    --breakpoint-lg: @breakpoint-lg;
+    --breakpoint-xl: @breakpoint-xl;
+
+    /** Dimensions */
+    --app-width: @app-width;
+    --app-width-min: @app-width-min;
+    --app-margin: @app-margin;
+
+    /** Motion */
+    --ffe-ease-in-out-back: @ffe-ease-in-out-back;
+    --ffe-ease: @ffe-ease;
+    --ffe-transition-duration: @ffe-transition-duration;
+
+    /** Spacing */
+    --ffe-spacing: @ffe-spacing;
+    --ffe-spacing-2xs: @ffe-spacing-2xs;
+    --ffe-spacing-xs: @ffe-spacing-xs;
+    --ffe-spacing-sm: @ffe-spacing-sm;
+    --ffe-spacing-md: @ffe-spacing-md;
+    --ffe-spacing-lg: @ffe-spacing-lg;
+    --ffe-spacing-xl: @ffe-spacing-xl;
+    --ffe-spacing-2xl: @ffe-spacing-2xl;
+    --ffe-spacing-3xl: @ffe-spacing-3xl;
+    --ffe-spacing-4xl: @ffe-spacing-4xl;
+    --ffe-spacing-5xl: @ffe-spacing-5xl;
+
     @media (min-width: @breakpoint-sm) {
         --ffe-fontsize-lead-paragraph: 1.5rem;
         --ffe-fontsize-sub-lead-paragraph: 1.125rem;


### PR DESCRIPTION
## Beskrivelse

Har lagt til css custom props for breakpoints, dimensions, motion og spacing. Disse eksisterte kun som less variabler tidligere. 

## Motivasjon og kontekst

Løser #1823.

Løser problem med manglende padding i Accordion pga [bruk av --ffe-spacing-xs fremfor @ffe-spacing-xs](https://github.com/SpareBank1/designsystem/blob/develop/packages/ffe-accordion/less/accordion.less#L64).

## Testing
