### PR TITLE
fix(ffe-buttons): fjerner statisk høyde på expand button

### DIFF
--- a/packages/ffe-buttons/less/base-button.less
+++ b/packages/ffe-buttons/less/base-button.less
@@ -149,7 +149,6 @@
 
 .ffe-button--expand {
     border-radius: 34px;
-    height: 45px;
 }
 
 .ffe-button--expanded {


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse

Fjerner statisk høyde på expand button, for å unngå at lange tekster forsvinner ut av synsfeltet ved tekstskalering og lignende.

## Motivasjon og kontekst

Fixes #1833 

## Testing

Testet i component-overview.