### PR TITLE
Develop fiks hover

### DIFF
--- a/packages/ffe-accordion/less/accordion.less
+++ b/packages/ffe-accordion/less/accordion.less
@@ -31,15 +31,18 @@
         outline: none;
         color: var(--ffe-v-accordion-primary-color);
 
-        &:hover {
-            .ffe-accordion-item__heading-icon {
-                transition: fill @ffe-transition-duration @ffe-ease;
-                color: var(--ffe-v-accordion-secondary-color);
-            }
+        @media (hover: hover) and (pointer: fine) {
+            &:hover {
+                .ffe-accordion-item__heading-icon {
+                    transition: fill @ffe-transition-duration @ffe-ease;
+                    color: var(--ffe-v-accordion-secondary-color);
+                }
 
-            .ffe-accordion-item__heading-icon-wrapper {
-                transition: background-color @ffe-transition-duration @ffe-ease;
-                background-color: var(--ffe-v-accordion-primary-color);
+                .ffe-accordion-item__heading-icon-wrapper {
+                    transition: background-color @ffe-transition-duration
+                        @ffe-ease;
+                    background-color: var(--ffe-v-accordion-primary-color);
+                }
             }
         }
 
@@ -96,13 +99,16 @@
             &__heading-icon {
                 color: var(--ffe-v-accordion-primary-color);
             }
-            &:hover {
-                .ffe-accordion-item__heading-icon {
-                    color: var(--ffe-v-accordion-secondary-color);
-                }
 
-                .ffe-accordion-item__heading-icon-wrapper {
-                    background-color: var(--ffe-v-accordion-primary-color);
+            @media (hover: hover) and (pointer: fine) {
+                &:hover {
+                    .ffe-accordion-item__heading-icon {
+                        color: var(--ffe-v-accordion-secondary-color);
+                    }
+
+                    .ffe-accordion-item__heading-icon-wrapper {
+                        background-color: var(--ffe-v-accordion-primary-color);
+                    }
                 }
             }
         }

--- a/packages/ffe-account-selector-react/less/account-suggestion-multi.less
+++ b/packages/ffe-account-selector-react/less/account-suggestion-multi.less
@@ -22,7 +22,12 @@
     overflow: hidden;
     display: flex;
 
-    &:hover,
+    @media (hover: hover) and (pointer: fine) {
+        &:hover {
+            .highlighted();
+        }
+    }
+
     &--highlighted {
         .highlighted();
     }
@@ -77,7 +82,12 @@
 .native & {
     @media (prefers-color-scheme: dark) {
         .ffe-account-suggestion-multi {
-            &:hover,
+            @media (hover: hover) and (pointer: fine) {
+                &:hover {
+                    background: var(--ffe-g-primary-color);
+                }
+            }
+
             &--highlighted {
                 background: var(--ffe-g-primary-color);
             }

--- a/packages/ffe-account-selector-react/less/account-suggestion-single.less
+++ b/packages/ffe-account-selector-react/less/account-suggestion-single.less
@@ -4,7 +4,18 @@
     cursor: pointer;
     padding: @ffe-spacing-xs @ffe-spacing-sm @ffe-spacing-xs @ffe-spacing-md;
 
-    &:hover,
+    @media (hover: hover) and (pointer: fine) {
+        &:hover {
+            background: var(--ffe-g-primary-color);
+            color: var(--ffe-v-accountselector-option-primary-color);
+
+            & .ffe-account-suggestion-single__details,
+            & .ffe-account-suggestion-single__name {
+                color: var(--ffe-v-accountselector-option-primary-color);
+            }
+        }
+    }
+
     &--highlighted {
         background: var(--ffe-g-primary-color);
         color: var(--ffe-v-accountselector-option-primary-color);

--- a/packages/ffe-buttons/less/base-button.less
+++ b/packages/ffe-buttons/less/base-button.less
@@ -85,8 +85,10 @@
         background-color: var(--ffe-v-button-action-color);
     }
 
-    &:hover {
-        background-color: var(--ffe-v-button-action-color-hover);
+    @media (hover: hover) and (pointer: fine) {
+        &:hover {
+            background-color: var(--ffe-v-button-action-color-hover);
+        }
     }
 }
 
@@ -102,8 +104,10 @@
         background-color: var(--ffe-v-button-primary-color);
     }
 
-    &:hover {
-        background-color: var(--ffe-v-button-primary-color-hover);
+    @media (hover: hover) and (pointer: fine) {
+        &:hover {
+            background-color: var(--ffe-v-button-primary-color-hover);
+        }
     }
 }
 
@@ -129,19 +133,23 @@
         }
     }
 
-    &:hover {
-        background-color: var(--ffe-v-button-secondary-color);
-        border-color: var(--ffe-v-button-secondary-color);
-        color: var(--ffe-v-button-secondary-color-bg);
-
-        .ffe-button__icon {
+    @media (hover: hover) and (pointer: fine) {
+        &:hover {
+            background-color: var(--ffe-v-button-secondary-color);
+            border-color: var(--ffe-v-button-secondary-color);
             color: var(--ffe-v-button-secondary-color-bg);
-        }
-        .native & {
-            @media (prefers-color-scheme: dark) {
-                background-color: var(--ffe-v-button-secondary-border-color);
-                border-color: var(--ffe-v-button-secondary-border-color);
+
+            .ffe-button__icon {
                 color: var(--ffe-v-button-secondary-color-bg);
+            }
+            .native & {
+                @media (prefers-color-scheme: dark) {
+                    background-color: var(
+                        --ffe-v-button-secondary-border-color
+                    );
+                    border-color: var(--ffe-v-button-secondary-border-color);
+                    color: var(--ffe-v-button-secondary-color-bg);
+                }
             }
         }
     }
@@ -172,12 +180,14 @@
         color: var(--ffe-v-button-task-primary-color);
     }
 
-    &:hover {
-        color: var(--ffe-v-button-task-text-color-hover);
-        box-shadow: none;
+    @media (hover: hover) and (pointer: fine) {
+        &:hover {
+            color: var(--ffe-v-button-task-text-color-hover);
+            box-shadow: none;
 
-        .ffe-button__icon > .ffe-icons {
-            color: var(--ffe-v-button-primary-color-text);
+            .ffe-button__icon > .ffe-icons {
+                color: var(--ffe-v-button-primary-color-text);
+            }
         }
     }
 
@@ -215,9 +225,14 @@
         will-change: transform;
     }
 
-    .ffe-button--shortcut:focus &,
-    .ffe-button--shortcut:hover & {
+    .ffe-button--shortcut:focus & {
         transform: translateX(12px);
+    }
+
+    @media (hover: hover) and (pointer: fine) {
+        .ffe-button--shortcut:hover & {
+            transform: translateX(12px);
+        }
     }
 
     .ffe-button--task & {
@@ -242,19 +257,24 @@
     .ffe-button--expand & {
         color: var(--ffe-v-button-task-primary-color);
     }
-    .ffe-button--expand:hover & {
-        color: @ffe-farge-hvit;
-        .native & {
-            @media (prefers-color-scheme: dark) {
-                color: @ffe-farge-svart;
+    @media (hover: hover) and (pointer: fine) {
+        .ffe-button--expand:hover & {
+            color: @ffe-farge-hvit;
+
+            .native & {
+                @media (prefers-color-scheme: dark) {
+                    color: @ffe-farge-svart;
+                }
             }
         }
     }
 
-    .ffe-button--task:hover & {
-        border-color: var(--ffe-v-button-primary-color);
-        background-color: var(--ffe-v-button-primary-color);
-        color: var(--ffe-v-button-primary-color-text);
+    @media (hover: hover) and (pointer: fine) {
+        .ffe-button--task:hover & {
+            border-color: var(--ffe-v-button-primary-color);
+            background-color: var(--ffe-v-button-primary-color);
+            color: var(--ffe-v-button-primary-color-text);
+        }
     }
 }
 

--- a/packages/ffe-buttons/less/inline-base-button.less
+++ b/packages/ffe-buttons/less/inline-base-button.less
@@ -63,13 +63,15 @@
         color: var(--ffe-v-button-primary-color);
     }
 
-    &:hover .ffe-inline-button__icon {
-        color: var(--ffe-v-button-primary-color-hover);
-    }
+    @media (hover: hover) and (pointer: fine) {
+        &:hover .ffe-inline-button__icon {
+            color: var(--ffe-v-button-primary-color-hover);
+        }
 
-    &:hover .ffe-inline-button__label {
-        color: var(--ffe-v-button-secondary-color-hover);
-        border-bottom-color: var(--ffe-v-button-secondary-color-hover);
+        &:hover .ffe-inline-button__label {
+            color: var(--ffe-v-button-secondary-color-hover);
+            border-bottom-color: var(--ffe-v-button-secondary-color-hover);
+        }
     }
 }
 
@@ -83,9 +85,11 @@
         color: var(--ffe-v-button-primary-color);
         transition: transform @ffe-transition-duration @ffe-ease-in-out-back;
     }
-    &:hover .ffe-inline-button__icon,
-    &:hover .ffe-inline-button__label {
-        color: var(--ffe-v-button-primary-color-hover);
+    @media (hover: hover) and (pointer: fine) {
+        &:hover .ffe-inline-button__icon,
+        &:hover .ffe-inline-button__label {
+            color: var(--ffe-v-button-primary-color-hover);
+        }
     }
 }
 
@@ -126,15 +130,17 @@
         border-color: transparent;
     }
 
-    &:hover {
-        color: var(--ffe-v-button-tertiary-color-hover);
-
-        .ffe-inline-button__icon {
+    @media (hover: hover) and (pointer: fine) {
+        &:hover {
             color: var(--ffe-v-button-tertiary-color-hover);
-        }
-        .native & {
-            @media (prefers-color-scheme: dark) {
-                color: @ffe-farge-hvit;
+
+            .ffe-inline-button__icon {
+                color: var(--ffe-v-button-tertiary-color-hover);
+            }
+            .native & {
+                @media (prefers-color-scheme: dark) {
+                    color: @ffe-farge-hvit;
+                }
             }
         }
     }

--- a/packages/ffe-cards/less/common-card-styling.less
+++ b/packages/ffe-cards/less/common-card-styling.less
@@ -32,9 +32,14 @@
     }
 
     &:focus,
-    &:active,
-    &:hover {
+    &:active {
         border-color: var(--ffe-g-primary-color);
+    }
+
+    @media (hover: hover) and (pointer: fine) {
+        &:hover {
+            border-color: var(--ffe-g-primary-color);
+        }
     }
 
     @media (min-width: @breakpoint-md) {

--- a/packages/ffe-cards/less/image-card.less
+++ b/packages/ffe-cards/less/image-card.less
@@ -10,9 +10,17 @@
     border: 0;
     flex-flow: column nowrap;
 
+    @media (hover: hover) and (pointer: fine) {
+        &:hover {
+            .ffe-image-card__image-overlay,
+            .ffe-image-card__body {
+                border-color: var(--ffe-v-cards-image-card-border-hover-color);
+            }
+        }
+    }
+
     &:focus,
-    &:active,
-    &:hover {
+    &:active {
         .ffe-image-card__image-overlay,
         .ffe-image-card__body {
             border-color: var(--ffe-v-cards-image-card-border-hover-color);

--- a/packages/ffe-cards/less/stippled-card.less
+++ b/packages/ffe-cards/less/stippled-card.less
@@ -13,7 +13,13 @@
     padding: @ffe-spacing-md;
     gap: @ffe-spacing-sm;
 
-    &:hover,
+    @media (hover: hover) and (pointer: fine) {
+        &:hover {
+            border-style: solid;
+            box-shadow: none;
+        }
+    }
+
     &:focus,
     &:active {
         border-style: solid;

--- a/packages/ffe-context-message/less/context-message.less
+++ b/packages/ffe-context-message/less/context-message.less
@@ -75,9 +75,13 @@
         border-bottom: 1px solid var(--ffe-v-context-message-link-color);
         color: var(--ffe-v-context-message-link-color);
 
-        &:hover {
-            border-bottom-color: var(--ffe-v-context-message-link-color-hover);
-            color: var(--ffe-v-context-message-link-color-hover);
+        @media (hover: hover) and (pointer: fine) {
+            &:hover {
+                border-bottom-color: var(
+                    --ffe-v-context-message-link-color-hover
+                );
+                color: var(--ffe-v-context-message-link-color-hover);
+            }
         }
 
         &:visited {
@@ -165,8 +169,12 @@
         }
         .ffe-icons {
             color: var(--ffe-v-context-message-close-button-color);
-            &:hover {
-                color: var(--ffe-v-context-message-close-button-color-hover);
+            @media (hover: hover) and (pointer: fine) {
+                &:hover {
+                    color: var(
+                        --ffe-v-context-message-close-button-color-hover
+                    );
+                }
             }
         }
     }

--- a/packages/ffe-core/less/typography.less
+++ b/packages/ffe-core/less/typography.less
@@ -299,10 +299,12 @@
     line-height: 1em;
     transition: all @ffe-transition-duration @ffe-ease;
 
-    &:hover {
-        border-bottom-color: var(--ffe-g-link-color-hover);
-        color: var(--ffe-g-link-color-hover);
-        text-decoration: none;
+    @media (hover: hover) and (pointer: fine) {
+        &:hover {
+            border-bottom-color: var(--ffe-g-link-color-hover);
+            color: var(--ffe-g-link-color-hover);
+            text-decoration: none;
+        }
     }
 
     &:visited {
@@ -339,9 +341,13 @@
     border: 2px solid transparent;
     outline: 0;
     padding: @ffe-spacing-2xs;
-    &:hover {
-        fill: var(--ffe-g-link-icon-color-hover);
+
+    @media (hover: hover) and (pointer: fine) {
+        &:hover {
+            fill: var(--ffe-g-link-icon-color-hover);
+        }
     }
+
     &:focus {
         box-shadow: 0 0 0 2px var(--ffe-g-link-icon-color-focus);
     }

--- a/packages/ffe-datepicker/less/calendar.less
+++ b/packages/ffe-datepicker/less/calendar.less
@@ -41,10 +41,16 @@
         border-radius: 4px;
 
         &:focus,
-        &:hover,
         &:active {
             box-shadow: 0 0 0 2px var(--ffe-v-datepicker-bg-color),
                 0 0 0 4px var(--ffe-v-datepicker-border-hover-color);
+        }
+
+        @media (hover: hover) and (pointer: fine) {
+            &:hover {
+                box-shadow: 0 0 0 2px var(--ffe-v-datepicker-bg-color),
+                    0 0 0 4px var(--ffe-v-datepicker-border-hover-color);
+            }
         }
     }
 
@@ -128,14 +134,17 @@
             border: 1px solid var(--ffe-v-datepicker-date-color-today);
         }
 
-        &:hover,
         &:focus {
             border: 2px solid var(--ffe-v-datepicker-border-hover-color);
             color: var(--ffe-v-datepicker-date-color-hover);
+            outline: none;
         }
 
-        &:focus {
-            outline: none;
+        @media (hover: hover) and (pointer: fine) {
+            &:hover {
+                border: 2px solid var(--ffe-v-datepicker-border-hover-color);
+                color: var(--ffe-v-datepicker-date-color-hover);
+            }
         }
 
         &--focus {
@@ -147,8 +156,10 @@
             background: var(--ffe-v-datepicker-border-hover-color);
             color: var(--ffe-v-datepicker-bg-color);
 
-            &:hover {
-                color: var(--ffe-v-datepicker-bg-color);
+            @media (hover: hover) and (pointer: fine) {
+                &:hover {
+                    color: var(--ffe-v-datepicker-bg-color);
+                }
             }
         }
 
@@ -160,10 +171,16 @@
         &--disabled {
             color: var(--ffe-v-datepicker-date-color-disabled);
 
-            &:focus,
-            &:hover {
+            &:focus {
                 border: 2px solid var(--ffe-v-datepicker-date-color-disabled);
                 color: var(--ffe-v-datepicker-date-color-disabled);
+            }
+            @media (hover: hover) and (pointer: fine) {
+                &:hover {
+                    border: 2px solid
+                        var(--ffe-v-datepicker-date-color-disabled);
+                    color: var(--ffe-v-datepicker-date-color-disabled);
+                }
             }
         }
 

--- a/packages/ffe-datepicker/less/dateinput.less
+++ b/packages/ffe-datepicker/less/dateinput.less
@@ -6,8 +6,10 @@
         display: block;
     }
 
-    &:hover {
-        color: var(--ffe-g-primary-color);
+    @media (hover: hover) and (pointer: fine) {
+        &:hover {
+            color: var(--ffe-g-primary-color);
+        }
     }
 
     &__field {
@@ -47,10 +49,15 @@
         border-bottom-right-radius: 4px;
         transition: all @ffe-transition-duration @ffe-ease;
 
-        &:hover,
         &:focus,
         &:active {
             border-color: var(--ffe-v-datepicker-border-hover-color);
+        }
+
+        @media (hover: hover) and (pointer: fine) {
+            &:hover {
+                border-color: var(--ffe-v-datepicker-border-hover-color);
+            }
         }
 
         .ffe-dateinput__field:focus + &:hover {

--- a/packages/ffe-feedback/less/feedback-thumb.less
+++ b/packages/ffe-feedback/less/feedback-thumb.less
@@ -17,7 +17,17 @@
             display: none;
         }
 
-        &:hover,
+        @media (hover: hover) and (pointer: fine) {
+            &:hover {
+                .ffe-feedback__thumb-icon--fill {
+                    display: block;
+                }
+                .ffe-feedback__thumb-icon {
+                    display: none;
+                }
+            }
+        }
+
         &:focus {
             .ffe-feedback__thumb-icon--fill {
                 display: block;

--- a/packages/ffe-file-upload/less/ffe-file-upload.less
+++ b/packages/ffe-file-upload/less/ffe-file-upload.less
@@ -150,9 +150,32 @@
             margin-right: @ffe-spacing-sm;
         }
 
+        @media (hover: hover) and (pointer: fine) {
+            &:hover {
+                color: var(--ffe-v-fileupload-btn-delete-color-hover);
+
+                ~ .ffe-file-upload__file-item-filename {
+                    text-decoration: underline;
+                }
+
+                ~ .ffe-file-upload__file-item-error-info
+                    > .ffe-file-upload__file-item-error-filename {
+                    text-decoration: underline;
+                }
+
+                ~ .ffe-file-upload__file-item-stencil-info
+                    > .ffe-file-upload__file-item-stencil-info-filename {
+                    text-decoration: underline;
+                }
+
+                .ffe-file-upload__file-item-delete-button-text {
+                    text-decoration: underline;
+                }
+            }
+        }
+
         &:active,
-        &:focus,
-        &:hover {
+        &:focus {
             color: var(--ffe-v-fileupload-btn-delete-color-hover);
 
             ~ .ffe-file-upload__file-item-filename {

--- a/packages/ffe-form/less/checkbox.less
+++ b/packages/ffe-form/less/checkbox.less
@@ -78,14 +78,16 @@
     height: 0;
 
     &:checked + .ffe-checkbox::before,
-    &:hover + .ffe-checkbox::before,
     &:focus + .ffe-checkbox::before,
     &:active + .ffe-checkbox::before {
         outline: none;
     }
 
-    &:hover + .ffe-checkbox::before {
-        border-color: var(--ffe-v-checkbox-color);
+    @media (hover: hover) and (pointer: fine) {
+        &:hover + .ffe-checkbox::before {
+            outline: none;
+            border-color: var(--ffe-v-checkbox-color);
+        }
     }
 
     &:focus + .ffe-checkbox::before {

--- a/packages/ffe-form/less/dropdown.less
+++ b/packages/ffe-form/less/dropdown.less
@@ -25,8 +25,10 @@
     width: 100%;
     font-size: var(--ffe-fontsize-form-dropdown);
 
-    &:hover {
-        border-color: var(--ffe-g-primary-color);
+    @media (hover: hover) and (pointer: fine) {
+        &:hover {
+            border-color: var(--ffe-g-primary-color);
+        }
     }
 
     &:focus,

--- a/packages/ffe-form/less/input-field.less
+++ b/packages/ffe-form/less/input-field.less
@@ -26,8 +26,10 @@
         }
     }
 
-    &:hover {
-        border-color: var(--ffe-g-primary-color);
+    @media (hover: hover) and (pointer: fine) {
+        &:hover {
+            border-color: var(--ffe-g-primary-color);
+        }
     }
 
     &:focus,

--- a/packages/ffe-form/less/radio-block.less
+++ b/packages/ffe-form/less/radio-block.less
@@ -74,8 +74,10 @@
         }
     }
 
-    &:hover {
-        --ffe-radio-block-border-color: var(--ffe-g-primary-color);
+    @media (hover: hover) and (pointer: fine) {
+        &:hover {
+            --ffe-radio-block-border-color: var(--ffe-g-primary-color);
+        }
     }
 
     .ffe-fieldset--error & {

--- a/packages/ffe-form/less/radio-button.less
+++ b/packages/ffe-form/less/radio-button.less
@@ -90,15 +90,25 @@
 }
 
 .ffe-radio-input {
+    @media (hover: hover) and (pointer: fine) {
+        &:hover + .ffe-radio-button::before {
+            outline: none;
+        }
+    }
+
     &:checked + .ffe-radio-button::before,
-    &:hover + .ffe-radio-button::before,
     &:focus + .ffe-radio-button::before,
     &:active + .ffe-radio-button::before {
         outline: none;
     }
 
-    &:checked + .ffe-radio-button::after,
-    &:hover + .ffe-radio-button::after {
+    @media (hover: hover) and (pointer: fine) {
+        &:hover + .ffe-radio-button::after {
+            border-color: var(--ffe-g-primary-color);
+        }
+    }
+
+    &:checked + .ffe-radio-button::after {
         border-color: var(--ffe-g-primary-color);
     }
 
@@ -129,9 +139,14 @@
         box-shadow: none;
     }
 
-    [aria-invalid='true'] &:hover + .ffe-radio-button::after,
     [aria-invalid='true'] &:checked + .ffe-radio-button::after {
         border-color: var(--ffe-g-error-color);
+    }
+
+    @media (hover: hover) and (pointer: fine) {
+        [aria-invalid='true'] &:hover + .ffe-radio-button::after {
+            border-color: var(--ffe-g-error-color);
+        }
     }
 }
 

--- a/packages/ffe-form/less/radio-switch.less
+++ b/packages/ffe-form/less/radio-switch.less
@@ -64,9 +64,10 @@
         background-color: var(--ffe-g-secondary-color);
         color: var(--ffe-v-input-bg-color);
     }
-
-    &:hover + .ffe-radio-switch {
-        border-color: var(--ffe-g-secondary-color);
+    @media (hover: hover) and (pointer: fine) {
+        &:hover + .ffe-radio-switch {
+            border-color: var(--ffe-g-secondary-color);
+        }
     }
 
     &:focus-visible + .ffe-radio-switch {

--- a/packages/ffe-form/less/textarea.less
+++ b/packages/ffe-form/less/textarea.less
@@ -17,8 +17,10 @@
         }
     }
 
-    &:hover {
-        border-color: var(--ffe-g-primary-color);
+    @media (hover: hover) and (pointer: fine) {
+        &:hover {
+            border-color: var(--ffe-g-primary-color);
+        }
     }
 
     &:focus,

--- a/packages/ffe-form/less/toggle-switch.less
+++ b/packages/ffe-form/less/toggle-switch.less
@@ -74,13 +74,14 @@
                 }
             }
         }
+        @media (hover: hover) and (pointer: fine) {
+            .ffe-toggle-switch__label:hover &::before {
+                background: @ffe-farge-moerkgraa;
 
-        .ffe-toggle-switch__label:hover &::before {
-            background: @ffe-farge-moerkgraa;
-
-            .native & {
-                @media (prefers-color-scheme: dark) {
-                    background: @ffe-farge-lysgraa;
+                .native & {
+                    @media (prefers-color-scheme: dark) {
+                        background: @ffe-farge-lysgraa;
+                    }
                 }
             }
         }
@@ -100,8 +101,10 @@
         }
     }
 
-    &__input:checked + &__label:hover &__switch::before {
-        background: var(--ffe-g-secondary-color);
+    @media (hover: hover) and (pointer: fine) {
+        &__input:checked + &__label:hover &__switch::before {
+            background: var(--ffe-g-secondary-color);
+        }
     }
 
     &__input:focus:not(:focus-visible) + &__label &__switch::before {

--- a/packages/ffe-form/less/tooltip.less
+++ b/packages/ffe-form/less/tooltip.less
@@ -21,9 +21,11 @@
             margin-top: 2px;
         }
 
-        &:hover {
-            border-color: var(--ffe-v-checkbox-selected-color);
-            color: var(--ffe-v-tooltip-icon-color);
+        @media (hover: hover) and (pointer: fine) {
+            &:hover {
+                border-color: var(--ffe-v-checkbox-selected-color);
+                color: var(--ffe-v-tooltip-icon-color);
+            }
         }
 
         &:focus {

--- a/packages/ffe-header/less/ffe-header.less
+++ b/packages/ffe-header/less/ffe-header.less
@@ -55,11 +55,15 @@
             text-decoration: none;
         }
 
-        &:hover {
-            color: var(--ffe-v-link-hover-color);
+        @media (hover: hover) and (pointer: fine) {
+            &:hover {
+                color: var(--ffe-v-link-hover-color);
 
-            .ffe-header__user-nav & {
-                background: var(--ffe-v-usernav-link-hover-background-color);
+                .ffe-header__user-nav & {
+                    background: var(
+                        --ffe-v-usernav-link-hover-background-color
+                    );
+                }
             }
         }
 
@@ -158,7 +162,9 @@
         /* stylelint-disable declaration-block-no-duplicate-properties */
         &:extend(.ffe-inline-button--tertiary);
 
-        &:hover:extend(.ffe-inline-button--tertiary:hover) {
+        @media (hover: hover) and (pointer: fine) {
+            &:hover:extend(.ffe-inline-button--tertiary:hover) {
+            }
         }
 
         /* stylelint-enable declaration-block-no-duplicate-properties */
@@ -204,7 +210,9 @@
         &:focus:extend(.ffe-button--secondary:focus) {
         }
 
-        &:hover:extend(.ffe-button--secondary:hover) {
+        @media (hover: hover) and (pointer: fine) {
+            &:hover:extend(.ffe-button--secondary:hover) {
+            }
         }
 
         &:active:extend(.ffe-button:active) {
@@ -526,10 +534,12 @@
         .ffe-header {
             &__user-nav-list {
                 .ffe-header__link {
-                    &:hover {
-                        color: var(
-                            --ffe-v-usernav-header-link-hover-focus-color
-                        );
+                    @media (hover: hover) and (pointer: fine) {
+                        &:hover {
+                            color: var(
+                                --ffe-v-usernav-header-link-hover-focus-color
+                            );
+                        }
                     }
 
                     &:focus {
@@ -549,9 +559,10 @@
                 &:active {
                     color: var(--ffe-v-link-color);
                 }
-
-                &:hover {
-                    color: var(--ffe-v-link-hover-color);
+                @media (hover: hover) and (pointer: fine) {
+                    &:hover {
+                        color: var(--ffe-v-link-hover-color);
+                    }
                 }
 
                 &--active:link,

--- a/packages/ffe-header/less/local-normalize.less
+++ b/packages/ffe-header/less/local-normalize.less
@@ -23,9 +23,13 @@
         background-color: transparent;
         -webkit-text-decoration-skip: objects;
 
-        &:active,
-        &:hover {
+        &:active {
             outline-width: 0;
+        }
+        @media (hover: hover) and (pointer: fine) {
+            &:hover {
+                outline-width: 0;
+            }
         }
     }
 

--- a/packages/ffe-message-box/less/message-box.less
+++ b/packages/ffe-message-box/less/message-box.less
@@ -20,9 +20,11 @@
         border-bottom: 1px solid var(--ffe-v-message-box-link-color);
         color: var(--ffe-v-message-box-link-color);
 
-        &:hover {
-            border-bottom-color: var(--ffe-v-message-box-link-color-hover);
-            color: var(--ffe-v-message-box-link-color-hover);
+        @media (hover: hover) and (pointer: fine) {
+            &:hover {
+                border-bottom-color: var(--ffe-v-message-box-link-color-hover);
+                color: var(--ffe-v-message-box-link-color-hover);
+            }
         }
 
         &:visited {

--- a/packages/ffe-searchable-dropdown-react/less/ffe-searchable-dropdown.less
+++ b/packages/ffe-searchable-dropdown-react/less/ffe-searchable-dropdown.less
@@ -54,9 +54,21 @@
         padding: @ffe-spacing @ffe-spacing-sm;
         cursor: pointer;
 
-        &:hover,
-        &--highlighted,
-        &--highlighted:hover {
+        @media (hover: hover) and (pointer: fine) {
+            &:hover,
+            &--highlighted:hover {
+                background: var(--ffe-g-primary-color);
+                color: var(--ffe-farge-hvit);
+
+                .ffe-searchable-dropdown__list-item-body-details {
+                    .ffe-micro-text {
+                        color: var(--ffe-farge-lysgraa);
+                    }
+                }
+            }
+        }
+
+        &--highlighted {
             background: var(--ffe-g-primary-color);
             color: var(--ffe-farge-hvit);
 
@@ -100,10 +112,12 @@
             display: none;
         }
 
-        &:hover {
-            border-color: var(--ffe-g-primary-color);
-            > .ffe-icons {
-                color: var(--ffe-v-searchable-dropdown-icon-hover-color);
+        @media (hover: hover) and (pointer: fine) {
+            &:hover {
+                border-color: var(--ffe-g-primary-color);
+                > .ffe-icons {
+                    color: var(--ffe-v-searchable-dropdown-icon-hover-color);
+                }
             }
         }
 
@@ -111,9 +125,11 @@
             border: 2px solid var(--ffe-g-primary-color);
         }
 
-        .ffe-input-field:focus ~ &:hover {
-            border-color: transparent;
-            box-shadow: 0 0 0 2px var(--ffe-g-primary-color);
+        @media (hover: hover) and (pointer: fine) {
+            .ffe-input-field:focus ~ &:hover {
+                border-color: transparent;
+                box-shadow: 0 0 0 2px var(--ffe-g-primary-color);
+            }
         }
 
         &-icon {
@@ -138,14 +154,25 @@
         &__list-item-body {
             color: var(--ffe-farge-hvit);
 
-            &:hover,
-            &--highlighted,
-            &--highlighted:hover {
+            &--highlighted {
                 color: var(--ffe-farge-svart);
 
                 .ffe-searchable-dropdown__list-item-body-details {
                     .ffe-micro-text {
                         color: var(--ffe-farge-svart);
+                    }
+                }
+            }
+
+            @media (hover: hover) and (pointer: fine) {
+                &:hover,
+                &--highlighted:hover {
+                    color: var(--ffe-farge-svart);
+
+                    .ffe-searchable-dropdown__list-item-body-details {
+                        .ffe-micro-text {
+                            color: var(--ffe-farge-svart);
+                        }
                     }
                 }
             }

--- a/packages/ffe-system-message/less/system-message.less
+++ b/packages/ffe-system-message/less/system-message.less
@@ -18,11 +18,13 @@
             border-bottom: 1px solid var(--ffe-v-system-message-link-color);
             color: var(--ffe-v-system-message-link-color);
 
-            &:hover {
-                border-bottom-color: var(
-                    --ffe-v-system-message-link-color-hover
-                );
-                color: var(--ffe-v-system-message-link-color-hover);
+            @media (hover: hover) and (pointer: fine) {
+                &:hover {
+                    border-bottom-color: var(
+                        --ffe-v-system-message-link-color-hover
+                    );
+                    color: var(--ffe-v-system-message-link-color-hover);
+                }
             }
 
             &:visited {
@@ -203,8 +205,10 @@
         > .ffe-icons {
             color: var(--ffe-v-system-message-close-button-color);
 
-            &:hover {
-                color: var(--ffe-v-system-message-close-button-color-hover);
+            @media (hover: hover) and (pointer: fine) {
+                &:hover {
+                    color: var(--ffe-v-system-message-close-button-color-hover);
+                }
             }
         }
 
@@ -216,8 +220,10 @@
         .ffe-system-message-wrapper--news & {
             color: var(--ffe-farge-hvit);
 
-            &:hover {
-                color: var(--ffe-farge-lysvarmgraa);
+            @media (hover: hover) and (pointer: fine) {
+                &:hover {
+                    color: var(--ffe-farge-lysvarmgraa);
+                }
             }
 
             &:focus {

--- a/packages/ffe-tables/less/expandable-row.less
+++ b/packages/ffe-tables/less/expandable-row.less
@@ -3,8 +3,10 @@
         cursor: pointer;
         position: relative;
 
-        &:hover {
-            background-color: var(--ffe-v-table-expandable-row-hover);
+        @media (hover: hover) and (pointer: fine) {
+            &:hover {
+                background-color: var(--ffe-v-table-expandable-row-hover);
+            }
         }
 
         &:focus {

--- a/packages/ffe-tables/less/sortable-table.less
+++ b/packages/ffe-tables/less/sortable-table.less
@@ -7,19 +7,22 @@
         border-radius: 4px 4px 0 0;
         padding-top: 2px;
 
-        &:hover {
-            cursor: pointer;
-            color: var(--ffe-v-table-sortable-header-hover);
-            border-color: inherit;
-            user-select: none;
-            .native & {
-                @media (prefers-color-scheme: dark) {
-                    border-color: var(--ffe-v-table-sortable-header-hover);
-                }
-            }
-
-            .ffe-sortable-table__sort-arrow.ffe-icons {
+        @media (hover: hover) and (pointer: fine) {
+            &:hover {
+                cursor: pointer;
                 color: var(--ffe-v-table-sortable-header-hover);
+                border-color: inherit;
+                user-select: none;
+
+                .native & {
+                    @media (prefers-color-scheme: dark) {
+                        border-color: var(--ffe-v-table-sortable-header-hover);
+                    }
+                }
+
+                .ffe-sortable-table__sort-arrow.ffe-icons {
+                    color: var(--ffe-v-table-sortable-header-hover);
+                }
             }
         }
 

--- a/packages/ffe-tabs/less/tab.less
+++ b/packages/ffe-tabs/less/tab.less
@@ -58,9 +58,11 @@
         overflow: unset;
     }
 
-    &:hover {
-        color: var(--ffe-v-tabs-secondary-color);
-        background-color: var(--ffe-v-tabs-tab-hover-color);
+    @media (hover: hover) and (pointer: fine) {
+        &:hover {
+            color: var(--ffe-v-tabs-secondary-color);
+            background-color: var(--ffe-v-tabs-tab-hover-color);
+        }
     }
 
     &--selected,
@@ -69,8 +71,10 @@
         color: var(--ffe-v-tabs-secondary-color);
         z-index: 2;
 
-        &:hover {
-            background-color: var(--ffe-v-tabs-tab-active-hover-color);
+        @media (hover: hover) and (pointer: fine) {
+            &:hover {
+                background-color: var(--ffe-v-tabs-tab-active-hover-color);
+            }
         }
     }
 


### PR DESCRIPTION
Bilden viser att vi opnet ett nytt lag på mobil genom att det klicka på "kortet" som er blått. Vi har sedan lukkat laget og når vi sedan kommer tilbake så ligger hover stilarna  kvar. Det er vell ikke ønskligt på device. 

![image](https://github.com/SpareBank1/designsystem/assets/2248579/8082a746-41a0-4c25-8672-b98cc3c8e1df)


https://stackoverflow.com/questions/23885255/how-to-remove-ignore-hover-css-style-on-touch-devices/64553121#64553121

Føler det blir noe duplisert der det er samma stilar før focus active også. 