### PR TITLE
fix(ffe-spinner-react): gjør loadingText optional i typings

### DIFF
--- a/packages/ffe-spinner-react/src/index.d.ts
+++ b/packages/ffe-spinner-react/src/index.d.ts
@@ -4,7 +4,7 @@ export interface SpinnerProps extends React.ComponentProps<'span'> {
     className?: string;
     immediate?: boolean;
     large?: boolean;
-    loadingText: React.ReactNode;
+    loadingText?: React.ReactNode;
     locale?: 'en' | 'nb' | 'nn';
 }
 


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse
Gjør loadingtext optional i typings
<!-- Detaljert beskrivelse av endringene dine. Skjermskudd er lov. -->

## Motivasjon og kontekst
Vi får feilmelding når vi bruker spinner uten loadingText i typescript
<!-- Hvorfor trengs denne endringen, og hva løser den? -->

## Testing

<!-- Hvordan har du har testet endringene dine? Ta gjerne med systeminfo o.l -->

<!--

Helt til slutt, har du ..

.. lest retningslinjene våre for bidrag?
.. tatt en siste sjekk for kode og skrivefeil, debug informasjon o.l?
.. kjørt og eventuelt oppdatert testene?
.. kommentert og dokumentert det som trengs?
.. knyttet denne opp til relaterte issues?

-->
