### PR TITLE
fix(ffe-account-selector-react): Lukking når noe er valgt, fjerner ubrukte props og oppdaterer typer

### DIFF
--- a/packages/ffe-account-selector-react/src/components/account-selector-multi/AccountSelectorMulti.js
+++ b/packages/ffe-account-selector-react/src/components/account-selector-multi/AccountSelectorMulti.js
@@ -141,11 +141,14 @@ class AccountSelectorMulti extends React.Component {
 
     render() {
         const {
+            id,
             noMatches,
-            onAccountSelected,
             locale,
             value,
             highCapacity,
+            onChange,
+            onFocus,
+            onReset,
         } = this.props;
         return (
             <div
@@ -153,18 +156,19 @@ class AccountSelectorMulti extends React.Component {
                 onKeyDown={this.onKeyDown}
             >
                 <BaseSelector
+                    id={id}
+                    value={value ?? ''}
+                    onChange={onChange}
+                    onFocus={onFocus}
+                    onReset={onReset}
                     renderSuggestion={account => this.renderSuggestion(account)}
                     renderNoMatches={() => (
                         <AccountNoMatch value={noMatches} locale={locale} />
                     )}
                     suggestionDetails={this.renderSuggestionDetails()}
-                    shouldHideSuggestionsOnSelect={false}
                     shouldSelectHighlightedOnTab={false}
-                    shouldHideSuggestionsOnBlur={false}
                     shouldHideSuggestionsOnReset={true}
                     onSuggestionSelect={this.onSuggestionSelect}
-                    suggestionFilter={accountFilter}
-                    onSelect={onAccountSelected}
                     locale={locale}
                     onSuggestionListChange={height => {
                         this.setState({ suggestionListHeight: height });
@@ -173,7 +177,6 @@ class AccountSelectorMulti extends React.Component {
                     ref={element => {
                         this.baseRef = element;
                     }}
-                    {...this.props}
                     onBlur={e => this.onBlur(e)}
                     highCapacity={highCapacity}
                 />
@@ -215,6 +218,7 @@ AccountSelectorMulti.propTypes = {
     onChange: func,
     onFocus: func,
     onBlur: func.isRequired,
+    onReset: func,
     onSelectAll: func,
     /**
      * Array of objects:

--- a/packages/ffe-account-selector-react/src/components/base-selector/BaseSelector.js
+++ b/packages/ffe-account-selector-react/src/components/base-selector/BaseSelector.js
@@ -264,13 +264,9 @@ class BaseSelector extends Component {
 
 BaseSelector.propTypes = {
     suggestions: arrayOf(object).isRequired,
-    suggestionFilter: func.isRequired,
-    onSelect: func.isRequired,
     value: string.isRequired,
     locale: Locale.isRequired,
-    shouldHideSuggestionsOnSelect: bool.isRequired,
     shouldSelectHighlightedOnTab: bool.isRequired,
-    shouldHideSuggestionsOnBlur: bool.isRequired,
     shouldHideSuggestionsOnReset: bool.isRequired,
     shouldShowSuggestionsOnFocus: bool,
     onSuggestionSelect: func.isRequired,
@@ -298,7 +294,6 @@ BaseSelector.defaultProps = {
     onSuggestionListChange: Function.prototype,
     ariaInvalid: false,
     placeholder: '',
-    value: '',
     shouldShowSuggestionsOnFocus: true,
     highCapacity: false,
 };

--- a/packages/ffe-account-selector-react/src/components/base-selector/BaseSelector.spec.js
+++ b/packages/ffe-account-selector-react/src/components/base-selector/BaseSelector.spec.js
@@ -18,14 +18,11 @@ function propsBaseSelector(_suggestions = suggestions()) {
     return {
         suggestions: _suggestions,
         suggestionFilter: () => () => true,
-        onSelect: () => {},
         renderSuggestion: () => <h1>hei</h1>,
         onSuggestionSelect: suggestion => {},
         value: '',
         locale: 'nb',
-        shouldHideSuggestionsOnSelect: true,
         shouldSelectHighlightedOnTab: true,
-        shouldHideSuggestionsOnBlur: true,
         shouldHideSuggestionsOnReset: true,
         id: 'account-selector',
     };
@@ -115,14 +112,9 @@ describe('<BaseSelector> methods', () => {
     });
 
     it('should not hide suggestions when suggestion is empty', () => {
-        const onSelectSpy = jest.fn();
-        const component = mountBaseSelector({
-            onSelect: onSelectSpy,
-            shouldHideSuggestionsOnSelect: false,
-        }).instance();
+        const component = mountBaseSelector().instance();
 
         component.props.onSuggestionSelect(null);
-        expect(onSelectSpy).not.toHaveBeenCalled();
         expect(component.state.showSuggestions).toBe(false);
     });
 

--- a/packages/ffe-account-selector-react/src/index.d.ts
+++ b/packages/ffe-account-selector-react/src/index.d.ts
@@ -54,44 +54,46 @@ export interface AccountSelectorMultiProps<T extends Account = Account> {
     noMatches?: string;
     onAccountSelected: (account: T) => void;
     onChange?: (value: string) => void;
-    onFocus?: Function;
-    onBlur: Function;
-    onSelectAll: Function;
+    onFocus?: () => void;
+    onBlur: () => void;
+    onReset?: () => void;
+    onSelectAll: (allSelected: boolean) => void;
     selectedAccounts?: Array<T>;
     showSelectAllOption?: boolean;
     value?: string;
+    highCapacity?: boolean;
 }
 
 declare class AccountSelectorMulti<
     T extends Account = Account
 > extends React.Component<AccountSelectorMultiProps<T>, any> {}
 
-export interface BaseSelectorProps {
-    suggestions: Array<any>;
-    suggestionsFilter: Function;
-    onSelect: Function;
+export interface BaseSelectorProps<T> {
+    suggestions: Array<T>;
     value: string;
     locale: 'nb' | 'nn' | 'en';
-    shouldHideSuggestionsOnSelect: boolean;
     shouldSelectHighlightedOnTab: boolean;
-    shouldHideSuggestionsOnBlur: boolean;
     shouldHideSuggestionsOnReset: boolean;
     shouldShowSuggestionsOnFocus?: boolean;
-    onSuggestionSelect: Function;
-    onChange?: React.ChangeEventHandler<Element>;
-    onBlur?: Function;
-    onClick?: Function;
-    onReset?: Function;
-    onFocus?: Function;
-    onSuggestionListChange?: Function;
+    onSuggestionSelect: (suggestion?: T) => void;
+    onChange?: (value: string) => void;
+    onBlur?: () => void;
+    onClick?: () => void;
+    onReset?: () => void;
+    onFocus?: () => void;
+    onSuggestionListChange?: (height: number) => void;
     placeholder?: string;
     ariaInvalid?: boolean;
     suggestionsHeightMax?: number;
     id?: string;
     name?: string;
     readOnly?: boolean;
+    highCapacity?: boolean;
 }
 
-declare class BaseSelector extends React.Component<BaseSelectorProps, any> {}
+declare class BaseSelector<T> extends React.Component<
+    BaseSelectorProps<T>,
+    any
+> {}
 
 export { AccountSelector, AccountSelectorMulti, BaseSelector };

--- a/packages/ffe-account-selector-react/src/subcomponents/input-field/InputField.js
+++ b/packages/ffe-account-selector-react/src/subcomponents/input-field/InputField.js
@@ -45,7 +45,7 @@ const InputField = props => {
         if (isSuggestionsShowing) {
             onBlur();
         } else {
-            e.currentTarget.previousElementSibling.focus();
+            e.currentTarget.parentNode.firstElementChild.focus();
             onFocus();
         }
     };


### PR DESCRIPTION
Hvis man velger noen kontoer i AccountSelectorMulti, lukker den og deretter åpner den ved å trykke på chevron-knappen skjer det ingenting om man trykker utenfor. Dette er fordi den nåværende selectoren setter fokus på reset-knappen og ikke på input-feltet i dette tilfellet.

Har også fjernet en del props som ikke er brukt og oppdatert typer. Usikker hvordan dette bør versjoneres, fjerner noen typer som kanskje er breaking? Men de gjør altså ingenting i koden.
