### PR TITLE
fix(ffe-buttons): use overflow-wrap:normal instead og overflow-wrap:a…

### DIFF
--- a/packages/ffe-buttons/less/base-button.less
+++ b/packages/ffe-buttons/less/base-button.less
@@ -16,7 +16,6 @@
     text-decoration: none;
     transition: all @ffe-transition-duration @ffe-ease;
     user-select: none;
-    overflow-wrap: anywhere;
     hyphens: auto;
     width: 100%;
     font-size: var(--ffe-fontsize-button);


### PR DESCRIPTION
Ref diskussionen på Slack. `overflow-wrap: normal;` er default 