### PR TITLE
refactor(ffe-searchable-dropdown-react): remove unused css

### DIFF
--- a/packages/ffe-searchable-dropdown-react/less/ffe-searchable-dropdown.less
+++ b/packages/ffe-searchable-dropdown-react/less/ffe-searchable-dropdown.less
@@ -45,11 +45,6 @@
         border-bottom: 1px solid var(--ffe-g-border-color);
     }
 
-    // Fixes https://github.com/SpareBank1/designsystem/issues/1245
-    &__list-item-high-capacity-container:not(:last-child) {
-        border-bottom: 1px solid var(--ffe-g-border-color);
-    }
-
     &__list-item-body {
         padding: @ffe-spacing @ffe-spacing-sm;
         cursor: pointer;


### PR DESCRIPTION
VI trenger en ny version og high capacity er vell ikke en ting lenger. 