### PR TITLE
fix(ffe-form): fix spacing between checkboxes and radio buttons

### DIFF
--- a/packages/ffe-form/less/checkbox.less
+++ b/packages/ffe-form/less/checkbox.less
@@ -1,13 +1,13 @@
 .ffe-checkbox {
-    --line-height: 1.15rem;
+    --line-height: 1.5rem;
     --square-color: var(--ffe-v-checkbox-color);
+    --square-background-color: var(--ffe-v-input-bg-color);
     --checkmark-color: transparent;
 
     line-height: var(--line-height);
     display: grid;
-    grid-column-gap: @ffe-spacing-xs;
+    grid-column-gap: var(--ffe-spacing-xs);
     align-items: center;
-    margin: @ffe-spacing-xs 0;
     cursor: pointer;
     transition: width @ffe-transition-duration @ffe-ease;
     font-family: var(--ffe-g-font);
@@ -28,7 +28,7 @@
 
     &--inline {
         display: inline-grid;
-        margin-right: @ffe-spacing-sm;
+        margin-right: var(--ffe-spacing-sm);
     }
 
     &::before,
@@ -41,6 +41,7 @@
     }
 
     &::before {
+        background: var(--square-background-color);
         border: solid 2px var(--square-color);
         border-radius: var(--ffe-g-border-radius);
         height: 20px;
@@ -64,6 +65,11 @@
         width: 6px;
         height: 11px;
     }
+}
+
+.ffe-hidden-checkbox + .ffe-checkbox {
+    padding: var(--ffe-spacing-xs) 0;
+    margin-bottom: 0;
 }
 
 .ffe-checkbox__content {

--- a/packages/ffe-form/less/radio-button.less
+++ b/packages/ffe-form/less/radio-button.less
@@ -1,7 +1,7 @@
 .ffe-radio-button {
-    --line-height: 1.15rem;
+    --line-height: 1.5rem;
     --outer-circle-color: var(--ffe-g-border-color);
-    --inner-circle-color: transparent;
+    --inner-circle-color: var(--ffe-v-input-bg-color);
 
     line-height: var(--line-height);
     overflow-wrap: anywhere;
@@ -12,7 +12,6 @@
     position: relative;
     color: var(--ffe-g-text-color);
     cursor: pointer;
-    margin: 0 0 @ffe-spacing-xs 0;
     transition: width @ffe-transition-duration @ffe-ease-in-out-back;
     text-align: left;
     padding-left: 0;
@@ -20,12 +19,12 @@
     -webkit-tap-highlight-color: fade(@ffe-farge-vann, 15%);
     grid-template-columns: auto 1fr;
     grid-template-rows: var(--line-height) 1fr;
-    grid-column-gap: @ffe-spacing-xs;
+    grid-column-gap: var(--ffe-spacing-xs);
 
     &--inline,
     &--with-tooltip {
         display: inline-grid;
-        margin-right: @ffe-spacing-md;
+        margin-right: var(--ffe-spacing-md);
     }
 
     &--with-tooltip {
@@ -38,7 +37,7 @@
         width: 25px;
         position: absolute;
         right: 0;
-        margin-top: @ffe-spacing-xs;
+        margin-top: var(--ffe-spacing-xs);
 
         & .ffe-tooltip__icon {
             margin: 0;
@@ -48,13 +47,13 @@
     &__tooltip-text.ffe-tooltip__text {
         &:extend(.ffe-small-text);
 
-        margin-left: @ffe-spacing-lg;
+        margin-left: var(--ffe-spacing-lg);
         margin-top: 0;
         margin-bottom: 0;
     }
 
     &__tooltip-text.ffe-tooltip__text--active {
-        margin-top: @ffe-spacing-2xs;
+        margin-top: var(--ffe-spacing-2xs);
     }
 
     &::before,
@@ -82,6 +81,11 @@
     }
 }
 
+.ffe-radio-input + .ffe-radio-button {
+    padding: var(--ffe-spacing-xs) 0;
+    margin-bottom: 0;
+}
+
 .ffe-radio-input {
     &:where(:checked, :focus, :active, :hover) + .ffe-radio-button::before {
         outline: none;
@@ -98,14 +102,14 @@
     }
 
     &:focus-visible + .ffe-radio-button::after {
-        --background-color: @ffe-farge-hvit;
+        --background-color: var(--ffe-farge-hvit);
 
         box-shadow: 0 0 0 3px var(--background-color),
             0 0 0 5px var(--ffe-g-primary-color);
 
         .native & {
             @media (prefers-color-scheme: dark) {
-                --background-color: @ffe-farge-svart;
+                --background-color: var(--ffe-farge-svart);
             }
         }
     }


### PR DESCRIPTION
Ser på https://github.com/SpareBank1/designsystem/issues/1860

Ser ikke ut som en ny feil: Avstanderna kommer fra 

```
.ffe-input-group > * { // denne har høyare spesifitet en marginen som ligger i komponenten før endringen 
    margin-top: 0;
    margin-bottom: 8px;
}
```

Avstanderna stemmer ikke øverens med figma helt da det ikke var brukt multiplar av 8 der men har spurt UX om vad det burde vare. 



![image](https://github.com/SpareBank1/designsystem/assets/2248579/03a07589-1e7b-4d6c-88a9-b6e3a646538b)
![image](https://github.com/SpareBank1/designsystem/assets/2248579/3278d386-9366-4a75-ba0f-8ebefa451540)
![image](https://github.com/SpareBank1/designsystem/assets/2248579/e02194d4-4818-4131-9773-98d0718a8c98)
![image](https://github.com/SpareBank1/designsystem/assets/2248579/1a9cf454-6050-488c-a2ef-041fc10fe70f)


