### PR TITLE
fix(ffe-form): legger tilbake bakgrunnsfarge på checkbox

### DIFF
--- a/packages/ffe-form/less/checkbox.less
+++ b/packages/ffe-form/less/checkbox.less
@@ -41,6 +41,7 @@
     }
 
     &::before {
+        background-color: var(--ffe-v-input-bg-color);
         border: solid 2px var(--square-color);
         border-radius: var(--ffe-g-border-radius);
         height: 20px;


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse

Bakgrunnsfarge på checkbox ble fjernet ved en feil i en tidligere pull request, noe som førte til at det så feil ut i tilfeller der checkbox lå på andre bakgrunner enn default hvit.

## Motivasjon og kontekst

Checkbox trenger bakgrunnsfarge for å ikke se "gjennomsiktig" ut.

## Testing

Testet i component-overview
