### PR TITLE
Fjern massa onødvendig javascript fra Collapse

### DIFF
--- a/component-overview/examples/buttons/InlineExpandButton.jsx
+++ b/component-overview/examples/buttons/InlineExpandButton.jsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { InlineExpandButton } from '@sb1/ffe-buttons-react';
-import Collapse from '@sb1/ffe-collapse-react';
+import { Collapse } from '@sb1/ffe-collapse-react';
 import { Paragraph } from '@sb1/ffe-core-react';
 
 () => {

--- a/component-overview/examples/collapse/Collapse-onRest.jsx
+++ b/component-overview/examples/collapse/Collapse-onRest.jsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import Collapse from '@sb1/ffe-collapse-react';
+import { Collapse } from '@sb1/ffe-collapse-react';
 import { ExpandButton } from '@sb1/ffe-buttons-react';
 
 () => {

--- a/component-overview/examples/collapse/Collapse.jsx
+++ b/component-overview/examples/collapse/Collapse.jsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import Collapse from '@sb1/ffe-collapse-react';
+import { Collapse } from '@sb1/ffe-collapse-react';
 import { ExpandButton } from '@sb1/ffe-buttons-react';
 
 () => {

--- a/packages/ffe-accordion-react/src/AccordionItem.js
+++ b/packages/ffe-accordion-react/src/AccordionItem.js
@@ -2,7 +2,7 @@ import React, { useEffect, useRef, useState } from 'react';
 import { bool, func, node, string } from 'prop-types';
 import { v4 as uuid } from 'uuid';
 import { Icon } from '@sb1/ffe-icons-react';
-import Collapse from '@sb1/ffe-collapse-react';
+import { Collapse } from '@sb1/ffe-collapse-react';
 import classNames from 'classnames';
 
 const AccordionItem = ({

--- a/packages/ffe-collapse-react/less/collapse.less
+++ b/packages/ffe-collapse-react/less/collapse.less
@@ -1,3 +1,18 @@
-.ffe-collapse-transition {
-    transition: height @ffe-transition-duration @ffe-ease;
+.ffe-collapse {
+    display: grid;
+    grid-template-rows: 0fr;
+    transition: grid-template-rows var(--ffe-transition-duration)
+        var(--ffe-ease);
+}
+
+.ffe-collapse--hidden {
+    visibility: hidden;
+}
+
+.ffe-collapse--open {
+    grid-template-rows: 1fr;
+}
+
+.ffe-collapse__inner {
+    overflow: hidden;
 }

--- a/packages/ffe-collapse-react/src/index.d.ts
+++ b/packages/ffe-collapse-react/src/index.d.ts
@@ -1,10 +1,10 @@
 import * as React from 'react';
 
-export interface CollapseProps extends React.HTMLProps<HTMLDivElement> {
+export interface CollapseProps extends React.ComponentProps<'div'> {
     isOpen: boolean;
     onRest?: () => void;
 }
 
 declare class Collapse extends React.Component<CollapseProps, any> {}
 
-export default Collapse;
+export { Collapse };

--- a/packages/ffe-collapse-react/src/index.js
+++ b/packages/ffe-collapse-react/src/index.js
@@ -1,1 +1,1 @@
-export { default } from './Collapse';
+export { Collapse } from './Collapse';

--- a/packages/ffe-form-react/src/Tooltip.js
+++ b/packages/ffe-form-react/src/Tooltip.js
@@ -1,7 +1,7 @@
 import React, { useState, useRef } from 'react';
 import { bool, func, node, string, number } from 'prop-types';
 import classNames from 'classnames';
-import Collapse from '@sb1/ffe-collapse-react';
+import { Collapse } from '@sb1/ffe-collapse-react';
 import { v4 as uuid } from 'uuid';
 
 const Tooltip = React.forwardRef(


### PR DESCRIPTION
Dagens Collapse har en svaghet. Accordion har ett proplem som kom up på vår Slack. Det  går ikke att att legge til innehold dynasmisk.  Jag tror det skyldes att dagens Collpase bergener højden som skall animeras med javascript. 

```
 setHeight(`${content.current.scrollHeight}px`);
 ```
  Når man legger til nytt innehold så ær det forsatt denne bergenande højden som blir stående. 

Vi skall se om dette hjelper. Det er oansett en mye elagantare løsning med mye mindre kode synes jag. 
Bytta også fra default til named export for det er vel i stort sett det som er brukt andre steder. Det måtte oansett bli en breaking change pga av ny  markup. 

Det er vell denne jag bruker. 
https://caniuse.com/mdn-css_properties_grid-template-rows_animation