### PR TITLE
fix(component-overview): erstatter ikon som ikke lenger finnes

### DIFF
--- a/component-overview/examples/icons/Icon-ariahidden.jsx
+++ b/component-overview/examples/icons/Icon-ariahidden.jsx
@@ -1,5 +1,5 @@
 import { Icon } from '@sb1/ffe-icons-react';
-import checkOutlineIcon from '@sb1/ffe-icons/icons/open/300/md/check_circle_outline.svg';
+import checkOutlineIcon from '@sb1/ffe-icons/icons/open/300/md/check_circle.svg';
 
 
 () => {

--- a/component-overview/examples/icons/Icon-wrong-size.jsx
+++ b/component-overview/examples/icons/Icon-wrong-size.jsx
@@ -1,5 +1,5 @@
 import { Icon } from '@sb1/ffe-icons-react';
-import checkOutlineIcon from '@sb1/ffe-icons/icons/open/300/md/check_circle_outline.svg';
+import checkOutlineIcon from '@sb1/ffe-icons/icons/open/300/md/check_circle.svg';
 
 
 () => {

--- a/component-overview/examples/icons/Icon.jsx
+++ b/component-overview/examples/icons/Icon.jsx
@@ -1,5 +1,5 @@
 import { Icon } from '@sb1/ffe-icons-react';
-import checkOutlineIcon from '@sb1/ffe-icons/icons/open/300/md/check_circle_outline.svg';
+import checkOutlineIcon from '@sb1/ffe-icons/icons/open/300/md/check_circle.svg';
 
 
 () => {


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse
Circle_check_outline finnes ikke så erstatter det ikonet
<!-- Detaljert beskrivelse av endringene dine. Skjermskudd er lov. -->

## Motivasjon og kontekst
Forhåpentligvis retter det byggfeil med component-overview
<!-- Hvorfor trengs denne endringen, og hva løser den? -->

## Testing

<!-- Hvordan har du har testet endringene dine? Ta gjerne med systeminfo o.l -->

<!--

Helt til slutt, har du ..

.. lest retningslinjene våre for bidrag?
.. tatt en siste sjekk for kode og skrivefeil, debug informasjon o.l?
.. kjørt og eventuelt oppdatert testene?
.. kommentert og dokumentert det som trengs?
.. knyttet denne opp til relaterte issues?

-->
