### PR TITLE
Develop fix inputgroup text zoom

### DIFF
--- a/packages/ffe-form-react/src/InputGroup.js
+++ b/packages/ffe-form-react/src/InputGroup.js
@@ -123,16 +123,18 @@ const InputGroup = ({
 
             {modifiedChildren}
 
-            {typeof fieldMessage === 'string' && (
-                <ErrorFieldMessage element="p" id={fieldMessageId}>
-                    {fieldMessage}
-                </ErrorFieldMessage>
-            )}
-            {React.isValidElement(fieldMessage) &&
-                React.cloneElement(fieldMessage, {
-                    id: fieldMessageId,
-                })}
-            {fieldMessageReturn}
+            <div className="ffe-input-group__field-message">
+                {typeof fieldMessage === 'string' && (
+                    <ErrorFieldMessage element="p" id={fieldMessageId}>
+                        {fieldMessage}
+                    </ErrorFieldMessage>
+                )}
+                {React.isValidElement(fieldMessage) &&
+                    React.cloneElement(fieldMessage, {
+                        id: fieldMessageId,
+                    })}
+                {fieldMessageReturn}
+            </div>
         </div>
     );
 };

--- a/packages/ffe-form/less/input-group.less
+++ b/packages/ffe-form/less/input-group.less
@@ -1,6 +1,5 @@
 .ffe-input-group {
     border: 0;
-    padding: 0 0 @ffe-spacing-lg;
     position: relative;
 
     [aria-invalid='true'] {
@@ -25,7 +24,7 @@
 
     > * {
         margin-top: 0;
-        margin-bottom: @ffe-spacing-xs;
+        margin-bottom: var(--ffe-spacing-xs);
 
         &:nth-child(1) {
             margin-bottom: 0;
@@ -34,18 +33,22 @@
 
     .ffe-field-message--error {
         margin: 0;
-        height: 0;
     }
+
     &__description {
-        margin-bottom: @ffe-spacing-xs;
+        margin-bottom: var(--ffe-spacing-xs);
     }
 
     &--no-extra-margin {
         padding-bottom: 0;
 
         .ffe-field-message--error {
-            margin-bottom: @ffe-spacing-xs;
+            margin-bottom: var(--ffe-spacing-xs);
             height: initial;
         }
+    }
+
+    &__field-message {
+        min-height: 1lh;
     }
 }


### PR DESCRIPTION
Provar løsa fonskaleringproplematik på feilmeldninger. Dette er ett problem i alla inputgrupper, inklusive feedback https://github.com/SpareBank1/designsystem/issues/1835. Problemet er att dagen løsning lager padding under og feilmeldningen blir i prinsip absolut positionert der. Drar man upp fonten så ær paddingen. Det går nok ikke att bruke rem på paddingen under før vad hvis meldninen brekker på flere linjer. 

![image](https://github.com/SpareBank1/designsystem/assets/2248579/15feb228-1960-44a0-8556-cd916ef4da05)
![image](https://github.com/SpareBank1/designsystem/assets/2248579/81cde99e-f992-40c9-9e78-347b7fd463d4)

Det jag gjort istellet er att laga en wrapper med minhøjde som er lika høy som en rad av texten. Dette er ingen perfekt løsning hvis man har zoom og høja meldninger så vill ting flytta seg men trot allt vare fullt synlig. 

Jag tror dock dette funker bra før det man i utgangspunktet provade løsa. Korta meldniner som holder seg på en linje? 


Hvis dere tester med firefox så funker det muligens ikke trots att nyare versioner skal l funka.  Det er egentligen veldig bra support og dette er trots all en progressive enhancement.

Måtte endre markup. Breaking change?

https://caniuse.com/mdn-css_types_length_lh
![image](https://github.com/SpareBank1/designsystem/assets/2248579/9bb4b976-25bf-4550-bfac-1a1183834857)
