### PR TITLE
fix(ffe-form): fiks farge og størrelse på radio-knapp

### DIFF
--- a/packages/ffe-form/less/radio-button.less
+++ b/packages/ffe-form/less/radio-button.less
@@ -70,7 +70,7 @@
 
     &::before {
         background-color: var(--inner-circle-color);
-        width: 60%;
+        width: 50%;
         aspect-ratio: 1;
     }
 
@@ -99,6 +99,7 @@
 
     &:checked + .ffe-radio-button {
         --inner-circle-color: var(--ffe-g-primary-color);
+        --outer-circle-color: var(--ffe-g-primary-color);
     }
 
     &:focus-visible + .ffe-radio-button::after {


### PR DESCRIPTION
Det ble nylig gjort noe endring på styling for radio-buttons. Ser ut som det ble litt avvik fra design i figma på størrelse av sirkel i midten og farge på ringen rundt når knappen er valgt. Regner med at det ikke var tiltenkt.

Før:
![Screenshot 2024-04-16 at 13 25 12](https://github.com/SpareBank1/designsystem/assets/8751346/8b23d317-c43b-4f76-9843-3a7c1a81fe7c)

Etter:
![Screenshot 2024-04-16 at 13 26 16](https://github.com/SpareBank1/designsystem/assets/8751346/efdedd87-b31a-4029-be3f-4a5a7951c7bf)