### PR TITLE
Develop fix account selecto

### DIFF
--- a/component-overview/examples/account-selector/AccountSelector-accountNumberFormatting-off.jsx
+++ b/component-overview/examples/account-selector/AccountSelector-accountNumberFormatting-off.jsx
@@ -42,7 +42,6 @@ import { InputGroup } from '@sb1/ffe-form-react';
             selectedAccount={selectedAccount}
             formatAccountNumber={false}
             labelledById={label3}
-            ariaInvalid={false}
         />
     </InputGroup>);
 }

--- a/component-overview/examples/account-selector/AccountSelector-allowCustomAccount.jsx
+++ b/component-overview/examples/account-selector/AccountSelector-allowCustomAccount.jsx
@@ -42,7 +42,6 @@ import { InputGroup } from '@sb1/ffe-form-react';
                 selectedAccount={selectedAccount}
                 allowCustomAccount={true}
                 labelledById={label2}
-                ariaInvalid={false}
             />
         </InputGroup>
     );

--- a/component-overview/examples/account-selector/AccountSelector-customListDesign.jsx
+++ b/component-overview/examples/account-selector/AccountSelector-customListDesign.jsx
@@ -59,7 +59,6 @@ import { SmallText } from '@sb1/ffe-core-react';
                 selectedAccount={selectedAccount}
                 labelledById={label5}
                 listElementBody={CustomListElementBody}
-                ariaInvalid={false}
             />
         </InputGroup>
     )

--- a/component-overview/examples/account-selector/AccountSelector-doNotshowAccountDetails.jsx
+++ b/component-overview/examples/account-selector/AccountSelector-doNotshowAccountDetails.jsx
@@ -48,7 +48,6 @@ return (
         selectedAccount={selectedAccount}
         hideAccountDetails={true}
         labelledById={label2}
-        ariaInvalid={false}
     />
 </InputGroup>
 );

--- a/component-overview/examples/account-selector/AccountSelector-fieldMessage.jsx
+++ b/component-overview/examples/account-selector/AccountSelector-fieldMessage.jsx
@@ -4,9 +4,10 @@ import { InputGroup } from '@sb1/ffe-form-react';
 
 () => {
     const [selectedAccount, setSelectedAccount] = useState();
+
     const label1 = 'label1';
     return (
-        <InputGroup label="Velg konto" extraMargin={false} labelId={label1}>
+        <InputGroup label="Velg konto" extraMargin={false} labelId={label1} fieldMessage="Dette feltet er obligatorisk">
             <AccountSelector
                 accounts={[
                     {
@@ -33,29 +34,10 @@ import { InputGroup } from '@sb1/ffe-form-react';
                         currencyCode: 'NOK',
                         balance: 0,
                     },
-                    {
-                        accountNumber: '1234 56 789102',
-                        name: 'Brukskonto2',
-                        currencyCode: 'NOK',
-                        balance: 13337,
-                    },
-                    {
-                        accountNumber: '2234 56 789102',
-                        name: 'Sparekonto1',
-                        currencyCode: 'NOK',
-                        balance: 109236,
-                    },
-                    {
-                        accountNumber: '1253 47 789102',
-                        name: 'Sparekonto2',
-                        currencyCode: 'NOK',
-                        balance: 0,
-                    },
                 ]}
                 id="account-selector-single"
                 locale="nb"
                 labelledById={label1}
-                postListElement={<span>Some text describing the list</span>}
                 onAccountSelected={val => setSelectedAccount(val)}
                 onReset={() => setSelectedAccount(null)}
                 selectedAccount={selectedAccount}

--- a/component-overview/examples/account-selector/AccountSelector-showBalance.jsx
+++ b/component-overview/examples/account-selector/AccountSelector-showBalance.jsx
@@ -42,7 +42,6 @@ return (
         selectedAccount={selectedAccount}
         showBalance
         labelledById={label2}
-        ariaInvalid={false}
     />
 </InputGroup>
 );

--- a/component-overview/examples/account-selector/AccountSelector.jsx
+++ b/component-overview/examples/account-selector/AccountSelector.jsx
@@ -41,7 +41,6 @@ import { InputGroup } from '@sb1/ffe-form-react';
                 onAccountSelected={val => setSelectedAccount(val)}
                 onReset={() => setSelectedAccount(null)}
                 selectedAccount={selectedAccount}
-                ariaInvalid={false}
             />
         </InputGroup>
     );

--- a/packages/ffe-account-selector-react/less/account-suggestion-multi.less
+++ b/packages/ffe-account-selector-react/less/account-suggestion-multi.less
@@ -18,7 +18,8 @@
     margin: 0;
     background: var(--ffe-v-accountselector-option-primary-color);
     cursor: pointer;
-    padding: @ffe-spacing-xs @ffe-spacing-sm @ffe-spacing-xs @ffe-spacing-xs;
+    padding: var(--ffe-spacing-xs) var(--ffe-spacing-sm) var(--ffe-spacing-xs)
+        var(--ffe-spacing-xs);
     overflow: hidden;
     display: flex;
 
@@ -35,7 +36,7 @@
     &__nomatches {
         background: var(--ffe-v-accountselector-option-primary-color);
         color: var(--ffe-g-lead-color);
-        padding: @ffe-spacing-sm;
+        padding: var(--ffe-spacing-sm);
         cursor: default;
     }
 
@@ -43,7 +44,7 @@
         line-height: 1;
         font-size: 1rem;
         display: block;
-        padding-bottom: @ffe-spacing-2xs;
+        padding-bottom: var(--ffe-spacing-2xs);
         color: var(--ffe-g-lead-color);
     }
 

--- a/packages/ffe-account-selector-react/less/account-suggestion-single.less
+++ b/packages/ffe-account-selector-react/less/account-suggestion-single.less
@@ -2,7 +2,8 @@
     margin: 0;
     background: var(--ffe-v-accountselector-option-primary-color);
     cursor: pointer;
-    padding: @ffe-spacing-xs @ffe-spacing-sm @ffe-spacing-xs @ffe-spacing-md;
+    padding: var(--ffe-spacing-xs) var(--ffe-spacing-sm) var(--ffe-spacing-xs)
+        var(--ffe-spacing-md);
 
     @media (hover: hover) and (pointer: fine) {
         &:hover {
@@ -30,7 +31,7 @@
         line-height: 1;
         font-size: 1rem;
         display: block;
-        padding-bottom: @ffe-spacing-2xs;
+        padding-bottom: var(--ffe-spacing-2xs);
         color: var(--ffe-g-lead-color);
     }
 

--- a/packages/ffe-account-selector-react/less/base-selector.less
+++ b/packages/ffe-account-selector-react/less/base-selector.less
@@ -8,7 +8,7 @@
         text-overflow: ellipsis;
         white-space: nowrap;
         overflow: hidden;
-        padding-right: @ffe-spacing-3xl;
+        padding-right: var(--ffe-spacing-3xl);
         &::-ms-clear {
             display: none;
         }
@@ -16,7 +16,7 @@
 
     &__expand-button {
         position: absolute;
-        padding: 0 @ffe-spacing-2xs;
+        padding: 0 var(--ffe-spacing-2xs);
         background: transparent;
         border: none;
         cursor: pointer;
@@ -50,7 +50,7 @@
     &__reset-button {
         position: absolute;
         z-index: 1;
-        padding: 0 @ffe-spacing-2xs;
+        padding: 0 var(--ffe-spacing-2xs);
         background: transparent;
         border: none;
         cursor: pointer;

--- a/packages/ffe-account-selector-react/less/ffe-account-selector-multi.less
+++ b/packages/ffe-account-selector-react/less/ffe-account-selector-multi.less
@@ -1,5 +1,3 @@
-@details-height: 32px;
-
 .ffe-account-selector-multi-container {
     /*
      * Disables margin collapse, which allows styling based on
@@ -12,24 +10,26 @@
     @import 'base-selector';
     @import 'account-suggestion-multi';
 
+    --details-height: var(--ffe-spacing-lg);
+
     position: relative;
     display: block;
 
     &--with-space-for-details {
-        margin-bottom: @details-height;
+        margin-bottom: var(--details-height);
     }
 
     &__details {
-        padding: @ffe-spacing-2xs;
+        padding: var(--ffe-spacing-2xs);
         color: var(--ffe-v-accountselector-text-color);
-        min-height: @details-height;
+        min-height: var(--details-height);
         display: flex;
         justify-content: space-between;
     }
 
     &__dropdown-statusbar {
         border: 1px solid var(--ffe-g-border-color);
-        padding: @ffe-spacing-xs;
+        padding: var(--ffe-spacing-xs);
         background: var(
             --ffe-v-accountselector-dropdown-statusbar-background-color
         );

--- a/packages/ffe-account-selector-react/less/ffe-account-selector-single.less
+++ b/packages/ffe-account-selector-react/less/ffe-account-selector-single.less
@@ -1,28 +1,18 @@
-@details-height: 32px;
-
-.ffe-account-selector-single-container {
-    /*
-     * Disables margin collapse, which allows styling based on
-     * withSpaceForDetails even when AccountSelector is wrapped in InputGroup
-     */
-    padding: 0.05px;
-}
-
 .ffe-account-selector-single {
     @import 'account-suggestion-single';
 
     position: relative;
     display: block;
 
-    &--with-space-for-details {
-        margin-bottom: @details-height;
-    }
-
     &__details {
-        padding: @ffe-spacing-2xs;
+        padding: var(--ffe-spacing-2xs) var(--ffe-spacing-2xs) 0;
         color: var(--ffe-v-accountselector-text-color);
-        min-height: @details-height;
+        min-height: calc(1lh);
         display: flex;
         justify-content: space-between;
+    }
+
+    &__details--invalid-empty {
+        display: none;
     }
 }

--- a/packages/ffe-account-selector-react/src/components/account-selector/AccountSelector.js
+++ b/packages/ffe-account-selector-react/src/components/account-selector/AccountSelector.js
@@ -31,9 +31,9 @@ export const AccountSelector = ({
     inputProps,
     formatAccountNumber,
     ariaInvalid,
-    withSpaceForDetails,
     onOpen,
     onClose,
+    ...rest
 }) => {
     return (
         <BaseAccountSelector
@@ -44,7 +44,7 @@ export const AccountSelector = ({
             locale={locale}
             listElementBody={listElementBody}
             postListElement={postListElement}
-            ariaInvalid={ariaInvalid}
+            ariaInvalid={ariaInvalid ?? rest['aria-invalid']}
             selectedAccount={selectedAccount}
             onOpen={onOpen}
             onClose={onClose}
@@ -56,7 +56,6 @@ export const AccountSelector = ({
             allowCustomAccount={allowCustomAccount}
             onReset={onReset}
             formatAccountNumber={formatAccountNumber}
-            withSpaceForDetails={withSpaceForDetails}
         >
             {props => <SearchableDropdown {...props} />}
         </BaseAccountSelector>
@@ -110,7 +109,7 @@ AccountSelector.propTypes = {
     /** Default true. */
     formatAccountNumber: bool,
     /** Sets aria-invalid on input field  */
-    ariaInvalid: oneOfType([string, bool]).isRequired,
+    ariaInvalid: oneOfType([string, bool]),
     /** Defines if you should save space for account details that is shown when an account is selected */
     withSpaceForDetails: bool,
     onClose: func,

--- a/packages/ffe-account-selector-react/src/components/account-selector/BaseAccountSelector.js
+++ b/packages/ffe-account-selector-react/src/components/account-selector/BaseAccountSelector.js
@@ -52,7 +52,6 @@ export const BaseAccountSelector = ({
     inputProps,
     formatAccountNumber = true,
     ariaInvalid,
-    withSpaceForDetails = true,
     onOpen,
     onClose,
     children,
@@ -127,53 +126,45 @@ export const BaseAccountSelector = ({
         : accounts;
 
     return (
-        <div className="ffe-account-selector-single-container">
-            <div
-                className={classNames(
-                    'ffe-account-selector-single',
-                    {
-                        'ffe-account-selector-single--with-space-for-details':
-                            !selectedAccount && withSpaceForDetails,
-                    },
-                    className,
-                )}
-                id={`${id}-account-selector-container`}
-            >
-                {children({
-                    id,
-                    labelledById,
-                    inputProps: {
-                        ...inputProps,
-                        onChange: onInputChange,
-                    },
-                    dropdownAttributes,
-                    postListElement,
-                    dropdownList,
-                    noMatch: customNoMatch,
-                    formatter,
-                    onChange: handleAccountSelected,
-                    searchAttributes: ['name', 'accountNumber'],
-                    locale,
-                    listElementBody: listElementBody || AccountSuggestionSingle,
-                    ariaInvalid,
-                    searchMatcher: searchMatcherIgnoringAccountNumberFormatting,
-                    selectedItem: selectedAccount,
-                    onOpen,
-                    onClose,
-                })}
-                {!hideAccountDetails && selectedAccount && (
-                    <AccountDetails
-                        account={selectedAccount}
-                        locale={locale}
-                        showBalance={
-                            showBalance &&
-                            ['string', 'number'].includes(
-                                typeof selectedAccount.balance,
-                            )
-                        }
-                    />
-                )}
-            </div>
+        <div
+            className={classNames('ffe-account-selector-single', className)}
+            id={`${id}-account-selector-container`}
+        >
+            {children({
+                id,
+                labelledById,
+                inputProps: {
+                    ...inputProps,
+                    onChange: onInputChange,
+                },
+                dropdownAttributes,
+                postListElement,
+                dropdownList,
+                noMatch: customNoMatch,
+                formatter,
+                onChange: handleAccountSelected,
+                searchAttributes: ['name', 'accountNumber'],
+                locale,
+                listElementBody: listElementBody || AccountSuggestionSingle,
+                ariaInvalid,
+                searchMatcher: searchMatcherIgnoringAccountNumberFormatting,
+                selectedItem: selectedAccount,
+                onOpen,
+                onClose,
+            })}
+            {!hideAccountDetails && (
+                <AccountDetails
+                    ariaInvalid={ariaInvalid}
+                    account={selectedAccount}
+                    locale={locale}
+                    showBalance={
+                        showBalance &&
+                        ['string', 'number'].includes(
+                            typeof selectedAccount?.balance,
+                        )
+                    }
+                />
+            )}
         </div>
     );
 };
@@ -225,11 +216,9 @@ BaseAccountSelector.propTypes = {
     /** Props passed to the input field */
     inputProps: shape(),
     /** Sets aria-invalid on input field  */
-    ariaInvalid: oneOfType([string, bool]).isRequired,
+    ariaInvalid: oneOfType([string, bool]),
     /** Default true. */
     formatAccountNumber: bool,
-    /** Defines if you should save space for account details that is shown when an account is selected */
-    withSpaceForDetails: bool,
     /** Prop passed to the dropdown list */
     onClose: func,
     /** Prop passed to the dropdown list */

--- a/packages/ffe-account-selector-react/src/index.d.ts
+++ b/packages/ffe-account-selector-react/src/index.d.ts
@@ -36,8 +36,7 @@ export interface AccountSelectorProps<T extends Account = Account> {
     allowCustomAccount?: boolean;
     listElementBody?: (props: ListElementBodyProps<T>) => React.ReactElement;
     postListElement?: React.ReactNode;
-    withSpaceForDetails?: boolean;
-    ariaInvalid: boolean;
+    ariaInvalid?: boolean;
     onOpen?: () => void;
     onClose?: () => void;
 }

--- a/packages/ffe-account-selector-react/src/subcomponents/account-selector-single/AccountDetails.js
+++ b/packages/ffe-account-selector-react/src/subcomponents/account-selector-single/AccountDetails.js
@@ -1,29 +1,45 @@
 import React from 'react';
-import { bool } from 'prop-types';
-
+import { bool, oneOfType, string } from 'prop-types';
 import { accountFormatter, balanceWithCurrency } from '../../util/format';
 import { Account, Locale } from '../../util/types';
+import classnames from 'classnames';
 
-function AccountDetails({ account, locale, showBalance = true }) {
-    const { balance, accountNumber, currencyCode } = account;
+function AccountDetails({ account, locale, showBalance = true, ariaInvalid }) {
+    const { balance, accountNumber, currencyCode } = account ?? {};
+    const isInvalidWithNoAccount =
+        !account && (ariaInvalid === 'true' || ariaInvalid === true);
+
     return (
-        <div className="ffe-small-text ffe-account-selector-single__details">
-            <div className="ffe-account-selector-single__details--left">
-                {accountFormatter(accountNumber)}
-            </div>
-            {showBalance && (
-                <div className="ffe-account-selector-single__details--right">
-                    {balanceWithCurrency(balance, locale, currencyCode)}
-                </div>
+        <div
+            className={classnames(
+                'ffe-small-text',
+                'ffe-account-selector-single__details',
+                {
+                    'ffe-account-selector-single__details--invalid-empty': isInvalidWithNoAccount,
+                },
+            )}
+        >
+            {account && (
+                <>
+                    <div className="ffe-account-selector-single__details--left">
+                        {accountFormatter(accountNumber)}
+                    </div>
+                    {showBalance && (
+                        <div className="ffe-account-selector-single__details--right">
+                            {balanceWithCurrency(balance, locale, currencyCode)}
+                        </div>
+                    )}
+                </>
             )}
         </div>
     );
 }
 
 AccountDetails.propTypes = {
-    account: Account.isRequired,
+    account: Account,
     locale: Locale.isRequired,
     showBalance: bool,
+    ariaInvalid: oneOfType([string, bool]),
 };
 
 export default AccountDetails;


### PR DESCRIPTION
Ordne spacing og feildninger i AccountSelector

## Beskrivelse

Gjelder denne saken https://github.com/SpareBank1/designsystem/issues/1913. AccountSelecot ble aldrig heller satt til aria-invalid så man fikk aldrig den røda fergen. inputGroup sender "aria-invalid" og ikke ariaInvalid så støttar begge. 

Efter fiks
![image](https://github.com/SpareBank1/designsystem/assets/2248579/b6865231-92ba-4dc4-b996-57bbc658a42f)
![image](https://github.com/SpareBank1/designsystem/assets/2248579/eee74a04-7f56-4ef9-a940-2c7c838658c1)
![image](https://github.com/SpareBank1/designsystem/assets/2248579/4b587d8c-f880-469c-83d2-06c426391555)


