### PR TITLE
fix(ffe-system-message-react): SystemMessageProps now extends React.C…

### DIFF
--- a/packages/ffe-system-message-react/src/index.d.ts
+++ b/packages/ffe-system-message-react/src/index.d.ts
@@ -1,12 +1,11 @@
 import * as React from 'react';
 
-export interface SystemMessageProps {
+export interface SystemMessageProps
+    extends React.ComponentPropsWithoutRef<'div'> {
     animationLengthMs?: number;
-    children: React.ReactNode;
-    className?: string;
     icon?: React.ReactNode;
     locale?: 'en' | 'nb' | 'nn';
-    onClose?: (e: React.MouseEvent | undefined) => void;
+    onClose?: React.MouseEventHandler<HTMLButtonElement>;
     onColoredBg?: boolean;
 }
 


### PR DESCRIPTION
…omponentProps<'div'>

<!-- Gi saken en oppsummerende tittel ovenfor. -->

La til extends React.ComponentProps<'div'> for at man skal kunne ha JSX elementer inni. 

<!-- Detaljert beskrivelse av endringene dine. Skjermskudd er lov. -->

## Testing

Testet lokalt