### PR TITLE
fix(ffe-form): stabler telefon-inputs over hverandre på små skjermer

### DIFF
--- a/packages/ffe-form/less/phone-number.less
+++ b/packages/ffe-form/less/phone-number.less
@@ -1,5 +1,11 @@
 .ffe-phone-number {
     &__input-group {
+        @media (min-width: @breakpoint-sm) {
+            display: flex;
+        }
+    }
+
+    &__country-code &__input-group {
         display: flex;
     }
 
@@ -11,13 +17,20 @@
             white-space: nowrap;
             margin-right: @ffe-spacing-xs;
         }
+
+        @media (max-width: (@breakpoint-sm - 1)) {
+            margin-bottom: var(--ffe-spacing-sm);
+        }
     }
 
     &__country-code-input {
-        max-width: 60px;
         border-top-left-radius: 0;
         border-bottom-left-radius: 0;
-        margin-right: @ffe-spacing-sm;
+
+        @media (min-width: @breakpoint-sm) {
+            max-width: 4rem;
+            margin-right: var(--ffe-spacing-sm);
+        }
     }
 
     &__plus {
@@ -30,6 +43,8 @@
         border-right: 0;
         transition: all @ffe-transition-duration @ffe-ease;
         color: var(--ffe-v-input-color);
+        display: flex;
+        align-items: center;
     }
 
     &__number {


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse

Inputene for landskode og telefonnummer stables i høyden på små skjermer, for å unngå overflow-issues ved zoom og tekstskalering.

Før:
![image](https://github.com/SpareBank1/designsystem/assets/463847/5ce5009c-e94c-4f18-a609-a74fcd22e415)


Etter: 
![image](https://github.com/SpareBank1/designsystem/assets/463847/24f09ac3-12ee-494f-9ef5-906c84c2d1d9)


## Motivasjon og kontekst

Fixes #1731 

## Testing

Testet i component-overview