### PR TITLE
fix(ffe-message-box): change title font size to rem from px

### DIFF
--- a/packages/ffe-message-box/less/message-box.less
+++ b/packages/ffe-message-box/less/message-box.less
@@ -41,8 +41,8 @@
     }
 
     &__box {
-        padding: @ffe-spacing-xl @ffe-spacing-lg;
-        border-radius: @ffe-spacing-xs;
+        padding: var(--ffe-spacing-xl) var(--ffe-spacing-lg);
+        border-radius: var(--ffe-spacing-xs);
         color: var(--ffe-farge-svart);
         .native & {
             @media (prefers-color-scheme: dark) {
@@ -105,8 +105,8 @@
 
     &__title {
         color: var(--ffe-farge-svart);
-        font-size: 18px;
-        margin-bottom: @ffe-spacing-sm;
+        font-size: var(--ffe-fontsize-h5);
+        margin-bottom: var(--ffe-spacing-sm);
         margin-top: 0;
         .native & {
             @media (prefers-color-scheme: dark) {
@@ -117,7 +117,7 @@
     }
 
     &__list {
-        padding-left: @ffe-spacing-sm;
+        padding-left: var(--ffe-spacing-sm);
         margin: 0;
         line-height: 2;
         text-align: left;


### PR DESCRIPTION

<!-- Gi saken en oppsummerende tittel ovenfor. -->
## Beskrivelse
Endrer tekststørrelsen for tittel i messageBox til å bruke rem istedenfor pixler.
Endrer også noen variabler fra å være less til CSS variabler. 

<!-- Detaljert beskrivelse av endringene dine. Skjermskudd er lov. -->

## Motivasjon og kontekst
Retter feil med tekstforstørrelse

Før:
![Skjermbilde 2024-04-24 kl  17 21 56](https://github.com/SpareBank1/designsystem/assets/39946146/ee6bad9a-4b5e-4e2f-b371-dd8aa6f5857b)

Etter: 
![Skjermbilde 2024-04-24 kl  17 24 00](https://github.com/SpareBank1/designsystem/assets/39946146/ecf02d7a-34e5-451f-bb07-8e4c651dc484)

<!-- Hvorfor trengs denne endringen, og hva løser den? -->

## Testing

<!-- Hvordan har du har testet endringene dine? Ta gjerne med systeminfo o.l -->

<!--

Helt til slutt, har du ..

.. lest retningslinjene våre for bidrag?
.. tatt en siste sjekk for kode og skrivefeil, debug informasjon o.l?
.. kjørt og eventuelt oppdatert testene?
.. kommentert og dokumentert det som trengs?
.. knyttet denne opp til relaterte issues?

-->
