### PR TITLE
Develop fix donut

### DIFF
--- a/component-overview/examples/chart-donut/ChartDonut-customLabel.jsx
+++ b/component-overview/examples/chart-donut/ChartDonut-customLabel.jsx
@@ -6,7 +6,8 @@ import ChartDonut from '@sb1/ffe-chart-donut-react';
             style={{
                 marginTop: 10,
                 textAlign: 'center',
-                width: '100%',
+                width: '70%',
+                margin: '0 auto',
             }}
         >
             Du har selv ansvar

--- a/packages/ffe-chart-donut-react/less/chart-donut.less
+++ b/packages/ffe-chart-donut-react/less/chart-donut.less
@@ -1,8 +1,11 @@
 .ffe-chart-donut {
-    height: 200px;
+    display: grid;
+    width: fit-content;
+    grid-template-columns: auto;
+    grid-template-rows: auto;
+    place-items: center;
     position: relative;
     text-align: left;
-    width: 200px;
 
     &--first {
         stroke: var(--ffe-v-chart-donut-first-color);
@@ -12,27 +15,19 @@
         stroke: var(--ffe-v-chart-donut-last-color);
     }
 
-    &__circle {
-        height: 100%;
-        margin: 0 auto;
-        position: absolute;
-        width: 100%;
+    &__circle,
+    &__description {
+        grid-column: 1/1;
+        grid-row: 1/1;
+    }
 
-        @media (min-width: @breakpoint-md) {
-            margin: inherit;
-            width: 200px;
-        }
+    &__circle {
+        width: 12.5rem;
+        aspect-ratio: 1;
     }
 
     &__description {
-        left: calc(~'50% - 75px');
-        position: absolute;
-        top: 60px;
-        width: 150px;
-
-        @media (min-width: @breakpoint-md) {
-            left: 25px;
-        }
+        z-index: 1;
     }
 
     &__name {
@@ -41,31 +36,35 @@
     }
 
     &__fractions {
-        display: flex;
-        justify-content: space-around;
+        display: grid;
+        grid-template-columns: auto 1px auto;
+        grid-template-rows: auto auto;
+        grid-column-gap: var(--ffe-spacing-xs);
+        &:after {
+            grid-column: 2/3;
+            grid-row: 1/2;
+            display: flex;
+            background: var(--ffe-v-chart-donut-text-color);
+            height: 1lh;
+            content: '';
+        }
     }
 
     &__fraction {
-        > .ffe-chart-donut__amount {
-            color: var(--ffe-v-chart-donut-text-color);
-            text-align: center;
-        }
+        display: grid;
+        place-items: center;
+    }
 
-        &:last-child {
-            > .ffe-chart-donut__type {
-                padding-left: 20px;
-            }
+    .ffe-chart-donut__amount {
+        color: var(--ffe-v-chart-donut-text-color);
+    }
 
-            > .ffe-chart-donut__amount {
-                border-left: 1px solid var(--ffe-farge-graa);
-                padding-left: 20px;
-
-                .native & {
-                    @media (prefers-color-scheme: dark) {
-                        color: var(--ffe-v-chart-donut-text-color);
-                    }
-                }
-            }
-        }
+    &__fraction:first-of-type {
+        grid-column: 1/2;
+        grid-row: 1/3;
+    }
+    &__fraction:last-of-type {
+        grid-column: 3/4;
+        grid-row: 1/3;
     }
 }


### PR DESCRIPTION
Fikser: https://github.com/SpareBank1/designsystem/issues/1841

Vi kanskje skulle deprecata denne men ordner textzzom slik att det funker iaf. Nu vokser hele donuten når man textzoomer. Det må ju bare bedre en det var iaf. Man vill få scroll i sidled på små skjermar men det får man idag også hvis det ikke er plats så det er ingen ny opførsel