### PR TITLE
fix(ffe-accordion-react): use context for accordion item props

### DIFF
--- a/packages/ffe-accordion-react/src/Accordion.js
+++ b/packages/ffe-accordion-react/src/Accordion.js
@@ -1,21 +1,20 @@
 import React from 'react';
 import { node, oneOf, string } from 'prop-types';
 import classNames from 'classnames';
+import { AccordionProvider } from './AccordionContext';
 
-const Accordion = ({ children, headingLevel, className, ...rest }) => {
+export const Accordion = ({ children, headingLevel, className, ...rest }) => {
     return (
-        <div
-            className={classNames(className, 'ffe-accordion')}
-            role="group"
-            aria-label="Trekkspillmeny"
-            {...rest}
-        >
-            {React.Children.map(children, (child, index) => {
-                return React.cloneElement(child, {
-                    headingLevel,
-                });
-            })}
-        </div>
+        <AccordionProvider headingLevel={headingLevel}>
+            <div
+                className={classNames(className, 'ffe-accordion')}
+                role="group"
+                aria-label="Trekkspillmeny"
+                {...rest}
+            >
+                {children}
+            </div>
+        </AccordionProvider>
     );
 };
 
@@ -27,5 +26,3 @@ Accordion.propTypes = {
     /** Class assigned the container */
     className: string,
 };
-
-export default Accordion;

--- a/packages/ffe-accordion-react/src/Accordion.spec.js
+++ b/packages/ffe-accordion-react/src/Accordion.spec.js
@@ -1,5 +1,5 @@
-import Accordion from './Accordion';
-import AccordionItem from './AccordionItem';
+import { Accordion } from './Accordion';
+import { AccordionItem } from './AccordionItem';
 import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
 

--- a/packages/ffe-accordion-react/src/AccordionContext.js
+++ b/packages/ffe-accordion-react/src/AccordionContext.js
@@ -1,0 +1,17 @@
+import React, { createContext } from 'react';
+import { node, oneOf } from 'prop-types';
+
+export const AccordionContext = createContext({});
+
+export const AccordionProvider = ({ children, headingLevel }) => {
+    return (
+        <AccordionContext.Provider value={{ headingLevel }}>
+            {children}
+        </AccordionContext.Provider>
+    );
+};
+
+AccordionProvider.propTypes = {
+    children: node,
+    headingLevel: oneOf([1, 2, 3, 4, 5, 6]).isRequired,
+};

--- a/packages/ffe-accordion-react/src/AccordionItem.js
+++ b/packages/ffe-accordion-react/src/AccordionItem.js
@@ -1,11 +1,12 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState, useContext } from 'react';
 import { bool, func, node, string } from 'prop-types';
 import { v4 as uuid } from 'uuid';
 import { Icon } from '@sb1/ffe-icons-react';
 import { Collapse } from '@sb1/ffe-collapse-react';
 import classNames from 'classnames';
+import { AccordionContext } from './AccordionContext';
 
-const AccordionItem = ({
+export const AccordionItem = ({
     children,
     heading,
     defaultOpen,
@@ -13,13 +14,14 @@ const AccordionItem = ({
     className,
     onToggleOpen = Function.prototype,
     ariaLabel,
-    ...accordionProps
+    ...rest
 }) => {
     const [isExpanded, setIsExpanded] = useState(defaultOpen);
     const [isAnimating, setIsAnimating] = useState(false);
     const [isFocused, setFocus] = useState(false);
     const buttonId = useRef(uuid());
     const contentId = useRef(uuid());
+    const { headingLevel } = useContext(AccordionContext);
 
     const expandMoreIcon =
         'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGhlaWdodD0iMjQiIHZpZXdCb3g9IjAgLTk2MCA5NjAgOTYwIiB3aWR0aD0iMjQiPjxwYXRoIGQ9Ik00ODAtMzczLjUzOXEtNy4yMzEgMC0xMy40NjEtMi4zMDgtNi4yMzEtMi4zMDgtMTEuODQ2LTcuOTIzTDI3NC45MjQtNTYzLjUzOXEtOC4zMDgtOC4zMDctOC41LTIwLjg4NC0uMTkzLTEyLjU3NyA4LjUtMjEuMjY5IDguNjkyLTguNjkyIDIxLjA3Ni04LjY5MnQyMS4wNzYgOC42OTJMNDgwLTQ0Mi43NjhsMTYyLjkyNC0xNjIuOTI0cTguMzA3LTguMzA3IDIwLjg4NC04LjUgMTIuNTc2LS4xOTIgMjEuMjY4IDguNSA4LjY5MyA4LjY5MiA4LjY5MyAyMS4wNzcgMCAxMi4zODQtOC42OTMgMjEuMDc2TDUwNS4zMDctMzgzLjc3cS01LjYxNSA1LjYxNS0xMS44NDYgNy45MjMtNi4yMyAyLjMwOC0xMy40NjEgMi4zMDhaIi8+PC9zdmc+';
@@ -39,8 +41,6 @@ const AccordionItem = ({
         }
     };
 
-    const { headingLevel, forwardedRef, ...rest } = accordionProps;
-
     const collapseHidden = !isExpanded && !isAnimating;
 
     const H = `h${headingLevel}`;
@@ -57,7 +57,6 @@ const AccordionItem = ({
                 <button
                     type="button"
                     id={buttonId.current}
-                    ref={forwardedRef}
                     aria-expanded={isExpanded ? 'true' : 'false'}
                     aria-controls={contentId.current}
                     aria-label={ariaLabel}
@@ -116,7 +115,3 @@ AccordionItem.propTypes = {
     /** aria-label for the button */
     ariaLabel: string,
 };
-
-export default React.forwardRef((props, ref) => {
-    return <AccordionItem {...props} forwardedRef={ref} />;
-});

--- a/packages/ffe-accordion-react/src/index.d.ts
+++ b/packages/ffe-accordion-react/src/index.d.ts
@@ -1,6 +1,7 @@
 import * as React from 'react';
 
-export interface AccordionItemProps extends React.HTMLProps<HTMLDivElement> {
+export interface AccordionItemProps
+    extends React.ComponentPropsWithoutRef<'div'> {
     heading: string | React.ReactElement;
     defaultOpen?: boolean;
     isOpen?: boolean;
@@ -8,7 +9,7 @@ export interface AccordionItemProps extends React.HTMLProps<HTMLDivElement> {
     ariaLabel?: string;
 }
 
-export interface AccordionProps extends React.HTMLProps<HTMLDivElement> {
+export interface AccordionProps extends React.ComponentPropsWithoutRef<'div'> {
     children:
         | (React.ReactElement<AccordionItemProps> | null)[]
         | React.ReactElement<AccordionItemProps>;

--- a/packages/ffe-accordion-react/src/index.js
+++ b/packages/ffe-accordion-react/src/index.js
@@ -1,2 +1,2 @@
-export { default as Accordion } from './Accordion';
-export { default as AccordionItem } from './AccordionItem';
+export { Accordion } from './Accordion';
+export { AccordionItem } from './AccordionItem';


### PR DESCRIPTION
Sett denne `hundefined` 1000 ganger nå tror jag. Tenker er en context vill løsa det problemet. 

![image](https://github.com/SpareBank1/designsystem/assets/2248579/a0752efe-a2f2-41de-9aa9-679257a9f611)
