### PR TITLE
fix(component-overview): use correct language

### DIFF
--- a/component-overview/webapp/index.html
+++ b/component-overview/webapp/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="no-NB">
+<html lang="nb">
     <head>
         <meta charset="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />


### PR DESCRIPTION
Fikk beskjed av wave att lang som vi bruker ikke er gylig. Har vell inget og si kan man tenkte men merket faktisk forskjell når den brekker ord.. bruker hypens osv.  Nu bruker jag samma som SB1 har på opne sidor