### PR TITLE
fix(ffe-collapse-react): remove overflow hidden when expanden

### DIFF
--- a/packages/ffe-collapse-react/less/collapse.less
+++ b/packages/ffe-collapse-react/less/collapse.less
@@ -16,3 +16,7 @@
 .ffe-collapse__inner {
     overflow: hidden;
 }
+
+.ffe-collapse__inner.ffe-collapse__inner--visible {
+    overflow: visible;
+}


### PR DESCRIPTION
Opdaget en liten bugg. Man må fjerne overflow hidden når animasjonen er klar eftersom man kan ha dropdownmenyer, datepciker og mye annet i disse collapsen