### PR TITLE
fix(ffe-core): tvinger default font-size i safari til 16px

### DIFF
--- a/packages/ffe-core/less/ffe-normalize.less
+++ b/packages/ffe-core/less/ffe-normalize.less
@@ -16,5 +16,6 @@ html,
     :root,
     :host {
         font: -apple-system-body;
+        font-size: 100%;
     }
 }


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse

Spesifiserer default font-størrelse i `-apple-system-body` til `100%`. Dette gjør at default tekststørrelse er 16px i Safari. Andre browsere arver allerede 16px fra andre selectorer.

## Motivasjon og kontekst

Fixes #1948 

## Testing

Testet ok i component-overview med Safari, Chrome og Edge