### PR TITLE
fix(ffe-datepicker-react): make autofocus optional calendar

### DIFF
--- a/packages/ffe-datepicker-react/src/calendar/Calendar.js
+++ b/packages/ffe-datepicker-react/src/calendar/Calendar.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { func, string } from 'prop-types';
+import { func, string, bool } from 'prop-types';
 import { v4 as uuid } from 'uuid';
 import ClickableDate from './ClickableDate';
 import NonClickableDate from './NonClickableDate';
@@ -179,6 +179,7 @@ export default class Calendar extends Component {
                 language={this.props.language}
                 dateButtonRef={date.isFocus ? this.clickableDateRef : undefined}
                 isFocusingHeader={this.state.isFocusingHeader}
+                focusOnMount={this.props.focusOnMount}
             />
         );
     }
@@ -295,4 +296,5 @@ Calendar.propTypes = {
     onBlurHandler: func,
     onDatePicked: func.isRequired,
     selectedDate: string,
+    focusOnMount: bool,
 };

--- a/packages/ffe-datepicker-react/src/calendar/ClickableDate.js
+++ b/packages/ffe-datepicker-react/src/calendar/ClickableDate.js
@@ -12,7 +12,9 @@ import classNames from 'classnames';
 
 export default class ClickableDate extends Component {
     componentDidMount() {
-        this.focusIfNeeded();
+        if (this.props.focusOnMount) {
+            this.focusIfNeeded();
+        }
     }
 
     componentDidUpdate() {
@@ -92,4 +94,5 @@ ClickableDate.propTypes = {
     language: string.isRequired,
     dateButtonRef: object,
     isFocusingHeader: bool.isRequired,
+    focusOnMount: bool,
 };

--- a/packages/ffe-datepicker-react/src/datepicker/Datepicker.js
+++ b/packages/ffe-datepicker-react/src/datepicker/Datepicker.js
@@ -219,7 +219,9 @@ export default class Datepicker extends Component {
 
     datePickedHandler(date) {
         this.props.onChange(date);
-        this.props.onValidationComplete(date);
+        if (this.props.onValidationComplete) {
+            this.props.onValidationComplete(date);
+        }
         this.removeGlobalEventListeners();
         this.setState(
             {
@@ -366,6 +368,7 @@ export default class Datepicker extends Component {
                             ref={c => {
                                 this.datepickerCalendar = c;
                             }}
+                            focusOnMount={true}
                         />
                     )}
                 </div>


### PR DESCRIPTION
Fixes https://github.com/SpareBank1/designsystem/issues/1345 

...og en liten feil som ble inført når defaultPropTypes ble fjernet. 