### PR TITLE
chore: replace-pretty quick with lint-staged

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-npx --no -- pretty-quick --staged
+npx --no -- lint-staged

--- a/package.json
+++ b/package.json
@@ -24,6 +24,11 @@
         "lerna": "lerna",
         "prepare": "husky install"
     },
+    "lint-staged": {
+        "{packages,buildtool,component-overview,linting}/**/*.{js,jsx,ts,tsx,json,css,less,md}": [
+            "prettier --write"
+        ]
+    },
     "devDependencies": {
         "@commitlint/cli": "^16.1.0",
         "@commitlint/config-conventional": "^16.0.0",
@@ -38,10 +43,10 @@
         "eslint-plugin-prettier": "^5.1.3",
         "husky": "^7.0.4",
         "lerna": "^5.5.1",
+        "lint-staged": "^15.2.2",
         "mkdirp": "^1.0.4",
         "npm-run-all": "^4.1.5",
         "prettier": "^3.2.5",
-        "pretty-quick": "^4.0.0",
         "react": "^16.9.0",
         "react-dom": "^16.9.0",
         "regenerator-runtime": "^0.13.2",


### PR DESCRIPTION
Pretty-quick er ikke vedlikholt lenger og virker ikke med version 3 av prettier