### PR TITLE
Endre basecard så det også funker som ikke-klikkbart element

### DIFF
--- a/component-overview/examples/cards/CardBase-ikke-klikkbart.jsx
+++ b/component-overview/examples/cards/CardBase-ikke-klikkbart.jsx
@@ -1,0 +1,3 @@
+import { CardBase } from '@sb1/ffe-cards-react';
+
+<CardBase element='div' bgColor="syrin-30">Dette er ett ikke-klikkbart kort</CardBase>

--- a/packages/ffe-cards-react/src/CardBase.js
+++ b/packages/ffe-cards-react/src/CardBase.js
@@ -1,12 +1,36 @@
 import React from 'react';
 import classNames from 'classnames';
-import { oneOfType, node, func, string, elementType } from 'prop-types';
+import {
+    oneOfType,
+    node,
+    func,
+    string,
+    elementType,
+    bool,
+    oneOf,
+} from 'prop-types';
 
 const CardBase = React.forwardRef((props, ref) => {
-    const { className, element: Element = 'a', children, ...rest } = props;
+    const {
+        className,
+        element: Element = 'a',
+        bgColor,
+        bgDarkmodeColor,
+        shadow = false,
+        noMargin = false,
+        textCenter = false,
+        children,
+        ...rest
+    } = props;
     return (
         <Element
-            className={classNames('ffe-card-base', className)}
+            className={classNames('ffe-card-base', className, {
+                [`ffe-card-base--bg-${bgColor}`]: bgColor,
+                [`ffe-card-base--dm-bg-${bgDarkmodeColor}`]: bgDarkmodeColor,
+                'ffe-card-base--box-shadow': shadow,
+                'ffe-card-base--no-margin': noMargin,
+                'ffe-card-base--text-center': textCenter,
+            })}
             ref={ref}
             {...rest}
         >
@@ -17,6 +41,11 @@ const CardBase = React.forwardRef((props, ref) => {
 
 CardBase.propTypes = {
     className: string,
+    bgColor: oneOf(['sand-30', 'sand-70', 'frost-30', 'syrin-30', 'syrin-70']),
+    bgDarkmodeColor: oneOf(['natt', 'svart', 'koksgraa']),
+    shadow: bool,
+    noMargin: bool,
+    textCenter: bool,
     children: node,
     /** The element to render the card as */
     element: oneOfType([func, string, elementType]),

--- a/packages/ffe-cards-react/src/CardBase.spec.js
+++ b/packages/ffe-cards-react/src/CardBase.spec.js
@@ -19,4 +19,39 @@ describe('CardBase', () => {
         const article = screen.getByRole('article');
         expect(article.classList.contains('my-custom-class')).toBeTruthy();
     });
+    it('should set bgColor-prop correctly', () => {
+        render(<CardBase href="#" element="a" bgColor="frost-30" />);
+        const link = screen.getByRole('link');
+        expect(
+            link.classList.contains('ffe-card-base--bg-frost-30'),
+        ).toBeTruthy();
+    });
+    it('should set bgDarkmodeColor-prop correctly', () => {
+        render(<CardBase href="#" element="a" bgDarkmodeColor="natt" />);
+        const link = screen.getByRole('link');
+        expect(
+            link.classList.contains('ffe-card-base--dm-bg-natt'),
+        ).toBeTruthy();
+    });
+    it('should set shadow-prop correctly', () => {
+        render(<CardBase href="#" element="a" shadow={true} />);
+        const link = screen.getByRole('link');
+        expect(
+            link.classList.contains('ffe-card-base--box-shadow'),
+        ).toBeTruthy();
+    });
+    it('should set noMargin-prop correctly', () => {
+        render(<CardBase href="#" element="a" noMargin={true} />);
+        const link = screen.getByRole('link');
+        expect(
+            link.classList.contains('ffe-card-base--no-margin'),
+        ).toBeTruthy();
+    });
+    it('should set textCenter-prop correctly', () => {
+        render(<CardBase href="#" element="a" textCenter={true} />);
+        const link = screen.getByRole('link');
+        expect(
+            link.classList.contains('ffe-card-base--text-center'),
+        ).toBeTruthy();
+    });
 });

--- a/packages/ffe-cards-react/src/index.d.ts
+++ b/packages/ffe-cards-react/src/index.d.ts
@@ -21,6 +21,15 @@ export interface CardRenderProps {
 
 type NoInfer<T> = [T][T extends any ? 0 : never];
 
+export interface BaseCardProps<T = {}>
+    extends Omit<ComponentBaseProps, 'children'> {
+    children?: React.ReactNode | ((props: CardRenderProps) => React.ReactNode);
+    bgColor?: 'sand-30' | 'sand-70' | 'frost-30' | 'syrin-30' | 'syrin-70';
+    bgDarkmodeColor?: 'svart' | 'natt' | 'koksgraa';
+    shadow?: boolean;
+    noMargin?: boolean;
+    textCenter?: boolean;
+}
 export interface ImageCardProps<T = {}>
     extends Omit<ComponentBaseProps, 'children'> {
     imageSrc: string;
@@ -51,7 +60,7 @@ export interface TextCardProps extends Omit<ComponentBaseProps, 'children'> {
 }
 
 declare class CardBase<T = {}> extends React.Component<
-    NoInfer<T> & ComponentBaseProps,
+    NoInfer<T> & BaseCardProps,
     any
 > {}
 declare class IconCard<T = {}> extends React.Component<

--- a/packages/ffe-cards/less/card-base.less
+++ b/packages/ffe-cards/less/card-base.less
@@ -3,6 +3,61 @@
 .ffe-card-base {
     .common-card-styling();
 
-    display: block;
-    padding: 0;
+    --ffe-card-base-background-color: var(
+        --ffe-v-cards-common-card-background-color
+    );
+
+    background: var(--ffe-card-base-background-color);
+    padding: var(--ffe-spacing-sm);
+    box-shadow: none; // Overwrite common-card-styling
+
+    &--bg-sand-30 {
+        --ffe-card-base-background-color: var(--ffe-farge-sand-30);
+    }
+
+    &--bg-sand-70 {
+        --ffe-card-base-background-color: var(--ffe-farge-sand-70);
+    }
+
+    &--bg-frost-30 {
+        --ffe-card-base-background-color: var(--ffe-farge-frost-30);
+    }
+
+    &--bg-syrin-30 {
+        --ffe-card-base-background-color: var(--ffe-farge-syrin-30);
+    }
+
+    &--bg-syrin-70 {
+        --ffe-card-base-background-color: var(--ffe-farge-syrin-70);
+    }
+
+    &--box-shadow {
+        box-shadow: 0 1px 4px 0 var(--ffe-v-cards-common-card-box-shadow-color);
+    }
+
+    &--no-margin {
+        margin: 0;
+    }
+
+    &--text-center {
+        text-align: center;
+    }
+}
+
+.native & {
+    @media (prefers-color-scheme: dark) {
+        .ffe-card-base {
+            &--dm-bg-svart {
+                --ffe-card-base-background-color: var(--ffe-farge-svart);
+            }
+
+            &--dm-bg-natt {
+                --ffe-card-base-background-color: var(--ffe-farge-natt);
+            }
+
+            &--dm-bg-koksgraa {
+                --ffe-card-base-background-color: var(--ffe-farge-koksgraa);
+            }
+        }
+    }
 }

--- a/packages/ffe-cards/less/common-card-styling.less
+++ b/packages/ffe-cards/less/common-card-styling.less
@@ -8,37 +8,38 @@
     border-radius: var(--ffe-v-cards-common-card-border-radius);
     transition: border-color 0.2s;
     outline: none;
-    cursor: pointer;
     width: 100%;
     text-decoration: none;
+
     .native & {
         @media (prefers-color-scheme: dark) {
-            box-shadow: 0 0 0 1px
-                var(--ffe-v-cards-common-card-box-shadow-color);
             color: var(--ffe-farge-hvit);
         }
     }
 
-    &:visited {
-        .native & {
-            @media (prefers-color-scheme: dark) {
-                color: var(--ffe-farge-hvit);
+    &:is(a, button) {
+        cursor: pointer;
+        &:visited {
+            .native & {
+                @media (prefers-color-scheme: dark) {
+                    color: var(--ffe-farge-hvit);
+                }
             }
         }
-    }
 
-    &:focus {
-        box-shadow: 0 0 0 2px var(--ffe-g-primary-color);
-    }
+        &:focus {
+            box-shadow: 0 0 0 2px var(--ffe-g-primary-color);
+        }
 
-    &:focus,
-    &:active {
-        border-color: var(--ffe-g-primary-color);
-    }
-
-    @media (hover: hover) and (pointer: fine) {
-        &:hover {
+        &:focus,
+        &:active {
             border-color: var(--ffe-g-primary-color);
+        }
+
+        @media (hover: hover) and (pointer: fine) {
+            &:hover {
+                border-color: var(--ffe-g-primary-color);
+            }
         }
     }
 


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse
Endrer hvordan baseCard ser ut, sånn at man kan bruke det mer som frittstående kort.

Har definert dette som breaking change for de som bruker CardBase komponenten i dag, men det er ingen breaking changes for de som bruker noen av de andre card-komponentene, utenom at "hover/focus" effektene kun fungerer når kortet er en link eller knapp. 

- Fjerner hover/focus styling når kortet ikke er knapp eller link.
- Man kan nå  toggle av og på box-shadow og sette bakgrunnsfarge.
 
![Skjermbilde 2024-05-07 kl  09 10 08](https://github.com/SpareBank1/designsystem/assets/39946146/e344b155-a31a-4784-aa91-3c7e2e19f3fd)

Legger til følgende props på baseCard: 
- noMargin
- textCenter
- bgColor
- bgDarkmodeColor
- shadow 

<!-- Detaljert beskrivelse av endringene dine. Skjermskudd er lov. -->

## Motivasjon og kontekst
Vi bruker mye kort i våre layouts for å formidle og dele opp innhold på sidene, men vi har manglet en komponent for dette i FFE. BaseCard som den var oppførte seg alltid visuelt som ett klikkbart kort, og jeg mistenker at det ble veldig lite brukt. Endrer derfor BaseCard sånn at det forhåpentligvis kan brukes mer allsidig. 

<!-- Hvorfor trengs denne endringen, og hva løser den? -->

## Testing
Kjørt opp lokalt
<!-- Hvordan har du har testet endringene dine? Ta gjerne med systeminfo o.l -->

<!--

Helt til slutt, har du ..

.. lest retningslinjene våre for bidrag?
.. tatt en siste sjekk for kode og skrivefeil, debug informasjon o.l?
.. kjørt og eventuelt oppdatert testene?
.. kommentert og dokumentert det som trengs?
.. knyttet denne opp til relaterte issues?

-->
