### PR TITLE
fix(ffe-form): legger tilbake bakgrunnsfarge på radioknapp

### DIFF
--- a/packages/ffe-form/less/radio-button.less
+++ b/packages/ffe-form/less/radio-button.less
@@ -72,9 +72,11 @@
         background-color: var(--inner-circle-color);
         width: 50%;
         aspect-ratio: 1;
+        z-index: 1;
     }
 
     &::after {
+        background-color: var(--ffe-v-input-bg-color);
         border: 2px solid var(--outer-circle-color);
         width: 20px;
         height: 20px;


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse

Retter en bug der radioknapper hadde transparent bakgrunn i stedet for samme bakgrunn som andre inputs.

Bakgrunnsfargen er satt til `var(--ffe-v-input-bg-color)` i stedet for `var(--inner-circle-color)`, fordi sistnevnte endrer verdi basert på om radioknappen er markert eller ikke.

## Testing

Testet i diverse browsere med component-overview