### PR TITLE
chore: same ts version in project

### DIFF
--- a/packages/ffe-core/package.json
+++ b/packages/ffe-core/package.json
@@ -25,8 +25,7 @@
         "@sb1/ffe-buildtool": "^0.6.1",
         "case": "^1.5.5",
         "less": "^4.1.2",
-        "postcss": "^8.3.6",
-        "typescript": "^4.6.4"
+        "postcss": "^8.3.6"
     },
     "publishConfig": {
         "access": "public"


### PR DESCRIPTION
Vi har nu en ` "typescript": "^5.4.3"` på øversta nivå så denne trengs ikke mer. 