### PR TITLE
fix(ffe-accordion-react): transitionstart not triggered

### DIFF
--- a/packages/ffe-accordion-react/src/Accordion.spec.tsx
+++ b/packages/ffe-accordion-react/src/Accordion.spec.tsx
@@ -55,8 +55,12 @@ describe('<Accordion />', () => {
     it('should expand sections', () => {
         render(
             <Accordion headingLevel={3}>
-                <AccordionItem heading="heading1">content1</AccordionItem>
-                <AccordionItem heading="heading2">content2</AccordionItem>
+                <AccordionItem heading="heading1">
+                    <span data-testid="content1">content1</span>
+                </AccordionItem>
+                <AccordionItem heading="heading2">
+                    <span data-testid="content2">content2</span>
+                </AccordionItem>
             </Accordion>,
         );
 
@@ -66,12 +70,8 @@ describe('<Accordion />', () => {
         expect(firstButton.getAttribute('aria-expanded')).toEqual('false');
         expect(secondButton.getAttribute('aria-expanded')).toEqual('false');
 
-        expect(
-            screen.queryByRole('region', { name: /heading1/i }),
-        ).not.toBeInTheDocument();
-        expect(
-            screen.queryByRole('region', { name: /heading2/i }),
-        ).not.toBeInTheDocument();
+        expect(screen.queryByTestId('content1')).not.toBeInTheDocument();
+        expect(screen.queryByTestId('content2')).not.toBeInTheDocument();
 
         fireEvent.click(firstButton);
         fireEvent.click(secondButton);
@@ -79,11 +79,7 @@ describe('<Accordion />', () => {
         expect(firstButton.getAttribute('aria-expanded')).toEqual('true');
         expect(secondButton.getAttribute('aria-expanded')).toEqual('true');
 
-        expect(
-            screen.getByRole('region', { name: /heading1/i }),
-        ).toBeInTheDocument();
-        expect(
-            screen.getByRole('region', { name: /heading2/i }),
-        ).toBeInTheDocument();
+        expect(screen.queryByTestId('content1')).toBeInTheDocument();
+        expect(screen.queryByTestId('content2')).toBeInTheDocument();
     });
 });

--- a/packages/ffe-accordion-react/src/AccordionItem.tsx
+++ b/packages/ffe-accordion-react/src/AccordionItem.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useRef, useState, useContext } from 'react';
-import { bool, func, node, string } from 'prop-types';
 import { v4 as uuid } from 'uuid';
 import { Icon } from '@sb1/ffe-icons-react';
 import { Collapse } from '@sb1/ffe-collapse-react';
@@ -58,8 +57,6 @@ export const AccordionItem: React.FC<AccordionItemProps> = ({
 
     const collapseHidden = !isExpanded && !isAnimating;
 
-    const H = `h${headingLevel}`;
-
     return (
         <div
             className={classNames(className, 'ffe-accordion-item', {
@@ -105,7 +102,6 @@ export const AccordionItem: React.FC<AccordionItemProps> = ({
                 onRest={() => setIsAnimating(false)}
                 id={contentId.current}
                 aria-labelledby={buttonId.current}
-                hidden={collapseHidden}
                 role="region"
             >
                 {!collapseHidden && (
@@ -114,21 +110,4 @@ export const AccordionItem: React.FC<AccordionItemProps> = ({
             </Collapse>
         </div>
     );
-};
-
-AccordionItem.propTypes = {
-    /** The heading */
-    heading: node.isRequired,
-    /** The content to appear when expanded */
-    children: node.isRequired,
-    /** Should it be open by default */
-    defaultOpen: bool,
-    /** Is the item open or collapsed? Used for overriding default behaviour */
-    isOpen: bool,
-    /** Class assigned the container */
-    className: string,
-    /** Callback when the item is open/closed */
-    onToggleOpen: func,
-    /** aria-label for the button */
-    ariaLabel: string,
 };


### PR DESCRIPTION
transition start was not triggered in Collapse
because og hidden attribute. Collapse hides content from screen readers so this is not needed anymore

