### PR TITLE
fix(ffe-datepicker-react): add the id to input

### DIFF
--- a/packages/ffe-datepicker-react/src/datepicker/Datepicker.tsx
+++ b/packages/ffe-datepicker-react/src/datepicker/Datepicker.tsx
@@ -12,6 +12,7 @@ export interface DatepickerProps {
     'aria-invalid'?: React.ComponentProps<'input'>['aria-invalid'];
     ariaInvalid?: string | boolean;
     calendarAbove?: boolean;
+    id?: string;
     inputProps?: Pick<
         React.ComponentPropsWithRef<'input'>,
         'ref' | 'className' | 'id' | 'aria-describedby'
@@ -282,6 +283,7 @@ export class Datepicker extends Component<DatepickerProps, DatepickerState> {
                 >
                     <div className="ffe-datepicker--wrapper">
                         <DateInput
+                            id={this.props.id}
                             {...this.props.inputProps}
                             ariaInvalid={this.ariaInvalid()}
                             onBlur={this.onInputBlur}


### PR DESCRIPTION
Det ville vart mer komplisert hvis vi hade kvar muligheterna for label som props men det er fjernet nå. InputGroup sender id så hvis man bruker InputGroup vill det virke slik. Bruker man ikek InputGroup før man passa på att selv senda riktig id. Att gjøre den påkrevd er ikke så enkelt eftersom man ikke setter den i koden utan elementet klonas ju INputGroup og får extra props. 

 
fixes https://github.com/SpareBank1/designsystem/issues/1609