### PR TITLE
fix(ffe-form-react): Fikse div med tooltip inne i fieldset legend

### DIFF
--- a/packages/ffe-form-react/src/RadioButtonInputGroup.spec.tsx
+++ b/packages/ffe-form-react/src/RadioButtonInputGroup.spec.tsx
@@ -58,7 +58,7 @@ describe('<RadioButtonInputGroup />', () => {
             const { container } = renderRadioButtonInputGroup({
                 label: 'Test label',
             });
-            const legend = container.querySelector('legend');
+            const legend = container.querySelector('.ffe-form-label');
             expect(legend?.textContent).toBe('Test label');
         });
         it('does not render a legend if not set', () => {

--- a/packages/ffe-form-react/src/RadioButtonInputGroup.tsx
+++ b/packages/ffe-form-react/src/RadioButtonInputGroup.tsx
@@ -1,7 +1,8 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import classNames from 'classnames';
 import { ErrorFieldMessage } from './message';
 import { Tooltip } from './Tooltip';
+import { v4 as uuid } from 'uuid';
 
 export interface RadioButtonInputGroupProps
     extends Omit<
@@ -73,9 +74,11 @@ export const RadioButtonInputGroup: React.FC<RadioButtonInputGroupProps> = ({
             'Don\'t use both "tooltip" and "description" on an <RadioButtonInputGroup />, pick one of them',
         );
     }
+    const id = useRef(uuid()).current;
 
     return (
         <fieldset
+            aria-labelledby={id}
             className={classNames(
                 'ffe-input-group',
                 { 'ffe-input-group--no-extra-margin': !extraMargin },
@@ -85,7 +88,8 @@ export const RadioButtonInputGroup: React.FC<RadioButtonInputGroupProps> = ({
             {...rest}
         >
             {label && (
-                <legend
+                <div
+                    id={id}
                     className={classNames(
                         'ffe-form-label',
                         'ffe-form-label--block',
@@ -96,7 +100,7 @@ export const RadioButtonInputGroup: React.FC<RadioButtonInputGroupProps> = ({
                         <Tooltip>{tooltip}</Tooltip>
                     )}
                     {React.isValidElement(tooltip) && tooltip}
-                </legend>
+                </div>
             )}
 
             {typeof description === 'string' ? (


### PR DESCRIPTION
fixes #1614

## Beskrivelse

I ButtonInputGroup, fjernet bruken av legend og erstattet det med role.

## Motivasjon og kontekst

 For å unngå UU-feilen at div (Tooltippen) ikke kan være inne i legend. 

Et forslag var også å flytte tooltippen ut av <legend>. Det skapte to ulike problemer: 1) styling av legend + tooltip førte til at man måtte wrappe i en div, som gir feil i UU fordi <legend> må være direkte under <fieldset> ELLER ble veldig komplisert styling (jeg fikk det ikke til i alle fall, uten en div wrapper) og 2) Tooltippen oppfører seg da ikke som en del av legend/beskrivelsen, som også blir feil. 

## Testing

Bekreftet med @SindreSafvenbom at det er en ok måte å løse det på og har testet med skjermleser.  Har sjekket at koden nå passerer i https://validator.w3.org/

Legg gjerne ekstra merke til om commit-navnet er riktig, må bruke litt tid på å bli vandt med de
