### PR TITLE
fix(ffe-form): Legge til spacing for feilmelding på phoneNumber

### DIFF
--- a/packages/ffe-form/less/phone-number.less
+++ b/packages/ffe-form/less/phone-number.less
@@ -3,6 +3,10 @@
         @media (min-width: @breakpoint-sm) {
             display: flex;
         }
+        & > * {
+            margin-top: 0;
+            margin-bottom: var(--ffe-spacing-xs);
+        }
     }
 
     &__country-code &__input-group {
@@ -19,7 +23,7 @@
         }
 
         @media (max-width: (@breakpoint-sm - 1)) {
-            margin-bottom: var(--ffe-spacing-sm);
+            margin-bottom: var(--ffe-spacing-xs);
         }
     }
 


### PR DESCRIPTION
fixes #1727

## Beskrivelse

Lagt til spacing under phonenumberinput og feilmeldingen.

## Motivasjon og kontekst

Den trengte spacing

## Testing

Sjekket i chrome med flere skjermstørrelser. Dobbeltsjekket at det ikke ødela andre input-grupper. Zoomet inn også. 
