### PR TITLE
1741 medium micro tekst

### DIFF
--- a/component-overview/examples/typography/MicroText.jsx
+++ b/component-overview/examples/typography/MicroText.jsx
@@ -1,3 +1,8 @@
 import { MicroText } from '@sb1/ffe-core-react';
-
-<MicroText>Dette er den minste typen vi har</MicroText>
+<>
+    <MicroText>Dette er den minste typen vi har</MicroText>
+    <br />
+    <MicroText strong={true}>
+        Dette er den minste typen vi har, men i en tykkere variant
+    </MicroText>
+</>;

--- a/component-overview/examples/typography/StrongMicroText.jsx
+++ b/component-overview/examples/typography/StrongMicroText.jsx
@@ -1,0 +1,3 @@
+import { MicroText } from '@sb1/ffe-core-react';
+
+<MicroText>Dette er den minste typen vi har</MicroText>

--- a/component-overview/examples/typography/StrongMicroText.jsx
+++ b/component-overview/examples/typography/StrongMicroText.jsx
@@ -1,3 +1,0 @@
-import { MicroText } from '@sb1/ffe-core-react';
-
-<MicroText>Dette er den minste typen vi har</MicroText>

--- a/packages/ffe-core-react/src/typography/MicroText.tsx
+++ b/packages/ffe-core-react/src/typography/MicroText.tsx
@@ -8,12 +8,19 @@ export type MicroTextProps<As extends ElementType = 'span'> = {
 } & DistributiveOmit<
     ComponentProps<ElementType extends As ? 'span' : As>,
     'as' | 'ref'
-> & { underline?: boolean };
+> & { underline?: boolean; strong?: boolean };
 
 export function MicroText<As extends ElementType>(props: MicroTextProps<As>) {
-    const { as: Comp = 'span', className, ...rest } = props;
+    const { as: Comp = 'span', strong = false, className, ...rest } = props;
 
     return (
-        <Comp className={classNames('ffe-micro-text', className)} {...rest} />
+        <Comp
+            className={classNames(
+                'ffe-micro-text',
+                { 'ffe-micro-text--strong': strong },
+                className,
+            )}
+            {...rest}
+        />
     );
 }

--- a/packages/ffe-core/less/typography.less
+++ b/packages/ffe-core/less/typography.less
@@ -1,143 +1,6 @@
 @import 'breakpoints';
 @import 'colors';
 
-// Heading
-//
-// Markup:
-// <h1 class="ffe-h1">Overskrift nivå 1</h1>
-// <h2 class="ffe-h2">Overskrift nivå 2</h2>
-// <h3 class="ffe-h3">Overskrift nivå 3</h3>
-// <h4 class="ffe-h4">Overskrift nivå 4</h4>
-// <h5 class="ffe-h5">Overskrift nivå 5</h5>
-// <h6 class="ffe-h6">Overskrift nivå 6</h6>
-//
-// Styleguide ffe-core.typography.headings
-
-// Heading classes
-//
-// Markup:
-// <div class="{{modifier_class}}">Overskrift</div>
-//
-// .ffe-h1 - nivå 1
-// .ffe-h2 - nivå 2
-// .ffe-h3 - nivå 3
-// .ffe-h4 - nivå 4
-// .ffe-h5 - nivå 5
-// .ffe-h6 - nivå 6
-//
-// Styleguide ffe-core.typography.headings-classes
-
-// Heading modifiers
-//
-// Markup:
-// <div class="ffe-h3 ffe-h3{{modifier_class}}">Overskrift</div>
-//
-// --error         - Error
-// --inline        - Inline
-// --no-margin     - No margin
-// --with-border   - With border
-// --no-underline  - No underline
-//
-// Styleguide ffe-core.typography.headings-modifiers
-
-// Body paragraph
-//
-// Markup:
-// <p class="ffe-body-paragraph {{modifier_class}}">
-//    Velg en av bankene våre, og bruk BankID for å bli kunde. Nettbank og
-//    mobilbank får du med en gang, og bankkortet kommer i posten om en ukes
-//    tid.
-// </p>
-//
-// .ffe-body-paragraph--text-center - Centered
-// .ffe-body-paragraph--text-left   - Aligned left
-//
-// Styleguide ffe-core.typography.body-paragraph
-
-// Lead paragraph
-//
-// Markup:
-// <p class="ffe-lead-paragraph">
-//    Velg en av bankene våre, og bruk BankID for å bli kunde. Nettbank og
-//    mobilbank får du med en gang, og bankkortet kommer i posten om en ukes
-//    tid.
-// </p>
-// <p class="ffe-sub-lead-paragraph">
-//    Velg en av bankene våre, og bruk BankID for å bli kunde. Nettbank og
-//    mobilbank får du med en gang, og bankkortet kommer i posten om en ukes
-//    tid.
-// </p>
-// <p class="ffe-body-paragraph">
-//    Velg en av bankene våre, og bruk BankID for å bli kunde. Nettbank og
-//    mobilbank får du med en gang, og bankkortet kommer i posten om en ukes
-//    tid.
-// </p>
-//
-// Styleguide ffe-core.typography.lead-paragraph
-
-// Small text
-//
-// Markup:
-// <div class="ffe-small-text">Dette er en liten type</div>
-//
-// Styleguide ffe-core.typography.small-text
-
-// Micro text
-//
-// Markup:
-// <div class="ffe-micro-text">Dette er den minste typen vi har</div>
-//
-// Styleguide ffe-core.typography.micro-text
-
-// Strong text
-//
-// Markup:
-// <div class="ffe-strong-text">Dette er en sterk type</div>
-//
-// Styleguide ffe-core.typography.strong-text
-
-// Emphasized text
-//
-// Markup:
-// <div class="ffe-em-text">Dette bør utheves</div>
-//
-// Styleguide ffe-core.typography.em-text
-
-// Preformatted text
-//
-// Markup:
-// <pre class="ffe-pre-text">
-//    Gammal dam
-//    Ein frosk hoppar
-//    Lyden av vatnet
-// </pre>
-//
-// Styleguide ffe-core.typography.pre-text
-
-// Divider line
-//
-// Markup:
-// <hr class="ffe-divider-line"/>
-//
-// Styleguide ffe-core.typography.divider-line
-
-// Inline separator
-//
-// Markup:
-// <hr class="ffe-inline-seperator"/>
-//
-// Styleguide ffe-core.typography.inline-seperator
-
-// Link
-//
-// Markup:
-// <a class="ffe-link-text {{modifier_class}}" href="#na">Link text</a>
-//
-// :hover - Hover state
-// .ffe-link-text--no-underline - not underlined
-//
-// Styleguide ffe-core.typography.link-text
-
 .ffe-h1 {
     line-height: 2.25rem;
     font-size: var(--ffe-fontsize-h1);
@@ -184,6 +47,10 @@
 
 .ffe-micro-text {
     font-size: var(--ffe-fontsize-micro-text);
+
+    &--strong {
+        font-family: var(--ffe-g-font-strong);
+    }
 }
 
 .ffe-h1,


### PR DESCRIPTION
fixes #1741

## Beskrivelse

Legger til en ny tekst-stil: StrongMicroText. Altså en variant av microtekst med medium tykkelse

## Motivasjon og kontekst

Det har kommet inn forespørsel via design om et ønske om denne stilen, via #1741 . Det kunne også bli gjort ved å legge til en strong-prop på microtekst, men jeg valgte å følge prinsippene som allerede er fulgt via StrongText. 

## Testing

Gå inn på designsystemet via lenken som blir opprettet og legg til typography_StrongMicroText, eller søk på typografi. 
