### PR TITLE
Add noPadding prop to baseCard

### DIFF
--- a/component-overview/examples/cards/CardBase-no-padding.jsx
+++ b/component-overview/examples/cards/CardBase-no-padding.jsx
@@ -1,0 +1,10 @@
+import { CardBase } from '@sb1/ffe-cards-react';
+
+<CardBase
+    as="div"
+    bgColor="syrin-30"
+    bgDarkmodeColor="koksgraa"
+    noPadding={true}
+>
+    Dette er ett kort uten padding
+</CardBase>;

--- a/packages/ffe-cards-react/src/CardBase.tsx
+++ b/packages/ffe-cards-react/src/CardBase.tsx
@@ -14,6 +14,7 @@ export type CardBaseProps<As extends ElementType = 'a'> =
         clickable?: boolean;
         bgColor?: BgColor;
         bgDarkmodeColor?: BgColorDarkmode;
+        noPadding?: boolean;
     };
 
 function CardBaseWithForwardRef<As extends ElementType>(
@@ -29,6 +30,7 @@ function CardBaseWithForwardRef<As extends ElementType>(
         bgColor,
         bgDarkmodeColor,
         clickable,
+        noPadding,
         ...rest
     } = props;
 
@@ -40,6 +42,7 @@ function CardBaseWithForwardRef<As extends ElementType>(
                 'ffe-card-base--box-shadow': shadow,
                 'ffe-card-base--no-margin': noMargin,
                 'ffe-card-base--text-center': textCenter,
+                'ffe-card-base--no-padding': noPadding,
                 'ffe-card-base--clickable': clickable,
             })}
             {...rest}

--- a/packages/ffe-cards/less/card-base.less
+++ b/packages/ffe-cards/less/card-base.less
@@ -11,6 +11,9 @@
     padding: var(--ffe-spacing-sm);
     box-shadow: none; // Overwrite common-card-styling
 
+    &--no-padding {
+        padding: 0;
+    }
     &--bg-sand-30 {
         --ffe-card-base-background-color: var(--ffe-farge-sand-30);
     }


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse
Legger til noPadding prop til baseCard
<!-- Detaljert beskrivelse av endringene dine. Skjermskudd er lov. -->

## Motivasjon og kontekst
Ved å legge til muligheten til å fjerne padding, står man friere til hva slags innhold man vil sende inn i kortet.
Vi i Team Oversikt bruker blant annet baseCard til å ha klikkbare-rader i ett kort, og paddingen gjorde at hover-effekten fikk hvite "streker" pga padding. `no-padding`-prop vil løse det problemet for oss. 

<!-- Hvorfor trengs denne endringen, og hva løser den? -->

## Testing

<!-- Hvordan har du har testet endringene dine? Ta gjerne med systeminfo o.l -->

<!--

Helt til slutt, har du ..

.. lest retningslinjene våre for bidrag?
.. tatt en siste sjekk for kode og skrivefeil, debug informasjon o.l?
.. kjørt og eventuelt oppdatert testene?
.. kommentert og dokumentert det som trengs?
.. knyttet denne opp til relaterte issues?

-->
