### PR TITLE
fix(ffe-account-selector-react): åpne currencycode for alle currencycodes

### DIFF
--- a/packages/ffe-account-selector-react/src/types.ts
+++ b/packages/ffe-account-selector-react/src/types.ts
@@ -1,8 +1,36 @@
 export type Locale = 'nb' | 'nn' | 'en';
 
+type Letter =
+    | 'a'
+    | 'b'
+    | 'c'
+    | 'd'
+    | 'e'
+    | 'f'
+    | 'g'
+    | 'h'
+    | 'i'
+    | 'j'
+    | 'k'
+    | 'l'
+    | 'm'
+    | 'n'
+    | 'o'
+    | 'p'
+    | 'q'
+    | 'r'
+    | 's'
+    | 't'
+    | 'u'
+    | 'v'
+    | 'w'
+    | 'x'
+    | 'y'
+    | 'z';
+
 export interface Account {
     accountNumber: string;
     name: string;
-    currencyCode?: 'NOK' | 'EUR';
+    currencyCode?: `${Uppercase<Letter>}${Uppercase<Letter>}${Uppercase<Letter>}`;
     balance?: number;
 }


### PR DESCRIPTION
fixes [#2051](https://github.com/SpareBank1/designsystem/issues/2051)

## Beskrivelse

currencyCode i Account i AccountSelector aksepterte kun 'NOK' | 'EUR' | undefined. 

## Motivasjon og kontekst

For noen team var dette for restriktivt (f.eks Team BM Betaling) da de har flere currencies. 
Kunne ikke finne noen grunn til at vi kun aksepterer NOK og EUR

## Testing

Tror kanskje team BM Betailing har en annen typescript-config enn team DS, fordi andre currencies (for eksempel AUD) ga ikke noen feilmeldinger hos oss (prøvde build, run test og å kjøre). Men, denne endringen åpner opp for alle currencies. 

En utfordring da er at man kan skrive hva som helst. Jeg la til en test på at det burde være length 3 for at det skal være en currencyCode, men forståelsen min av tester er fortsatt litt begrenset, så jeg skjønner ikke om det faktisk kommer til å nå noe annet enn testdataene jeg har lagt til. Sikkert ikke, så jeg kan godt fjerne den hvis det ikke er vits. 