### PR TITLE
Fix input group extra margin

### DIFF
--- a/packages/ffe-form-react/src/InputGroup.tsx
+++ b/packages/ffe-form-react/src/InputGroup.tsx
@@ -159,17 +159,15 @@ export const InputGroup: React.FC<InputGroupProps> = ({
 
             {modifiedChildren}
 
-            <div className="ffe-input-group__field-message">
-                {typeof fieldMessage === 'string' && (
-                    <ErrorFieldMessage as="p" id={fieldMessageId}>
-                        {fieldMessage}
-                    </ErrorFieldMessage>
-                )}
-                {React.isValidElement(fieldMessage) &&
-                    React.cloneElement(fieldMessage, {
-                        id: fieldMessageId,
-                    })}
-            </div>
+            {typeof fieldMessage === 'string' && (
+                <ErrorFieldMessage as="p" id={fieldMessageId}>
+                    {fieldMessage}
+                </ErrorFieldMessage>
+            )}
+            {React.isValidElement(fieldMessage) &&
+                React.cloneElement(fieldMessage, {
+                    id: fieldMessageId,
+                })}
         </div>
     );
 };

--- a/packages/ffe-form/less/input-group.less
+++ b/packages/ffe-form/less/input-group.less
@@ -1,6 +1,7 @@
 .ffe-input-group {
     border: 0;
     position: relative;
+    padding-bottom: calc(1lh + var(--ffe-spacing-xs));
 
     [aria-invalid='true'] {
         border-color: var(--ffe-g-error-color);
@@ -32,11 +33,15 @@
     }
 
     .ffe-field-message--error {
-        margin: 0;
+        margin-top: 0;
     }
 
     &__description {
         margin-bottom: var(--ffe-spacing-xs);
+    }
+
+    &--message {
+        padding-bottom: 0;
     }
 
     &--no-extra-margin {
@@ -46,9 +51,5 @@
             margin-bottom: var(--ffe-spacing-xs);
             height: initial;
         }
-    }
-
-    &__field-message {
-        min-height: 1lh;
     }
 }


### PR DESCRIPTION
fixes #2050 

## Beskrivelse

Det er ikke mulig å fjerne ekstra plass i input group lenger, denne prøver å fikse det.

## Motivasjon og kontekst

Vi i Team BM Betaling bruker InputGroup med extraMargin={false} for våre skjemaer med mange felter.
Det var mulig før å fjerne ekstra plass under, virker som en feil at det ikke lenger er mulig.

## Testing

Har sjekket at det ser riktig ut i component-overview. Dette burde også fikse tilsvarende feil for RadioButtonInputGroup og PhoneNumber
