### PR TITLE
fix(ffe-cards): fjern min-height fra icon card

### DIFF
--- a/packages/ffe-cards/less/icon-card.less
+++ b/packages/ffe-cards/less/icon-card.less
@@ -8,7 +8,6 @@
     grid-template-columns: auto 1fr;
     align-items: center;
     padding: @ffe-spacing-md;
-    min-height: 130px;
 
     & > &__icon {
         color: var(--ffe-v-cards-icon-color);
@@ -23,10 +22,6 @@
 }
 
 .ffe-icon-card--condensed {
-    @media (min-width: @breakpoint-md) {
-        min-height: 100px;
-    }
-
     .ffe-icon-card__icon {
         margin: 0 var(--ffe-spacing-sm) 0 0;
     }


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse
Fjerner min-height fra Icon Card
<!-- Detaljert beskrivelse av endringene dine. Skjermskudd er lov. -->

## Motivasjon og kontekst
Usikker på hvorfor det var satt min-height i utgangspunktet, men det gjorde at kortet ble veldig stort på mindre skjerm, da plutselig min-height var 130px - selv på condensed. 

Istedenfor å bare sette det til 100 px sånn som det er på større skjermer, valgte jeg bare å fjerne min-height, da jeg mener høyden burde settes av innholdet og at padding sørger for at kortet uansett er` 24*2 ` i høyden. 
<!-- Hvorfor trengs denne endringen, og hva løser den? -->

## Testing
Kjørt opp lokalt
<!-- Hvordan har du har testet endringene dine? Ta gjerne med systeminfo o.l -->

<!--

Helt til slutt, har du ..

.. lest retningslinjene våre for bidrag?
.. tatt en siste sjekk for kode og skrivefeil, debug informasjon o.l?
.. kjørt og eventuelt oppdatert testene?
.. kommentert og dokumentert det som trengs?
.. knyttet denne opp til relaterte issues?

-->
