### PR TITLE
fix(ffe-account-selector-react): fix at currencycode var for streng

### DIFF
--- a/packages/ffe-account-selector-react/src/types.ts
+++ b/packages/ffe-account-selector-react/src/types.ts
@@ -1,36 +1,10 @@
 export type Locale = 'nb' | 'nn' | 'en';
 
-type Letter =
-    | 'a'
-    | 'b'
-    | 'c'
-    | 'd'
-    | 'e'
-    | 'f'
-    | 'g'
-    | 'h'
-    | 'i'
-    | 'j'
-    | 'k'
-    | 'l'
-    | 'm'
-    | 'n'
-    | 'o'
-    | 'p'
-    | 'q'
-    | 'r'
-    | 's'
-    | 't'
-    | 'u'
-    | 'v'
-    | 'w'
-    | 'x'
-    | 'y'
-    | 'z';
+type AutoComplete<T extends string> = T | (string & {});
 
 export interface Account {
     accountNumber: string;
     name: string;
-    currencyCode?: `${Uppercase<Letter>}${Uppercase<Letter>}${Uppercase<Letter>}`;
+    currencyCode?: AutoComplete<'NOK' | 'EUR'>;
     balance?: number;
 }


### PR DESCRIPTION
[<!-- Ref. denne committen. -->](https://github.com/SpareBank1/designsystem/pull/2053/files)

## Beskrivelse

Vi lagde en validering på at currencyCode må ha tre all caps bokstaver, men det ble for strengt for bruken til Team BM betaling da de ikke validerer formatet på det som kommer inn fra APIet. Har gjort den mindre streng nå, men med forslag om NOK og EUR sånn at autocomplete gir forslag. 
