### PR TITLE
Responsiv spacing i Grid

### DIFF
--- a/component-overview/examples/grid/Grid-spacing-responsive.jsx
+++ b/component-overview/examples/grid/Grid-spacing-responsive.jsx
@@ -1,0 +1,57 @@
+import { Grid, GridRow, GridCol } from '@sb1/ffe-grid-react';
+
+<>
+    <h3 className='ffe-h3'>Progressivt økende spacing</h3>
+    <Grid gap="none" sm={{ gap: 'sm' }} md={{ gap: 'md' }} lg={{ gap: 'lg' }}>
+        <GridRow sm={{ margin: 'sm', padding: 'sm' }} md={{ margin: 'md', padding: 'md' }} lg={{ margin: 'lg', padding: 'lg' }} background="frost-30">
+            <GridCol sm="6" md="4" lg="3" background="syrin-30">
+                Litt innhold
+            </GridCol>
+            <GridCol sm="6" md="4" lg="3" background="syrin-30">
+                Litt innhold
+            </GridCol>
+            <GridCol sm="6" md="4" lg="3" background="syrin-30">
+                Litt innhold
+            </GridCol>
+            <GridCol sm="6" md="4" lg="3" background="syrin-30">
+                Litt innhold
+            </GridCol>
+        </GridRow>
+    </Grid>
+
+    <h3 className='ffe-h3'>2xs som default, lg på store skjermer</h3>
+    <Grid gap="2xs" lg={{ gap: 'lg' }}>
+        <GridRow margin="2xs" padding="2xs" lg={{ margin: 'lg', padding: 'lg' }} background="vann-30">
+            <GridCol sm="6" md="4" lg="3" background="sand">
+                Litt innhold
+            </GridCol>
+            <GridCol sm="6" md="4" lg="3" background="sand">
+                Litt innhold
+            </GridCol>
+            <GridCol sm="6" md="4" lg="3" background="sand">
+                Litt innhold
+            </GridCol>
+            <GridCol sm="6" md="4" lg="3" background="sand">
+                Litt innhold
+            </GridCol>
+        </GridRow>
+    </Grid>
+
+    <h3 className='ffe-h3'>Uten responsive modifiere</h3>
+    <Grid gap="md">
+        <GridRow margin="5xl" padding="2xl" background="vann">
+            <GridCol sm="6" md="4" lg="3" background="fjell">
+                Litt innhold
+            </GridCol>
+            <GridCol sm="6" md="4" lg="3" background="fjell">
+                Litt innhold
+            </GridCol>
+            <GridCol sm="6" md="4" lg="3" background="fjell">
+                Litt innhold
+            </GridCol>
+            <GridCol sm="6" md="4" lg="3" background="fjell">
+                Litt innhold
+            </GridCol>
+        </GridRow>
+    </Grid>
+</>

--- a/packages/ffe-grid-react/src/Grid.tsx
+++ b/packages/ffe-grid-react/src/Grid.tsx
@@ -1,25 +1,59 @@
 import React, { ElementType } from 'react';
 import classNames from 'classnames';
-import { ComponentWithoutRefAsPropParams } from './types';
+import { ComponentWithoutRefAsPropParams, Gap } from './types';
+
+type SizeModifier = GridGapSize | Gap;
+
+interface GridGapSize {
+    gap?: Gap;
+}
 
 export type GridProps<As extends ElementType = any> =
     ComponentWithoutRefAsPropParams<As> & {
         /** Specify the internal gutter of the grid */
-        gap?: 'none' | '2xs' | 'xs' | 'sm' | 'md' | 'lg';
+        gap?: Gap;
+        /** Size modifiers for small screen sizes */
+        sm?: SizeModifier;
+        /** Size modifiers for medium screen sizes */
+        md?: SizeModifier;
+        /** Size modifiers for large screen sizes */
+        lg?: SizeModifier;
     };
+
+const sizeClasses = (size: 'none' | 'sm' | 'md' | 'lg', def?: SizeModifier) => {
+    if (def === undefined) {
+        return null;
+    } else if (typeof def === 'string') {
+        return `ffe-grid--gap-${size}-${def}`;
+    }
+
+    return classNames({
+        [`ffe-grid--${size}-gap-${def.gap}`]: def.gap,
+    });
+};
 
 export const Grid: React.FC<GridProps> = ({
     children,
     className,
     gap,
+    sm,
+    md,
+    lg,
     as: Comp = 'div',
     ...rest
 }) => {
     return (
         <Comp
-            className={classNames(className, 'ffe-grid', {
-                [`ffe-grid--gap-${gap}`]: gap,
-            })}
+            className={classNames(
+                className,
+                'ffe-grid',
+                {
+                    [`ffe-grid--gap-${gap}`]: gap,
+                },
+                sizeClasses('lg', lg),
+                sizeClasses('md', md),
+                sizeClasses('sm', sm),
+            )}
             {...rest}
         >
             {children}

--- a/packages/ffe-grid-react/src/GridRow.tsx
+++ b/packages/ffe-grid-react/src/GridRow.tsx
@@ -8,6 +8,13 @@ import {
     Padding,
 } from './types';
 
+interface GridRowSize {
+    margin?: Margin;
+    padding?: Padding;
+}
+
+type SizeModifier = GridRowSize | Margin | Padding;
+
 export type GridRowProps<As extends ElementType = any> =
     ComponentWithoutRefAsPropParams<As> & {
         /** Padding in the top and bottom of the row */
@@ -18,7 +25,26 @@ export type GridRowProps<As extends ElementType = any> =
         background?: BackgroundColor;
         /** Supported dark background colors */
         backgroundDark?: BackgroundColorDark;
+        /** Size modifiers for small screen sizes */
+        sm?: SizeModifier;
+        /** Size modifiers for medium screen sizes */
+        md?: SizeModifier;
+        /** Size modifiers for large screen sizes */
+        lg?: SizeModifier;
     };
+
+const sizeClasses = (size: 'sm' | 'md' | 'lg', def?: SizeModifier) => {
+    if (def === undefined) {
+        return null;
+    } else if (typeof def === 'string') {
+        return `ffe-grid__row--${size}-${def}`;
+    }
+
+    return classNames({
+        [`ffe-grid__row--${size}-margin-${def.margin}`]: def.margin,
+        [`ffe-grid__row--${size}-padding-${def.padding}`]: def.padding,
+    });
+};
 
 export const GridRow: React.FC<GridRowProps> = ({
     background,
@@ -26,6 +52,9 @@ export const GridRow: React.FC<GridRowProps> = ({
     className,
     children,
     as: Comp = 'div',
+    sm,
+    md,
+    lg,
     padding,
     margin,
     ...rest
@@ -43,6 +72,9 @@ export const GridRow: React.FC<GridRowProps> = ({
         <Comp
             className={classNames(
                 className,
+                sizeClasses('lg', lg),
+                sizeClasses('md', md),
+                sizeClasses('sm', sm),
                 'ffe-grid__row',
                 { [`ffe-grid__row--bg-${background}`]: hasBackgroundColor },
                 {

--- a/packages/ffe-grid-react/src/types.ts
+++ b/packages/ffe-grid-react/src/types.ts
@@ -37,6 +37,8 @@ export type Padding =
     | '4xl'
     | '5xl';
 
+export type Gap = 'none' | '2xs' | 'xs' | 'sm' | 'md' | 'lg';
+
 export type BackgroundColor =
     | 'frost-30'
     | 'sand'

--- a/packages/ffe-grid/less/ffe-grid.less
+++ b/packages/ffe-grid/less/ffe-grid.less
@@ -21,141 +21,538 @@
 }
 
 .ffe-grid__row {
-    padding-right: @ffe-spacing-sm;
-    padding-left: @ffe-spacing-sm;
+    padding-right: var(--ffe-spacing-sm);
+    padding-left: var(--ffe-spacing-sm);
 }
 
 .ffe-grid__row,
 .ffe-grid__row-wrapper {
     display: grid;
-    gap: @ffe-spacing-sm;
+    gap: var(--ffe-spacing-sm);
     margin: 0 auto;
-    max-width: @app-width;
+    max-width: var(--app-width);
     grid-template-columns: repeat(12, 1fr);
 
     .ffe-grid--gap-none & {
         gap: 0;
-        padding: 0;
+        padding-right: 0;
+        padding-left: 0;
     }
 
     .ffe-grid--gap-2xs & {
-        gap: @ffe-spacing-2xs;
-        padding-right: @ffe-spacing-2xs;
-        padding-left: @ffe-spacing-2xs;
+        gap: var(--ffe-spacing-2xs);
+        padding-right: var(--ffe-spacing-2xs);
+        padding-left: var(--ffe-spacing-2xs);
     }
 
     .ffe-grid--gap-xs & {
-        gap: @ffe-spacing-xs;
-        padding-right: @ffe-spacing-xs;
-        padding-left: @ffe-spacing-xs;
+        gap: var(--ffe-spacing-xs);
+        padding-right: var(--ffe-spacing-xs);
+        padding-left: var(--ffe-spacing-xs);
     }
 
     .ffe-grid--gap-sm & {
-        gap: @ffe-spacing-sm;
-        padding-right: @ffe-spacing-sm;
-        padding-left: @ffe-spacing-sm;
+        gap: var(--ffe-spacing-sm);
+        padding-right: var(--ffe-spacing-sm);
+        padding-left: var(--ffe-spacing-sm);
     }
 
     .ffe-grid--gap-md & {
-        gap: @ffe-spacing-md;
-        padding-right: @ffe-spacing-md;
-        padding-left: @ffe-spacing-md;
+        gap: var(--ffe-spacing-md);
+        padding-right: var(--ffe-spacing-md);
+        padding-left: var(--ffe-spacing-md);
     }
 
     .ffe-grid--gap-lg & {
-        gap: @ffe-spacing-lg;
-        padding-right: @ffe-spacing-lg;
-        padding-left: @ffe-spacing-lg;
+        gap: var(--ffe-spacing-lg);
+        padding-right: var(--ffe-spacing-lg);
+        padding-left: var(--ffe-spacing-lg);
+    }
+
+    @media (min-width: @breakpoint-sm) {
+        .ffe-grid--sm-gap-none & {
+            gap: 0;
+            padding-right: 0;
+            padding-left: 0;
+        }
+
+        .ffe-grid--sm-gap-2xs & {
+            gap: var(--ffe-spacing-2xs);
+            padding-right: var(--ffe-spacing-2xs);
+            padding-left: var(--ffe-spacing-2xs);
+        }
+
+        .ffe-grid--sm-gap-xs & {
+            gap: var(--ffe-spacing-xs);
+            padding-right: var(--ffe-spacing-xs);
+            padding-left: var(--ffe-spacing-xs);
+        }
+
+        .ffe-grid--sm-gap-sm & {
+            gap: var(--ffe-spacing-sm);
+            padding-right: var(--ffe-spacing-sm);
+            padding-left: var(--ffe-spacing-sm);
+        }
+
+        .ffe-grid--sm-gap-md & {
+            gap: var(--ffe-spacing-md);
+            padding-right: var(--ffe-spacing-md);
+            padding-left: var(--ffe-spacing-md);
+        }
+
+        .ffe-grid--sm-gap-lg & {
+            gap: var(--ffe-spacing-lg);
+            padding-right: var(--ffe-spacing-lg);
+            padding-left: var(--ffe-spacing-lg);
+        }
+    }
+
+    @media (min-width: @breakpoint-md) {
+        .ffe-grid--md-gap-none & {
+            gap: 0;
+            padding-right: 0;
+            padding-left: 0;
+        }
+
+        .ffe-grid--md-gap-2xs & {
+            gap: var(--ffe-spacing-2xs);
+            padding-right: var(--ffe-spacing-2xs);
+            padding-left: var(--ffe-spacing-2xs);
+        }
+
+        .ffe-grid--md-gap-xs & {
+            gap: var(--ffe-spacing-xs);
+            padding-right: var(--ffe-spacing-xs);
+            padding-left: var(--ffe-spacing-xs);
+        }
+
+        .ffe-grid--md-gap-sm & {
+            gap: var(--ffe-spacing-sm);
+            padding-right: var(--ffe-spacing-sm);
+            padding-left: var(--ffe-spacing-sm);
+        }
+
+        .ffe-grid--md-gap-md & {
+            gap: var(--ffe-spacing-md);
+            padding-right: var(--ffe-spacing-md);
+            padding-left: var(--ffe-spacing-md);
+        }
+
+        .ffe-grid--md-gap-lg & {
+            gap: var(--ffe-spacing-lg);
+            padding-right: var(--ffe-spacing-lg);
+            padding-left: var(--ffe-spacing-lg);
+        }
+    }
+
+    @media (min-width: @breakpoint-lg) {
+        .ffe-grid--lg-gap-none & {
+            gap: 0;
+            padding-right: 0;
+            padding-left: 0;
+        }
+
+        .ffe-grid--lg-gap-2xs & {
+            gap: var(--ffe-spacing-2xs);
+            padding-right: var(--ffe-spacing-2xs);
+            padding-left: var(--ffe-spacing-2xs);
+        }
+
+        .ffe-grid--lg-gap-xs & {
+            gap: var(--ffe-spacing-xs);
+            padding-right: var(--ffe-spacing-xs);
+            padding-left: var(--ffe-spacing-xs);
+        }
+
+        .ffe-grid--lg-gap-sm & {
+            gap: var(--ffe-spacing-sm);
+            padding-right: var(--ffe-spacing-sm);
+            padding-left: var(--ffe-spacing-sm);
+        }
+
+        .ffe-grid--lg-gap-md & {
+            gap: var(--ffe-spacing-md);
+            padding-right: var(--ffe-spacing-md);
+            padding-left: var(--ffe-spacing-md);
+        }
+
+        .ffe-grid--lg-gap-lg & {
+            gap: var(--ffe-spacing-lg);
+            padding-right: var(--ffe-spacing-lg);
+            padding-left: var(--ffe-spacing-lg);
+        }
     }
 
     &--padding-2xs {
-        padding-top: @ffe-spacing-2xs;
-        padding-bottom: @ffe-spacing-2xs;
+        padding-top: var(--ffe-spacing-2xs);
+        padding-bottom: var(--ffe-spacing-2xs);
     }
 
     &--padding-xs {
-        padding-top: @ffe-spacing-xs;
-        padding-bottom: @ffe-spacing-xs;
+        padding-top: var(--ffe-spacing-2xs);
+        padding-bottom: var(--ffe-spacing-2xs);
     }
 
     &--padding-sm {
-        padding-top: @ffe-spacing-sm;
-        padding-bottom: @ffe-spacing-sm;
+        padding-top: var(--ffe-spacing-sm);
+        padding-bottom: var(--ffe-spacing-sm);
     }
 
     &--padding-md {
-        padding-top: @ffe-spacing-md;
-        padding-bottom: @ffe-spacing-md;
+        padding-top: var(--ffe-spacing-md);
+        padding-bottom: var(--ffe-spacing-md);
     }
 
     &--padding-lg {
-        padding-top: @ffe-spacing-lg;
-        padding-bottom: @ffe-spacing-lg;
+        padding-top: var(--ffe-spacing-lg);
+        padding-bottom: var(--ffe-spacing-lg);
     }
 
     &--padding-xl {
-        padding-top: @ffe-spacing-xl;
-        padding-bottom: @ffe-spacing-xl;
+        padding-top: var(--ffe-spacing-xl);
+        padding-bottom: var(--ffe-spacing-xl);
     }
 
     &--padding-2xl {
-        padding-top: @ffe-spacing-2xl;
-        padding-bottom: @ffe-spacing-2xl;
+        padding-top: var(--ffe-spacing-2xl);
+        padding-bottom: var(--ffe-spacing-2xl);
     }
 
     &--padding-3xl {
-        padding-top: @ffe-spacing-3xl;
-        padding-bottom: @ffe-spacing-3xl;
+        padding-top: var(--ffe-spacing-3xl);
+        padding-bottom: var(--ffe-spacing-3xl);
     }
 
     &--padding-4xl {
-        padding-top: @ffe-spacing-4xl;
-        padding-bottom: @ffe-spacing-4xl;
+        padding-top: var(--ffe-spacing-4xl);
+        padding-bottom: var(--ffe-spacing-4xl);
     }
 
     &--padding-5xl {
-        padding-top: @ffe-spacing-5xl;
-        padding-bottom: @ffe-spacing-5xl;
+        padding-top: var(--ffe-spacing-5xl);
+        padding-bottom: var(--ffe-spacing-5xl);
+    }
+
+    @media (min-width: @breakpoint-sm) {
+        &--sm-padding-2xs {
+            padding-top: var(--ffe-spacing-2xs);
+            padding-bottom: var(--ffe-spacing-2xs);
+        }
+
+        &--sm-padding-xs {
+            padding-top: var(--ffe-spacing-2xs);
+            padding-bottom: var(--ffe-spacing-2xs);
+        }
+
+        &--sm-padding-sm {
+            padding-top: var(--ffe-spacing-sm);
+            padding-bottom: var(--ffe-spacing-sm);
+        }
+
+        &--sm-padding-md {
+            padding-top: var(--ffe-spacing-md);
+            padding-bottom: var(--ffe-spacing-md);
+        }
+
+        &--sm-padding-lg {
+            padding-top: var(--ffe-spacing-lg);
+            padding-bottom: var(--ffe-spacing-lg);
+        }
+
+        &--sm-padding-xl {
+            padding-top: var(--ffe-spacing-xl);
+            padding-bottom: var(--ffe-spacing-xl);
+        }
+
+        &--sm-padding-2xl {
+            padding-top: var(--ffe-spacing-2xl);
+            padding-bottom: var(--ffe-spacing-2xl);
+        }
+
+        &--sm-padding-3xl {
+            padding-top: var(--ffe-spacing-3xl);
+            padding-bottom: var(--ffe-spacing-3xl);
+        }
+
+        &--sm-padding-4xl {
+            padding-top: var(--ffe-spacing-4xl);
+            padding-bottom: var(--ffe-spacing-4xl);
+        }
+
+        &--sm-padding-5xl {
+            padding-top: var(--ffe-spacing-5xl);
+            padding-bottom: var(--ffe-spacing-5xl);
+        }
+    }
+
+    @media (min-width: @breakpoint-md) {
+        &--md-padding-2xs {
+            padding-top: var(--ffe-spacing-2xs);
+            padding-bottom: var(--ffe-spacing-2xs);
+        }
+
+        &--md-padding-xs {
+            padding-top: var(--ffe-spacing-2xs);
+            padding-bottom: var(--ffe-spacing-2xs);
+        }
+
+        &--md-padding-sm {
+            padding-top: var(--ffe-spacing-sm);
+            padding-bottom: var(--ffe-spacing-sm);
+        }
+
+        &--md-padding-md {
+            padding-top: var(--ffe-spacing-md);
+            padding-bottom: var(--ffe-spacing-md);
+        }
+
+        &--md-padding-lg {
+            padding-top: var(--ffe-spacing-lg);
+            padding-bottom: var(--ffe-spacing-lg);
+        }
+
+        &--md-padding-xl {
+            padding-top: var(--ffe-spacing-xl);
+            padding-bottom: var(--ffe-spacing-xl);
+        }
+
+        &--md-padding-2xl {
+            padding-top: var(--ffe-spacing-2xl);
+            padding-bottom: var(--ffe-spacing-2xl);
+        }
+
+        &--md-padding-3xl {
+            padding-top: var(--ffe-spacing-3xl);
+            padding-bottom: var(--ffe-spacing-3xl);
+        }
+
+        &--md-padding-4xl {
+            padding-top: var(--ffe-spacing-4xl);
+            padding-bottom: var(--ffe-spacing-4xl);
+        }
+
+        &--md-padding-5xl {
+            padding-top: var(--ffe-spacing-5xl);
+            padding-bottom: var(--ffe-spacing-5xl);
+        }
+    }
+
+    @media (min-width: @breakpoint-lg) {
+        &--lg-padding-2xs {
+            padding-top: var(--ffe-spacing-2xs);
+            padding-bottom: var(--ffe-spacing-2xs);
+        }
+
+        &--lg-padding-xs {
+            padding-top: var(--ffe-spacing-2xs);
+            padding-bottom: var(--ffe-spacing-2xs);
+        }
+
+        &--lg-padding-sm {
+            padding-top: var(--ffe-spacing-sm);
+            padding-bottom: var(--ffe-spacing-sm);
+        }
+
+        &--lg-padding-md {
+            padding-top: var(--ffe-spacing-md);
+            padding-bottom: var(--ffe-spacing-md);
+        }
+
+        &--lg-padding-lg {
+            padding-top: var(--ffe-spacing-lg);
+            padding-bottom: var(--ffe-spacing-lg);
+        }
+
+        &--lg-padding-xl {
+            padding-top: var(--ffe-spacing-xl);
+            padding-bottom: var(--ffe-spacing-xl);
+        }
+
+        &--lg-padding-2xl {
+            padding-top: var(--ffe-spacing-2xl);
+            padding-bottom: var(--ffe-spacing-2xl);
+        }
+
+        &--lg-padding-3xl {
+            padding-top: var(--ffe-spacing-3xl);
+            padding-bottom: var(--ffe-spacing-3xl);
+        }
+
+        &--lg-padding-4xl {
+            padding-top: var(--ffe-spacing-4xl);
+            padding-bottom: var(--ffe-spacing-4xl);
+        }
+
+        &--lg-padding-5xl {
+            padding-top: var(--ffe-spacing-5xl);
+            padding-bottom: var(--ffe-spacing-5xl);
+        }
     }
 
     &--margin-2xs {
-        margin: @ffe-spacing-2xs auto;
+        margin: var(--ffe-spacing-2xs) auto;
     }
 
     &--margin-xs {
-        margin: @ffe-spacing-xs auto;
+        margin: var(--ffe-spacing-xs) auto;
     }
 
     &--margin-sm {
-        margin: @ffe-spacing-sm auto;
+        margin: var(--ffe-spacing-sm) auto;
     }
 
     &--margin-md {
-        margin: @ffe-spacing-md auto;
+        margin: var(--ffe-spacing-md) auto;
     }
 
     &--margin-lg {
-        margin: @ffe-spacing-lg auto;
+        margin: var(--ffe-spacing-lg) auto;
     }
 
     &--margin-xl {
-        margin: @ffe-spacing-xl auto;
+        margin: var(--ffe-spacing-xl) auto;
     }
 
     &--margin-2xl {
-        margin: @ffe-spacing-2xl auto;
+        margin: var(--ffe-spacing-2xl) auto;
     }
 
     &--margin-3xl {
-        margin: @ffe-spacing-3xl auto;
+        margin: var(--ffe-spacing-3xl) auto;
     }
 
     &--margin-4xl {
-        margin: @ffe-spacing-4xl auto;
+        margin: var(--ffe-spacing-4xl) auto;
     }
 
     &--margin-5xl {
-        margin: @ffe-spacing-5xl auto;
+        margin: var(--ffe-spacing-5xl) auto;
+    }
+
+    @media (min-width: @breakpoint-sm) {
+        &--sm-margin-2xs {
+            margin: var(--ffe-spacing-2xs) auto;
+        }
+
+        &--sm-margin-xs {
+            margin: var(--ffe-spacing-xs) auto;
+        }
+
+        &--sm-margin-sm {
+            margin: var(--ffe-spacing-sm) auto;
+        }
+
+        &--sm-margin-md {
+            margin: var(--ffe-spacing-md) auto;
+        }
+
+        &--sm-margin-lg {
+            margin: var(--ffe-spacing-lg) auto;
+        }
+
+        &--sm-margin-xl {
+            margin: var(--ffe-spacing-xl) auto;
+        }
+
+        &--sm-margin-2xl {
+            margin: var(--ffe-spacing-2xl) auto;
+        }
+
+        &--sm-margin-3xl {
+            margin: var(--ffe-spacing-3xl) auto;
+        }
+
+        &--sm-margin-4xl {
+            margin: var(--ffe-spacing-4xl) auto;
+        }
+
+        &--sm-margin-5xl {
+            margin: var(--ffe-spacing-5xl) auto;
+        }
+    }
+
+    @media (min-width: @breakpoint-md) {
+        &--md-margin-2xs {
+            margin: var(--ffe-spacing-2xs) auto;
+        }
+
+        &--md-margin-xs {
+            margin: var(--ffe-spacing-xs) auto;
+        }
+
+        &--md-margin-sm {
+            margin: var(--ffe-spacing-sm) auto;
+        }
+
+        &--md-margin-md {
+            margin: var(--ffe-spacing-md) auto;
+        }
+
+        &--md-margin-lg {
+            margin: var(--ffe-spacing-lg) auto;
+        }
+
+        &--md-margin-xl {
+            margin: var(--ffe-spacing-xl) auto;
+        }
+
+        &--md-margin-2xl {
+            margin: var(--ffe-spacing-2xl) auto;
+        }
+
+        &--md-margin-3xl {
+            margin: var(--ffe-spacing-3xl) auto;
+        }
+
+        &--md-margin-4xl {
+            margin: var(--ffe-spacing-4xl) auto;
+        }
+
+        &--md-margin-5xl {
+            margin: var(--ffe-spacing-5xl) auto;
+        }
+    }
+
+    @media (min-width: @breakpoint-lg) {
+        &--lg-margin-2xs {
+            margin: var(--ffe-spacing-2xs) auto;
+        }
+
+        &--lg-margin-xs {
+            margin: var(--ffe-spacing-xs) auto;
+        }
+
+        &--lg-margin-sm {
+            margin: var(--ffe-spacing-sm) auto;
+        }
+
+        &--lg-margin-md {
+            margin: var(--ffe-spacing-md) auto;
+        }
+
+        &--lg-margin-lg {
+            margin: var(--ffe-spacing-lg) auto;
+        }
+
+        &--lg-margin-xl {
+            margin: var(--ffe-spacing-xl) auto;
+        }
+
+        &--lg-margin-2xl {
+            margin: var(--ffe-spacing-2xl) auto;
+        }
+
+        &--lg-margin-3xl {
+            margin: var(--ffe-spacing-3xl) auto;
+        }
+
+        &--lg-margin-4xl {
+            margin: var(--ffe-spacing-4xl) auto;
+        }
+
+        &--lg-margin-5xl {
+            margin: var(--ffe-spacing-5xl) auto;
+        }
     }
 
     &--bg-frost-30 {


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse

Legger til støtte for responsiv spacing i Grid.

Overstyringene er lagt til i størrelses-propene `sm`, `md` og `lg`, som er et etablert mønster i Grid-komponenten. Man kan overstyre `gap` på `<Grid>`, samt `margin` og `padding` på `<GridRow>`. Verdier som kan brukes er tilsvarende som i de eksisterende, ikke-responsive `gap`, `margin` og `padding`-modifierne.

Tenkt eksempel der default verdi er `xs` og størrelsen progressivt øker med skjermstørrelse:

```
<Grid
    gap="xs"
    sm={{ gap: 'sm' }}
    md={{ gap: 'md' }}
    lg={{ gap: 'lg' }}
    >
    <GridRow
        margin="xs"
        padding="xs"
        sm={{ margin: 'sm', padding: 'sm' }}
        md={{ margin: 'md', padding: 'md' }}
        lg={{ margin: 'lg', padding: 'lg' }}
        >
        <GridCol>
            ...
        </GridCol>
    </GridRow>
</Grid>
```

## Motivasjon og kontekst

Fixes #1693 

## Testing

Testet med component-overview