### PR TITLE
fix(ffe-account-selector-react): add generic type for account

### DIFF
--- a/packages/ffe-account-selector-react/src/account-selector-multi/AccountSelectorMulti.tsx
+++ b/packages/ffe-account-selector-react/src/account-selector-multi/AccountSelectorMulti.tsx
@@ -16,8 +16,8 @@ const allAccountsElement: AllAccountsElement = {
     accountNumber: '',
 };
 
-const isAllAccountsElement = (
-    suggestion: Account | AllAccountsElement,
+const isAllAccountsElement = <T extends Account>(
+    suggestion: T | AllAccountsElement,
 ): suggestion is AllAccountsElement =>
     (suggestion as AllAccountsElement)?.id === 'all-accounts';
 
@@ -41,7 +41,7 @@ const renderSelectAll = (allSelected: boolean, locale: Locale) => (
     </div>
 );
 
-export interface AccountSelectorMultiProps {
+export interface AccountSelectorMultiProps<T extends Account> {
     /**
      * Array of objects:
      *  {
@@ -51,7 +51,7 @@ export interface AccountSelectorMultiProps {
      *      name: string.isRequired,
      *  }
      */
-    accounts?: Account[];
+    accounts?: T[];
     id: string;
     isLoading?: boolean;
     /** 'nb', 'nn', or 'en' */
@@ -59,7 +59,7 @@ export interface AccountSelectorMultiProps {
     /** Overrides default string for all locales. */
     noMatches?: string;
     /** Called when an account is clicked */
-    onAccountSelected: (account: Account | AllAccountsElement) => void;
+    onAccountSelected: (account: T | AllAccountsElement) => void;
     onChange?: (value: string) => void;
     onFocus?: () => void;
     onBlur: () => void;
@@ -74,7 +74,7 @@ export interface AccountSelectorMultiProps {
      *      name: string.isRequired,
      *  }
      */
-    selectedAccounts?: Account[];
+    selectedAccounts?: T[];
     showSelectAllOption?: boolean;
     value?: string;
 }
@@ -83,13 +83,15 @@ interface AccountSelectorMultiState {
     suggestionListHeight: number;
 }
 
-export class AccountSelectorMulti extends React.Component<
-    AccountSelectorMultiProps,
+export class AccountSelectorMulti<
+    T extends Account = Account,
+> extends React.Component<
+    AccountSelectorMultiProps<T>,
     AccountSelectorMultiState
 > {
     private shouldShowSuggestions?: boolean;
-    private baseRef?: BaseSelector<Account | AllAccountsElement> | null;
-    constructor(props: AccountSelectorMultiProps) {
+    private baseRef?: BaseSelector<T | AllAccountsElement> | null;
+    constructor(props: AccountSelectorMultiProps<T>) {
         super(props);
         autoBind(this);
         this.state = {
@@ -108,7 +110,7 @@ export class AccountSelectorMulti extends React.Component<
         return accounts.filter(accountFilter(value));
     }
 
-    onSuggestionSelect(suggestion: AllAccountsElement | Account) {
+    onSuggestionSelect(suggestion: AllAccountsElement | T) {
         const {
             onAccountSelected,
             selectedAccounts = [],
@@ -130,7 +132,7 @@ export class AccountSelectorMulti extends React.Component<
         }
     }
 
-    renderSuggestion(account: Account | AllAccountsElement) {
+    renderSuggestion(account: T | AllAccountsElement) {
         const { locale, selectedAccounts = [], accounts } = this.props;
         const isSelected = selectedAccounts.filter(
             it => it.accountNumber === account.accountNumber,

--- a/packages/ffe-account-selector-react/src/account-selector/AccountSelector.tsx
+++ b/packages/ffe-account-selector-react/src/account-selector/AccountSelector.tsx
@@ -9,13 +9,13 @@ import { Account } from '../types';
 import { formatIncompleteAccountNumber } from '../util/format';
 import { SearchableDropdown } from '@sb1/ffe-searchable-dropdown-react';
 
-const getAccountsWithCustomAccounts = ({
+const getAccountsWithCustomAccounts = <T extends Account>({
     accounts,
     selectedAccount,
     inputValue,
 }: {
-    accounts: Account[];
-    selectedAccount: Account | undefined;
+    accounts: T[];
+    selectedAccount: T | undefined;
     inputValue: string;
 }) => {
     const shouldAddSelectedAccountNotFoundInList =
@@ -30,7 +30,7 @@ const getAccountsWithCustomAccounts = ({
         : accounts;
 };
 
-export interface AccountSelectorProps {
+export interface AccountSelectorProps<T extends Account> {
     /**
      * Array of objects:
      *  {
@@ -40,19 +40,19 @@ export interface AccountSelectorProps {
      *      currencyCode: string,
      *  }
      */
-    accounts: Account[];
+    accounts: T[];
     className?: string;
     id: string;
     locale?: 'nb' | 'nn' | 'en';
     /** Overrides default string for all locales. */
     noMatches?: {
         text: string;
-        dropdownList?: Account[];
+        dropdownList?: T[];
     };
     /** Props passed to the input field */
     inputProps?: React.ComponentPropsWithoutRef<'input'>;
     /** Returns the selected account object */
-    onAccountSelected: (account: Account) => void;
+    onAccountSelected: (account: T) => void;
     /**
      * Called when emptying the input field and moving focus away from the account selector
      * *
@@ -72,7 +72,7 @@ export interface AccountSelectorProps {
      */
     allowCustomAccount?: boolean;
     /** Custom element to use for each item in the dropdown list */
-    listElementBody?: React.ComponentType<AccountSuggestionSingleProps>;
+    listElementBody?: React.ComponentType<AccountSuggestionSingleProps<T>>;
     /** Element to be shown below dropDownList */
     postListElement?: React.ReactNode;
     /** Sets aria-invalid on input field  */
@@ -80,12 +80,12 @@ export interface AccountSelectorProps {
     /** Prop passed to the dropdown list */
     onOpen?: () => void;
     onClose?: () => void;
-    selectedAccount?: Account;
+    selectedAccount?: T;
 
     onReset: () => void;
 }
 
-export const AccountSelector: React.FC<AccountSelectorProps> = ({
+export const AccountSelector = <T extends Account = Account>({
     id,
     className,
     locale = 'nb',
@@ -105,7 +105,7 @@ export const AccountSelector: React.FC<AccountSelectorProps> = ({
     ariaInvalid,
     onOpen,
     onClose,
-}) => {
+}: AccountSelectorProps<T>) => {
     const [inputValue, setInputValue] = useState(selectedAccount?.name || '');
 
     const formatter = formatAccountNumber
@@ -117,15 +117,14 @@ export const AccountSelector: React.FC<AccountSelectorProps> = ({
      * but it ignores all spaces and periods so that account number formatting won't mess with the search.
      */
     const searchMatcherIgnoringAccountNumberFormatting =
-        (searchString: string, searchAttributes: (keyof Account)[]) =>
-        (item: Account) => {
+        (searchString: string, searchAttributes: (keyof T)[]) => (item: T) => {
             const cleanString = (value: unknown) =>
                 `${value}`
                     .replace(/(\s|\.)/g, '') // Remove all spaces and periods
                     .toLowerCase();
             const cleanedSearchString = cleanString(searchString);
             return searchAttributes.some(searchAttribute =>
-                cleanString(item[searchAttribute as keyof Account]).includes(
+                cleanString(item[searchAttribute as keyof T]).includes(
                     cleanedSearchString,
                 ),
             );
@@ -137,7 +136,7 @@ export const AccountSelector: React.FC<AccountSelectorProps> = ({
         }
     };
 
-    const handleAccountSelected = (value: Account | null) => {
+    const handleAccountSelected = (value: T | null) => {
         const hasResetSelection = value === null;
         const hasSelectedCustomAccount = !value?.accountNumber;
         if (hasResetSelection) {
@@ -147,7 +146,7 @@ export const AccountSelector: React.FC<AccountSelectorProps> = ({
             onAccountSelected({
                 name: value.name,
                 accountNumber: value.name,
-            });
+            } as T);
             setInputValue(value.name);
         } else {
             onAccountSelected(value);
@@ -162,7 +161,7 @@ export const AccountSelector: React.FC<AccountSelectorProps> = ({
                       {
                           name: formatter ? formatter(inputValue) : inputValue,
                           accountNumber: '',
-                      },
+                      } as T,
                   ],
               }
             : noMatches;
@@ -180,7 +179,7 @@ export const AccountSelector: React.FC<AccountSelectorProps> = ({
             className={classNames('ffe-account-selector-single', className)}
             id={`${id}-account-selector-container`}
         >
-            <SearchableDropdown<Account>
+            <SearchableDropdown<T>
                 id={id}
                 labelledById={labelledById}
                 inputProps={{

--- a/packages/ffe-account-selector-react/src/account-selector/AccountSuggestionSingle.tsx
+++ b/packages/ffe-account-selector-react/src/account-selector/AccountSuggestionSingle.tsx
@@ -3,19 +3,19 @@ import classNames from 'classnames';
 import { accountFormatter, balanceWithCurrency } from '../util/format';
 import { Account, Locale } from '../types';
 
-export interface AccountSuggestionSingleProps {
-    item: Account;
+export interface AccountSuggestionSingleProps<T extends Account = Account> {
+    item: T;
     locale: Locale;
     isHighlighted: boolean;
-    dropdownAttributes: (keyof Account)[];
+    dropdownAttributes: (keyof T)[];
 }
 
-export const AccountSuggestionSingle = ({
+export const AccountSuggestionSingle = <T extends Account>({
     item,
     isHighlighted,
     locale,
     dropdownAttributes,
-}: AccountSuggestionSingleProps) => {
+}: AccountSuggestionSingleProps<T>) => {
     const { accountNumber, balance, name, currencyCode } = item;
     const shouldShowBalance =
         dropdownAttributes.includes('balance') &&

--- a/packages/ffe-account-selector-react/src/types.ts
+++ b/packages/ffe-account-selector-react/src/types.ts
@@ -6,5 +6,5 @@ export interface Account {
     accountNumber: string;
     name: string;
     currencyCode?: AutoComplete<'NOK' | 'EUR'>;
-    balance?: number;
+    balance?: number | string;
 }


### PR DESCRIPTION
## Beskrivelse

Legger til generics for AccountSelector-komponentene

## Motivasjon og kontekst

Før migrering til typescript var typen for Account generic. Dette er nyttig når man for eksempel skal bruke `onAccountSelected` for da får man typen man sendte inn. Vi har ofte kontotyper som er flere felt enn det som er i `Account`-typen og det er fint å få de med gjennom.

Har også endret typen for `balance` til å være `number | string`. Dette var også sånn det var tidligere, og det ser ut for meg som at det allerede er tatt hensyn til i koden.

Tar gjerne imot endringsforslag!
