### PR TITLE
chore: remove .nmprc

### DIFF
--- a/buildtool/.npmrc
+++ b/buildtool/.npmrc
@@ -1,1 +1,0 @@
-package-lock=false

--- a/component-overview/.npmrc
+++ b/component-overview/.npmrc
@@ -1,1 +1,0 @@
-package-lock=false

--- a/linting/eslint-config-ffe-base/.npmrc
+++ b/linting/eslint-config-ffe-base/.npmrc
@@ -1,1 +1,0 @@
-package-lock=false

--- a/linting/eslint-config-ffe/.npmrc
+++ b/linting/eslint-config-ffe/.npmrc
@@ -1,1 +1,0 @@
-package-lock=false

--- a/linting/stylelint-config-ffe/.npmrc
+++ b/linting/stylelint-config-ffe/.npmrc
@@ -1,1 +1,0 @@
-package-lock=false

--- a/packages/ffe-accordion-react/.npmrc
+++ b/packages/ffe-accordion-react/.npmrc
@@ -1,1 +1,0 @@
-package-lock=false

--- a/packages/ffe-accordion/.npmrc
+++ b/packages/ffe-accordion/.npmrc
@@ -1,1 +1,0 @@
-package-lock=false

--- a/packages/ffe-account-selector-react/.npmrc
+++ b/packages/ffe-account-selector-react/.npmrc
@@ -1,1 +1,0 @@
-package-lock=false

--- a/packages/ffe-buttons-react/.npmrc
+++ b/packages/ffe-buttons-react/.npmrc
@@ -1,1 +1,0 @@
-package-lock=false

--- a/packages/ffe-buttons/.npmrc
+++ b/packages/ffe-buttons/.npmrc
@@ -1,1 +1,0 @@
-package-lock=false

--- a/packages/ffe-cards-react/.npmrc
+++ b/packages/ffe-cards-react/.npmrc
@@ -1,1 +1,0 @@
-package-lock=false

--- a/packages/ffe-cards/.npmrc
+++ b/packages/ffe-cards/.npmrc
@@ -1,1 +1,0 @@
-package-lock=false

--- a/packages/ffe-chart-donut-react/.npmrc
+++ b/packages/ffe-chart-donut-react/.npmrc
@@ -1,1 +1,0 @@
-package-lock=false

--- a/packages/ffe-collapse-react/.npmrc
+++ b/packages/ffe-collapse-react/.npmrc
@@ -1,1 +1,0 @@
-package-lock=false

--- a/packages/ffe-context-message-react/.npmrc
+++ b/packages/ffe-context-message-react/.npmrc
@@ -1,1 +1,0 @@
-package-lock=false

--- a/packages/ffe-context-message/.npmrc
+++ b/packages/ffe-context-message/.npmrc
@@ -1,1 +1,0 @@
-package-lock=false

--- a/packages/ffe-core-react/.npmrc
+++ b/packages/ffe-core-react/.npmrc
@@ -1,1 +1,0 @@
-package-lock=false

--- a/packages/ffe-core/.npmrc
+++ b/packages/ffe-core/.npmrc
@@ -1,1 +1,0 @@
-package-lock=false

--- a/packages/ffe-datepicker-react/.npmrc
+++ b/packages/ffe-datepicker-react/.npmrc
@@ -1,1 +1,0 @@
-package-lock=false

--- a/packages/ffe-datepicker/.npmrc
+++ b/packages/ffe-datepicker/.npmrc
@@ -1,1 +1,0 @@
-package-lock=false

--- a/packages/ffe-details-list-react/.npmrc
+++ b/packages/ffe-details-list-react/.npmrc
@@ -1,1 +1,0 @@
-package-lock=false

--- a/packages/ffe-dropdown-react/.npmrc
+++ b/packages/ffe-dropdown-react/.npmrc
@@ -1,1 +1,0 @@
-package-lock=false

--- a/packages/ffe-feedback-react/.npmrc
+++ b/packages/ffe-feedback-react/.npmrc
@@ -1,1 +1,0 @@
-package-lock=false

--- a/packages/ffe-feedback/.npmrc
+++ b/packages/ffe-feedback/.npmrc
@@ -1,1 +1,0 @@
-package-lock=false

--- a/packages/ffe-file-upload-react/.npmrc
+++ b/packages/ffe-file-upload-react/.npmrc
@@ -1,1 +1,0 @@
-package-lock=false

--- a/packages/ffe-file-upload/.npmrc
+++ b/packages/ffe-file-upload/.npmrc
@@ -1,1 +1,0 @@
-package-lock=false

--- a/packages/ffe-form-react/.npmrc
+++ b/packages/ffe-form-react/.npmrc
@@ -1,1 +1,0 @@
-package-lock=false

--- a/packages/ffe-form/.npmrc
+++ b/packages/ffe-form/.npmrc
@@ -1,1 +1,0 @@
-package-lock=false

--- a/packages/ffe-formatters/.npmrc
+++ b/packages/ffe-formatters/.npmrc
@@ -1,1 +1,0 @@
-package-lock=false

--- a/packages/ffe-grid-react/.npmrc
+++ b/packages/ffe-grid-react/.npmrc
@@ -1,1 +1,0 @@
-package-lock=false

--- a/packages/ffe-grid/.npmrc
+++ b/packages/ffe-grid/.npmrc
@@ -1,1 +1,0 @@
-package-lock=false

--- a/packages/ffe-header/.npmrc
+++ b/packages/ffe-header/.npmrc
@@ -1,1 +1,0 @@
-package-lock=false

--- a/packages/ffe-icons-react/.npmrc
+++ b/packages/ffe-icons-react/.npmrc
@@ -1,1 +1,0 @@
-package-lock=false

--- a/packages/ffe-icons/.npmrc
+++ b/packages/ffe-icons/.npmrc
@@ -1,1 +1,0 @@
-package-lock=false

--- a/packages/ffe-lists-react/.npmrc
+++ b/packages/ffe-lists-react/.npmrc
@@ -1,1 +1,0 @@
-package-lock=false

--- a/packages/ffe-lists/.npmrc
+++ b/packages/ffe-lists/.npmrc
@@ -1,1 +1,0 @@
-package-lock=false

--- a/packages/ffe-message-box-react/.npmrc
+++ b/packages/ffe-message-box-react/.npmrc
@@ -1,1 +1,0 @@
-package-lock=false

--- a/packages/ffe-message-box/.npmrc
+++ b/packages/ffe-message-box/.npmrc
@@ -1,1 +1,0 @@
-package-lock=false

--- a/packages/ffe-messages-react/.npmrc
+++ b/packages/ffe-messages-react/.npmrc
@@ -1,1 +1,0 @@
-package-lock=false

--- a/packages/ffe-messages/.npmrc
+++ b/packages/ffe-messages/.npmrc
@@ -1,1 +1,0 @@
-package-lock=false

--- a/packages/ffe-modal/.npmrc
+++ b/packages/ffe-modal/.npmrc
@@ -1,1 +1,0 @@
-package-lock=false

--- a/packages/ffe-sb1-logos/.npmrc
+++ b/packages/ffe-sb1-logos/.npmrc
@@ -1,1 +1,0 @@
-package-lock=false

--- a/packages/ffe-searchable-dropdown-react/.npmrc
+++ b/packages/ffe-searchable-dropdown-react/.npmrc
@@ -1,1 +1,0 @@
-package-lock=false

--- a/packages/ffe-spinner-react/.npmrc
+++ b/packages/ffe-spinner-react/.npmrc
@@ -1,1 +1,0 @@
-package-lock=false

--- a/packages/ffe-spinner/.npmrc
+++ b/packages/ffe-spinner/.npmrc
@@ -1,1 +1,0 @@
-package-lock=false

--- a/packages/ffe-symbols-react/.npmrc
+++ b/packages/ffe-symbols-react/.npmrc
@@ -1,1 +1,0 @@
-package-lock=false

--- a/packages/ffe-system-message-react/.npmrc
+++ b/packages/ffe-system-message-react/.npmrc
@@ -1,1 +1,0 @@
-package-lock=false

--- a/packages/ffe-system-message/.npmrc
+++ b/packages/ffe-system-message/.npmrc
@@ -1,1 +1,0 @@
-package-lock=false

--- a/packages/ffe-tables-react/.npmrc
+++ b/packages/ffe-tables-react/.npmrc
@@ -1,1 +1,0 @@
-package-lock=false

--- a/packages/ffe-tables/.npmrc
+++ b/packages/ffe-tables/.npmrc
@@ -1,1 +1,0 @@
-package-lock=false

--- a/packages/ffe-tabs-react/.npmrc
+++ b/packages/ffe-tabs-react/.npmrc
@@ -1,1 +1,0 @@
-package-lock=false

--- a/packages/ffe-tabs/.npmrc
+++ b/packages/ffe-tabs/.npmrc
@@ -1,1 +1,0 @@
-package-lock=false

--- a/packages/ffe-webfonts/.npmrc
+++ b/packages/ffe-webfonts/.npmrc
@@ -1,1 +1,0 @@
-package-lock=false


### PR DESCRIPTION
Nu når vi har npm workspaces skall ikke disse vare nødvendiga. 

![image](https://github.com/SpareBank1/designsystem/assets/2248579/904e8fc4-48cb-4d8f-8f4e-910c6b1289c0)
