### PR TITLE
fix(ffe-account-selector-react): add default account type for generic account selector props

### DIFF
--- a/packages/ffe-account-selector-react/src/account-selector-multi/AccountSelectorMulti.tsx
+++ b/packages/ffe-account-selector-react/src/account-selector-multi/AccountSelectorMulti.tsx
@@ -41,7 +41,7 @@ const renderSelectAll = (allSelected: boolean, locale: Locale) => (
     </div>
 );
 
-export interface AccountSelectorMultiProps<T extends Account> {
+export interface AccountSelectorMultiProps<T extends Account = Account> {
     /**
      * Array of objects:
      *  {

--- a/packages/ffe-account-selector-react/src/account-selector/AccountSelector.tsx
+++ b/packages/ffe-account-selector-react/src/account-selector/AccountSelector.tsx
@@ -30,7 +30,7 @@ const getAccountsWithCustomAccounts = <T extends Account>({
         : accounts;
 };
 
-export interface AccountSelectorProps<T extends Account> {
+export interface AccountSelectorProps<T extends Account = Account> {
     /**
      * Array of objects:
      *  {


### PR DESCRIPTION
Legger på default verdi for generic props hvis noen ønsker å bruke props-typen uten å måtte spesifisere account-typen