### PR TITLE
fix(ffe-core): utvide breakpoint for typografi på tablets

### DIFF
--- a/packages/ffe-core/less/theme.less
+++ b/packages/ffe-core/less/theme.less
@@ -114,7 +114,7 @@
         --ffe-fontsize-h5: 1.125rem;
     }
 
-    @media (min-width: @breakpoint-md) {
+    @media (min-width: @breakpoint-lg) {
         --ffe-fontsize-h1: 2.875rem;
         --ffe-fontsize-h2: 2.25rem;
         --ffe-fontsize-h3: 1.75rem;

--- a/packages/ffe-core/less/typography.less
+++ b/packages/ffe-core/less/typography.less
@@ -322,7 +322,7 @@
     }
 }
 
-@media (min-width: @breakpoint-md) {
+@media (min-width: @breakpoint-lg) {
     .ffe-h1,
     .ffe-h2,
     .ffe-h3,


### PR DESCRIPTION
fixes https://github.com/SpareBank1/designsystem/issues/1403

## Beskrivelse

Breakpointet for tablets var litt for lite til å også tilrettelegge for landscape mode. Før denne committen fikk vi mindre skriftstørrelse på h1, h2 og h3 ved breakpoint-md (768px), men i følge microsoft kan landscape tablets være opp mot 1008px. 

Har nå satt det til breakpoint-lg (1024px), så litt høyere enn microsoft sin standard, men tenker det er bedre at vi er konsistente i bruken av breakpoints internt. Så, fra 1023px og nedover så er skriftstørrelsen for h1, h2 og h3 litt mindre. Håper at det blir bedre for flere. 

Vi nevner ikke typografi-breakpoints i dokumentasjonen så det trengs ikke oppdateres noe i designssystem-docs. 

## Testing
https://sparebank1.github.io/designsystem/typography_Heading sjekk på forskjellige skjermsørrelser. 