### PR TITLE
Default typografi og lenkefarge

### DIFF
--- a/component-overview/webapp/components/Layout.jsx
+++ b/component-overview/webapp/components/Layout.jsx
@@ -28,6 +28,7 @@ export default function Layout({ children }) {
                 <body
                     className={classNames({
                         'sb1ex-body': true,
+                        'ffe-body': true,
                         native: context.prefersDarkMode,
                         'regard-color-scheme-preference':
                             context.prefersDarkMode,

--- a/packages/ffe-core/less/body.less
+++ b/packages/ffe-core/less/body.less
@@ -1,11 +1,33 @@
-// Sets default body color and background color for light and dark themes
+// Sets default body color, font styles and background color for light and dark themes
 .ffe-body {
-    color: @ffe-farge-svart;
     background-color: @ffe-farge-hvit;
     &.native {
         @media (prefers-color-scheme: dark) {
             color: @ffe-farge-lysgraa;
             background-color: @ffe-farge-svart;
         }
+    }
+
+    font-family: var(--ffe-g-font);
+    color: var(--ffe-g-text-color);
+    font-variant-numeric: tabular-nums;
+
+    strong {
+        font-family: var(--ffe-g-font-strong);
+        font-weight: normal;
+    }
+
+    small {
+        font-size: var(--ffe-fontsize-small-text);
+    }
+
+    em {
+        font-family: var(--ffe-g-font-italic);
+        font-weight: normal;
+        font-style: normal;
+    }
+
+    pre {
+        font-family: consolas, menlo, monaco, monospace;
     }
 }


### PR DESCRIPTION
fixes https://github.com/SpareBank1/designsystem/issues/1729

## Beskrivelse
Legger til noen deafault verdier for font og noen verdier for strong, small, em og pre. 

## Motivasjon og kontekst

Som beskrevet i issuet er det greit å ha noe fallback. Har valgt å ikke oppdatere spesifikke headings eller lenker (h1, h2, a osv) fordi det overskriver for mye av stylingen vi har nå i for eksempel Accordion, Messages, CardBase osv. 

## Testing

Fjernet ffe-spesifikke klasser og sjekket at de fikk sb1-font og annet styling som spesifisert. 



Dobbeltsjekk gjerne at commit-meldingene ble riktig
