### PR TITLE
fix(ffe-core): enabler ios font-scaling kun på native

### DIFF
--- a/packages/ffe-core/less/ffe-normalize.less
+++ b/packages/ffe-core/less/ffe-normalize.less
@@ -15,7 +15,8 @@ html,
 @supports (font: -apple-system-body) {
     :root,
     :host {
-        font: -apple-system-body;
-        font-size: 100%;
+        .native {
+            font: -apple-system-body;
+        }
     }
 }


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse

Forsøker å prefixe fontskalering for ios med `.native`, slik at det kun slår inn på native devicer og ikke setter font-størrelsen til 13px på desktop Safari.

## Motivasjon og kontekst

Fixes #2034 

## Testing

Testet OK på component-overview med Safari på mobil og desktop. Dark mode i component-overview og designsystem-dokumentasjonen vil fortsatt få 13px default-tekst i Safari på desktop, fordi fordi vi toggler .native-klassen. Men det kan vi kanskje leve med inntil videre, fremfor at fontskalering ikke fungerer i det hele tatt ute i appene.