### PR TITLE
fix(ffe-form): set padding x and top to zero in input group

### DIFF
--- a/packages/ffe-form/less/input-group.less
+++ b/packages/ffe-form/less/input-group.less
@@ -1,7 +1,7 @@
 .ffe-input-group {
     border: 0;
     position: relative;
-    padding-bottom: calc(1lh + var(--ffe-spacing-xs));
+    padding: 0 0 calc(1lh + var(--ffe-spacing-xs));
 
     [aria-invalid='true'] {
         border-color: var(--ffe-g-error-color);


### PR DESCRIPTION
Slik var det før text zzom ble fikset. 

```
.ffe-input-group {
    padding: 0 0 @ffe-spacing-lg;
}
```

0 på top og horizontalt er pga av feks ett fieldset har padding som vi ikke ønsker i RadioInputGroup. 