### PR TITLE
feat(ffe-cards-react): component as props pattern on cards

### DIFF
--- a/packages/ffe-cards-react/src/CardBase.spec.tsx
+++ b/packages/ffe-cards-react/src/CardBase.spec.tsx
@@ -81,4 +81,24 @@ describe('<CardBase/>', () => {
             card.classList.contains('ffe-card-base--text-center'),
         ).toBeTruthy();
     });
+
+    it('should render as wished element', () => {
+        render(
+            <CardBase as="li">
+                <div />
+            </CardBase>,
+        );
+        expect(screen.getByRole('listitem')).toBeInTheDocument();
+    });
+
+    it('should set ref', () => {
+        const ref = React.createRef<HTMLLIElement>();
+        render(
+            <CardBase as="li" ref={ref}>
+                <div />
+            </CardBase>,
+        );
+        const listitem = screen.getByRole('listitem');
+        expect(listitem).toBe(ref.current);
+    });
 });

--- a/packages/ffe-cards-react/src/CardBase.tsx
+++ b/packages/ffe-cards-react/src/CardBase.tsx
@@ -1,12 +1,16 @@
-import React from 'react';
+import React, { ElementType, ForwardedRef } from 'react';
 import classNames from 'classnames';
 import { WithCardActionProps, WithCardAction } from './components';
+import { ComponentAsPropParams } from './types';
+import { fixedForwardRef } from './fixedForwardRef';
 
 type BgColor = 'sand-30' | 'sand-70' | 'frost-30' | 'syrin-30' | 'syrin-70';
 type BgColorDarkmode = 'natt' | 'svart' | 'koksgraa';
 
-export interface CardBaseProps
-    extends Omit<React.ComponentPropsWithoutRef<'div'>, 'children'> {
+export type CardBaseProps<As extends ElementType = 'div'> = Omit<
+    ComponentAsPropParams<As>,
+    'children'
+> & {
     shadow?: boolean;
     noMargin?: boolean;
     textCenter?: boolean;
@@ -14,19 +18,28 @@ export interface CardBaseProps
     bgDarkmodeColor?: BgColorDarkmode;
     noPadding?: boolean;
     children: WithCardActionProps['children'] | React.ReactNode;
-}
+};
 
-export const CardBase: React.FC<CardBaseProps> = ({
-    className,
-    shadow,
-    noMargin,
-    textCenter,
-    bgColor,
-    bgDarkmodeColor,
-    noPadding,
-    children,
-    ...rest
-}) => {
+function CardBaseWithForwardRef<As extends ElementType>(
+    props: CardBaseProps<As>,
+    ref: ForwardedRef<any>,
+) {
+    const {
+        className,
+        shadow,
+        noMargin,
+        textCenter,
+        bgColor,
+        bgDarkmodeColor,
+        noPadding,
+        children,
+        ...rest
+    } = props;
+
+    const withCardActionProps: React.ComponentProps<typeof WithCardAction> = {
+        ...rest,
+    };
+
     return (
         <WithCardAction
             className={classNames('ffe-card-base', className, {
@@ -37,7 +50,8 @@ export const CardBase: React.FC<CardBaseProps> = ({
                 'ffe-card-base--text-center': textCenter,
                 'ffe-card-base--no-padding': noPadding,
             })}
-            {...rest}
+            {...withCardActionProps}
+            ref={ref}
         >
             {({ CardAction }) =>
                 typeof children === 'function'
@@ -46,4 +60,6 @@ export const CardBase: React.FC<CardBaseProps> = ({
             }
         </WithCardAction>
     );
-};
+}
+
+export const CardBase = fixedForwardRef(CardBaseWithForwardRef);

--- a/packages/ffe-cards-react/src/IconCard/IconCard.spec.tsx
+++ b/packages/ffe-cards-react/src/IconCard/IconCard.spec.tsx
@@ -92,4 +92,31 @@ describe('IconCard', () => {
         expect(card.classList.contains('ffe-icon-card')).toBeTruthy();
         expect(card.classList.contains('my-custom-class')).toBeTruthy();
     });
+
+    it('should render as wished element', () => {
+        render(
+            <IconCard
+                as="li"
+                icon={<Icon fileUrl={savingsIconXlarge} size="xl" />}
+            >
+                {children}
+            </IconCard>,
+        );
+        expect(screen.getByRole('listitem')).toBeInTheDocument();
+    });
+
+    it('should set ref', () => {
+        const ref = React.createRef<HTMLLIElement>();
+        render(
+            <IconCard
+                as="li"
+                ref={ref}
+                icon={<Icon fileUrl={savingsIconXlarge} size="xl" />}
+            >
+                {children}
+            </IconCard>,
+        );
+        const listitem = screen.getByRole('listitem');
+        expect(listitem).toBe(ref.current);
+    });
 });

--- a/packages/ffe-cards-react/src/IconCard/IconCard.tsx
+++ b/packages/ffe-cards-react/src/IconCard/IconCard.tsx
@@ -1,10 +1,13 @@
-import React, { ReactElement } from 'react';
-import { CardRenderProps } from '../types';
+import React, { ElementType, ForwardedRef, ReactElement } from 'react';
+import { CardRenderProps, ComponentAsPropParams } from '../types';
 import classNames from 'classnames';
 import { WithCardAction, Text, Subtext, Title, CardName } from '../components';
+import { fixedForwardRef } from '../fixedForwardRef';
 
-export interface IconCardProps
-    extends Omit<React.ComponentPropsWithoutRef<'div'>, 'children'> {
+export type IconCardProps<As extends ElementType = 'div'> = Omit<
+    ComponentAsPropParams<As>,
+    'children'
+> & {
     /** Element of icon */
     icon: ReactElement;
     /** Smaller icon and less space */
@@ -12,15 +15,16 @@ export interface IconCardProps
     children:
         | React.ReactNode
         | ((cardRenderProps: CardRenderProps) => React.ReactNode);
-}
+};
 
-export const IconCard: React.FC<IconCardProps> = ({
-    className,
-    condensed,
-    icon,
-    children,
-    ...rest
-}) => {
+function IconCardWithForwardRef<As extends ElementType>(
+    props: IconCardProps<As>,
+    ref: ForwardedRef<any>,
+) {
+    const { className, condensed, icon, children, ...rest } = props;
+    const withCardActionProps: React.ComponentProps<typeof WithCardAction> = {
+        ...rest,
+    };
     return (
         <WithCardAction
             className={classNames(
@@ -28,7 +32,8 @@ export const IconCard: React.FC<IconCardProps> = ({
                 { 'ffe-icon-card--condensed': condensed },
                 className,
             )}
-            {...rest}
+            {...withCardActionProps}
+            ref={ref}
         >
             {({ CardAction }) => (
                 <>
@@ -54,4 +59,6 @@ export const IconCard: React.FC<IconCardProps> = ({
             )}
         </WithCardAction>
     );
-};
+}
+
+export const IconCard = fixedForwardRef(IconCardWithForwardRef);

--- a/packages/ffe-cards-react/src/ImageCard/ImageCard.spec.tsx
+++ b/packages/ffe-cards-react/src/ImageCard/ImageCard.spec.tsx
@@ -102,4 +102,33 @@ describe('ImageCard', () => {
         expect(card.classList.contains('ffe-image-card')).toBeTruthy();
         expect(card.classList.contains('my-custom-class')).toBeTruthy();
     });
+
+    it('should render as wished element', () => {
+        render(
+            <ImageCard
+                as="li"
+                imageAltText="Image alt text"
+                imageSrc="random/path"
+            >
+                {children}
+            </ImageCard>,
+        );
+        expect(screen.getByRole('listitem')).toBeInTheDocument();
+    });
+
+    it('should set ref', () => {
+        const ref = React.createRef<HTMLLIElement>();
+        render(
+            <ImageCard
+                as="li"
+                ref={ref}
+                imageAltText="Image alt text"
+                imageSrc="random/path"
+            >
+                {children}
+            </ImageCard>,
+        );
+        const listitem = screen.getByRole('listitem');
+        expect(listitem).toBe(ref.current);
+    });
 });

--- a/packages/ffe-cards-react/src/ImageCard/ImageCard.tsx
+++ b/packages/ffe-cards-react/src/ImageCard/ImageCard.tsx
@@ -1,10 +1,13 @@
-import React from 'react';
-import { CardRenderProps } from '../types';
+import React, { ElementType, ForwardedRef } from 'react';
+import { CardRenderProps, ComponentAsPropParams } from '../types';
 import classNames from 'classnames';
 import { CardName, Subtext, Text, Title, WithCardAction } from '../components';
+import { fixedForwardRef } from '../fixedForwardRef';
 
-export interface ImageCardProps
-    extends Omit<React.ComponentPropsWithoutRef<'div'>, 'children'> {
+export type ImageCardProps<As extends ElementType = 'div'> = Omit<
+    ComponentAsPropParams<As>,
+    'children'
+> & {
     /** The src for the image */
     imageSrc: string;
     /** The alt text for the image */
@@ -12,19 +15,21 @@ export interface ImageCardProps
     children:
         | React.ReactNode
         | ((cardRenderProps: CardRenderProps) => React.ReactNode);
-}
+};
 
-export const ImageCard: React.FC<ImageCardProps> = ({
-    className,
-    imageSrc,
-    imageAltText,
-    children,
-    ...rest
-}) => {
+function ImageCardWithForwardRef<As extends ElementType>(
+    props: ImageCardProps<As>,
+    ref: ForwardedRef<any>,
+) {
+    const { className, imageSrc, imageAltText, children, ...rest } = props;
+    const withCardActionProps: React.ComponentProps<typeof WithCardAction> = {
+        ...rest,
+    };
     return (
         <WithCardAction
             className={classNames('ffe-image-card', className)}
-            {...rest}
+            {...withCardActionProps}
+            ref={ref}
         >
             {({ CardAction }) => (
                 <>
@@ -51,4 +56,5 @@ export const ImageCard: React.FC<ImageCardProps> = ({
             )}
         </WithCardAction>
     );
-};
+}
+export const ImageCard = fixedForwardRef(ImageCardWithForwardRef);

--- a/packages/ffe-cards-react/src/StippledCard/StippledCard.spec.tsx
+++ b/packages/ffe-cards-react/src/StippledCard/StippledCard.spec.tsx
@@ -80,4 +80,37 @@ describe('StippledCard', () => {
         expect(card.classList.contains('ffe-stippled-card')).toBeTruthy();
         expect(card.classList.contains('my-custom-class')).toBeTruthy();
     });
+
+    it('should render as wished element', () => {
+        render(
+            <StippledCard
+                as="li"
+                img={{
+                    element: <Icon fileUrl="monitoring" size="md" />,
+                    type: 'icon',
+                }}
+            >
+                {children}
+            </StippledCard>,
+        );
+        expect(screen.getByRole('listitem')).toBeInTheDocument();
+    });
+
+    it('should set ref', () => {
+        const ref = React.createRef<HTMLLIElement>();
+        render(
+            <StippledCard
+                as="li"
+                ref={ref}
+                img={{
+                    element: <Icon fileUrl="monitoring" size="md" />,
+                    type: 'icon',
+                }}
+            >
+                {children}
+            </StippledCard>,
+        );
+        const listitem = screen.getByRole('listitem');
+        expect(listitem).toBe(ref.current);
+    });
 });

--- a/packages/ffe-cards-react/src/StippledCard/StippledCard.tsx
+++ b/packages/ffe-cards-react/src/StippledCard/StippledCard.tsx
@@ -1,10 +1,13 @@
-import React, { ReactNode } from 'react';
-import { CardRenderProps } from '../types';
+import React, { ElementType, ForwardedRef, ReactNode } from 'react';
+import { CardRenderProps, ComponentAsPropParams } from '../types';
 import classNames from 'classnames';
 import { CardName, Subtext, Text, Title, WithCardAction } from '../components';
+import { fixedForwardRef } from '../fixedForwardRef';
 
-export interface StippledCardProps
-    extends Omit<React.ComponentPropsWithoutRef<'div'>, 'children'> {
+export type StippledCardProps<As extends ElementType = 'div'> = Omit<
+    ComponentAsPropParams<As>,
+    'children'
+> & {
     /** Smaller icon and less space */
     condensed?: boolean;
     /** Image to be rendered*/
@@ -15,15 +18,16 @@ export interface StippledCardProps
     children:
         | React.ReactNode
         | ((cardRenderProps: CardRenderProps) => React.ReactNode);
-}
+};
 
-export const StippledCard: React.FC<StippledCardProps> = ({
-    className,
-    condensed,
-    img,
-    children,
-    ...rest
-}) => {
+function StippledCardWithForwardRef<As extends ElementType>(
+    props: StippledCardProps<As>,
+    ref: ForwardedRef<any>,
+) {
+    const { className, condensed, img, children, ...rest } = props;
+    const withCardActionProps: React.ComponentProps<typeof WithCardAction> = {
+        ...rest,
+    };
     return (
         <WithCardAction
             className={classNames(
@@ -31,7 +35,8 @@ export const StippledCard: React.FC<StippledCardProps> = ({
                 { 'ffe-stippled-card--condensed': condensed },
                 className,
             )}
-            {...rest}
+            {...withCardActionProps}
+            ref={ref}
         >
             {({ CardAction }) => (
                 <>
@@ -59,4 +64,5 @@ export const StippledCard: React.FC<StippledCardProps> = ({
             )}
         </WithCardAction>
     );
-};
+}
+export const StippledCard = fixedForwardRef(StippledCardWithForwardRef);

--- a/packages/ffe-cards-react/src/TextCard/TextCard.spec.tsx
+++ b/packages/ffe-cards-react/src/TextCard/TextCard.spec.tsx
@@ -37,4 +37,20 @@ describe('TextCard', () => {
         expect(card.classList.contains('ffe-text-card')).toBeTruthy();
         expect(card.classList.contains('my-custom-class')).toBeTruthy();
     });
+
+    it('should render as wished element', () => {
+        render(<TextCard as="li">{children}</TextCard>);
+        expect(screen.getByRole('listitem')).toBeInTheDocument();
+    });
+
+    it('should set ref', () => {
+        const ref = React.createRef<HTMLLIElement>();
+        render(
+            <TextCard as="li" ref={ref}>
+                {children}
+            </TextCard>,
+        );
+        const listitem = screen.getByRole('listitem');
+        expect(listitem).toBe(ref.current);
+    });
 });

--- a/packages/ffe-cards-react/src/TextCard/TextCard.tsx
+++ b/packages/ffe-cards-react/src/TextCard/TextCard.tsx
@@ -1,24 +1,31 @@
-import React from 'react';
-import { CardRenderProps } from '../types';
+import React, { ElementType, ForwardedRef } from 'react';
+import { CardRenderProps, ComponentAsPropParams } from '../types';
 import classNames from 'classnames';
 import { CardName, Subtext, Text, Title, WithCardAction } from '../components';
+import { fixedForwardRef } from '../fixedForwardRef';
 
-export interface TextCardProps
-    extends Omit<React.ComponentPropsWithoutRef<'div'>, 'children'> {
+export type TextCardProps<As extends ElementType = 'div'> = Omit<
+    ComponentAsPropParams<As>,
+    'children'
+> & {
     /** Left-aligned text on the card */
     leftAlign?: boolean;
     /** Function that's passed available sub-components as arguments, or regular children */
     children:
         | React.ReactNode
         | ((cardRenderProps: CardRenderProps) => React.ReactNode);
-}
+};
 
-export const TextCard: React.FC<TextCardProps> = ({
-    className,
-    leftAlign,
-    children,
-    ...rest
-}) => {
+function TextCardWithForwardRef<As extends ElementType>(
+    props: TextCardProps<As>,
+    ref: ForwardedRef<any>,
+) {
+    const { className, leftAlign, children, ...rest } = props;
+
+    const withCardActionProps: React.ComponentProps<typeof WithCardAction> = {
+        ...rest,
+    };
+
     return (
         <WithCardAction
             className={classNames(
@@ -26,7 +33,8 @@ export const TextCard: React.FC<TextCardProps> = ({
                 { 'ffe-text-card--left-align': leftAlign },
                 className,
             )}
-            {...rest}
+            {...withCardActionProps}
+            ref={ref}
         >
             {({ CardAction }) =>
                 typeof children === 'function'
@@ -35,4 +43,6 @@ export const TextCard: React.FC<TextCardProps> = ({
             }
         </WithCardAction>
     );
-};
+}
+
+export const TextCard = fixedForwardRef(TextCardWithForwardRef);

--- a/packages/ffe-cards-react/src/components/WithCardAction.spec.tsx
+++ b/packages/ffe-cards-react/src/components/WithCardAction.spec.tsx
@@ -81,4 +81,19 @@ describe('<WithCardAction />', () => {
         const button = screen.getByRole('button');
         expect(button).toBe(ref.current);
     });
+
+    it('should set refs on <CardAction />', () => {
+        const ref = React.createRef<HTMLButtonElement>();
+        render(
+            <WithCardAction>
+                {({ CardAction }) => (
+                    <CardAction as="button" ref={ref}>
+                        en knapp
+                    </CardAction>
+                )}
+            </WithCardAction>,
+        );
+        const button = screen.getByRole('button');
+        expect(button).toBe(ref.current);
+    });
 });


### PR DESCRIPTION
Legger up til att korten kan vare vilket elemen som helst men default er nå div og ikke lenke som før. 