### PR TITLE
fix(ffe-form): fiks sånn at input uten label får riktig margin

### DIFF
--- a/packages/ffe-form/less/input-group.less
+++ b/packages/ffe-form/less/input-group.less
@@ -26,10 +26,10 @@
     > * {
         margin-top: 0;
         margin-bottom: var(--ffe-spacing-xs);
+    }
 
-        &:nth-child(1) {
-            margin-bottom: 0;
-        }
+    .ffe-form-label {
+        margin-bottom: 0;
     }
 
     .ffe-field-message--error {

--- a/packages/ffe-form/less/phone-number.less
+++ b/packages/ffe-form/less/phone-number.less
@@ -5,7 +5,6 @@
         }
         & > * {
             margin-top: 0;
-            margin-bottom: var(--ffe-spacing-xs);
         }
     }
 


### PR DESCRIPTION
fixes #1917

## Beskrivelse

Hvis man ikke bruker label i inputgroup, forsvinner margin-bottom under inputfeltet, slik at fieldmessagen ser rar ut. 

## Testing
Kan ha invirkning på flere komponenter i form. 
Jeg har testet inputgroup og radiobuttongroup, vet ikke om det er flere steder det kan bli påvirket. 
Testet ved å slette label på ett av inputgroupene og slå på feilmelding
