### PR TITLE
fix(ffe-buttons): endre line-height i basebutton

### DIFF
--- a/packages/ffe-buttons/less/base-button.less
+++ b/packages/ffe-buttons/less/base-button.less
@@ -8,9 +8,9 @@
     display: flex;
     font-family: var(--ffe-g-font);
     justify-content: center;
-    line-height: 24px;
+    line-height: 1.2;
     overflow: hidden;
-    padding: @ffe-spacing-xs @ffe-spacing-md;
+    padding: calc(var(--ffe-spacing-xs) + 2px) var(--ffe-spacing-md); // The + 2px is ensure button is 44px after we made a change to line-height.
     position: relative;
     text-align: center;
     text-decoration: none;


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse
Endrer line-height i base button til å være 1.5 ch.
<!-- Detaljert beskrivelse av endringene dine. Skjermskudd er lov. -->

## Motivasjon og kontekst
Px verdien fungerer litt dårlig på høy tekstzoom, så tror 1.5ch vil skalere bedre. 
Dette ser også til å fikse ett issue der deler av bokstavene går "inn" i border på knapper ved høy zoom.

Før:
![Skjermbilde 2024-07-02 kl  13 21 49](https://github.com/SpareBank1/designsystem/assets/39946146/f79c9e0d-9357-4a9c-911a-d13eb07e0e45)

Etter:
![Skjermbilde 2024-07-02 kl  13 22 20](https://github.com/SpareBank1/designsystem/assets/39946146/e78cb919-4783-4c19-b03f-3a4d223d90b0)

<!-- Hvorfor trengs denne endringen, og hva løser den? -->

## Testing

<!-- Hvordan har du har testet endringene dine? Ta gjerne med systeminfo o.l -->

<!--

Helt til slutt, har du ..

.. lest retningslinjene våre for bidrag?
.. tatt en siste sjekk for kode og skrivefeil, debug informasjon o.l?
.. kjørt og eventuelt oppdatert testene?
.. kommentert og dokumentert det som trengs?
.. knyttet denne opp til relaterte issues?

-->
