### PR TITLE
fix(ffe-form): fallback lh support inputgroup

### DIFF
--- a/packages/ffe-form/less/field-message.less
+++ b/packages/ffe-form/less/field-message.less
@@ -5,7 +5,8 @@
     display: grid;
     grid-template-columns: auto 1fr;
     grid-column-gap: @ffe-spacing-2xs;
-    font-size: var(--ffe-fontsize-body-text);
+    font-size: var(--ffe-v-message-font-size);
+    line-height: var(--ffe-v-message-line-heigth);
     overflow-wrap: anywhere;
 
     &[aria-hidden='true'] {

--- a/packages/ffe-form/less/input-group.less
+++ b/packages/ffe-form/less/input-group.less
@@ -1,7 +1,7 @@
 .ffe-input-group {
     border: 0;
     position: relative;
-    padding: 0 0 calc(1lh + var(--ffe-spacing-xs));
+    padding: 0 0 calc(var(--ffe-v-message-line-heigth) + var(--ffe-spacing-xs));
 
     [aria-invalid='true'] {
         border-color: var(--ffe-g-error-color);

--- a/packages/ffe-form/less/theme.less
+++ b/packages/ffe-form/less/theme.less
@@ -16,6 +16,8 @@
     --ffe-v-radio-button-label-color: var(--ffe-g-primary-color);
     --ffe-v-tooltip-icon-color: var(--ffe-g-primary-color);
     --ffe-v-tooltip-border-color: var(--ffe-g-border-color);
+    --ffe-v-message-font-size: var(--ffe-fontsize-body-text);
+    --ffe-v-message-line-heigth: 1.5rem;
 
     @media (prefers-color-scheme: dark) {
         .native {


### PR DESCRIPTION
Burde vi gjøra noe med dette her. Slik er mine tanker

* Det er veldig få bruker som får dette hoppet. 
![image](https://github.com/SpareBank1/designsystem/assets/2248579/d21d4415-c3b1-4595-b30d-596b3dd0c9e5)

* Hoppet er ikke kritiskt, det er til og med en option att få det da man kan slå av extra margin. 

* Hvis vi gjør slik så kobler vi oss til lineheigth på fieldmessage hvis den skulle endres. 