### PR TITLE
fix(ffe-cards): strippled card avoid gap when no icon/illustration

### DIFF
--- a/packages/ffe-cards-react/src/StippledCard/StippledCard.tsx
+++ b/packages/ffe-cards-react/src/StippledCard/StippledCard.tsx
@@ -38,15 +38,17 @@ function StippledCardWithForwardRef<As extends ElementType>(
         >
             {({ CardAction }) => (
                 <>
-                    <div
-                        className={classNames('ffe-stippled-card__img', {
-                            'ffe-stippled-card__img--icon':
-                                img?.type === 'icon',
-                        })}
-                        aria-hidden={img?.type === 'icon'}
-                    >
-                        {img?.element}
-                    </div>
+                    {img && (
+                        <div
+                            className={classNames('ffe-stippled-card__img', {
+                                'ffe-stippled-card__img--icon':
+                                    img?.type === 'icon',
+                            })}
+                            aria-hidden={img?.type === 'icon'}
+                        >
+                            {img?.element}
+                        </div>
+                    )}
                     <div>
                         {typeof children === 'function'
                             ? children({


### PR DESCRIPTION
Man får en gap på venstre sidan hvis man ikke har bilde fordi att containern forsatt er der. 