### PR TITLE
Develop modal polyfill

### DIFF
--- a/packages/ffe-modals-react/package.json
+++ b/packages/ffe-modals-react/package.json
@@ -26,7 +26,8 @@
     },
     "dependencies": {
         "@sb1/ffe-icons-react": "^11.0.0",
-        "@sb1/ffe-modals": "^0.2.5"
+        "@sb1/ffe-modals": "^0.2.5",
+        "dialog-polyfill": "^0.5.6"
     },
     "devDependencies": {
         "@sb1/ffe-buildtool": "^0.6.4",

--- a/packages/ffe-modals/less/modal-polyfill.less
+++ b/packages/ffe-modals/less/modal-polyfill.less
@@ -1,0 +1,8 @@
+/* vi har ikke laget denne klassen  derav slå av lint */
+/* stylelint-disable */
+.ffe-modal + .backdrop {
+    /* stylelint-enable */
+    position: fixed;
+    background-color: var(--ffe-v-modal-backdrop-color);
+    inset: 0;
+}

--- a/packages/ffe-modals/less/modal.less
+++ b/packages/ffe-modals/less/modal.less
@@ -1,4 +1,5 @@
 @import 'theme';
+@import 'modal-polyfill';
 
 :root:has(.ffe-modal[open]) {
     overflow-y: hidden;


### PR DESCRIPTION
Tenker denne kan funke i FF eldre versioner også når det er så pass enkelt.  `dialogPolyfill.registerDialog` bruker native varianten hvis den er støttet så dom har søttet får native variant. Resten polyfill
![Screenshot from 2024-07-18 10-10-23](https://github.com/user-attachments/assets/c3d439fe-71a3-4a0c-bf14-aa8015c6bbc0)
