### PR TITLE
chore: testing hussky

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,4 +1,1 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
 npx --no -- commitlint --edit "$1"

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,1 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
 npx --no -- lint-staged

--- a/package.json
+++ b/package.json
@@ -1,70 +1,70 @@
 {
-    "name": "@sb1/ffe",
-    "version": "1.0.0",
-    "description": "Felles Front End",
-    "author": "SpareBank 1",
-    "license": "SEE LICENSE IN README.md",
-    "private": true,
-    "browserslist": [
-        "last 3 versions",
-        "not ie >= 0"
-    ],
-    "scripts": {
-        "clean": "run-s clean:lib clean:lerna:clean clean:lerna",
-        "clean:lib": "rimraf packages/*/lib packages/*/es packages/*/types",
-        "clean:lerna": "lerna clean --yes",
-        "clean:lerna:clean": "lerna run clean",
-        "build": "lerna run build",
-        "watch": "lerna watch -- lerna run build:es --scope=\\$LERNA_PACKAGE_NAME --ignore=@sb1/ffe-component-index",
-        "ghpages": "lerna run ghpages",
-        "lint": "lerna run lint",
-        "lint:fix": "lerna run lint:fix",
-        "start": "run-p watch start:component-overview watch:component-overview",
-        "watch:component-overview": "lerna run watch --scope='@sb1/ffe-component-index'",
-        "start:component-overview": "lerna run start --scope='@sb1/ffe-component-index'",
-        "test": "./buildtool/bin/cli.js jest",
-        "test:watch": "./buildtool/bin/cli.js jest --watch",
-        "test:playwright": "playwright test --config ./test/playwright.config.ts",
-        "test:playwright-head": "playwright test --config ./test/playwright.config.ts --headed",
-        "lerna": "lerna",
-        "prepare": "husky install"
-    },
-    "lint-staged": {
-        "{packages,buildtool,component-overview,linting,test}/**/*.{js,jsx,ts,tsx,json,css,less,md}": [
-            "prettier --write"
-        ]
-    },
-    "workspaces": [
-        "packages/*",
-        "linting/*",
-        "buildtool",
-        "component-overview"
-    ],
-    "devDependencies": {
-        "@axe-core/playwright": "^4.9.0",
-        "@commitlint/cli": "^19.3.0",
-        "@commitlint/config-conventional": "^19.2.2",
-        "@playwright/test": "^1.43.1",
-        "@testing-library/dom": "^10.1.0",
-        "@testing-library/react": "^16.0.0",
-        "@testing-library/user-event": "^14.5.2",
-        "@types/react": "^18.3.3",
-        "@types/react-dom": "18.3.0",
-        "@typescript-eslint/eslint-plugin": "^7.8.0",
-        "@typescript-eslint/parser": "^7.8.0",
-        "case": "^1.5.5",
-        "eslint": "^8.57.0",
-        "eslint-config-prettier": "^9.1.0",
-        "eslint-plugin-prettier": "^5.1.3",
-        "husky": "^9.0.11",
-        "lerna": "^8.1.3",
-        "lint-staged": "^15.2.2",
-        "mkdirp": "^3.0.1",
-        "npm-run-all": "^4.1.5",
-        "prettier": "^3.3.2",
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0",
-        "rimraf": "^5.0.7",
-        "typescript": "^5.4.3"
-    }
+  "name": "@sb1/ffe",
+  "version": "1.0.0",
+  "description": "Felles Front End",
+  "author": "SpareBank 1",
+  "license": "SEE LICENSE IN README.md",
+  "private": true,
+  "browserslist": [
+    "last 3 versions",
+    "not ie >= 0"
+  ],
+  "scripts": {
+    "clean": "run-s clean:lib clean:lerna:clean clean:lerna",
+    "clean:lib": "rimraf packages/*/lib packages/*/es packages/*/types",
+    "clean:lerna": "lerna clean --yes",
+    "clean:lerna:clean": "lerna run clean",
+    "build": "lerna run build",
+    "watch": "lerna watch -- lerna run build:es --scope=\\$LERNA_PACKAGE_NAME --ignore=@sb1/ffe-component-index",
+    "ghpages": "lerna run ghpages",
+    "lint": "lerna run lint",
+    "lint:fix": "lerna run lint:fix",
+    "start": "run-p watch start:component-overview watch:component-overview",
+    "watch:component-overview": "lerna run watch --scope='@sb1/ffe-component-index'",
+    "start:component-overview": "lerna run start --scope='@sb1/ffe-component-index'",
+    "test": "./buildtool/bin/cli.js jest",
+    "test:watch": "./buildtool/bin/cli.js jest --watch",
+    "test:playwright": "playwright test --config ./test/playwright.config.ts",
+    "test:playwright-head": "playwright test --config ./test/playwright.config.ts --headed",
+    "lerna": "lerna",
+    "prepare": "husky"
+  },
+  "lint-staged": {
+    "{packages,buildtool,component-overview,linting,test}/**/*.{js,jsx,ts,tsx,json,css,less,md}": [
+      "prettier --write"
+    ]
+  },
+  "workspaces": [
+    "packages/*",
+    "linting/*",
+    "buildtool",
+    "component-overview"
+  ],
+  "devDependencies": {
+    "@axe-core/playwright": "^4.9.0",
+    "@commitlint/cli": "^19.3.0",
+    "@commitlint/config-conventional": "^19.2.2",
+    "@playwright/test": "^1.43.1",
+    "@testing-library/dom": "^10.1.0",
+    "@testing-library/react": "^16.0.0",
+    "@testing-library/user-event": "^14.5.2",
+    "@types/react": "^18.3.3",
+    "@types/react-dom": "18.3.0",
+    "@typescript-eslint/eslint-plugin": "^7.8.0",
+    "@typescript-eslint/parser": "^7.8.0",
+    "case": "^1.5.5",
+    "eslint": "^8.57.0",
+    "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-prettier": "^5.1.3",
+    "husky": "^9.0.11",
+    "lerna": "^8.1.3",
+    "lint-staged": "^15.2.2",
+    "mkdirp": "^3.0.1",
+    "npm-run-all": "^4.1.5",
+    "prettier": "^3.3.2",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "rimraf": "^5.0.7",
+    "typescript": "^5.4.3"
+  }
 }


### PR DESCRIPTION
Kjørde husky init på nytt. Det som får byggen på cs til og fail er deprecated og husky init fjernet det. 