### PR TITLE
fix(ffe-tables-react): update to correct collapse version

### DIFF
--- a/packages/ffe-tables-react/package.json
+++ b/packages/ffe-tables-react/package.json
@@ -26,7 +26,7 @@
         "test:watch": "ffe-buildtool jest --watch"
     },
     "dependencies": {
-        "@sb1/ffe-collapse-react": "^4.0.9",
+        "@sb1/ffe-collapse-react": "^5.0.2",
         "@sb1/ffe-icons-react": "^11.0.1",
         "@sb1/ffe-tables": "^15.0.1",
         "classnames": "^2.3.1"


### PR DESCRIPTION
Her har det blitt noe rart med releaserna ser det ut. Siste version skall vell automatisk vare der. Feilen gjør att  man går gamla avheninghter til ffe-core