### PR TITLE
fix(ffe-modals-react): use polyfill only when not supported

### DIFF
--- a/packages/ffe-modals-react/src/Modal.tsx
+++ b/packages/ffe-modals-react/src/Modal.tsx
@@ -64,7 +64,10 @@ export const Modal = React.forwardRef<ModalHandle, ModalProps>(
         }, [isOpen]);
 
         useEffect(() => {
-            if (dialogRef.current) {
+            if (
+                dialogRef.current &&
+                typeof dialogRef.current.showModal !== 'function'
+            ) {
                 dialogPolyfill.registerDialog(dialogRef.current);
             }
         }, []);


### PR DESCRIPTION
De så iaf ut som chrome bruke native implmentasjonen av polyfillet utan dette men react-testing-library klager på att man skall bruke native hvis den er supported så tenker denne sjekken ikke skader iaf. 