### PR TITLE
fix(ffe-modals-react): fjerner dailog-polyill

### DIFF
--- a/packages/ffe-modals-react/package.json
+++ b/packages/ffe-modals-react/package.json
@@ -26,8 +26,7 @@
     },
     "dependencies": {
         "@sb1/ffe-icons-react": "^11.0.1",
-        "@sb1/ffe-modals": "^0.2.7",
-        "dialog-polyfill": "^0.5.6"
+        "@sb1/ffe-modals": "^0.2.7"
     },
     "devDependencies": {
         "@sb1/ffe-buildtool": "^0.7.0",

--- a/packages/ffe-modals-react/src/Modal.tsx
+++ b/packages/ffe-modals-react/src/Modal.tsx
@@ -62,22 +62,6 @@ export const Modal = React.forwardRef<ModalHandle, ModalProps>(
             }
         }, [isOpen]);
 
-        useEffect(() => {
-            if (
-                typeof window !== 'undefined' && // to support Gatsby build(server side rendering)
-                dialogRef.current &&
-                typeof dialogRef.current.showModal !== 'function'
-            ) {
-                import('dialog-polyfill').then(
-                    ({ default: dialogPolyfill }) => {
-                        if (dialogRef.current) {
-                            dialogPolyfill.registerDialog(dialogRef.current);
-                        }
-                    },
-                );
-            }
-        }, []);
-
         return createPortal(
             // eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions
             <dialog

--- a/packages/ffe-modals-react/src/__mocks__/dialog-polyfill.ts
+++ b/packages/ffe-modals-react/src/__mocks__/dialog-polyfill.ts
@@ -1,3 +1,0 @@
-export default {
-    registerDialog: () => null,
-};


### PR DESCRIPTION
Dynamic imports funker ikke helelr på Gatsby. Vi får vurdere att ta tillbake dette hvis vi kommer oss fra Gatsby. Dette funket på Firefox RHEL. Det var den utvikkler utgaven av FF det ikke funket på.