### PR TITLE
fix(ffe-cards): no margin on group card element

### DIFF
--- a/packages/ffe-cards/less/group-card.less
+++ b/packages/ffe-cards/less/group-card.less
@@ -25,6 +25,7 @@
         padding: var(--ffe-spacing-sm);
         border: 2px solid transparent;
         transition: all var(--ffe-transition-duration) var(--ffe-ease);
+        margin: 0;
 
         &--no-padding {
             padding: 0;


### PR DESCRIPTION
Setter margin her. Det er nyttig hvis man bruker "as" 