### PR TITLE
fix(ffe-core): make -apple-system-body apply on :root/:host and not body

### DIFF
--- a/packages/ffe-core/less/ffe-normalize.less
+++ b/packages/ffe-core/less/ffe-normalize.less
@@ -13,10 +13,8 @@ html,
 
 /* stylelint-disable */
 @supports (font: -apple-system-body) {
-    :root,
-    :host {
-        .native {
-            font: -apple-system-body;
-        }
+    :root:has(.native),
+    :host:has(.native) {
+        font: -apple-system-body;
     }
 }


### PR DESCRIPTION
Zoom er broken. Jag mistenker att dette kan ha med saken att gjøra kanske. Vert att prova iaf. Foskjellen er att innan endringen så havner `font: -apple-system-body;` på `body`. Efter endringen på `:root/:host`. Det er ikke sikkert da har att si men mistenklig. 

Det var `:root/:host` før det brakk iaf. 