### PR TITLE
fix(ffe-cards): borders when only one card in card group

### DIFF
--- a/packages/ffe-cards/less/group-card.less
+++ b/packages/ffe-cards/less/group-card.less
@@ -21,6 +21,10 @@
             var(--ffe-v-cards-common-card-border-radius);
     }
 
+    & > :first-child:last-child {
+        border-radius: var(--ffe-v-cards-common-card-border-radius);
+    }
+
     &__element {
         padding: var(--ffe-spacing-sm);
         border: 2px solid transparent;


### PR DESCRIPTION
Det er ju ikke meningen att man skall kun ha ett kort i vard group men det kan ju fort skje i apparna avhenge av vad brukaren har. Om lager en lista over spareavtaler feks og noen bruker har 4 og noen har 1. 