### PR TITLE
Develop darkmode desktop

### DIFF
--- a/buildtool/config/stylelint.config.js
+++ b/buildtool/config/stylelint.config.js
@@ -39,7 +39,7 @@ module.exports = {
         'selector-combinator-space-before': null,
         'no-descending-specificity': null,
         'selector-class-pattern': [
-            '^(native|ffe-([a-z0-9-]+)?(__([a-z0-9]+-?)+)?(--([a-z0-9]+-?)+){0,2})$',
+            '^(regard-color-scheme-preference|ffe-([a-z0-9-]+)?(__([a-z0-9]+-?)+)?(--([a-z0-9]+-?)+){0,2})$',
             {
                 message: 'Expected class selector to be ffe-bem',
             },

--- a/component-overview/webapp/components/Layout.jsx
+++ b/component-overview/webapp/components/Layout.jsx
@@ -29,7 +29,6 @@ export default function Layout({ children }) {
                     className={classNames({
                         'sb1ex-body': true,
                         'ffe-body': true,
-                        native: context.prefersDarkMode,
                         'regard-color-scheme-preference':
                             context.prefersDarkMode,
                     })}

--- a/packages/ffe-accordion/less/theme.less
+++ b/packages/ffe-accordion/less/theme.less
@@ -6,7 +6,7 @@
     --ffe-v-accordion-focus-border-color: var(--ffe-farge-vann);
 
     @media (prefers-color-scheme: dark) {
-        .native {
+        .regard-color-scheme-preference {
             --ffe-v-accordion-primary-color: var(--ffe-farge-frost);
             --ffe-v-accordion-secondary-color: var(--ffe-farge-natt);
             --ffe-v-accordion-body-text-color: var(--ffe-farge-hvit);

--- a/packages/ffe-account-selector-react/less/account-suggestion-multi.less
+++ b/packages/ffe-account-selector-react/less/account-suggestion-multi.less
@@ -82,7 +82,7 @@
     }
 }
 
-.native & {
+.regard-color-scheme-preference & {
     @media (prefers-color-scheme: dark) {
         .ffe-account-suggestion-multi {
             @media (hover: hover) and (pointer: fine) {

--- a/packages/ffe-account-selector-react/less/base-selector.less
+++ b/packages/ffe-account-selector-react/less/base-selector.less
@@ -30,7 +30,7 @@
 
         .ffe-base-selector &-icon {
             color: var(--ffe-g-primary-color);
-            .native & {
+            .regard-color-scheme-preference & {
                 @media (prefers-color-scheme: dark) {
                     color: var(--ffe-g-primary-color);
                 }
@@ -39,7 +39,7 @@
 
         .ffe-base-selector &-icon--invalid {
             color: var(--ffe-g-error-color);
-            .native & {
+            .regard-color-scheme-preference & {
                 @media (prefers-color-scheme: dark) {
                     color: var(--ffe-g-error-color);
                 }
@@ -63,7 +63,7 @@
 
         .ffe-base-selector &-icon {
             color: var(--ffe-g-primary-color);
-            .native & {
+            .regard-color-scheme-preference & {
                 @media (prefers-color-scheme: dark) {
                     color: var(--ffe-g-primary-color);
                 }

--- a/packages/ffe-account-selector-react/less/theme.less
+++ b/packages/ffe-account-selector-react/less/theme.less
@@ -7,7 +7,7 @@
     --ffe-v-accountselector-option-primary-color: var(--ffe-farge-hvit);
 
     @media (prefers-color-scheme: dark) {
-        .native {
+        .regard-color-scheme-preference {
             --ffe-v-accountselector-text-color: var(--ffe-farge-hvit);
             --ffe-v-accountselector-dropdown-statusbar-background-color: var(
                 --ffe-farge-svart

--- a/packages/ffe-buttons/less/base-button.less
+++ b/packages/ffe-buttons/less/base-button.less
@@ -31,7 +31,7 @@
         box-shadow: 0 0 0 2px var(--ffe-farge-vann);
         transition: opacity var(--ffe-transition-duration) var(--ffe-ease);
 
-        .native & {
+        .regard-color-scheme-preference & {
             box-shadow: 0 0 0 2px var(--ffe-farge-hvit);
         }
     }
@@ -72,7 +72,7 @@
         color: var(--ffe-v-button-text-color);
     }
 
-    .native & {
+    .regard-color-scheme-preference & {
         @media (prefers-color-scheme: dark) {
             border: 2px solid transparent;
         }
@@ -122,7 +122,7 @@
     &:focus,
     &:visited {
         color: var(--ffe-v-button-secondary-color);
-        .native & {
+        .regard-color-scheme-preference & {
             @media (prefers-color-scheme: dark) {
                 color: var(--ffe-v-button-secondary-color);
             }
@@ -138,7 +138,7 @@
             .ffe-button__icon {
                 color: var(--ffe-v-button-secondary-color-bg);
             }
-            .native & {
+            .regard-color-scheme-preference & {
                 @media (prefers-color-scheme: dark) {
                     background-color: var(
                         --ffe-v-button-secondary-border-color
@@ -245,7 +245,7 @@
         margin: 0 var(--ffe-spacing-xs) 0 0;
         width: 45px;
         transition: all var(--ffe-transition-duration) var(--ffe-ease);
-        .native & {
+        .regard-color-scheme-preference & {
             @media (prefers-color-scheme: dark) {
                 background-color: transparent;
             }
@@ -260,7 +260,7 @@
         .ffe-button--expand:hover & {
             color: var(--ffe-farge-hvit);
 
-            .native & {
+            .regard-color-scheme-preference & {
                 @media (prefers-color-scheme: dark) {
                     color: var(--ffe-farge-svart);
                 }

--- a/packages/ffe-buttons/less/inline-base-button.less
+++ b/packages/ffe-buttons/less/inline-base-button.less
@@ -22,7 +22,7 @@
         box-shadow: 0 0 0 2px var(--ffe-farge-vann);
         outline: none;
 
-        .native & {
+        .regard-color-scheme-preference & {
             @media (prefers-color-scheme: dark) {
                 box-shadow: 0 0 0 2px var(--ffe-farge-hvit);
             }
@@ -108,7 +108,7 @@
         border-color: var(--ffe-v-button-tertiary-color);
         color: var(--ffe-v-button-tertiary-color);
 
-        .native & {
+        .regard-color-scheme-preference & {
             @media (prefers-color-scheme: dark) {
                 border-color: var(--ffe-farge-hvit);
                 box-shadow: none;
@@ -127,7 +127,7 @@
             .ffe-inline-button__icon {
                 color: var(--ffe-v-button-tertiary-color-hover);
             }
-            .native & {
+            .regard-color-scheme-preference & {
                 @media (prefers-color-scheme: dark) {
                     color: var(--ffe-farge-hvit);
                 }

--- a/packages/ffe-buttons/less/theme.less
+++ b/packages/ffe-buttons/less/theme.less
@@ -35,7 +35,7 @@
     --ffe-v-button-task-border-focus: var(--ffe-farge-vann);
 
     @media (prefers-color-scheme: dark) {
-        .native {
+        .regard-color-scheme-preference {
             --ffe-v-button-text-color: var(--ffe-farge-svart);
             --ffe-v-button-action-color: var(--ffe-farge-skog-70);
             --ffe-v-button-action-color-hover: var(--ffe-farge-skog-30);

--- a/packages/ffe-cards/less/card-base.less
+++ b/packages/ffe-cards/less/card-base.less
@@ -29,7 +29,7 @@
     }
 }
 
-.native & {
+.regard-color-scheme-preference & {
     @media (prefers-color-scheme: dark) {
         .ffe-card-base {
             .card-background-dm-styling();

--- a/packages/ffe-cards/less/common-card-styling.less
+++ b/packages/ffe-cards/less/common-card-styling.less
@@ -9,7 +9,7 @@
     width: 100%;
     text-decoration: none;
 
-    .native & {
+    .regard-color-scheme-preference & {
         @media (prefers-color-scheme: dark) {
             color: var(--ffe-farge-hvit);
         }
@@ -105,7 +105,7 @@
     }
 
     .ffe-card__action--raw:visited {
-        .native & {
+        .regard-color-scheme-preference & {
             @media (prefers-color-scheme: dark) {
                 color: var(--ffe-farge-hvit);
             }

--- a/packages/ffe-cards/less/group-card.less
+++ b/packages/ffe-cards/less/group-card.less
@@ -50,7 +50,7 @@
     }
 }
 
-.native & {
+.regard-color-scheme-preference & {
     @media (prefers-color-scheme: dark) {
         .ffe-group-card {
             .card-background-dm-styling();

--- a/packages/ffe-cards/less/stippled-card.less
+++ b/packages/ffe-cards/less/stippled-card.less
@@ -27,7 +27,7 @@
     padding: var(--ffe-spacing-md);
     gap: var(--ffe-spacing-md);
 
-    .native & {
+    .regard-color-scheme-preference & {
         @media (prefers-color-scheme: dark) {
             box-shadow: none;
         }

--- a/packages/ffe-cards/less/theme.less
+++ b/packages/ffe-cards/less/theme.less
@@ -14,7 +14,7 @@
     );
 
     @media (prefers-color-scheme: dark) {
-        .native {
+        .regard-color-scheme-preference {
             --ffe-v-cards-common-card-background-color: var(--ffe-farge-svart);
             --ffe-v-cards-common-card-box-shadow-color: var(
                 --ffe-farge-moerkgraa

--- a/packages/ffe-chart-donut-react/less/theme.less
+++ b/packages/ffe-chart-donut-react/less/theme.less
@@ -5,7 +5,7 @@
     --ffe-v-chart-donut-text-color: var(--ffe-farge-koksgraa);
 
     @media (prefers-color-scheme: dark) {
-        .native {
+        .regard-color-scheme-preference {
             --ffe-v-chart-donut-first-color: var(--ffe-farge-vann-30);
             --ffe-v-chart-donut-last-color: var(--ffe-farge-vann-70);
             --ffe-v-chart-donut-text-color: var(--ffe-farge-lysgraa);

--- a/packages/ffe-context-message/less/context-message.less
+++ b/packages/ffe-context-message/less/context-message.less
@@ -17,7 +17,7 @@
     .ffe-body-paragraph,
     .ffe-body-text,
     .ffe-small-text {
-        .native & {
+        .regard-color-scheme-preference & {
             @media (prefers-color-scheme: dark) {
                 color: var(--ffe-farge-svart);
             }
@@ -80,7 +80,7 @@
             height: 4em;
             width: 4em;
 
-            .native & {
+            .regard-color-scheme-preference & {
                 @media (prefers-color-scheme: dark) {
                     background-color: var(--ffe-farge-svart);
                 }
@@ -96,7 +96,7 @@
             font-size: 2.5rem;
         }
 
-        .native & {
+        .regard-color-scheme-preference & {
             @media (prefers-color-scheme: dark) {
                 color: var(--ffe-farge-hvit);
             }
@@ -203,7 +203,7 @@
     &--info&--coloredbg {
         background-color: var(--ffe-v-context-message-variant-bg-color);
 
-        .native & {
+        .regard-color-scheme-preference & {
             @media (prefers-color-scheme: dark) {
                 background-color: var(--ffe-v-context-message-info-bg-color);
             }
@@ -249,7 +249,7 @@
     &--tips&--coloredbg {
         background-color: var(--ffe-v-context-message-variant-bg-color);
 
-        .native & {
+        .regard-color-scheme-preference & {
             @media (prefers-color-scheme: dark) {
                 background-color: var(--ffe-v-context-message-tips-bg-color);
             }
@@ -294,7 +294,7 @@
     &--success&--coloredbg {
         background-color: var(--ffe-v-context-message-variant-bg-color);
 
-        .native & {
+        .regard-color-scheme-preference & {
             @media (prefers-color-scheme: dark) {
                 background-color: var(--ffe-v-context-message-success-bg-color);
             }
@@ -340,7 +340,7 @@
     &--error&--coloredbg {
         background-color: var(--ffe-v-context-message-variant-bg-color);
 
-        .native & {
+        .regard-color-scheme-preference & {
             @media (prefers-color-scheme: dark) {
                 background-color: var(--ffe-v-context-message-error-bg-color);
             }

--- a/packages/ffe-context-message/less/theme.less
+++ b/packages/ffe-context-message/less/theme.less
@@ -38,7 +38,7 @@
     --ffe-v-context-message-link-color-focus: var(--ffe-farge-hvit);
 
     @media (prefers-color-scheme: dark) {
-        .native {
+        .regard-color-scheme-preference {
             --ffe-v-context-message-icon-bg-color: var(--ffe-farge-svart);
             --ffe-v-context-message-info-bg-color: var(--ffe-farge-vann-30);
             --ffe-v-context-message-info-color: var(--ffe-farge-vann-70);

--- a/packages/ffe-core/less/body.less
+++ b/packages/ffe-core/less/body.less
@@ -1,15 +1,19 @@
 // Sets default body color, font styles and background color for light and dark themes
 .ffe-body {
-    background-color: var(--ffe-farge-hvit);
-    &.native {
+    --color: var(--ffe-g-text-color);
+    --background-color: var(--ffe-farge-hvit);
+
+    background-color: var(--background-color);
+    color: var(--color);
+
+    &.regard-color-scheme-preference {
         @media (prefers-color-scheme: dark) {
-            color: var(--ffe-farge-lysgraa);
-            background-color: var(--ffe-farge-svart);
+            --color: var(--ffe-farge-lysgraa);
+            --background-color: var(--ffe-farge-svart);
         }
     }
 
     font-family: var(--ffe-g-font);
-    color: var(--ffe-g-text-color);
     font-variant-numeric: tabular-nums;
 
     strong {

--- a/packages/ffe-core/less/theme.less
+++ b/packages/ffe-core/less/theme.less
@@ -173,7 +173,7 @@
     --ffe-g-link-icon-color-focus: var(--ffe-farge-vann);
 
     @media (prefers-color-scheme: dark) {
-        .native {
+        .regard-color-scheme-preference {
             --ffe-g-primary-color: var(--ffe-farge-vann-70);
             --ffe-g-secondary-color: var(--ffe-farge-vann-70);
             --ffe-g-border-color: var(--ffe-farge-graa);

--- a/packages/ffe-core/less/typography.less
+++ b/packages/ffe-core/less/typography.less
@@ -81,7 +81,7 @@
     &--with-border {
         border-bottom: 1px solid var(--ffe-farge-lysgraa);
         padding-bottom: var(--ffe-spacing-xs);
-        .native & {
+        .regard-color-scheme-preference & {
             @media (prefers-color-scheme: dark) {
                 border-color: var(--ffe-farge-graa);
             }
@@ -192,7 +192,7 @@
         box-shadow: 0 0 0 2px var(--ffe-g-link-color);
         outline: none;
 
-        .native & {
+        .regard-color-scheme-preference & {
             @media (prefers-color-scheme: dark) {
                 border-color: var(--ffe-farge-svart) !important;
                 color: var(--ffe-farge-svart) !important;
@@ -226,7 +226,7 @@
     padding-top: 1px;
     padding-bottom: 1px;
     width: 100%;
-    .native & {
+    .regard-color-scheme-preference & {
         @media (prefers-color-scheme: dark) {
             border-color: var(--ffe-farge-graa);
         }
@@ -251,7 +251,7 @@
     font-family: consolas, menlo, monaco, monospace;
     margin: 0;
     text-align: left;
-    .native & {
+    .regard-color-scheme-preference & {
         @media (prefers-color-scheme: dark) {
             background-color: var(--ffe-farge-koksgraa);
         }

--- a/packages/ffe-core/less/waves.less
+++ b/packages/ffe-core/less/waves.less
@@ -71,7 +71,7 @@
     }
 
     &--dm-bg-svart {
-        .native & {
+        .regard-color-scheme-preference & {
             @media (prefers-color-scheme: dark) {
                 background-color: var(--ffe-farge-svart);
             }
@@ -79,7 +79,7 @@
     }
 
     &--dm-bg-natt {
-        .native & {
+        .regard-color-scheme-preference & {
             @media (prefers-color-scheme: dark) {
                 background-color: @ffe-farge-natt;
             }

--- a/packages/ffe-datepicker/less/calendar.less
+++ b/packages/ffe-datepicker/less/calendar.less
@@ -4,7 +4,7 @@
     padding: var(--ffe-spacing-2xs);
     background: var(--ffe-farge-hvit);
     overflow-y: auto;
-    .native & {
+    .regard-color-scheme-preference & {
         @media (prefers-color-scheme: dark) {
             background-color: var(--ffe-farge-svart);
         }

--- a/packages/ffe-datepicker/less/theme.less
+++ b/packages/ffe-datepicker/less/theme.less
@@ -13,7 +13,7 @@
     --ffe-v-datepicker-date-color-disabled: var(--ffe-farge-varmgraa);
 
     @media (prefers-color-scheme: dark) {
-        .native {
+        .regard-color-scheme-preference {
             --ffe-v-datepicker-bg-color: var(--ffe-farge-svart);
             --ffe-v-datepicker-border-hover-color: var(--ffe-g-primary-color);
             --ffe-v-datepicker-icon-color: var(--ffe-g-primary-color);

--- a/packages/ffe-feedback/less/feedback-container.less
+++ b/packages/ffe-feedback/less/feedback-container.less
@@ -25,7 +25,7 @@
     }
 
     &--dm-bg-svart {
-        body.native & {
+        .regard-color-scheme-preference & {
             @media (prefers-color-scheme: dark) {
                 background-color: var(--ffe-farge-svart);
             }
@@ -33,7 +33,7 @@
     }
 
     &--dm-bg-natt {
-        body.native & {
+        .regard-color-scheme-preference & {
             @media (prefers-color-scheme: dark) {
                 background-color: var(--ffe-farge-natt);
             }

--- a/packages/ffe-feedback/less/feedback-thumb.less
+++ b/packages/ffe-feedback/less/feedback-thumb.less
@@ -8,7 +8,7 @@
         outline: none; // Remove focus outline
 
         @media (prefers-color-scheme: dark) {
-            body.native & {
+            .regard-color-scheme-preference & {
                 fill: var(--ffe-farge-vann-70);
             }
         }

--- a/packages/ffe-file-upload/less/theme.less
+++ b/packages/ffe-file-upload/less/theme.less
@@ -9,7 +9,7 @@
     --ffe-v-fileupload-error-icon-color: var(--ffe-farge-hvit);
 
     @media (prefers-color-scheme: dark) {
-        .native {
+        .regard-color-scheme-preference {
             --ffe-v-fileupload-bgcolor: var(--ffe-farge-svart);
             --ffe-v-fileupload-bordercolor: var(--ffe-farge-vann-30);
             --ffe-v-fileupload-btn-delete-color: var(--ffe-g-link-color);

--- a/packages/ffe-form/less/dropdown.less
+++ b/packages/ffe-form/less/dropdown.less
@@ -9,7 +9,7 @@
     color: var(--ffe-v-input-color);
     display: block;
     background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' height='24' viewBox='0 -960 960 960' width='24'%3E%3Cpath fill='%23005aa4' d='M480-373.539q-7.231 0-13.461-2.308-6.231-2.308-11.846-7.923L274.924-563.539q-8.308-8.307-8.5-20.884-.193-12.577 8.5-21.269 8.692-8.692 21.076-8.692t21.076 8.692L480-442.768l162.924-162.924q8.307-8.307 20.884-8.5 12.576-.192 21.268 8.5 8.693 8.692 8.693 21.077 0 12.384-8.693 21.076L505.307-383.77q-5.615 5.615-11.846 7.923-6.23 2.308-13.461 2.308Z'/%3E%3C/svg%3E%0A");
-    .native & {
+    .regard-color-scheme-preference & {
         @media (prefers-color-scheme: dark) {
             box-shadow: none;
             background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' height='24' viewBox='0 -960 960 960' width='24'%3E%3Cpath fill='%234d8cbf' d='M480-373.539q-7.231 0-13.461-2.308-6.231-2.308-11.846-7.923L274.924-563.539q-8.308-8.307-8.5-20.884-.193-12.577 8.5-21.269 8.692-8.692 21.076-8.692t21.076 8.692L480-442.768l162.924-162.924q8.307-8.307 20.884-8.5 12.576-.192 21.268 8.5 8.693 8.692 8.693 21.077 0 12.384-8.693 21.076L505.307-383.77q-5.615 5.615-11.846 7.923-6.23 2.308-13.461 2.308Z'/%3E%3C/svg%3E%0A");
@@ -40,7 +40,7 @@
     &:focus::-ms-value {
         background: var(--ffe-farge-hvit);
         color: var(--ffe-v-input-color);
-        .native & {
+        .regard-color-scheme-preference & {
             @media (prefers-color-scheme: dark) {
                 background: var(--ffe-farge-koksgraa);
             }

--- a/packages/ffe-form/less/input-field.less
+++ b/packages/ffe-form/less/input-field.less
@@ -20,7 +20,7 @@
         text-align: left;
     }
 
-    .native & {
+    .regard-color-scheme-preference & {
         @media (prefers-color-scheme: dark) {
             box-shadow: none;
         }
@@ -63,7 +63,7 @@
         height: 2em;
         transition: all var(--ffe-transition-duration) var(--ffe-ease);
 
-        .native & {
+        .regard-color-scheme-preference & {
             @media (prefers-color-scheme: dark) {
                 background-color: transparent;
                 box-shadow: none !important;

--- a/packages/ffe-form/less/radio-button.less
+++ b/packages/ffe-form/less/radio-button.less
@@ -111,7 +111,7 @@
             0 0 0 3px var(--background-color),
             0 0 0 5px var(--ffe-g-primary-color);
 
-        .native & {
+        .regard-color-scheme-preference & {
             @media (prefers-color-scheme: dark) {
                 --background-color: var(--ffe-farge-svart);
             }

--- a/packages/ffe-form/less/radio-switch.less
+++ b/packages/ffe-form/less/radio-switch.less
@@ -35,7 +35,7 @@
 
     &.ffe-radio-button--invalid {
         border-color: var(--ffe-farge-baer);
-        .native & {
+        .regard-color-scheme-preference & {
             @media (prefers-color-scheme: dark) {
                 border-color: var(--ffe-farge-baer);
             }

--- a/packages/ffe-form/less/radioblob-mixin.less
+++ b/packages/ffe-form/less/radioblob-mixin.less
@@ -10,7 +10,7 @@
     border-radius: 50%;
     position: absolute;
     pointer-events: none;
-    .native & {
+    .regard-color-scheme-preference & {
         @media (prefers-color-scheme: dark) {
             background-color: var(--ffe-farge-svart) !important;
             border-color: var(--ffe-farge-graa) !important;
@@ -24,7 +24,7 @@
 .ffe-sb1-radioblob-active() {
     background-color: var(--ffe-g-primary-color);
     border: 5px solid var(--ffe-farge-hvit);
-    .native & {
+    .regard-color-scheme-preference & {
         @media (prefers-color-scheme: dark) {
             background-color: var(--ffe-farge-vann-70) !important;
             border-color: var(--ffe-farge-svart) !important;

--- a/packages/ffe-form/less/textarea.less
+++ b/packages/ffe-form/less/textarea.less
@@ -11,7 +11,7 @@
     transition: all var(--ffe-transition-duration) var(--ffe-ease);
     font-size: var(--ffe-fontsize-form-input);
 
-    .native & {
+    .regard-color-scheme-preference & {
         @media (prefers-color-scheme: dark) {
             box-shadow: none;
         }

--- a/packages/ffe-form/less/theme.less
+++ b/packages/ffe-form/less/theme.less
@@ -19,7 +19,7 @@
     --ffe-v-tooltip-border-color: var(--ffe-g-border-color);
 
     @media (prefers-color-scheme: dark) {
-        .native {
+        .regard-color-scheme-preference {
             --ffe-v-input-color: var(--ffe-farge-hvit);
             --ffe-v-input-bg-color: var(--ffe-farge-svart);
             --ffe-v-input-placeholder-color: var(--ffe-farge-graa);

--- a/packages/ffe-form/less/toggle-switch.less
+++ b/packages/ffe-form/less/toggle-switch.less
@@ -69,7 +69,7 @@
             left: 2px;
             transition: transform var(--ffe-transition-duration) var(--ffe-ease)-in-out-back;
 
-            .native & {
+            .regard-color-scheme-preference & {
                 @media (prefers-color-scheme: dark) {
                     background: @ffe-farge-svart;
                 }
@@ -80,7 +80,7 @@
             .ffe-toggle-switch__label:hover &::before {
                 background: @ffe-farge-moerkgraa;
 
-                .native & {
+                .regard-color-scheme-preference & {
                     @media (prefers-color-scheme: dark) {
                         background: @ffe-farge-lysgraa;
                     }
@@ -96,7 +96,7 @@
     &__input:checked + &__label &__switch::before {
         background: var(--ffe-g-primary-color);
 
-        .native & {
+        .regard-color-scheme-preference & {
             @media (prefers-color-scheme: dark) {
                 background: var(--ffe-g-primary-color);
             }
@@ -112,7 +112,7 @@
     &__input:focus:not(:focus-visible) + &__label &__switch::before {
         box-shadow: none;
 
-        .native & {
+        .regard-color-scheme-preference & {
             @media (prefers-color-scheme: dark) {
                 box-shadow: none;
             }
@@ -124,7 +124,7 @@
             0 0 0 3px @ffe-farge-hvit,
             0 0 0 5px var(--ffe-g-primary-color);
 
-        .native & {
+        .regard-color-scheme-preference & {
             @media (prefers-color-scheme: dark) {
                 box-shadow:
                     0 0 0 3px @ffe-farge-svart,

--- a/packages/ffe-grid/less/ffe-grid.less
+++ b/packages/ffe-grid/less/ffe-grid.less
@@ -557,7 +557,7 @@
 
     &--bg-frost-30 {
         background-color: var(--ffe-farge-frost-30);
-        .native & {
+        .regard-color-scheme-preference & {
             @media (prefers-color-scheme: dark) {
                 background-color: var(--ffe-farge-svart);
             }
@@ -566,7 +566,7 @@
 
     &--bg-sand {
         background-color: var(--ffe-farge-sand);
-        .native & {
+        .regard-color-scheme-preference & {
             @media (prefers-color-scheme: dark) {
                 background-color: var(--ffe-farge-svart);
             }
@@ -575,7 +575,7 @@
 
     &--bg-sand-70 {
         background-color: var(--ffe-farge-sand-70);
-        .native & {
+        .regard-color-scheme-preference & {
             @media (prefers-color-scheme: dark) {
                 background-color: var(--ffe-farge-svart);
             }
@@ -584,7 +584,7 @@
 
     &--bg-sand-30 {
         background-color: var(--ffe-farge-sand-30);
-        .native & {
+        .regard-color-scheme-preference & {
             @media (prefers-color-scheme: dark) {
                 background-color: var(--ffe-farge-svart);
             }
@@ -592,7 +592,7 @@
     }
     &--bg-syrin-70 {
         background-color: var(--ffe-farge-syrin-70);
-        .native & {
+        .regard-color-scheme-preference & {
             @media (prefers-color-scheme: dark) {
                 background-color: var(--ffe-farge-svart);
             }
@@ -600,7 +600,7 @@
     }
     &--bg-syrin-30 {
         background-color: var(--ffe-farge-syrin-30);
-        .native & {
+        .regard-color-scheme-preference & {
             @media (prefers-color-scheme: dark) {
                 background-color: var(--ffe-farge-svart);
             }
@@ -610,7 +610,7 @@
     &--bg-vann {
         background-color: var(--ffe-farge-vann);
         color: var(--ffe-farge-hvit);
-        .native & {
+        .regard-color-scheme-preference & {
             @media (prefers-color-scheme: dark) {
                 background-color: var(--ffe-farge-svart);
             }
@@ -618,7 +618,7 @@
     }
     &--bg-vann-30 {
         background-color: var(--ffe-farge-vann-30);
-        .native & {
+        .regard-color-scheme-preference & {
             @media (prefers-color-scheme: dark) {
                 background-color: var(--ffe-farge-svart);
             }
@@ -628,7 +628,7 @@
     &--bg-fjell {
         background-color: var(--ffe-farge-fjell);
         color: var(--ffe-farge-hvit);
-        .native & {
+        .regard-color-scheme-preference & {
             @media (prefers-color-scheme: dark) {
                 background-color: var(--ffe-farge-svart);
             }
@@ -637,7 +637,7 @@
 
     &--bg-hvit {
         background-color: var(--ffe-farge-hvit);
-        .native & {
+        .regard-color-scheme-preference & {
             @media (prefers-color-scheme: dark) {
                 background-color: var(--ffe-farge-svart);
             }
@@ -645,7 +645,7 @@
     }
 
     &--bg-dark-svart {
-        .native & {
+        .regard-color-scheme-preference & {
             @media (prefers-color-scheme: dark) {
                 background-color: var(--ffe-farge-svart);
             }
@@ -653,7 +653,7 @@
     }
 
     &--bg-dark-natt {
-        .native & {
+        .regard-color-scheme-preference & {
             @media (prefers-color-scheme: dark) {
                 background-color: var(--ffe-farge-natt);
             }
@@ -661,7 +661,7 @@
     }
 
     &--bg-dark-koksgraa {
-        .native & {
+        .regard-color-scheme-preference & {
             @media (prefers-color-scheme: dark) {
                 background-color: var(--ffe-farge-koksgraa);
             }
@@ -679,7 +679,7 @@
 
     &--bg-frost-30 {
         background-color: var(--ffe-farge-frost-30);
-        .native & {
+        .regard-color-scheme-preference & {
             @media (prefers-color-scheme: dark) {
                 background-color: var(--ffe-farge-svart);
             }
@@ -688,7 +688,7 @@
 
     &--bg-sand {
         background-color: var(--ffe-farge-sand);
-        .native & {
+        .regard-color-scheme-preference & {
             @media (prefers-color-scheme: dark) {
                 background-color: var(--ffe-farge-svart);
             }
@@ -697,7 +697,7 @@
 
     &--bg-sand-70 {
         background-color: var(--ffe-farge-sand-70);
-        .native & {
+        .regard-color-scheme-preference & {
             @media (prefers-color-scheme: dark) {
                 background-color: var(--ffe-farge-svart);
             }
@@ -706,7 +706,7 @@
 
     &--bg-sand-30 {
         background-color: var(--ffe-farge-sand-30);
-        .native & {
+        .regard-color-scheme-preference & {
             @media (prefers-color-scheme: dark) {
                 background-color: var(--ffe-farge-svart);
             }
@@ -714,7 +714,7 @@
     }
     &--bg-syrin-70 {
         background-color: var(--ffe-farge-syrin-70);
-        .native & {
+        .regard-color-scheme-preference & {
             @media (prefers-color-scheme: dark) {
                 background-color: var(--ffe-farge-svart);
             }
@@ -722,7 +722,7 @@
     }
     &--bg-syrin-30 {
         background-color: var(--ffe-farge-syrin-30);
-        .native & {
+        .regard-color-scheme-preference & {
             @media (prefers-color-scheme: dark) {
                 background-color: var(--ffe-farge-svart);
             }
@@ -732,7 +732,7 @@
     &--bg-vann {
         background-color: var(--ffe-farge-vann);
         color: var(--ffe-farge-hvit);
-        .native & {
+        .regard-color-scheme-preference & {
             @media (prefers-color-scheme: dark) {
                 background-color: var(--ffe-farge-svart);
             }
@@ -740,7 +740,7 @@
     }
     &--bg-vann-30 {
         background-color: var(--ffe-farge-vann-30);
-        .native & {
+        .regard-color-scheme-preference & {
             @media (prefers-color-scheme: dark) {
                 background-color: var(--ffe-farge-svart);
             }
@@ -749,7 +749,7 @@
     &--bg-fjell {
         background-color: var(--ffe-farge-fjell);
         color: var(--ffe-farge-hvit);
-        .native & {
+        .regard-color-scheme-preference & {
             @media (prefers-color-scheme: dark) {
                 background-color: var(--ffe-farge-svart);
             }
@@ -758,7 +758,7 @@
 
     &--bg-hvit {
         background-color: var(--ffe-farge-hvit);
-        .native & {
+        .regard-color-scheme-preference & {
             @media (prefers-color-scheme: dark) {
                 background-color: var(--ffe-farge-svart);
             }
@@ -766,7 +766,7 @@
     }
 
     &--bg-dark-svart {
-        .native & {
+        .regard-color-scheme-preference & {
             @media (prefers-color-scheme: dark) {
                 background-color: var(--ffe-farge-svart);
             }
@@ -774,7 +774,7 @@
     }
 
     &--bg-dark-natt {
-        .native & {
+        .regard-color-scheme-preference & {
             @media (prefers-color-scheme: dark) {
                 background-color: var(--ffe-farge-natt);
             }
@@ -782,7 +782,7 @@
     }
 
     &--bg-dark-koksgraa {
-        .native & {
+        .regard-color-scheme-preference & {
             @media (prefers-color-scheme: dark) {
                 background-color: var(--ffe-farge-koksgraa);
             }

--- a/packages/ffe-header/less/ffe-header.less
+++ b/packages/ffe-header/less/ffe-header.less
@@ -279,7 +279,8 @@
     }
 
     &__user-nav {
-        transition: transform var(--ffe-transition-duration) var(--ffe-ease),
+        transition:
+            transform var(--ffe-transition-duration) var(--ffe-ease),
             opacity 0.1s;
         overflow: hidden;
 
@@ -317,7 +318,8 @@
             position: absolute;
             left: 0;
             bottom: 10px;
-            transition: transform var(--ffe-transition-duration)
+            transition:
+                transform var(--ffe-transition-duration)
                     var(--ffe-ease-in-out-back),
                 width var(--ffe-transition-duration) var(--ffe-ease-in-out-back);
         }
@@ -532,7 +534,7 @@
 }
 
 @media (prefers-color-scheme: dark) {
-    .native {
+    .regard-color-scheme-preference {
         .ffe-header {
             &__user-nav {
                 .ffe-header__link {

--- a/packages/ffe-header/less/theme.less
+++ b/packages/ffe-header/less/theme.less
@@ -17,7 +17,7 @@
     --ffe-v-usernav-list-border-color: @ffe-farge-vann;
 
     @media (prefers-color-scheme: dark) {
-        .native {
+        .regard-color-scheme-preference {
             --ffe-v-background-color: @ffe-farge-svart;
             --ffe-v-primary-color: @ffe-farge-vann-70;
             --ffe-v-header-border-bottom-color: @ffe-farge-moerkgraa;

--- a/packages/ffe-icons/less/theme.less
+++ b/packages/ffe-icons/less/theme.less
@@ -6,7 +6,7 @@
     --ffe-v-icons-size-xl: 48px;
     --ffe-v-icons-default-color: var(--ffe-farge-vann);
 
-    .native & {
+    .regard-color-scheme-preference & {
         @media (prefers-color-scheme: dark) {
             --ffe-v-icons-default-color: var(--ffe-farge-vann-70);
         }

--- a/packages/ffe-lists/less/description-list.less
+++ b/packages/ffe-lists/less/description-list.less
@@ -14,7 +14,7 @@
         padding-bottom: var(--vertical-seperation);
         margin-left: 0;
         &:extend(.ffe-body-text);
-        .native & {
+        .regard-color-scheme-preference & {
             @media (prefers-color-scheme: dark) {
                 color: var(--ffe-v-lists-description-description-color);
             }

--- a/packages/ffe-lists/less/detail-list-card.less
+++ b/packages/ffe-lists/less/detail-list-card.less
@@ -86,7 +86,7 @@
     }
 }
 
-.native & {
+.regard-color-scheme-preference & {
     @media (prefers-color-scheme: dark) {
         .ffe-detail-list-card {
             &--dm-bg-svart {

--- a/packages/ffe-lists/less/regular-lists.less
+++ b/packages/ffe-lists/less/regular-lists.less
@@ -125,7 +125,7 @@
     grid-template-rows: var(--line-height) 1fr;
     grid-column-gap: 1.5em;
 
-    .native & {
+    .regard-color-scheme-preference & {
         @media (prefers-color-scheme: dark) {
             color: var(--ffe-farge-hvit);
         }

--- a/packages/ffe-lists/less/theme.less
+++ b/packages/ffe-lists/less/theme.less
@@ -9,7 +9,7 @@
     --ffe-v-detail-list-card-border-radius: 16px;
 
     @media (prefers-color-scheme: dark) {
-        .native {
+        .regard-color-scheme-preference {
             --ffe-v-lists-title-color: var(--ffe-farge-hvit);
             --ffe-v-lists-description-description-color: var(
                 --ffe-farge-lysgraa

--- a/packages/ffe-message-box/less/message-box.less
+++ b/packages/ffe-message-box/less/message-box.less
@@ -11,7 +11,7 @@
 
     &__list,
     .ffe-body-paragraph {
-        .native & {
+        .regard-color-scheme-preference & {
             @media (prefers-color-scheme: dark) {
                 color: var(--ffe-farge-svart);
             }
@@ -46,7 +46,7 @@
         padding: var(--ffe-spacing-xl) var(--ffe-spacing-lg);
         border-radius: var(--ffe-spacing-xs);
         color: var(--ffe-farge-svart);
-        .native & {
+        .regard-color-scheme-preference & {
             @media (prefers-color-scheme: dark) {
                 color: var(--ffe-farge-svart);
             }
@@ -59,7 +59,7 @@
 
     &--tips&--coloredbg &__box {
         background-color: var(--ffe-v-message-box-variant-bg-color);
-        .native & {
+        .regard-color-scheme-preference & {
             @media (prefers-color-scheme: dark) {
                 background-color: var(--ffe-v-message-box-tips-bg-color);
             }
@@ -72,7 +72,7 @@
 
     &--info&--coloredbg &__box {
         background-color: var(--ffe-v-message-box-variant-bg-color);
-        .native & {
+        .regard-color-scheme-preference & {
             @media (prefers-color-scheme: dark) {
                 background-color: var(--ffe-v-message-box-info-bg-color);
             }
@@ -85,7 +85,7 @@
 
     &--success&--coloredbg &__box {
         background-color: var(--ffe-v-message-box-variant-bg-color);
-        .native & {
+        .regard-color-scheme-preference & {
             @media (prefers-color-scheme: dark) {
                 background-color: var(--ffe-v-message-box-success-bg-color);
             }
@@ -98,7 +98,7 @@
 
     &--error&--coloredbg &__box {
         background-color: var(--ffe-v-message-box-variant-bg-color);
-        .native & {
+        .regard-color-scheme-preference & {
             @media (prefers-color-scheme: dark) {
                 background-color: var(--ffe-v-message-box-error-bg-color);
             }
@@ -110,7 +110,7 @@
         font-size: var(--ffe-fontsize-h5);
         margin-bottom: var(--ffe-spacing-sm);
         margin-top: 0;
-        .native & {
+        .regard-color-scheme-preference & {
             @media (prefers-color-scheme: dark) {
                 color: var(--ffe-farge-svart);
             }
@@ -123,7 +123,7 @@
         margin: 0;
         line-height: 2;
         text-align: left;
-        .native {
+        .regard-color-scheme-preference {
             li {
                 color: var(--ffe-farge-svart);
             }

--- a/packages/ffe-message-box/less/theme.less
+++ b/packages/ffe-message-box/less/theme.less
@@ -29,7 +29,7 @@
     --ffe-v-message-box-link-color-focus: var(--ffe-farge-hvit);
 
     @media (prefers-color-scheme: dark) {
-        .native {
+        .regard-color-scheme-preference {
             --ffe-v-message-box-info-bg-color: var(--ffe-farge-vann-30);
             --ffe-v-message-box-icon-bg-color: var(--ffe-farge-svart);
             --ffe-v-message-box-info-icon-color: var(--ffe-farge-vann-70);

--- a/packages/ffe-messages/less/common.less
+++ b/packages/ffe-messages/less/common.less
@@ -244,10 +244,11 @@
     line-height: 2;
     text-align: left;
     width: fit-content;
-    .native {
-        li {
-            color: var(--ffe-farge-svart);
-        }
+}
+
+@media (prefers-color-scheme: dark) {
+    .regard-color-scheme-preference .ffe-message__list li {
+        color: var(--ffe-farge-svart);
     }
 }
 

--- a/packages/ffe-messages/less/theme.less
+++ b/packages/ffe-messages/less/theme.less
@@ -50,7 +50,7 @@
     --ffe-v-messages-link-color-focus: var(--ffe-farge-hvit);
 
     @media (prefers-color-scheme: dark) {
-        .native {
+        .regard-color-scheme-preference {
             --ffe-v-messages-tips-icon-variant-bg-color: var(--ffe-farge-sol);
             --ffe-v-messages-info-icon-variant-bg-color: var(--ffe-farge-vann);
             --ffe-v-messages-success-icon-variant-bg-color: var(

--- a/packages/ffe-modals/less/theme.less
+++ b/packages/ffe-modals/less/theme.less
@@ -7,7 +7,7 @@
     --ffe-v-modal-border-radius: 24px;
 
     @media (prefers-color-scheme: dark) {
-        .native {
+        .regard-color-scheme-preference {
             --ffe-v-modal-backdrop-color: rgba(103, 103, 103, 0.5);
             --ffe-v-modal-bg-color: var(--ffe-farge-svart);
             --ffe-v-modal-close-button-cross-color: var(--ffe-farge-vann-30);

--- a/packages/ffe-pagination/less/theme.less
+++ b/packages/ffe-pagination/less/theme.less
@@ -3,7 +3,7 @@
     --ffe-v-pagination-dots: var(--ffe-farge-vann);
 
     @media (prefers-color-scheme: dark) {
-        .native {
+        .regard-color-scheme-preference {
             --ffe-v-pagination-dots: var(--ffe-farge-vann-70);
         }
     }

--- a/packages/ffe-searchable-dropdown-react/less/ffe-searchable-dropdown.less
+++ b/packages/ffe-searchable-dropdown-react/less/ffe-searchable-dropdown.less
@@ -142,7 +142,7 @@
 }
 
 @media (prefers-color-scheme: dark) {
-    .native .ffe-searchable-dropdown {
+    .regard-color-scheme-preference .ffe-searchable-dropdown {
         &__list {
             color: var(--ffe-farge-hvit);
         }

--- a/packages/ffe-searchable-dropdown-react/less/theme.less
+++ b/packages/ffe-searchable-dropdown-react/less/theme.less
@@ -4,7 +4,7 @@
     --ffe-v-searchable-dropdown-icon-hover-color: var(--ffe-farge-fjell);
 
     @media (prefers-color-scheme: dark) {
-        .native {
+        .regard-color-scheme-preference {
             --ffe-v-searchable-dropdown-list-background-color: var(
                 --ffe-farge-svart
             );

--- a/packages/ffe-system-message/less/system-message.less
+++ b/packages/ffe-system-message/less/system-message.less
@@ -40,7 +40,7 @@
     &--error&--coloredbg {
         background-color: var(--ffe-v-system-message-variant-bg-color);
 
-        .native & {
+        .regard-color-scheme-preference & {
             @media (prefers-color-scheme: dark) {
                 background-color: var(--ffe-v-system-message-error-bg-color);
             }
@@ -62,7 +62,7 @@
     &--info&--coloredbg {
         background-color: var(--ffe-v-system-message-variant-bg-color);
 
-        .native & {
+        .regard-color-scheme-preference & {
             @media (prefers-color-scheme: dark) {
                 background-color: var(--ffe-v-system-message-info-bg-color);
             }
@@ -85,7 +85,7 @@
         background-color: var(--ffe-v-system-message-variant-bg-color);
         color: var(--ffe-farge-svart);
 
-        .native & {
+        .regard-color-scheme-preference & {
             @media (prefers-color-scheme: dark) {
                 background-color: var(--ffe-v-system-message-news-bg-color);
                 color: var(--ffe-farge-hvit);
@@ -99,7 +99,7 @@
                 color: var(--ffe-farge-hvit);
             }
 
-            .native & {
+            .regard-color-scheme-preference & {
                 @media (prefers-color-scheme: dark) {
                     background: var(--ffe-farge-hvit);
 
@@ -127,7 +127,7 @@
     &--success&--coloredbg {
         background-color: var(--ffe-v-system-message-variant-bg-color);
 
-        .native & {
+        .regard-color-scheme-preference & {
             @media (prefers-color-scheme: dark) {
                 background: var(--ffe-v-system-message-success-bg-color);
             }
@@ -229,7 +229,7 @@
 .ffe-system-message-wrapper--success,
 .ffe-system-message-wrapper--error {
     .ffe-system-message__content {
-        .native & {
+        .regard-color-scheme-preference & {
             @media (prefers-color-scheme: dark) {
                 color: var(--ffe-farge-svart);
             }

--- a/packages/ffe-system-message/less/theme.less
+++ b/packages/ffe-system-message/less/theme.less
@@ -33,7 +33,7 @@
     --ffe-v-system-message-link-color-focus: var(--ffe-farge-hvit);
 
     @media (prefers-color-scheme: dark) {
-        .native {
+        .regard-color-scheme-preference {
             --ffe-v-system-message-info-bg-color: var(--ffe-farge-vann-30);
         }
     }

--- a/packages/ffe-tables/less/theme.less
+++ b/packages/ffe-tables/less/theme.less
@@ -11,7 +11,7 @@
     --ffe-v-table-content-color: var(--ffe-farge-svart);
 
     @media (prefers-color-scheme: dark) {
-        .native {
+        .regard-color-scheme-preference {
             --ffe-v-table-heading-color: var(--ffe-farge-vann-70);
             --ffe-v-table-row-bordercolor: var(--ffe-farge-graa);
             --ffe-v-table-expand-icon-color: var(--ffe-farge-vann-70);

--- a/packages/ffe-tabs/less/theme.less
+++ b/packages/ffe-tabs/less/theme.less
@@ -7,7 +7,7 @@
     --ffe-v-tabs-tab-active-hover-color: var(--ffe-farge-natt);
 
     @media (prefers-color-scheme: dark) {
-        .native {
+        .regard-color-scheme-preference {
             --ffe-v-tabs-primary-color: var(--ffe-farge-vann-30);
             --ffe-v-tabs-secondary-color: var(--ffe-farge-svart);
             --ffe-v-tabs-tab-focus-color: var(--ffe-farge-hvit);


### PR DESCRIPTION
Bytter ut all `.native` med `.regard-color-scheme-preference`. Denne brukes på samma måte. Forskjellen er att man også kan bruke darkmode på desktop når man har lust.   

Vi må forsatt bruke `.native` her men det har ikke med darkmode att gjøra. 
```
@supports (font: -apple-system-body) {
  :host:has(.native), :root:has(.native) {
    font: -apple-system-body;
  }
}
```