### PR TITLE
Theming regard-color-scheme-preference

### DIFF
--- a/component-overview/examples/theming/Skjema.jsx
+++ b/component-overview/examples/theming/Skjema.jsx
@@ -32,8 +32,9 @@ import {
         --ffe-v-button-action-color-hover: #000;
         --ffe-v-button-tertiary-color: #020a0a;
         --ffe-v-button-tertiary-color-hover: #de1a21;
-        --ffe-v-button-secondary-color: #000;
-        --ffe-v-button-secondary-color-bg: #d6d6d6;
+        --ffe-v-button-secondary-color: #d6d6d6;
+        --ffe-v-button-secondary-color-bg-hover: #000;
+        --ffe-v-button-secondary-color-text: #000;
     }`;
 
     return (
@@ -49,7 +50,7 @@ import {
 
                 <InputGroup label="Måned">
                     <Dropdown defaultValue="placeholder">
-                        <option value="placeholder" disabled>
+                        <option value="placeholder" disabled={true}>
                             Velg måned
                         </option>
                         <option value="jan">Januar</option>

--- a/packages/ffe-buttons/less/base-button.less
+++ b/packages/ffe-buttons/less/base-button.less
@@ -28,12 +28,8 @@
         background: transparent;
         border-radius: 1.5rem;
         inset: -5px;
-        box-shadow: 0 0 0 2px var(--ffe-farge-vann);
+        box-shadow: 0 0 0 2px var(--ffe-v-button-shadow-color);
         transition: opacity var(--ffe-transition-duration) var(--ffe-ease);
-
-        .regard-color-scheme-preference & {
-            box-shadow: 0 0 0 2px var(--ffe-farge-hvit);
-        }
     }
 
     &:focus::after {
@@ -66,17 +62,12 @@
 
 .ffe-button--action {
     background-color: var(--ffe-v-button-action-color);
-    color: var(--ffe-v-button-text-color);
+    color: var(--ffe-v-button-action-color-text);
 
     .ffe-button__icon {
-        color: var(--ffe-v-button-text-color);
+        color: var(--ffe-v-button-action-color-text);
     }
 
-    .regard-color-scheme-preference & {
-        @media (prefers-color-scheme: dark) {
-            border: 2px solid transparent;
-        }
-    }
     &:focus {
         background-color: var(--ffe-v-button-action-color);
     }
@@ -90,10 +81,10 @@
 
 .ffe-button--primary {
     background-color: var(--ffe-v-button-primary-color);
-    color: var(--ffe-v-button-text-color);
+    color: var(--ffe-v-button-primary-color-text);
 
     .ffe-button__icon {
-        color: var(--ffe-v-button-text-color);
+        color: var(--ffe-v-button-primary-color-text);
     }
 
     &:focus {
@@ -110,42 +101,30 @@
 .ffe-button--secondary,
 .ffe-button--shortcut,
 .ffe-button--expand {
-    background-color: var(--ffe-v-button-secondary-color-bg);
+    background-color: var(--ffe-v-button-secondary-color);
     border: solid 2px var(--ffe-v-button-secondary-border-color);
-    color: var(--ffe-v-button-secondary-color);
+    color: var(--ffe-v-button-secondary-color-text);
 
-    .ffe-button__icon {
-        color: var(--ffe-v-button-secondary-color);
+    .ffe-button__icon,
+    .ffe-button__label {
+        color: var(--ffe-v-button-secondary-color-text);
     }
 
     &:active,
     &:focus,
     &:visited {
-        color: var(--ffe-v-button-secondary-color);
-        .regard-color-scheme-preference & {
-            @media (prefers-color-scheme: dark) {
-                color: var(--ffe-v-button-secondary-color);
-            }
-        }
+        color: var(--ffe-v-button-secondary-color-text);
     }
 
     @media (hover: hover) and (pointer: fine) {
         &:hover {
-            background-color: var(--ffe-v-button-secondary-color);
-            border-color: var(--ffe-v-button-secondary-color);
-            color: var(--ffe-v-button-secondary-color-bg);
+            background-color: var(--ffe-v-button-secondary-color-bg-hover);
+            border-color: var(--ffe-v-button-secondary-color-bg-hover);
+            color: var(--ffe-v-button-secondary-color-text-hover);
 
-            .ffe-button__icon {
-                color: var(--ffe-v-button-secondary-color-bg);
-            }
-            .regard-color-scheme-preference & {
-                @media (prefers-color-scheme: dark) {
-                    background-color: var(
-                        --ffe-v-button-secondary-border-color
-                    );
-                    border-color: var(--ffe-v-button-secondary-border-color);
-                    color: var(--ffe-v-button-secondary-color-bg);
-                }
+            .ffe-button__icon,
+            .ffe-button__label {
+                color: var(--ffe-v-button-secondary-color-text-hover);
             }
         }
     }
@@ -165,7 +144,7 @@
     border-radius: 1.75rem;
     border: 2px solid transparent;
     box-shadow: none;
-    color: var(--ffe-v-button-task-primary-color);
+    color: var(--ffe-v-button-task-color-text);
     display: inline-block;
     padding: var(--ffe-spacing-2xs) var(--ffe-spacing-sm) var(--ffe-spacing-2xs)
         var(--ffe-spacing-2xs);
@@ -175,16 +154,16 @@
 
     .ffe-button__icon > .ffe-icons {
         display: block;
-        color: var(--ffe-v-button-task-primary-color);
+        color: var(--ffe-v-button-task-color-icon);
     }
 
     @media (hover: hover) and (pointer: fine) {
         &:hover {
-            color: var(--ffe-v-button-task-text-color-hover);
+            color: var(--ffe-v-button-task-color-text-hover);
             box-shadow: none;
 
             .ffe-button__icon > .ffe-icons {
-                color: var(--ffe-v-button-primary-color-text);
+                color: var(--ffe-v-button-task-color-icon-hover);
             }
         }
     }
@@ -234,22 +213,17 @@
     }
 
     .ffe-button--task & {
-        border: 2px solid var(--ffe-v-button-primary-color);
+        border: 2px solid var(--ffe-v-button-task-color-border);
         border-radius: 50%;
-        background-color: var(--ffe-farge-hvit);
-        color: var(--ffe-v-button-task-primary-color);
+        background-color: var(--ffe-v-button-task-color);
+        color: var(--ffe-v-button-task-color-icon);
         height: 45px;
+        width: 45px;
         display: flex;
         align-items: center;
         justify-content: center;
         margin: 0 var(--ffe-spacing-xs) 0 0;
-        width: 45px;
         transition: all var(--ffe-transition-duration) var(--ffe-ease);
-        .regard-color-scheme-preference & {
-            @media (prefers-color-scheme: dark) {
-                background-color: transparent;
-            }
-        }
     }
 
     .ffe-button--expand & {
@@ -258,17 +232,9 @@
 
     @media (hover: hover) and (pointer: fine) {
         .ffe-button--expand:hover & {
-            color: var(--ffe-farge-hvit);
-
-            .regard-color-scheme-preference & {
-                @media (prefers-color-scheme: dark) {
-                    color: var(--ffe-farge-svart);
-                }
-            }
+            color: var(--ffe-v-button-secondary-color-text-hover);
         }
-    }
 
-    @media (hover: hover) and (pointer: fine) {
         .ffe-button--task:hover & {
             border-color: var(--ffe-v-button-primary-color);
             background-color: var(--ffe-v-button-primary-color);

--- a/packages/ffe-buttons/less/inline-base-button.less
+++ b/packages/ffe-buttons/less/inline-base-button.less
@@ -19,18 +19,29 @@
     }
 
     &:focus {
-        box-shadow: 0 0 0 2px var(--ffe-farge-vann);
+        box-shadow: 0 0 0 2px var(--ffe-v-button-shadow-color);
         outline: none;
-
-        .regard-color-scheme-preference & {
-            @media (prefers-color-scheme: dark) {
-                box-shadow: 0 0 0 2px var(--ffe-farge-hvit);
-            }
-        }
     }
 
     &:focus:not(:focus-visible) {
         box-shadow: none;
+    }
+
+    &__icon {
+        margin-bottom: -2px;
+        will-change: transform, opacity;
+
+        .ffe-inline-button--expanded & {
+            transform: rotateZ(180deg);
+        }
+
+        &--left {
+            margin-right: 6px;
+        }
+
+        &--right {
+            margin-left: 6px;
+        }
     }
 }
 
@@ -57,8 +68,8 @@
         }
 
         &:hover .ffe-inline-button__label {
-            color: var(--ffe-v-button-secondary-color-hover);
-            border-bottom-color: var(--ffe-v-button-secondary-color-hover);
+            color: var(--ffe-v-button-primary-color-hover);
+            border-bottom-color: var(--ffe-v-button-primary-color-hover);
         }
     }
 }
@@ -105,19 +116,12 @@
 
     &:focus {
         box-shadow: none;
-        border-color: var(--ffe-v-button-tertiary-color);
+        border-color: var(--ffe-v-button-tertiary-color-focus);
         color: var(--ffe-v-button-tertiary-color);
 
-        .regard-color-scheme-preference & {
-            @media (prefers-color-scheme: dark) {
-                border-color: var(--ffe-farge-hvit);
-                box-shadow: none;
-            }
+        &:not(:focus-visible) {
+            border-color: transparent;
         }
-    }
-
-    &:focus:not(:focus-visible) {
-        border-color: transparent;
     }
 
     @media (hover: hover) and (pointer: fine) {
@@ -127,28 +131,6 @@
             .ffe-inline-button__icon {
                 color: var(--ffe-v-button-tertiary-color-hover);
             }
-            .regard-color-scheme-preference & {
-                @media (prefers-color-scheme: dark) {
-                    color: var(--ffe-farge-hvit);
-                }
-            }
         }
     }
-}
-
-.ffe-inline-button__icon {
-    margin-bottom: -2px;
-    will-change: transform, opacity;
-
-    .ffe-inline-button--expanded & {
-        transform: rotateZ(180deg);
-    }
-}
-
-.ffe-inline-button__icon--left {
-    margin-right: 6px;
-}
-
-.ffe-inline-button__icon--right {
-    margin-left: 6px;
 }

--- a/packages/ffe-buttons/less/theme.less
+++ b/packages/ffe-buttons/less/theme.less
@@ -8,9 +8,12 @@
     /* Button border radius renders as 50% */
     --ffe-v-buttons-border-radius: 6em;
 
+    /* Button box shadow */
+    --ffe-v-button-shadow-color: var(--ffe-farge-vann);
+
     /** Action button */
     --ffe-v-button-action-color: var(--ffe-farge-skog);
-    --ffe-v-button-action-color-hover: #095139; // Temporary, until dark mode palette is finished
+    --ffe-v-button-action-color-hover: #095139;
     --ffe-v-button-action-color-text: var(--ffe-farge-hvit);
 
     /** Primary button */
@@ -18,41 +21,62 @@
     --ffe-v-button-primary-color-hover: var(--ffe-farge-fjell);
     --ffe-v-button-primary-color-text: var(--ffe-farge-hvit);
 
-    /** Secondary buttons (+ task, back, expand, etc) are inverted */
-    --ffe-v-button-secondary-color: var(--ffe-farge-vann);
+    /** Secondary buttons (+ back, expand, etc) */
+    --ffe-v-button-secondary-color: var(--ffe-farge-hvit);
     --ffe-v-button-secondary-border-color: var(--ffe-farge-vann);
-    --ffe-v-button-secondary-color-hover: var(--ffe-farge-fjell);
-    --ffe-v-button-secondary-color-bg: var(--ffe-farge-hvit);
+    --ffe-v-button-secondary-color-text-hover: var(--ffe-farge-hvit);
+    --ffe-v-button-secondary-color-bg-hover: var(--ffe-farge-vann);
+    --ffe-v-button-secondary-color-text: var(--ffe-farge-vann);
 
     /** Tertiary button */
     --ffe-v-button-tertiary-color: var(--ffe-farge-vann);
     --ffe-v-button-tertiary-color-hover: var(--ffe-farge-fjell);
-    --ffe-v-button-tertiary-color-text: var(--ffe-farge-hvit);
+    --ffe-v-button-tertiary-color-focus: var(--ffe-farge-vann);
 
     /** Task button */
-    --ffe-v-button-task-primary-color: var(--ffe-farge-vann);
-    --ffe-v-button-task-text-color-hover: var(--ffe-farge-fjell);
+    --ffe-v-button-task-color: var(--ffe-farge-hvit);
+    --ffe-v-button-task-color-border: var(--ffe-farge-vann);
+    --ffe-v-button-task-color-text: var(--ffe-farge-vann);
+    --ffe-v-button-task-color-text-hover: var(--ffe-farge-fjell);
+    --ffe-v-button-task-color-icon: var(--ffe-farge-vann);
+    --ffe-v-button-task-color-icon-hover: var(--ffe-farge-hvit);
     --ffe-v-button-task-border-focus: var(--ffe-farge-vann);
 
     @media (prefers-color-scheme: dark) {
         .regard-color-scheme-preference {
             --ffe-v-button-text-color: var(--ffe-farge-svart);
+            --ffe-v-button-shadow-color: var(--ffe-farge-hvit);
+
+            /** Action button */
             --ffe-v-button-action-color: var(--ffe-farge-skog-70);
             --ffe-v-button-action-color-hover: var(--ffe-farge-skog-30);
             --ffe-v-button-action-color-text: var(--ffe-farge-svart);
+
+            /** Primary button */
             --ffe-v-button-primary-color: var(--ffe-farge-vann-70);
             --ffe-v-button-primary-color-hover: var(--ffe-farge-vann-30);
             --ffe-v-button-primary-color-text: var(--ffe-farge-svart);
-            --ffe-v-button-secondary-color: var(--ffe-farge-vann-30);
+
+            /** Secondary buttons (+ task, back, expand, etc) */
+            --ffe-v-button-secondary-color: var(--ffe-farge-svart);
             --ffe-v-button-secondary-border-color: var(--ffe-farge-vann-70);
-            --ffe-v-button-secondary-color-hover: var(--ffe-farge-vann-30);
-            --ffe-v-button-secondary-color-bg: var(--ffe-farge-svart);
+            --ffe-v-button-secondary-color-text-hover: var(--ffe-farge-svart);
+            --ffe-v-button-secondary-color-bg-hover: var(--ffe-farge-vann-30);
+            --ffe-v-button-secondary-color-text: var(--ffe-farge-vann-30);
+
+            /** Tertiary button */
             --ffe-v-button-tertiary-color: var(--ffe-farge-vann-30);
             --ffe-v-button-tertiary-color-hover: var(--ffe-farge-hvit);
-            --ffe-v-button-tertiary-color-text: var(--ffe-farge-svart);
-            --ffe-v-button-task-text-color-hover: var(--ffe-farge-hvit);
+            --ffe-v-button-tertiary-color-focus: var(--ffe-farge-hvit);
+
+            /** Task button */
+            --ffe-v-button-task-color: transparent;
+            --ffe-v-button-task-color-border: var(--ffe-farge-vann-30);
+            --ffe-v-button-task-color-text: var(--ffe-farge-vann-30);
+            --ffe-v-button-task-color-text-hover: var(--ffe-farge-hvit);
+            --ffe-v-button-task-color-icon: var(--ffe-farge-vann-30);
+            --ffe-v-button-task-color-icon-hover: var(--ffe-farge-svart);
             --ffe-v-button-task-border-focus: var(--ffe-farge-hvit);
-            --ffe-v-button-task-primary-color: var(--ffe-farge-vann-30);
         }
     }
 }


### PR DESCRIPTION
Som en del av overgangen til semantiske farger og bruken av tokens i Figma, ønsker vi å dra ut all bruk av `.regard-color-scheme-preference`(tidligere `.native`) og kun ha det i theme.less. 

Koden blir ryddigere, og det blir lettere å introdusere OnBlueBg og OnBlueDarkMode senere. 

Dette fikser også feilen #2169 