### PR TITLE
refactor(ffe-cards): flytter dm-variabler inn til theme

### DIFF
--- a/packages/ffe-cards/less/card-base.less
+++ b/packages/ffe-cards/less/card-base.less
@@ -27,11 +27,9 @@
     &--text-center {
         text-align: center;
     }
-}
 
-.regard-color-scheme-preference & {
-    @media (prefers-color-scheme: dark) {
-        .ffe-card-base {
+    .regard-color-scheme-preference & {
+        @media (prefers-color-scheme: dark) {
             .card-background-dm-styling();
         }
     }

--- a/packages/ffe-cards/less/common-card-styling.less
+++ b/packages/ffe-cards/less/common-card-styling.less
@@ -2,18 +2,12 @@
     background: var(--ffe-v-cards-common-card-background-color);
     box-shadow: var(--ffe-v-cards-common-card-box-shadow);
     margin: 0 0 var(--ffe-spacing-2xs);
-    border: 2px solid transparent;
+    border: 2px solid var(--ffe-v-cards-common-card-border-color);
     border-radius: var(--ffe-v-cards-common-card-border-radius);
     transition: all var(--ffe-transition-duration) var(--ffe-ease);
     outline: none;
     width: 100%;
     text-decoration: none;
-
-    .regard-color-scheme-preference & {
-        @media (prefers-color-scheme: dark) {
-            color: var(--ffe-farge-hvit);
-        }
-    }
 
     @media (min-width: @breakpoint-md) {
         margin-bottom: var(--ffe-spacing-md);
@@ -105,10 +99,6 @@
     }
 
     .ffe-card__action--raw:visited {
-        .regard-color-scheme-preference & {
-            @media (prefers-color-scheme: dark) {
-                color: var(--ffe-farge-hvit);
-            }
-        }
+        color: var(--ffe-v-cards-clickabe-card-link-visited-color);
     }
 }

--- a/packages/ffe-cards/less/components.less
+++ b/packages/ffe-cards/less/components.less
@@ -10,7 +10,7 @@
     &__subtext {
         &:extend(.ffe-small-text);
 
-        color: var(--ffe-v-cards-text-color);
+        color: var(--ffe-v-cards-subtext-color);
         margin: var(--ffe-spacing-2xs) 0 0 0;
     }
 

--- a/packages/ffe-cards/less/group-card.less
+++ b/packages/ffe-cards/less/group-card.less
@@ -5,7 +5,7 @@
     .card-background-styling();
 
     position: relative;
-    border: none;
+    border: var(--ffe-v-cards-common-group-card-border);
     box-shadow: none;
 
     &--shadow {
@@ -40,10 +40,6 @@
         display: flex;
         justify-content: center;
         align-items: center;
-
-        &--clickable {
-            color: var(--ffe-farge-fjell);
-        }
     }
 
     &__title,
@@ -83,42 +79,10 @@
             --ffe-v-cards-common-group-card-separation-border-color
         );
     }
-}
 
-.regard-color-scheme-preference & {
-    @media (prefers-color-scheme: dark) {
-        .ffe-group-card {
+    .regard-color-scheme-preference & {
+        @media (prefers-color-scheme: dark) {
             .card-background-dm-styling();
-
-            box-shadow: none;
-            border: 1px solid
-                var(--ffe-v-cards-common-group-card-separation-border-color-dm);
-
-            &__title {
-                color: var(--ffe-farge-vann-30);
-            }
-
-            &__title,
-            &__element {
-                border-bottom-color: var(
-                    --ffe-v-cards-common-group-card-separation-border-color-dm
-                );
-
-                &--no-separator {
-                    border-bottom-color: transparent;
-                }
-            }
-
-            &__title--clickable:hover,
-            &__element--clickable:hover {
-                border-color: var(--ffe-v-cards-border-hover-color);
-            }
-
-            &__footer {
-                background-color: var(
-                    --ffe-v-group-card-footer-background-color-dm
-                );
-            }
         }
     }
 }

--- a/packages/ffe-cards/less/image-card.less
+++ b/packages/ffe-cards/less/image-card.less
@@ -13,7 +13,7 @@
     display: flex;
     padding: 0;
     max-width: 290px;
-    border: 0;
+    border: var(--ffe-v-cards-image-card-border);
     flex-flow: column nowrap;
 
     .ffe-image-card__image-overlay,

--- a/packages/ffe-cards/less/stippled-card.less
+++ b/packages/ffe-cards/less/stippled-card.less
@@ -26,12 +26,6 @@
     align-items: center;
     padding: var(--ffe-spacing-md);
     gap: var(--ffe-spacing-md);
-
-    .regard-color-scheme-preference & {
-        @media (prefers-color-scheme: dark) {
-            box-shadow: none;
-        }
-    }
 }
 
 .ffe-stippled-card__img--icon {

--- a/packages/ffe-cards/less/text-card.less
+++ b/packages/ffe-cards/less/text-card.less
@@ -18,8 +18,8 @@
     @media (min-width: @breakpoint-md) {
         min-height: 100px;
     }
-}
 
-.ffe-text-card--left-align {
-    text-align: left;
+    &--left-align {
+        text-align: left;
+    }
 }

--- a/packages/ffe-cards/less/theme.less
+++ b/packages/ffe-cards/less/theme.less
@@ -1,33 +1,46 @@
 :root,
 :host {
+    --ffe-v-cards-common-text-color: var(--ffe-g-text-color);
     --ffe-v-cards-common-card-background-color: var(--ffe-farge-hvit);
+    --ffe-v-cards-common-card-border-color: transparent;
     --ffe-v-cards-common-card-box-shadow-color: var(--ffe-farge-graa);
     --ffe-v-cards-common-card-box-shadow: 0 1px 4px 0
         var(--ffe-v-cards-common-card-box-shadow-color);
     --ffe-v-cards-common-card-border-radius: 16px;
-    --ffe-v-cards-text-color: var(--ffe-farge-moerkgraa);
+    --ffe-v-cards-clickabe-card-link-visited-color: inherit;
+    --ffe-v-cards-subtext-color: var(--ffe-farge-moerkgraa);
     --ffe-v-cards-border-hover-color: var(--ffe-farge-vann);
     --ffe-v-cards-stippled-border-color: var(--ffe-farge-vann);
     --ffe-v-cards-icon-color: var(--ffe-farge-fjell);
+    --ffe-v-cards-image-card-border: none;
+    --ffe-v-cards-common-group-card-border: none;
     --ffe-v-cards-common-group-card-separation-border-color: var(
         --ffe-farge-lysgraa
     );
-    --ffe-v-cards-common-group-card-separation-border-color-dm: var(
-        --ffe-farge-koksgraa
-    );
     --ffe-v-group-card-footer-background-color: var(--ffe-farge-syrin-30);
-    --ffe-v-group-card-footer-background-color-dm: var(--ffe-farge-koksgraa);
 
     @media (prefers-color-scheme: dark) {
         .regard-color-scheme-preference {
+            --ffe-v-cards-common-text-color: var(--ffe-farge-hvit);
             --ffe-v-cards-common-card-background-color: var(--ffe-farge-svart);
-            --ffe-v-cards-common-card-box-shadow-color: var(
-                --ffe-farge-moerkgraa
+            --ffe-v-cards-common-card-border-color: var(--ffe-farge-koksgraa);
+            --ffe-v-cards-common-card-box-shadow: none;
+            --ffe-v-cards-clickabe-card-link-visited-color: var(
+                --ffe-farge-hvit
             );
-            --ffe-v-cards-text-color: var(--ffe-farge-graa);
+            --ffe-v-cards-subtext-color: var(--ffe-farge-graa);
+            --ffe-v-cards-border-hover-color: var(--ffe-g-primary-color);
             --ffe-v-cards-stippled-border-color: var(--ffe-farge-vann-70);
             --ffe-v-cards-icon-color: var(--ffe-farge-vann-70);
-            --ffe-v-cards-border-hover-color: var(--ffe-g-primary-color);
+            --ffe-v-cards-image-card-border: 1px solid var(--ffe-farge-koksgraa);
+            --ffe-v-cards-common-group-card-border: 1px solid
+                var(--ffe-farge-koksgraa);
+            --ffe-v-cards-common-group-card-separation-border-color: var(
+                --ffe-farge-koksgraa
+            );
+            --ffe-v-group-card-footer-background-color: var(
+                --ffe-farge-koksgraa
+            );
         }
     }
 }


### PR DESCRIPTION
Ifbm. semantiske verdier flytter vi varibler som har med dm ut. 
Dette er for cards. 

To synlige endringer: 
- Kort har nå border i stedet for shadow i darkmode. En enda penere variant kommer nok snart
- Tekst-fargen til Footer er endret til vanlig svart, da vi ikke burde endre denne fargen uten noe markup.

Fixes #2229 