### PR TITLE
Legg til nomargin-prop på Paragraph

### DIFF
--- a/component-overview/examples/typography/Paragraph-noMargin.jsx
+++ b/component-overview/examples/typography/Paragraph-noMargin.jsx
@@ -1,0 +1,12 @@
+import { Paragraph } from '@sb1/ffe-core-react';
+
+<>
+    <Paragraph noMargin={true}>
+        Velg en av bankene våre, og bruk BankID for å bli kunde. Nettbank og
+        mobilbank får du med en gang, og bankkortet kommer i posten om en ukes
+        tid.
+    </Paragraph>
+    <Paragraph noMargin={true}>
+        Denne paragrafen viser at den over ikke lenger har noen margin
+    </Paragraph>
+</>

--- a/packages/ffe-core-react/src/typography/Paragraph.tsx
+++ b/packages/ffe-core-react/src/typography/Paragraph.tsx
@@ -10,6 +10,8 @@ export interface ParagraphProps extends ComponentPropsWithoutRef<'p'> {
     textCenter?: boolean;
     /** Use if text alignment should override that of its container. */
     textLeft?: boolean;
+    /** Use if the paragraph should have no margin. */
+    noMargin?: boolean;
 }
 
 export function Paragraph(props: ParagraphProps) {
@@ -20,6 +22,7 @@ export function Paragraph(props: ParagraphProps) {
         subLead,
         textCenter,
         textLeft,
+        noMargin,
         ...rest
     } = props;
 
@@ -35,6 +38,7 @@ export function Paragraph(props: ParagraphProps) {
                 mainClass,
                 { 'ffe-body-paragraph--text-center': textCenter },
                 { 'ffe-body-paragraph--text-left': textLeft },
+                { 'ffe-body-paragraph--no-margin': noMargin },
                 className,
             )}
             {...rest}

--- a/packages/ffe-core/less/typography.less
+++ b/packages/ffe-core/less/typography.less
@@ -134,6 +134,10 @@
     &--text-left {
         text-align: left;
     }
+
+    &--no-margin {
+        margin: 0;
+    }
 }
 
 .ffe-lead-paragraph,


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse
Legger til `noMargin`-prop på Paragraph
<!-- Detaljert beskrivelse av endringene dine. Skjermskudd er lov. -->

## Motivasjon og kontekst
Vi legger ofte til klasser på paragraph kun for å fjerne margins, typisk i tilfeller der vi ønsker å plassere to paragrafer nærmere hverandre.

Tenkte at siden `noMargin` allerede eksisterer på blant annet `Heading`-komponentene så bryter ikke denne med eksisterende mønster i FFE. 

<!-- Hvorfor trengs denne endringen, og hva løser den? -->

## Testing
Kjørt opp lokalt 
<!-- Hvordan har du har testet endringene dine? Ta gjerne med systeminfo o.l -->

<!--

Helt til slutt, har du ..

.. lest retningslinjene våre for bidrag?
.. tatt en siste sjekk for kode og skrivefeil, debug informasjon o.l?
.. kjørt og eventuelt oppdatert testene?
.. kommentert og dokumentert det som trengs?
.. knyttet denne opp til relaterte issues?

-->
