### PR TITLE
refactor(ffe-searchable-dropdown-react): flytte darkmode-variabler til theme.less

### DIFF
--- a/packages/ffe-searchable-dropdown-react/less/ffe-searchable-dropdown.less
+++ b/packages/ffe-searchable-dropdown-react/less/ffe-searchable-dropdown.less
@@ -49,27 +49,41 @@
         padding: @ffe-spacing @ffe-spacing-sm;
         cursor: pointer;
 
+        &-details {
+            .ffe-micro-text {
+                color: var(--ffe-v-searchable-dropdown-micro-text-color);
+            }
+        }
+
         @media (hover: hover) and (pointer: fine) {
             &:hover,
             &--highlighted:hover {
-                background: var(--ffe-g-primary-color);
-                color: var(--ffe-farge-hvit);
+                background: var(
+                    --ffe-v-searchable-dropdown-highlighted-background-color
+                );
+                color: var(--ffe-v-searchable-dropdown-highlighted-text-color);
 
                 .ffe-searchable-dropdown__list-item-body-details {
                     .ffe-micro-text {
-                        color: var(--ffe-farge-lysgraa);
+                        color: var(
+                            --ffe-v-searchable-dropdown-highlighted-micro-text-color
+                        );
                     }
                 }
             }
         }
 
         &--highlighted {
-            background: var(--ffe-g-primary-color);
-            color: var(--ffe-farge-hvit);
+            background: var(
+                --ffe-v-searchable-dropdown-highlighted-background-color
+            );
+            color: var(--ffe-v-searchable-dropdown-highlighted-text-color);
 
             .ffe-searchable-dropdown__list-item-body-details {
                 .ffe-micro-text {
-                    color: var(--ffe-farge-lysgraa);
+                    color: var(
+                        --ffe-v-searchable-dropdown-highlighted-micro-text-color
+                    );
                 }
             }
         }
@@ -136,47 +150,6 @@
         &--flip {
             .ffe-searchable-dropdown__button-icon {
                 transform: rotateZ(180deg);
-            }
-        }
-    }
-}
-
-@media (prefers-color-scheme: dark) {
-    .regard-color-scheme-preference .ffe-searchable-dropdown {
-        &__list {
-            color: var(--ffe-farge-hvit);
-        }
-
-        &__list-item-body {
-            color: var(--ffe-farge-hvit);
-
-            &--highlighted {
-                color: var(--ffe-farge-svart);
-
-                .ffe-searchable-dropdown__list-item-body-details {
-                    .ffe-micro-text {
-                        color: var(--ffe-farge-svart);
-                    }
-                }
-            }
-
-            @media (hover: hover) and (pointer: fine) {
-                &:hover,
-                &--highlighted:hover {
-                    color: var(--ffe-farge-svart);
-
-                    .ffe-searchable-dropdown__list-item-body-details {
-                        .ffe-micro-text {
-                            color: var(--ffe-farge-svart);
-                        }
-                    }
-                }
-            }
-        }
-
-        &__list-item-body-details {
-            .ffe-micro-text {
-                color: var(--ffe-farge-graa);
             }
         }
     }

--- a/packages/ffe-searchable-dropdown-react/less/theme.less
+++ b/packages/ffe-searchable-dropdown-react/less/theme.less
@@ -2,6 +2,14 @@
 :host {
     --ffe-v-searchable-dropdown-list-background-color: var(--ffe-farge-hvit);
     --ffe-v-searchable-dropdown-icon-hover-color: var(--ffe-farge-fjell);
+    --ffe-v-searchable-dropdown-micro-text-color: var(--ffe-g-text-color);
+    --ffe-v-searchable-dropdown-highlighted-background-color: var(
+        --ffe-g-primary-color
+    );
+    --ffe-v-searchable-dropdown-highlighted-text-color: var(--ffe-farge-hvit);
+    --ffe-v-searchable-dropdown-highlighted-micro-text-color: var(
+        --ffe-farge-lysgraa
+    );
 
     @media (prefers-color-scheme: dark) {
         .regard-color-scheme-preference {
@@ -10,6 +18,16 @@
             );
             --ffe-v-searchable-dropdown-icon-hover-color: var(
                 --ffe-farge-vann-30
+            );
+            --ffe-v-searchable-dropdown-micro-text-color: var(--ffe-farge-graa);
+            --ffe-v-searchable-dropdown-highlighted-background-color: var(
+                --ffe-farge-vann-70
+            );
+            --ffe-v-searchable-dropdown-highlighted-text-color: var(
+                --ffe-farge-hvit
+            );
+            --ffe-v-searchable-dropdown-highlighted-micro-text-color: var(
+                --ffe-farge-lysgraa
             );
         }
     }


### PR DESCRIPTION
Ifbm. semantiske verdier flytter vi varibler som har med dm ut.
Dette er for searchable-dropdown.

En endring har blitt gjort: 
Før var `hover` og `focus` forskjellige i darkmode. Altså hvis man brukte piltastene så det annerledes ut enn å bruke musa. De er nå gjort like.
Fixes [#2239](https://github.com/SpareBank1/designsystem/issues/2239)