### PR TITLE
fix(ffe-header): fargerna fra buttons mangler i wtf

### DIFF
--- a/packages/ffe-header/less/theme.less
+++ b/packages/ffe-header/less/theme.less
@@ -16,6 +16,52 @@
     --ffe-v-usernav-link-focus-background-color: @ffe-farge-frost-30;
     --ffe-v-usernav-list-border-color: @ffe-farge-vann;
 
+    //Fjerne dette
+
+    /** Buttons */
+
+    /* Common button text color */
+    --ffe-v-button-text-color: var(--ffe-farge-hvit);
+
+    /* Button border radius renders as 50% */
+    --ffe-v-buttons-border-radius: 6em;
+
+    /* Button box shadow */
+    --ffe-v-button-shadow-color: var(--ffe-farge-vann);
+
+    /** Action button */
+    --ffe-v-button-action-color: var(--ffe-farge-skog);
+    --ffe-v-button-action-color-hover: #095139;
+    --ffe-v-button-action-color-text: var(--ffe-farge-hvit);
+
+    /** Primary button */
+    --ffe-v-button-primary-color: var(--ffe-farge-vann);
+    --ffe-v-button-primary-color-hover: var(--ffe-farge-fjell);
+    --ffe-v-button-primary-color-text: var(--ffe-farge-hvit);
+
+    /** Secondary buttons (+ back, expand, etc) */
+    --ffe-v-button-secondary-color: var(--ffe-farge-hvit);
+    --ffe-v-button-secondary-border-color: var(--ffe-farge-vann);
+    --ffe-v-button-secondary-color-text-hover: var(--ffe-farge-hvit);
+    --ffe-v-button-secondary-color-bg-hover: var(--ffe-farge-vann);
+    --ffe-v-button-secondary-color-text: var(--ffe-farge-vann);
+
+    /** Tertiary button */
+    --ffe-v-button-tertiary-color: var(--ffe-farge-vann);
+    --ffe-v-button-tertiary-color-hover: var(--ffe-farge-fjell);
+    --ffe-v-button-tertiary-color-focus: var(--ffe-farge-vann);
+
+    /** Task button */
+    --ffe-v-button-task-color: var(--ffe-farge-hvit);
+    --ffe-v-button-task-color-hover: var(--ffe-farge-vann);
+    --ffe-v-button-task-color-border-hover: var(--ffe-farge-vann);
+    --ffe-v-button-task-color-border: var(--ffe-farge-vann);
+    --ffe-v-button-task-color-text: var(--ffe-farge-vann);
+    --ffe-v-button-task-color-text-hover: var(--ffe-farge-fjell);
+    --ffe-v-button-task-color-icon: var(--ffe-farge-vann);
+    --ffe-v-button-task-color-icon-hover: var(--ffe-farge-hvit);
+    --ffe-v-button-task-border-focus: var(--ffe-farge-vann);
+
     @media (prefers-color-scheme: dark) {
         .regard-color-scheme-preference {
             --ffe-v-background-color: @ffe-farge-svart;
@@ -31,6 +77,43 @@
             --ffe-v-usernav-link-hover-background-color: @ffe-farge-vann-30;
             --ffe-v-usernav-list-border-color: @ffe-farge-vann-70;
             --ffe-v-usernav-header-link-hover-focus-color: @ffe-farge-svart;
+
+            // Fjerne dette!
+            --ffe-v-button-text-color: var(--ffe-farge-svart);
+            --ffe-v-button-shadow-color: var(--ffe-farge-hvit);
+
+            /** Action button */
+            --ffe-v-button-action-color: var(--ffe-farge-skog-70);
+            --ffe-v-button-action-color-hover: var(--ffe-farge-skog-30);
+            --ffe-v-button-action-color-text: var(--ffe-farge-svart);
+
+            /** Primary button */
+            --ffe-v-button-primary-color: var(--ffe-farge-vann-70);
+            --ffe-v-button-primary-color-hover: var(--ffe-farge-vann-30);
+            --ffe-v-button-primary-color-text: var(--ffe-farge-svart);
+
+            /** Secondary buttons (+ task, back, expand, etc) */
+            --ffe-v-button-secondary-color: var(--ffe-farge-svart);
+            --ffe-v-button-secondary-border-color: var(--ffe-farge-vann-70);
+            --ffe-v-button-secondary-color-text-hover: var(--ffe-farge-svart);
+            --ffe-v-button-secondary-color-bg-hover: var(--ffe-farge-vann-30);
+            --ffe-v-button-secondary-color-text: var(--ffe-farge-vann-30);
+
+            /** Tertiary button */
+            --ffe-v-button-tertiary-color: var(--ffe-farge-vann-30);
+            --ffe-v-button-tertiary-color-hover: var(--ffe-farge-hvit);
+            --ffe-v-button-tertiary-color-focus: var(--ffe-farge-hvit);
+
+            /** Task button */
+            --ffe-v-button-task-color: transparent;
+            --ffe-v-button-task-color-hover: var(--ffe-farge-vann-70);
+            --ffe-v-button-task-color-border-hover: var(--ffe-farge-vann-70);
+            --ffe-v-button-task-color-border: var(--ffe-farge-vann-30);
+            --ffe-v-button-task-color-text: var(--ffe-farge-vann-30);
+            --ffe-v-button-task-color-text-hover: var(--ffe-farge-hvit);
+            --ffe-v-button-task-color-icon: var(--ffe-farge-vann-30);
+            --ffe-v-button-task-color-icon-hover: var(--ffe-farge-svart);
+            --ffe-v-button-task-border-focus: var(--ffe-farge-hvit);
         }
     }
 }


### PR DESCRIPTION
@tuva-odegard @antidecaf  jag skall forklare sedan vad som skjedd men fargen på logut knappen er borte

Når vi rydder her så burde vi fjerne all bruk avv ffe buttons. denn erver fra ffe-buttons klasser og da må man ha siste version av begge.