### PR TITLE
refactor(ffe-messages): flytter darkmode-variabler inn i theme.less

### DIFF
--- a/packages/ffe-messages/less/common.less
+++ b/packages/ffe-messages/less/common.less
@@ -246,12 +246,6 @@
     width: fit-content;
 }
 
-@media (prefers-color-scheme: dark) {
-    .regard-color-scheme-preference .ffe-message__list li {
-        color: var(--ffe-farge-svart);
-    }
-}
-
 .ffe-message__heading {
     font-family: var(--ffe-g-font-strong);
     font-variant-numeric: tabular-nums;


### PR DESCRIPTION
Ifbm. semantiske verdier flytter vi varibler som har med dm ut.
Dette er for messages
Det var allerede veldig mye bra gjort, så denne endringen var veldig liten. Alle kortene ser like ut i lightmode og darkmode per i dag, men det endres forhåpentligvis med semantiske farger

fixes [#2238](https://github.com/SpareBank1/designsystem/issues/2238)