### PR TITLE
refactor(ffe-lists): flytter darkmode-variabler til theme.less

### DIFF
--- a/packages/ffe-lists/less/description-list.less
+++ b/packages/ffe-lists/less/description-list.less
@@ -13,12 +13,8 @@
     .ffe-description-list__description {
         padding-bottom: var(--vertical-seperation);
         margin-left: 0;
+        color: var(--ffe-v-lists-description-description-color);
         &:extend(.ffe-body-text);
-        .regard-color-scheme-preference & {
-            @media (prefers-color-scheme: dark) {
-                color: var(--ffe-v-lists-description-description-color);
-            }
-        }
     }
 
     .ffe-description-list__description + .ffe-description-list__description {

--- a/packages/ffe-lists/less/regular-lists.less
+++ b/packages/ffe-lists/less/regular-lists.less
@@ -1,55 +1,3 @@
-// Bullet list
-//
-// Markup:
-// <ul class="ffe-bullet-list ffe-bullet-list{{modifier_class}}">
-//     <li class="ffe-bullet-list__item">Bilforsikring</li>
-//     <li class="ffe-bullet-list__item">Reiseforsikring</li>
-//     <li class="ffe-bullet-list__item">Innboforsikring</li>
-// </ul>
-//
-// --condensed  - Condensed
-//
-// Styleguide ffe-lists.regular-lists.1
-
-// Check list
-//
-// Markup:
-// <ul class="ffe-check-list ffe-check-list{{modifier_class}}">
-//     <li class="ffe-check-list__item">Massevis av ferdige, testede komponenter</li>
-//     <li class="ffe-check-list__item">Likt design som resten av SpareBank 1</li>
-//     <li class="ffe-check-list__item">Høyere utviklingshastighet</li>
-//     <li class="ffe-check-list__item ffe-check-list__item--cross">Null bugs</li>
-// </ul>
-//
-// --bg-sand        - Sand background
-// --two-columns    - Two columns
-//
-// Styleguide ffe-lists.regular-lists.2
-
-// Numbered list
-//
-// Markup:
-// <ol class="ffe-numbered-list ffe-numbered-list{{modifier_class}}">
-//     <li class="ffe-numbered-list__item">Installer pakken du vil bruke via NPM</li>
-//     <li class="ffe-numbered-list__item">Importer pakken i koden din</li>
-//     <li class="ffe-numbered-list__item">Profit!</li>
-// </ol>
-//
-// --condensed  - Condensed
-//
-// Styleguide ffe-lists.regular-lists.3
-
-// Stylized numbered list
-//
-// Markup:
-// <ol class="ffe-stylized-numbered-list">
-//     <li class="ffe-stylized-numbered-list__item">Installer pakken du vil bruke via NPM</li>
-//     <li class="ffe-stylized-numbered-list__item">Importer pakken i koden din</li>
-//     <li class="ffe-stylized-numbered-list__item">Profit!</li>
-// </ol>
-//
-// Styleguide ffe-lists.regular-lists.4
-
 .ffe-numbered-list,
 .ffe-bullet-list {
     font-family: var(--ffe-g-font);
@@ -124,12 +72,6 @@
     grid-template-columns: auto 1fr;
     grid-template-rows: var(--line-height) 1fr;
     grid-column-gap: 1.5em;
-
-    .regard-color-scheme-preference & {
-        @media (prefers-color-scheme: dark) {
-            color: var(--ffe-farge-hvit);
-        }
-    }
 }
 
 .ffe-check-list {


### PR DESCRIPTION
Ifbm. semantiske verdier flytter vi varibler som har med darkmode å gjøre ut til theme.less, slik at det blir lettere å oppdatere verdiene senere

Dette er for lists. 

Vi har per i dag ikke en bedre måte å gjøre `bgDarkmodeColor` på, så det forblir sånn her, i `detail-list-card.less`
![image](https://github.com/user-attachments/assets/8f7b0b8d-c7f3-40b7-b1bd-736fc6282ffd)

Forhåpentligvis blir dette oppdatert når vi får inn semantiske farger. 