### PR TITLE
fix(ffe-cards): fix border color blending in with background on group…

### DIFF
--- a/packages/ffe-cards/less/theme.less
+++ b/packages/ffe-cards/less/theme.less
@@ -34,9 +34,9 @@
             --ffe-v-cards-icon-color: var(--ffe-farge-vann-70);
             --ffe-v-cards-image-card-border: 1px solid var(--ffe-farge-koksgraa);
             --ffe-v-cards-common-group-card-border: 1px solid
-                var(--ffe-farge-koksgraa);
+                var(--ffe-farge-moerkgraa);
             --ffe-v-cards-common-group-card-separation-border-color: var(
-                --ffe-farge-koksgraa
+                --ffe-farge-moerkgraa
             );
             --ffe-v-group-card-footer-background-color: var(
                 --ffe-farge-koksgraa


### PR DESCRIPTION
… card

<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse

Tok utgangspunkt i endringen til @pethel [her](https://github.com/SpareBank1/designsystem/pull/2159/files#diff-f455ccf08c5fe7142781bda92b56de63160dddbe6412de039dd6362961c07e0eR19) 😊 

## Motivasjon og kontekst

Ved valg av koksgraa som bakgrunn, blir borderen blenda inn med bakgrunnsfargen. 
![Skjermbilde 2024-09-13 kl  11 03 56](https://github.com/user-attachments/assets/13ad509b-a77d-4d81-b739-190770ec0438)

## Testing

Jeg sliter med å få kjørt opp designsystemet i dag pga. `"Daemon is not running. The watch command is not supported without the Nx Daemon."`. Så har ikke fått testa, men har hardkoda endringene, og har ikke tid til å bruke så mye tid på det. Men det skal se sånn her ut etter endringene:
![Skjermbilde 2024-09-13 kl  11 03 05](https://github.com/user-attachments/assets/679ad185-7d14-4aa2-8c87-66c29e11e659)
![Skjermbilde 2024-09-13 kl  11 03 25](https://github.com/user-attachments/assets/be12cfc4-2007-4f61-b596-87298e3f88db)

