### PR TITLE
Add nomargin on cards

### DIFF
--- a/packages/ffe-cards-react/src/CardBase.tsx
+++ b/packages/ffe-cards-react/src/CardBase.tsx
@@ -9,6 +9,7 @@ export type CardBaseProps<As extends ElementType = 'div'> = Omit<
     'children'
 > & {
     shadow?: boolean;
+    /** No margin on card */
     noMargin?: boolean;
     textCenter?: boolean;
     bgColor?: BgColor;

--- a/packages/ffe-cards-react/src/GroupCard/GroupCard.tsx
+++ b/packages/ffe-cards-react/src/GroupCard/GroupCard.tsx
@@ -12,6 +12,8 @@ export interface GroupCardProps
     bgColor?: BgColor;
     /** The background color for darkmode of the whole groupcard element */
     bgDarkmodeColor?: BgColorDarkmode;
+    /** No margin on card */
+    noMargin?: boolean;
 }
 
 function GroupCardWithForwardRef(
@@ -21,6 +23,7 @@ function GroupCardWithForwardRef(
         children,
         bgColor,
         bgDarkmodeColor,
+        noMargin,
         ...rest
     }: GroupCardProps,
     ref: ForwardedRef<any>,
@@ -31,6 +34,7 @@ function GroupCardWithForwardRef(
                 'ffe-group-card',
                 {
                     'ffe-group-card--shadow': shadow,
+                    'ffe-group-card--no-margin': noMargin,
                     [`ffe-group-card--bg-${bgColor}`]: bgColor,
                     [`ffe-group-card--dm-bg-${bgDarkmodeColor}`]:
                         bgDarkmodeColor,

--- a/packages/ffe-cards-react/src/IconCard/IconCard.tsx
+++ b/packages/ffe-cards-react/src/IconCard/IconCard.tsx
@@ -14,6 +14,8 @@ export type IconCardProps<As extends ElementType = 'div'> = Omit<
     condensed?: boolean;
     /** Position icon at left (default) or right of the card content */
     iconPosition?: 'right' | 'left';
+    /** No margin on card */
+    noMargin?: boolean;
     children:
         | React.ReactNode
         | ((cardRenderProps: CardRenderProps) => React.ReactNode);
@@ -23,8 +25,15 @@ function IconCardWithForwardRef<As extends ElementType>(
     props: IconCardProps<As>,
     ref: ForwardedRef<any>,
 ) {
-    const { className, condensed, icon, children, iconPosition, ...rest } =
-        props;
+    const {
+        className,
+        condensed,
+        icon,
+        noMargin,
+        children,
+        iconPosition,
+        ...rest
+    } = props;
 
     return (
         <WithCardAction
@@ -32,6 +41,7 @@ function IconCardWithForwardRef<As extends ElementType>(
             className={classNames(
                 'ffe-icon-card',
                 { 'ffe-icon-card--condensed': condensed },
+                { 'ffe-icon-card--no-margin': noMargin },
                 { 'ffe-icon-card--right': iconPosition === 'right' },
                 className,
             )}

--- a/packages/ffe-cards-react/src/IllustrationCard/IllustrationCard.tsx
+++ b/packages/ffe-cards-react/src/IllustrationCard/IllustrationCard.tsx
@@ -14,6 +14,8 @@ export type IllustrationCardProps<As extends ElementType = 'div'> = Omit<
     condensed?: boolean;
     /** Position illustration at left (default) or right of the card content */
     illustrationPosition?: 'right' | 'left';
+    /** No margin on card */
+    noMargin?: boolean;
     children:
         | React.ReactNode
         | ((cardRenderProps: CardRenderProps) => React.ReactNode);
@@ -28,6 +30,7 @@ function IllustrationCardWithForwardRef<As extends ElementType>(
         condensed,
         img,
         illustrationPosition,
+        noMargin,
         children,
         ...rest
     } = props;
@@ -37,6 +40,7 @@ function IllustrationCardWithForwardRef<As extends ElementType>(
             className={classNames(
                 'ffe-illustration-card',
                 { 'ffe-illustration-card--condensed': condensed },
+                { 'ffe-illustration-card--no-margin': noMargin },
                 {
                     'ffe-illustration-card--right':
                         illustrationPosition === 'right',

--- a/packages/ffe-cards-react/src/ImageCard/ImageCard.tsx
+++ b/packages/ffe-cards-react/src/ImageCard/ImageCard.tsx
@@ -12,6 +12,8 @@ export type ImageCardProps<As extends ElementType = 'div'> = Omit<
     imageSrc: string;
     /** The alt text for the image */
     imageAltText: string;
+    /** No margin on card */
+    noMargin?: boolean;
     children:
         | React.ReactNode
         | ((cardRenderProps: CardRenderProps) => React.ReactNode);
@@ -21,12 +23,17 @@ function ImageCardWithForwardRef<As extends ElementType>(
     props: ImageCardProps<As>,
     ref: ForwardedRef<any>,
 ) {
-    const { className, imageSrc, imageAltText, children, ...rest } = props;
+    const { className, imageSrc, imageAltText, noMargin, children, ...rest } =
+        props;
 
     return (
         <WithCardAction
             baseClassName="ffe-image-card"
-            className={classNames('ffe-image-card', className)}
+            className={classNames(
+                'ffe-image-card',
+                { 'ffe-image-card--no-margin': noMargin },
+                className,
+            )}
             {...(rest as Record<string, unknown>)}
             ref={ref}
         >

--- a/packages/ffe-cards-react/src/StippledCard/StippledCard.tsx
+++ b/packages/ffe-cards-react/src/StippledCard/StippledCard.tsx
@@ -15,6 +15,8 @@ export type StippledCardProps<As extends ElementType = 'div'> = Omit<
         element: ReactNode;
         type: 'icon' | 'custom';
     };
+    /** No margin on card */
+    noMargin?: boolean;
     children:
         | React.ReactNode
         | ((cardRenderProps: CardRenderProps) => React.ReactNode);
@@ -24,7 +26,7 @@ function StippledCardWithForwardRef<As extends ElementType>(
     props: StippledCardProps<As>,
     ref: ForwardedRef<any>,
 ) {
-    const { className, condensed, img, children, ...rest } = props;
+    const { className, condensed, img, noMargin, children, ...rest } = props;
 
     return (
         <WithCardAction
@@ -32,6 +34,7 @@ function StippledCardWithForwardRef<As extends ElementType>(
             className={classNames(
                 'ffe-stippled-card',
                 { 'ffe-stippled-card--condensed': condensed },
+                { 'ffe-stippled-card--no-margin': noMargin },
                 className,
             )}
             {...(rest as Record<string, unknown>)}

--- a/packages/ffe-cards-react/src/TextCard/TextCard.tsx
+++ b/packages/ffe-cards-react/src/TextCard/TextCard.tsx
@@ -10,6 +10,8 @@ export type TextCardProps<As extends ElementType = 'div'> = Omit<
 > & {
     /** Left-aligned text on the card */
     leftAlign?: boolean;
+    /** No margin on card */
+    noMargin?: boolean;
     /** Function that's passed available subcomponents as arguments, or regular children */
     children:
         | React.ReactNode
@@ -20,7 +22,7 @@ function TextCardWithForwardRef<As extends ElementType>(
     props: TextCardProps<As>,
     ref: ForwardedRef<any>,
 ) {
-    const { className, leftAlign, children, ...rest } = props;
+    const { className, leftAlign, noMargin, children, ...rest } = props;
 
     return (
         <WithCardAction
@@ -28,6 +30,7 @@ function TextCardWithForwardRef<As extends ElementType>(
             className={classNames(
                 'ffe-text-card',
                 { 'ffe-text-card--left-align': leftAlign },
+                { 'ffe-text-card--no-margin': noMargin },
                 className,
             )}
             {...(rest as Record<string, unknown>)}

--- a/packages/ffe-cards/less/group-card.less
+++ b/packages/ffe-cards/less/group-card.less
@@ -12,6 +12,10 @@
         box-shadow: var(--ffe-v-cards-common-card-box-shadow);
     }
 
+    &--no-margin {
+        margin: 0;
+    }
+
     & > :first-child {
         border-radius: var(--ffe-v-cards-common-card-border-radius)
             var(--ffe-v-cards-common-card-border-radius) 0 0;

--- a/packages/ffe-cards/less/icon-card.less
+++ b/packages/ffe-cards/less/icon-card.less
@@ -8,6 +8,10 @@
         .clickable-card-styling();
     }
 
+    &--no-margin {
+        margin: 0;
+    }
+
     display: grid;
     grid-template-columns: auto 1fr;
     align-items: center;

--- a/packages/ffe-cards/less/illustration-card.less
+++ b/packages/ffe-cards/less/illustration-card.less
@@ -8,6 +8,10 @@
         .clickable-card-styling();
     }
 
+    &--no-margin {
+        margin: 0;
+    }
+
     display: grid;
     grid-template-columns: auto 1fr;
     column-gap: var(--ffe-spacing-md);

--- a/packages/ffe-cards/less/image-card.less
+++ b/packages/ffe-cards/less/image-card.less
@@ -8,6 +8,10 @@
         .clickable-card-styling();
     }
 
+    &--no-margin {
+        margin: 0;
+    }
+
     --border-color: transparent;
 
     display: flex;

--- a/packages/ffe-cards/less/stippled-card.less
+++ b/packages/ffe-cards/less/stippled-card.less
@@ -18,6 +18,10 @@
         }
     }
 
+    &--no-margin {
+        margin: 0;
+    }
+
     background: transparent;
     border: 2px dashed var(--ffe-v-cards-stippled-border-color);
     box-shadow: none;

--- a/packages/ffe-cards/less/text-card.less
+++ b/packages/ffe-cards/less/text-card.less
@@ -8,6 +8,10 @@
         .clickable-card-styling();
     }
 
+    &--no-margin {
+        margin: 0;
+    }
+
     display: flex;
     padding: var(--ffe-spacing-sm) var(--ffe-spacing-lg);
     flex-flow: column nowrap;


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse
Legger til noMargin-prop, med tilhørende styling klasse på:
- TextCard
- StippledCard
- ImageCard
- IllustrationCard
- IconCard

Basecard hadde det allerede. 
<!-- Detaljert beskrivelse av endringene dine. Skjermskudd er lov. -->

## Motivasjon og kontekst
Vi bruker noen ganger flere kort under hverandre, og da ble det feil avstand i applikasjonen på nederste kort.
Fant ut den beste og mest fleksible løsningen var å legge til noMargin-prop sånn at man kan skru margin av og på etter behov.  
<!-- Hvorfor trengs denne endringen, og hva løser den? -->

## Testing
Prøvd å kjøre opp lokalt, men component-overview krasjet så ofte, så fikk egentlig kun testet at prop funker på StippledCard, men er samme løsning på alle den andre kortene 
<!-- Hvordan har du har testet endringene dine? Ta gjerne med systeminfo o.l -->

<!--

Helt til slutt, har du ..

.. lest retningslinjene våre for bidrag?
.. tatt en siste sjekk for kode og skrivefeil, debug informasjon o.l?
.. kjørt og eventuelt oppdatert testene?
.. kommentert og dokumentert det som trengs?
.. knyttet denne opp til relaterte issues?

-->
