### PR TITLE
fix: install postcss-less at root

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "lint-staged": "^15.2.2",
     "mkdirp": "^3.0.1",
     "npm-run-all": "^4.1.5",
+    "postcss-less": "^6.0.0",
     "prettier": "^3.3.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",


### PR DESCRIPTION
It is used by many packages togheter with stylint. Stylinelint is hoisted because its a dependency to 2 packages.

