### PR TITLE
fix(ffe-form): sentrering av checkmark i checkbox

### DIFF
--- a/packages/ffe-form/less/checkbox.less
+++ b/packages/ffe-form/less/checkbox.less
@@ -64,6 +64,7 @@
         border-top: 3px solid var(--checkmark-color);
         width: 6px;
         height: 11px;
+        margin-bottom: 2px;
     }
 }
 


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse

Legger inn margin-bottom i bunnen av checkmark for å sentrere dette.

Checkmarket er en svg som tar opp plass rektangulært som et normalt bilde, og er i utgangspunktet sentrert på normal måte. Men fordi svgen er rotert blir det noe whitespace i toppen som gjør at det fremstår som om checkmarket ikke er sentrert.

![image](https://github.com/user-attachments/assets/1ad47630-349d-421e-8a56-2309d6c6b40b)
 
## Motivasjon og kontekst

Før:
![image](https://github.com/user-attachments/assets/2bcbfa81-807e-44cd-a72a-d9684b66b09c)

Etter:
![image](https://github.com/user-attachments/assets/d1f226c4-55f6-46a4-baab-8a7630587620)


## Testing

Testet i Safari og Chrome på Mac og iPhone
