### PR TITLE
fix(ffe-cards-react): possible to copy text in card

### DIFF
--- a/packages/ffe-cards-react/src/components/WithCardAction.tsx
+++ b/packages/ffe-cards-react/src/components/WithCardAction.tsx
@@ -81,7 +81,12 @@ function WithCardActionForwardRef<As extends ElementType>(
                 isUsingCardAction && `${baseClassName}--clickable`,
             )}
             onClick={(e: React.MouseEvent<HTMLElement>) => {
-                if (!cardActionInnerRef.current?.contains(e.target as Node)) {
+                const hasSelectedText = !!window.getSelection()?.toString()
+                    .length;
+                if (
+                    !hasSelectedText &&
+                    !cardActionInnerRef.current?.contains(e.target as Node)
+                ) {
                     cardActionInnerRef.current?.click();
                 }
                 onClick?.(e);


### PR DESCRIPTION
Jag fant denne oppsriften her https://www.ark.no/produkt/boker/fagboker/web-accessibility-cookbook-9781098145606

Denne fiksen gjør det mulig att markera og kopiera text i ett kort utan att klicka på det hvis man ønsker. Dere kan teste litt på dom klickbara korten og se vad dere synes. Jag synes det virka bra det jag testa. 