### PR TITLE
fix(ffe-header): transition kun på aktuelle properties

### DIFF
--- a/packages/ffe-header/less/ffe-header.less
+++ b/packages/ffe-header/less/ffe-header.less
@@ -32,7 +32,9 @@
     }
 
     &__link {
-        transition: all var(--ffe-transition-duration) var(--ffe-ease);
+        transition:
+            color var(--ffe-transition-duration) var(--ffe-ease),
+            background-color var(--ffe-transition-duration) var(--ffe-ease);
         border: 2px solid transparent;
 
         &:link,


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse

Endrer transition fra `all` til `color` og `background-color` (som er de eneste propertyene som i utgangspunktet animeres) på `.ffe-header__link`. Dette gjør at vi slipper en bieffekt der linkteksten også animerer på transform som arves fra et annet element.

## Motivasjon og kontekst

Fixes #2343 

## Testing

Testet lokalt med storybook