### PR TITLE
fix(ffe-formatters): Lagt til formatering for nummer basert på språket som er satt i banken

### DIFF
--- a/packages/ffe-formatters/src/formatNumber.spec.ts
+++ b/packages/ffe-formatters/src/formatNumber.spec.ts
@@ -88,4 +88,21 @@ describe('formatNumber with options', () => {
         expect(formatNumber('1234', opts)).toBe('1,234');
         expect(formatNumber('-1234567', opts)).toBe('-1,234,567');
     });
+
+    test('format number based on language', () => {
+        expect(formatNumber(123456, {}, 'nb')).toBe('123 456');
+        expect(formatNumber(123456.78, { decimals: 2 }, 'nb')).toBe(
+            '123 456,78',
+        );
+        expect(formatNumber('123456,78', { decimals: 2 }, 'nb')).toBe(
+            '123 456,78',
+        );
+        expect(formatNumber(123456, {}, 'en')).toBe('123,456');
+        expect(formatNumber(123456.78, { decimals: 2 }, 'en')).toBe(
+            '123,456.78',
+        );
+        expect(formatNumber('123456.78', { decimals: 2 }, 'en')).toBe(
+            '123,456.78',
+        );
+    });
 });

--- a/packages/ffe-formatters/src/formatNumber.ts
+++ b/packages/ffe-formatters/src/formatNumber.ts
@@ -2,17 +2,6 @@ import { NON_BREAKING_SPACE } from './internal/unicode';
 import { parseNumber } from './internal/parseNumber';
 import { numberFormat } from 'underscore.string';
 
-function customNumberFormat(
-    number: number,
-    decimals: number,
-    decimalMark: string,
-    thousandSeparator: string,
-) {
-    const parts = number.toFixed(decimals).split('.');
-    parts[0] = parts[0].replace(/\B(?=(\d{3})+(?!\d))/g, thousandSeparator);
-    return parts.join(decimalMark);
-}
-
 export const formatNumber = (
     number: number | string | null | undefined,
     opts = {},
@@ -42,10 +31,10 @@ export const formatNumber = (
     if (typeof toFormat !== 'number') {
         return number;
     }
-    return customNumberFormat(
+    return `${numberFormat(
         toFormat,
         decimals,
         decimalMark,
         thousandSeparator,
-    );
+    )}`;
 };

--- a/packages/ffe-formatters/src/formatNumber.ts
+++ b/packages/ffe-formatters/src/formatNumber.ts
@@ -1,26 +1,51 @@
-import { numberFormat } from 'underscore.string';
 import { NON_BREAKING_SPACE } from './internal/unicode';
 import { parseNumber } from './internal/parseNumber';
+import { numberFormat } from 'underscore.string';
+
+function customNumberFormat(
+    number: number,
+    decimals: number,
+    decimalMark: string,
+    thousandSeparator: string,
+) {
+    const parts = number.toFixed(decimals).split('.');
+    parts[0] = parts[0].replace(/\B(?=(\d{3})+(?!\d))/g, thousandSeparator);
+    return parts.join(decimalMark);
+}
 
 export const formatNumber = (
     number: number | string | null | undefined,
     opts = {},
+    language?: string,
 ) => {
-    const { decimals, thousandSeparator, decimalMark } = {
-        decimals: 0,
-        thousandSeparator: NON_BREAKING_SPACE,
-        decimalMark: ',',
-        ...opts,
-    };
+    let decimals: number;
+    let thousandSeparator: string;
+    let decimalMark: string;
 
-    const toFormat = parseNumber(number);
+    if (language === 'en') {
+        ({ decimals, thousandSeparator, decimalMark } = {
+            decimals: 0,
+            thousandSeparator: ',',
+            decimalMark: '.',
+            ...opts,
+        });
+    } else {
+        ({ decimals, thousandSeparator, decimalMark } = {
+            decimals: 0,
+            thousandSeparator: NON_BREAKING_SPACE,
+            decimalMark: ',',
+            ...opts,
+        });
+    }
+
+    const toFormat = parseNumber(number, language);
     if (typeof toFormat !== 'number') {
         return number;
     }
-    return `${numberFormat(
+    return customNumberFormat(
         toFormat,
         decimals,
         decimalMark,
         thousandSeparator,
-    )}`;
+    );
 };

--- a/packages/ffe-formatters/src/internal/parseNumber.ts
+++ b/packages/ffe-formatters/src/internal/parseNumber.ts
@@ -1,11 +1,22 @@
-export const parseNumber = (number: number | string | null | undefined) => {
+export const parseNumber = (
+    number: number | string | null | undefined,
+    language?: string,
+) => {
     if (!number || typeof number === 'number') {
         return number;
     }
 
-    const parsed = parseFloat(
-        number.replace(/[^\d,.-]/g, '').replace(/,/g, '.'),
-    );
+    let numberString: string;
+
+    if (language === 'en') {
+        numberString = number.replace(/[^\d,.-]/g, '').replace(/,/g, '.');
+    } else {
+        numberString = number
+            .replace(/[^\d,.-]/g, '')
+            .replace(/,(?=[^.]*$)/, '.');
+    }
+
+    const parsed = parseFloat(numberString);
     if (Number.isNaN(parsed)) {
         return null;
     }


### PR DESCRIPTION

## Beskrivelse

Har lagt til sjekk som baserer seg på språket som er satt i banken. Ved språk lik 'en' vil den nå automatisk formatere med "," som tusenseparator og "." som desimalseparator. Ved 'nb' og 'nn' vil tusenseparator være " " og desimalseparator være ","

## Motivasjon og kontekst

I og med at det er forskjellig formatering av nummer for ulike språk bør dette følge språket i banken. 

## Testing

Har skrevet nye tester