### PR TITLE
chore: designsystem-runner should no be used in public repo

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build:
-    runs-on: designsystem-runner
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3


### PR DESCRIPTION
Leste igår att man ikke skall ha egna runners i public repos så jag bare tester litt. Får ju ikke testa utan merge vell