### PR TITLE
fix(component-overview): add locale to examples

### DIFF
--- a/component-overview/examples/formatting/Currency.jsx
+++ b/component-overview/examples/formatting/Currency.jsx
@@ -1,6 +1,8 @@
 import { formatCurrency } from '@sb1/ffe-formatters';
 
 <>
-    <div>{formatCurrency(100)}</div>
-    <div>{formatCurrency(1000, { prefix: '', postfix: ' kroner' })}</div>
-</>
+    <div>{formatCurrency(100, { locale: 'nb ' })}</div>
+    <div>
+        {formatCurrency(1000, { prefix: '', postfix: ' kroner', locale: 'nb' })}
+    </div>
+</>;

--- a/component-overview/examples/formatting/Numbers.jsx
+++ b/component-overview/examples/formatting/Numbers.jsx
@@ -1,14 +1,13 @@
 import { formatNumber } from '@sb1/ffe-formatters';
 
 <>
-    <div>{formatNumber(1000000)}</div>
-    <div>{formatNumber(1234.567)}</div>
-    <div>{formatNumber(1234.567, { decimals: 2 })}</div>
+    <div>{formatNumber(1000000, { locale: 'nb' })}</div>
+    <div>{formatNumber(1234.567, { locale: 'nb' })}</div>
+    <div>{formatNumber(1234.567, { decimals: 2, locale: 'nb' })}</div>
     <div>
         {formatNumber(1234.567, {
             decimals: 2,
-            thousandSeparator: ',',
-            decimalMark: '.',
+            locale: 'en',
         })}
     </div>
-</>
+</>;


### PR DESCRIPTION
Hade ikke ens fått med meg att formatering var i komponent overview :) 