### PR TITLE
fix(ffe-cards): icon card condensed smalelr padding larger gap

### DIFF
--- a/packages/ffe-cards/less/icon-card.less
+++ b/packages/ffe-cards/less/icon-card.less
@@ -16,7 +16,7 @@
     grid-template-columns: auto 1fr;
     align-items: center;
     padding: var(--ffe-spacing-md);
-    gap: var(--ffe-spacing-xs);
+    gap: var(--ffe-spacing-sm);
 
     &--right {
         grid-template-columns: 1fr auto;
@@ -26,11 +26,15 @@
     @media (min-width: @breakpoint-md) {
         gap: var(--ffe-spacing-md);
         &--condensed {
-            gap: var(--ffe-spacing-xs);
+            gap: var(--ffe-spacing-sm);
         }
     }
 
     .ffe-icon-card__icon {
         color: var(--ffe-v-cards-icon-color);
+    }
+
+    &--condensed {
+        padding: var(--ffe-spacing-sm);
     }
 }


### PR DESCRIPTION
Tilbakemeldning på sSlack om att gap er for lite. 

Dette er avstander brukt på strippled card. Minskade padding også vilket gir mening på en condesned version