### PR TITLE
Develop bump 0 versions

### DIFF
--- a/packages/ffe-messages-react/src/SystemMessage.tsx
+++ b/packages/ffe-messages-react/src/SystemMessage.tsx
@@ -7,6 +7,7 @@ import { MessageCollapse } from './MessageCollapse';
 import { Content } from './Content';
 import { txt } from './texts';
 
+/* Remove me*/
 export interface SystemMessageProps
     extends React.ComponentPropsWithoutRef<'div'> {
     /** info, success, tips, news or error */

--- a/packages/ffe-messages/less/common.less
+++ b/packages/ffe-messages/less/common.less
@@ -1,3 +1,4 @@
+/*Remove me */
 .ffe-message {
     --icon-size: var(--ffe-v-icons-size-md);
     --icon-padding: var(--ffe-spacing-2xs);

--- a/packages/ffe-modals-react/src/Modal.tsx
+++ b/packages/ffe-modals-react/src/Modal.tsx
@@ -20,6 +20,7 @@ export type ModalHandle = {
     readonly close: () => void;
 };
 
+/* Remove me */
 export const Modal = React.forwardRef<ModalHandle, ModalProps>(
     (
         {

--- a/packages/ffe-modals/less/modal.less
+++ b/packages/ffe-modals/less/modal.less
@@ -1,6 +1,7 @@
 @import 'theme';
 @import 'modal-polyfill';
 
+/*Remove me */
 :root:has(.ffe-modal[open]) {
     overflow-y: hidden;
 }


### PR DESCRIPTION
Begynner på 1.0.0

Fra Slack
```
Problemet med å bruke en 0.x-release er at npm behandler caret i dependency-definisjonen på en annen måte og man får kanskje ikke det man hadde forventet.
```