### PR TITLE
Mdx-docs for knapper

### DIFF
--- a/packages/Docs.mdx
+++ b/packages/Docs.mdx
@@ -1,0 +1,3 @@
+# Docs
+
+Her kan man putte retningslinjer som ikke hører til blant komponentene.

--- a/packages/ffe-buttons-react/src/ActionButton.mdx
+++ b/packages/ffe-buttons-react/src/ActionButton.mdx
@@ -1,0 +1,12 @@
+import { Canvas, Meta, Controls } from '@storybook/blocks';
+import * as ActionButtonStories from './ActionButton.stories.tsx';
+import { ActionButton } from "@sb1/ffe-buttons-react";
+
+<Meta of={ActionButtonStories} />
+
+# ActionButton
+
+Brukes for svært høyt prioriterte handlinger (call to action), og der du trenger en knapp som skiller seg ut. Det skal som hovedregel kun være en ActionButton per side/view.
+
+<Canvas of={ActionButtonStories.Standard} />
+<Controls of={ActionButtonStories.Standard} />

--- a/packages/ffe-buttons-react/src/ActionButton.stories.tsx
+++ b/packages/ffe-buttons-react/src/ActionButton.stories.tsx
@@ -12,7 +12,6 @@ const Custom: React.FC<React.ComponentProps<'a'>> = props => (
 const meta: Meta<typeof ActionButton<any>> = {
     title: 'components/buttons/ActionButton',
     component: ActionButton,
-    tags: ['autodocs'],
     argTypes: {
         as: {
             options: ['a', 'button', 'custom'],

--- a/packages/ffe-buttons-react/src/BackButton.mdx
+++ b/packages/ffe-buttons-react/src/BackButton.mdx
@@ -1,0 +1,12 @@
+import { Canvas, Meta, Controls } from '@storybook/blocks';
+import * as BackButtonStories from './BackButton.stories.tsx';
+import { BackButton } from "@sb1/ffe-buttons-react";
+
+<Meta of={BackButtonStories} />
+
+# BackButton
+
+Brukes der du vil gi brukerne muligheten til å navigere tilbake dit de var.
+
+<Canvas of={BackButtonStories.Standard} />
+<Controls of={BackButtonStories.Standard} />

--- a/packages/ffe-buttons-react/src/BackButton.stories.tsx
+++ b/packages/ffe-buttons-react/src/BackButton.stories.tsx
@@ -12,7 +12,6 @@ const Custom: React.FC<React.ComponentProps<'a'>> = props => (
 const meta: Meta<typeof BackButton<any>> = {
     title: 'components/buttons/BackButton',
     component: BackButton,
-    tags: ['autodocs'],
     argTypes: {
         as: {
             options: ['a', 'button', 'custom'],

--- a/packages/ffe-buttons-react/src/ButtonGroup.mdx
+++ b/packages/ffe-buttons-react/src/ButtonGroup.mdx
@@ -1,0 +1,12 @@
+import { Canvas, Meta, Controls } from '@storybook/blocks';
+import * as ButtonGroupStories from './ButtonGroup.stories.tsx';
+import { ButtonGroup } from "@sb1/ffe-buttons-react";
+
+<Meta of={ButtonGroupStories} />
+
+# ButtonGroup
+
+ButtonGroup hjelper deg med å samle alle knappene og få de på en rad. På mindre skjermer vil knappene vises under hverandre.
+
+<Canvas of={ButtonGroupStories.Standard} />
+<Controls of={ButtonGroupStories.Standard} />

--- a/packages/ffe-buttons-react/src/ButtonGroup.stories.tsx
+++ b/packages/ffe-buttons-react/src/ButtonGroup.stories.tsx
@@ -8,7 +8,6 @@ import type { StoryObj, Meta } from '@storybook/react';
 const meta: Meta<typeof ButtonGroup> = {
     title: 'components/buttons/ButtonGroup',
     component: ButtonGroup,
-    tags: ['autodocs'],
 };
 export default meta;
 

--- a/packages/ffe-buttons-react/src/Buttons.mdx
+++ b/packages/ffe-buttons-react/src/Buttons.mdx
@@ -1,0 +1,163 @@
+import { Meta } from '@storybook/blocks';
+import { CheckList, CheckListItem } from "@sb1/ffe-lists-react";
+import { Icon } from '@sb1/ffe-icons-react';
+import { ActionButton, PrimaryButton, SecondaryButton, TertiaryButton, ExpandButton, InlineExpandButton, ShortcutButton, TaskButton, BackButton } from '@sb1/ffe-buttons-react';
+import {
+    Table,
+    TableHead,
+    TableBody,
+    TableHeaderCell,
+    TableRow,
+    TableDataCell,
+} from '@sb1/ffe-tables-react';
+
+<Meta title="components/buttons/Buttons" />
+
+# Knapper
+
+## Bruk av knapper
+
+I SpareBank 1 har vi flere typer knapper og hvilken du skal bruke kommer an på situasjonen, og hvilke andre knapper som ligger i «nærheten». Felles for alle knappene er at de kan brukes i situasjoner der du vil gi brukerne muligheten til å utføre ulike typer handlinger i brukergrensesnittet. 
+
+Noen eksempler på scenarioer der knapper kan komme til nytte:
+
+-   Starte en prosess. F.eks. «Bli kunde», «Sjekk pris», «Meld skade»
+-   Gi en kommando til systemet. F.eks. «Skriv ut», «Last ned», «Betal», «Bestill»
+-   Beslutte noe. F.eks. «Kjøp», «Aksepter», «Overfør»
+-   Navigere i brukergrensesnittet. F.eks. «Neste», «Fortsett», «Søk»
+-   Endre modus eller visning. F.eks. «Redigér» for å gå til redigeringsmodus, «Vis flere» for å ekspandere en liste
+
+Knapper skal brukes der kundene utfører en handling. Der de skal navigere til andre sider og sider utenfor løsningen brukes [lenker](/komponenter/typografi/) istedenfor. Når du vil at brukeren skal ta et valg er det best å bruke [radioknapper](/komponenter/skjemaelementer/) eller [checkboxer](/komponenter/skjemaelementer/), for å så bekrefte med en knapp.
+
+### Gjør sånn:
+<CheckList>
+    <CheckListItem>Knappen skal brukes til å utføre en handling</CheckListItem>
+    <CheckListItem>Ha informativ og beskrivende tekst, ikon eller begge deler</CheckListItem>
+    <CheckListItem>Bruk verb i imperiativ form (unntak: konvensjoner som «neste»)</CheckListItem>
+    <CheckListItem>Ha så kort tekst som mulig</CheckListItem>
+</CheckList>
+
+### Ikke sånn:
+<CheckList>
+    <CheckListItem isCross={true}>Ha tekst som går over 2 linjer</CheckListItem>
+    <CheckListItem isCross={true}>Gjem knappen eller sett den som disabled</CheckListItem>
+    <CheckListItem isCross={true}>Ha flere primærknapper på en side</CheckListItem>
+    <CheckListItem isCross={true}>Bruk knapp til å navigere utenfor løsningen (bruk lenke istedenfor)</CheckListItem>
+    <CheckListItem isCross={true}>Bruk knapp til å la bruker ta valg (bruk checkbox/radioknapp istedenfor)</CheckListItem>
+</CheckList>
+
+## Deaktiverte knapper
+
+I SpareBank 1 bruker vi ikke deaktiverte versjoner av knappene (`disabled`). Istedenfor en deaktivert knapp, la knappen alltid være synlig og vis gode feilmeldinger hvis brukeren prøver å trykke på knappen før betingelsene for å bruke knappen er innfridd.
+
+
+## Valg av knapp
+
+I SpareBank 1 har vi kommandoknapper som kan brukes til alle typer handlinger, og spesielle knapper som kun skal brukes i spesifikke situasjoner.
+
+For å velge mellom kommandoknappene ActionButton, PrimaryButton, SecondaryButton og TertiaryButton, må du vurdere handlingens prioritet. Prioriteten vurderes kvalitativt basert på viktighet og frekvens:
+
+-   En handling som gjøres sjelden, men har svært høy viktighet enten for brukeren eller SpareBank 1, bør få høy eller svært høy prioritet. F.eks. knapper for å starte en prosess eller beslutte noe, som "Bli kunde", "Meld skade" og "Kjøp".
+-   En handling som har lav eller middels viktighet, men høy bruksfrekvens vil kunne få høy eller middels prioritet (men aldri svært høy). F.eks. knapper som er del av en prosess, som "Legg til godkjenning" og "Fortsett".
+-   En handling som sjelden brukes og har lav viktighet, men fortsatt må være tilgjengelig, vil som regel få lav prioritet. F.eks. å hente opp et klageskjema.
+
+Valg av kommandoknapp må også vurderes relativt avhengig av hvilke andre knapper som er i umiddelbar nærhet. F.eks. vil kanskje en lagre-knapp gis høy prioritet, mens avbryt-knappen ved siden av gis lav prioritet (selv om den brukes relativt ofte).
+
+<Table>
+    <TableHead>
+        <TableRow>
+            <TableHeaderCell scope="col">
+                Knapp
+            </TableHeaderCell>
+            <TableHeaderCell scope="col">
+                Bruksområde
+            </TableHeaderCell>
+        </TableRow>
+    </TableHead>
+    <TableBody>
+        <TableRow>
+            <TableDataCell>
+                <ActionButton onClick={f => f}>ActionButton</ActionButton>
+            </TableDataCell>
+            <TableDataCell>
+                Svært høyt prioriterte handlinger (call to action) som krever en
+                knapp som skiller seg ut fra de andre knappene. Det skal som
+                hovedregel kun være én ActionButton per side/view.
+            </TableDataCell>
+        </TableRow>
+        <TableRow>
+            <TableDataCell>
+                <PrimaryButton onClick={f => f}>PrimaryButton</PrimaryButton>
+            </TableDataCell>
+            <TableDataCell>Høyt prioriterte handlinger.</TableDataCell>
+        </TableRow>
+        <TableRow>
+            <TableDataCell>
+                <SecondaryButton onClick={f => f}>
+                    SecondaryButton
+                </SecondaryButton>
+            </TableDataCell>
+            <TableDataCell>
+                Middels prioriterte handlinger. Kan ha ikon.
+            </TableDataCell>
+        </TableRow>
+        <TableRow>
+            <TableDataCell>
+                <TertiaryButton onClick={f => f}>TertiaryButton</TertiaryButton>
+            </TableDataCell>
+            <TableDataCell>
+                Lavt prioriterte handlinger. Kan ha ikon.
+            </TableDataCell>
+        </TableRow>
+        <TableRow>
+            <TableDataCell>
+                <ExpandButton onClick={f => f} isExpanded={false}>
+                    ExpandButton
+                </ExpandButton>
+            </TableDataCell>
+            <TableDataCell>
+                Brukes kun for den spesifikke handlingen å ekspandere/kollapse
+                en seksjon.
+            </TableDataCell>
+        </TableRow>
+        <TableRow>
+            <TableDataCell>
+                <InlineExpandButton onClick={f => f} isExpanded={false}>
+                    InlineExpandButton
+                </InlineExpandButton>
+            </TableDataCell>
+            <TableDataCell>
+                Brukes kun for den spesifikke handlingen å ekspandere/kollapse
+                en seksjon fra en linje med tekst.
+            </TableDataCell>
+        </TableRow>
+        <TableRow>
+            <TableDataCell>
+                <ShortcutButton onClick={f => f}>ShortcutButton</ShortcutButton>
+            </TableDataCell>
+            <TableDataCell>
+                Brukes kun som snarvei for å navigere til et annet sted i
+                løsningen. Alternativ til <a href="#!/LinkText">Lenke</a>.
+            </TableDataCell>
+        </TableRow>
+        <TableRow>
+            <TableDataCell>
+                <TaskButton icon={<Icon size="sm" fileUrl="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGhlaWdodD0iMjAiIHZpZXdCb3g9IjAgLTk2MCA5NjAgOTYwIiB3aWR0aD0iMjAiPjxwYXRoIGQ9Ik00NTQuMDAxLTQ1NC4wMDFoLTE2OHEtMTEuMDUgMC0xOC41MjUtNy40MTgtNy40NzUtNy40MTgtNy40NzUtMTguMzg0IDAtMTAuOTY2IDcuNDc1LTE4LjU4MXQxOC41MjUtNy42MTVoMTY4di0xNjhxMC0xMS4wNSA3LjQxOC0xOC41MjUgNy40MTgtNy40NzUgMTguMzg0LTcuNDc1IDEwLjk2NiAwIDE4LjU4MSA3LjQ3NXQ3LjYxNSAxOC41MjV2MTY4aDE2OHExMS4wNSAwIDE4LjUyNSA3LjQxOCA3LjQ3NSA3LjQxOCA3LjQ3NSAxOC4zODQgMCAxMC45NjYtNy40NzUgMTguNTgxdC0xOC41MjUgNy42MTVoLTE2OHYxNjhxMCAxMS4wNS03LjQxOCAxOC41MjUtNy40MTggNy40NzUtMTguMzg0IDcuNDc1LTEwLjk2NiAwLTE4LjU4MS03LjQ3NXQtNy42MTUtMTguNTI1di0xNjhaIi8+PC9zdmc+" />}>TaskButton</TaskButton>
+            </TableDataCell>
+            <TableDataCell>
+                Kan brukes som alternativ til en kommandoknapp for handlingen å
+                legge til noe.
+            </TableDataCell>
+        </TableRow>
+        <TableRow>
+            <TableDataCell>
+                <BackButton onClick={f => f}>Tilbake</BackButton>
+            </TableDataCell>
+            <TableDataCell>
+                Brukes bare der man vil gå tilbake til forrige steg/side
+            </TableDataCell>
+        </TableRow>
+    </TableBody>
+</Table>
+
+

--- a/packages/ffe-buttons-react/src/ExpandButton.mdx
+++ b/packages/ffe-buttons-react/src/ExpandButton.mdx
@@ -1,0 +1,12 @@
+import { Canvas, Meta, Controls } from '@storybook/blocks';
+import * as ExpandButtonStories from './ExpandButton.stories.tsx';
+import { ExpandButton } from "@sb1/ffe-buttons-react";
+
+<Meta of={ExpandButtonStories} />
+
+# ExpandButton
+
+Brukes i spesifikke situasjoner der du vil ekspandere/kollapse en seksjon.
+
+<Canvas of={ExpandButtonStories.Standard} />
+<Controls of={ExpandButtonStories.Standard} />

--- a/packages/ffe-buttons-react/src/ExpandButton.stories.tsx
+++ b/packages/ffe-buttons-react/src/ExpandButton.stories.tsx
@@ -5,7 +5,6 @@ import { ExpandButton } from './ExpandButton';
 const meta: Meta<typeof ExpandButton> = {
     title: 'components/buttons/ExpandButton',
     component: ExpandButton,
-    tags: ['autodocs'],
     argTypes: {},
 };
 export default meta;

--- a/packages/ffe-buttons-react/src/InlineExpandButton.mdx
+++ b/packages/ffe-buttons-react/src/InlineExpandButton.mdx
@@ -1,0 +1,12 @@
+import { Canvas, Meta, Controls } from '@storybook/blocks';
+import * as InlineExpandButtonStories from './InlineExpandButton.stories.tsx';
+import { InlineExpandButton } from "@sb1/ffe-buttons-react";
+
+<Meta of={InlineExpandButtonStories} />
+
+# InlineExpandButton
+
+Samme som ExpandButton, bortsett fra at denne brukes når du vil ekspandere/kollapse en seksjon fra en linje med tekst.
+
+<Canvas of={InlineExpandButtonStories.Standard} />
+<Controls of={InlineExpandButtonStories.Standard} />

--- a/packages/ffe-buttons-react/src/InlineExpandButton.stories.tsx
+++ b/packages/ffe-buttons-react/src/InlineExpandButton.stories.tsx
@@ -14,7 +14,6 @@ const Custom: React.FC<React.ComponentProps<'a'>> = props => (
 const meta: Meta<typeof InlineExpandButton<any>> = {
     title: 'components/buttons/InlineExpandButton',
     component: InlineExpandButton,
-    tags: ['autodocs'],
     argTypes: {
         as: {
             options: ['a', 'button', 'custom'],

--- a/packages/ffe-buttons-react/src/PrimaryButton.mdx
+++ b/packages/ffe-buttons-react/src/PrimaryButton.mdx
@@ -1,0 +1,12 @@
+import { Canvas, Meta, Controls } from '@storybook/blocks';
+import * as PrimaryButtonStories from './PrimaryButton.stories.tsx';
+import { PrimaryButton } from "@sb1/ffe-buttons-react";
+
+<Meta of={PrimaryButtonStories} />
+
+# PrimaryButton
+
+For høyt prioriterte handlinger, som det også kan finnes flere av på en side/view.
+
+<Canvas of={PrimaryButtonStories.Standard} />
+<Controls of={PrimaryButtonStories.Standard} />

--- a/packages/ffe-buttons-react/src/PrimaryButton.stories.tsx
+++ b/packages/ffe-buttons-react/src/PrimaryButton.stories.tsx
@@ -12,7 +12,6 @@ const Custom: React.FC<React.ComponentProps<'a'>> = props => (
 const meta: Meta<typeof PrimaryButton<any>> = {
     title: 'components/buttons/PrimaryButton',
     component: PrimaryButton,
-    tags: ['autodocs'],
     argTypes: {
         as: {
             options: ['a', 'button', 'custom'],

--- a/packages/ffe-buttons-react/src/SecondaryButton.mdx
+++ b/packages/ffe-buttons-react/src/SecondaryButton.mdx
@@ -1,0 +1,13 @@
+import { Canvas, Meta, Controls } from '@storybook/blocks';
+import * as SecondaryButtonStories from './SecondaryButton.stories.tsx';
+import { SecondaryButton } from "@sb1/ffe-buttons-react";
+
+<Meta of={SecondaryButtonStories} />
+
+# SecondaryButton
+
+Kan brukes der du har middels prioriterte handlinger, eller i kombinasjon med andre knapper, for eksempel som en «avbryt»-knapp ved siden av en ActionButton.
+SecondaryButtons kan ha ikon. 
+
+<Canvas of={SecondaryButtonStories.Standard} />
+<Controls of={SecondaryButtonStories.Standard} />

--- a/packages/ffe-buttons-react/src/SecondaryButton.stories.tsx
+++ b/packages/ffe-buttons-react/src/SecondaryButton.stories.tsx
@@ -12,7 +12,6 @@ const Custom: React.FC<React.ComponentProps<'a'>> = props => (
 const meta: Meta<typeof SecondaryButton<any>> = {
     title: 'components/buttons/SecondaryButton',
     component: SecondaryButton,
-    tags: ['autodocs'],
     argTypes: {
         as: {
             options: ['a', 'button', 'custom'],

--- a/packages/ffe-buttons-react/src/ShortcutButton.mdx
+++ b/packages/ffe-buttons-react/src/ShortcutButton.mdx
@@ -1,0 +1,12 @@
+import { Canvas, Meta, Controls } from '@storybook/blocks';
+import * as ShortcutButtonStories from './ShortcutButton.stories.tsx';
+import { ShortcutButton } from "@sb1/ffe-buttons-react";
+
+<Meta of={ShortcutButtonStories} />
+
+# ShortcutButton
+
+Et alternativ til lenke der du ønsker å tilby en snarvei til et annet sted i løsningen.
+
+<Canvas of={ShortcutButtonStories.Standard} />
+<Controls of={ShortcutButtonStories.Standard} />

--- a/packages/ffe-buttons-react/src/ShortcutButton.stories.tsx
+++ b/packages/ffe-buttons-react/src/ShortcutButton.stories.tsx
@@ -12,7 +12,6 @@ const Custom: React.FC<React.ComponentProps<'a'>> = props => (
 const meta: Meta<typeof ShortcutButton<any>> = {
     title: 'components/buttons/ShortcutButton',
     component: ShortcutButton,
-    tags: ['autodocs'],
     argTypes: {
         as: {
             options: ['a', 'button', 'custom'],

--- a/packages/ffe-buttons-react/src/TaskButton.mdx
+++ b/packages/ffe-buttons-react/src/TaskButton.mdx
@@ -1,0 +1,12 @@
+import { Canvas, Meta, Controls } from '@storybook/blocks';
+import * as TaskButtonStories from './TaskButton.stories.tsx';
+import { TaskButton } from "@sb1/ffe-buttons-react";
+
+<Meta of={TaskButtonStories} />
+
+# TaskButton
+
+Kan brukes som et alternativ til en kommandoknapp i scenarioer der man ønsker å legge til noe.
+
+<Canvas of={TaskButtonStories.Standard} />
+<Controls of={TaskButtonStories.Standard} />

--- a/packages/ffe-buttons-react/src/TaskButton.stories.tsx
+++ b/packages/ffe-buttons-react/src/TaskButton.stories.tsx
@@ -13,7 +13,6 @@ const Custom: React.FC<React.ComponentProps<'a'>> = props => (
 const meta: Meta<typeof TaskButton<any>> = {
     title: 'components/buttons/TaskButton',
     component: TaskButton,
-    tags: ['autodocs'],
     argTypes: {
         as: {
             options: ['a', 'button', 'custom'],

--- a/packages/ffe-buttons-react/src/TertiaryButton.mdx
+++ b/packages/ffe-buttons-react/src/TertiaryButton.mdx
@@ -1,0 +1,12 @@
+import { Canvas, Meta, Controls } from '@storybook/blocks';
+import * as TertiaryButtonStories from './TertiaryButton.stories.tsx';
+import { TertiaryButton } from "@sb1/ffe-buttons-react";
+
+<Meta of={TertiaryButtonStories} />
+
+# TertiaryButton
+
+For lavt prioriterte handlinger, eller i situasjoner der du trenger å «linke» til innhold på samme side. For eksempel «anchors» som leder deg til et avsnitt i en artikkel.
+
+<Canvas of={TertiaryButtonStories.Standard} />
+<Controls of={TertiaryButtonStories.Standard} />

--- a/packages/ffe-buttons-react/src/TertiaryButton.stories.tsx
+++ b/packages/ffe-buttons-react/src/TertiaryButton.stories.tsx
@@ -12,7 +12,6 @@ const Custom: React.FC<React.ComponentProps<'a'>> = props => (
 const meta: Meta<typeof TertiaryButton<any>> = {
     title: 'components/buttons/TertiaryButton',
     component: TertiaryButton,
-    tags: ['autodocs'],
     argTypes: {
         as: {
             options: ['a', 'button', 'custom'],


### PR DESCRIPTION
## Beskrivelse

Fjerner autodocs og legger til mdx for knapper.

Buttons.mdx hører til knappene, men ikke en spesifikk komponent. Docs.mdx er lagt til som eksempel på hvordan vi kan legge til retningslinjer og annen dokumentasjon som ikke hører naturlig hjemme i komponentene.