### PR TITLE
fix(ffe-formatters): use nb or en in parseNumber

### DIFF
--- a/packages/ffe-formatters/src/internal/parseNumber.ts
+++ b/packages/ffe-formatters/src/internal/parseNumber.ts
@@ -38,7 +38,7 @@ export const parseNumber = (
     number: number | string | null | undefined,
     locale: Locale,
 ) => {
-    const parsed = new NumberParser(locale).parse(
+    const parsed = new NumberParser(locale === 'en' ? 'en' : 'nb').parse(
         `${number}`.replace(/\s/g, ''),
     );
     return Number.isNaN(parsed) ? null : parsed;


### PR DESCRIPTION
Noen team oplever en merkelig feil der tall blir før stora i noen enkelte tillfeller. Tester om dette gjrø noen forsjell 