### PR TITLE
feat(ffe-feedback-react): legg til className prop

### DIFF
--- a/packages/ffe-feedback-react/src/Feedback.tsx
+++ b/packages/ffe-feedback-react/src/Feedback.tsx
@@ -19,6 +19,7 @@ export interface FeedbackProps {
     texts?: {
         feedbackNotSentHeading?: string;
     };
+    className?: string;
 }
 export const Feedback: React.FC<FeedbackProps> = ({
     headingLevel,
@@ -29,6 +30,7 @@ export const Feedback: React.FC<FeedbackProps> = ({
     bgDarkmodeColor,
     contactLink,
     texts,
+    className,
 }) => {
     const feedbackSentRef = useRef<HTMLHeadingElement>();
     const expandedRef = useRef<HTMLHeadingElement>();
@@ -37,10 +39,14 @@ export const Feedback: React.FC<FeedbackProps> = ({
     const [feedbackSent, setFeedbackSent] = useState(false);
     const headingId = useId();
 
-    const feedbackClassnames = classNames('ffe-feedback', {
-        [`ffe-feedback--bg-${bgColor}`]: bgColor,
-        [`ffe-feedback--dm-bg-${bgDarkmodeColor}`]: bgDarkmodeColor,
-    });
+    const feedbackClassnames = classNames(
+        'ffe-feedback',
+        {
+            [`ffe-feedback--bg-${bgColor}`]: bgColor,
+            [`ffe-feedback--dm-bg-${bgDarkmodeColor}`]: bgDarkmodeColor,
+        },
+        className,
+    );
 
     const handleThumbClicked = (thumb: Thumb) => {
         setFeedbackThumbClicked(thumb);


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse
Legger til muligheten til å sende med egne klasser inn i feedback komponenten
<!-- Detaljert beskrivelse av endringene dine. Skjermskudd er lov. -->

## Motivasjon og kontekst
Vi sliter med at det er for mye padding rundt feedback komponenten (spesielt på ffe-feedback__content klassen) og ønsker derfor å sende med en egen klasse sånn at vi kan tilpasse spacingen. 

Endringen gjør også at komponenten fungerer på samme måte som andre FFE komponenter der man også kan sende med egen klasse.

<!-- Hvorfor trengs denne endringen, og hva løser den? -->

## Testing
Kjørt opp lokalt og sett at det funker i storybook. 
<!-- Hvordan har du har testet endringene dine? Ta gjerne med systeminfo o.l -->

<!--

Helt til slutt, har du ..

.. lest retningslinjene våre for bidrag?
.. tatt en siste sjekk for kode og skrivefeil, debug informasjon o.l?
.. kjørt og eventuelt oppdatert testene?
.. kommentert og dokumentert det som trengs?
.. knyttet denne opp til relaterte issues?

-->
