### PR TITLE
fix(ffe-account-selector-react): format account number in drodown

### DIFF
--- a/packages/ffe-account-selector-react/src/account-selector/AccountSelector.tsx
+++ b/packages/ffe-account-selector-react/src/account-selector/AccountSelector.tsx
@@ -2,7 +2,11 @@ import React, { AriaAttributes, useState } from 'react';
 import classNames from 'classnames';
 import { AccountDetails } from './AccountDetails';
 import { Account, Locale } from '../types';
-import { balanceWithCurrency, formatIncompleteAccountNumber } from '../format';
+import {
+    balanceWithCurrency,
+    formatIncompleteAccountNumber,
+    accountFormatter,
+} from '../format';
 import { SearchableDropdown } from '@sb1/ffe-searchable-dropdown-react';
 import { getAccountsWithCustomAccounts } from './getAccountsWithCustomAccounts';
 import { searchMatcherIgnoringAccountNumberFormatting } from '../searchMatcherIgnoringAccountNumberFormatting';
@@ -126,6 +130,7 @@ export const AccountSelector = <T extends Account = Account>({
 
     const dropdownListAccounts = accounts.map(it => ({
         ...it,
+        accountNumber: accountFormatter(it.accountNumber),
         balance: OptionBody
             ? it.balance
             : balanceWithCurrency(it.balance, locale, it.currencyCode),


### PR DESCRIPTION
fixes: https://github.com/SpareBank1/designsystem/issues/2426