### PR TITLE
Legg til muligheten for 2 ikoner og ikon på høyre side i StippledCard

### DIFF
--- a/packages/ffe-cards-react/src/StippledCard/StippledCard.stories.tsx
+++ b/packages/ffe-cards-react/src/StippledCard/StippledCard.stories.tsx
@@ -83,6 +83,68 @@ export const WithIcon: Story = {
     ),
 };
 
+export const WithRightIconOnly: Story = {
+    args: {
+        as: 'div',
+        rightImg: {
+            type: 'icon',
+            element: <Icon fileUrl="./icons/open/300/md/add.svg" size="md" />,
+        },
+    },
+    render: args => (
+        <StippledCard {...args}>
+            {({ CardName, Title, Subtext, Text }) => (
+                <>
+                    <CardName>CardName</CardName>
+                    <Title>Tittel</Title>
+                    <Subtext as="span">Subtext er grå</Subtext>
+                    <Text>
+                        Lorem ipsum dolor sit amet, consectetur adipiscing elit,
+                        sed do eiusmod tempor incididunt ut labore et dolore
+                        magna aliqua. Ut enim ad minim veniam, quis nostrud
+                        exercitation ullamco laboris nisi ut aliquip ex ea
+                        commodo consequat.
+                    </Text>
+                </>
+            )}
+        </StippledCard>
+    ),
+};
+
+export const With2Icons: Story = {
+    args: {
+        as: 'div',
+        img: {
+            type: 'icon',
+            element: (
+                <Icon fileUrl="./icons/open/300/xl/monitoring.svg" size="xl" />
+            ),
+        },
+        rightImg: {
+            type: 'icon',
+            element: <Icon fileUrl="./icons/open/300/md/add.svg" size="md" />,
+        },
+    },
+    render: args => (
+        <StippledCard {...args}>
+            {({ CardName, Title, Subtext, Text }) => (
+                <>
+                    <CardName>CardName</CardName>
+                    <Title>Tittel</Title>
+                    <Subtext as="span">Subtext er grå</Subtext>
+                    <Text>
+                        Lorem ipsum dolor sit amet, consectetur adipiscing elit,
+                        sed do eiusmod tempor incididunt ut labore et dolore
+                        magna aliqua. Ut enim ad minim veniam, quis nostrud
+                        exercitation ullamco laboris nisi ut aliquip ex ea
+                        commodo consequat.
+                    </Text>
+                </>
+            )}
+        </StippledCard>
+    ),
+};
+
 export const WithCustom: Story = {
     args: {
         as: 'div',

--- a/packages/ffe-cards-react/src/StippledCard/StippledCard.tsx
+++ b/packages/ffe-cards-react/src/StippledCard/StippledCard.tsx
@@ -4,6 +4,10 @@ import classNames from 'classnames';
 import { CardName, Subtext, Text, Title, WithCardAction } from '../components';
 import { fixedForwardRef } from '../fixedForwardRef';
 
+type Img = {
+    element: ReactNode;
+    type: 'icon' | 'custom';
+};
 export type StippledCardProps<As extends ElementType = 'div'> = Omit<
     ComponentAsPropParams<As>,
     'children'
@@ -11,10 +15,8 @@ export type StippledCardProps<As extends ElementType = 'div'> = Omit<
     /** Smaller icon and less space */
     condensed?: boolean;
     /** Image to be rendered*/
-    img?: {
-        element: ReactNode;
-        type: 'icon' | 'custom';
-    };
+    img?: Img;
+    rightImg?: Img;
     /** No margin on card */
     noMargin?: boolean;
     children:
@@ -26,7 +28,8 @@ function StippledCardWithForwardRef<As extends ElementType>(
     props: StippledCardProps<As>,
     ref: ForwardedRef<any>,
 ) {
-    const { className, condensed, img, noMargin, children, ...rest } = props;
+    const { className, condensed, img, noMargin, rightImg, children, ...rest } =
+        props;
 
     return (
         <WithCardAction
@@ -53,7 +56,7 @@ function StippledCardWithForwardRef<As extends ElementType>(
                             {img?.element}
                         </div>
                     )}
-                    <div>
+                    <div className={'ffe-stippled-card__content'}>
                         {typeof children === 'function'
                             ? children({
                                   CardName,
@@ -64,6 +67,17 @@ function StippledCardWithForwardRef<As extends ElementType>(
                               })
                             : children}
                     </div>
+                    {rightImg && (
+                        <div
+                            className={classNames('ffe-stippled-card__img', {
+                                'ffe-stippled-card__img--icon':
+                                    rightImg?.type === 'icon',
+                            })}
+                            aria-hidden={rightImg?.type === 'icon'}
+                        >
+                            {rightImg?.element}
+                        </div>
+                    )}
                 </>
             )}
         </WithCardAction>

--- a/packages/ffe-cards/less/stippled-card.less
+++ b/packages/ffe-cards/less/stippled-card.less
@@ -25,15 +25,23 @@
     background: transparent;
     border: 2px dashed var(--ffe-v-cards-stippled-border-color);
     box-shadow: none;
-    display: grid;
-    grid-template-columns: auto 1fr;
+    display: flex;
     align-items: center;
     padding: var(--ffe-spacing-md);
     gap: var(--ffe-spacing-md);
 }
 
+.ffe-stippled-card__content {
+    flex-grow: 1;
+}
+.ffe-stippled-card__img {
+    flex-shrink: 0;
+    flex-grow: 0;
+}
+
 .ffe-stippled-card__img--icon {
     margin: 0 var(--ffe-spacing-md);
+    display: flex;
 }
 
 .ffe-stippled-card--condensed {


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse
Legger til `rightImg`-prop som lar brukerne legge til ett ikon som plasseres på høyreside av kortet.
I tillegg åpner jeg for at man kan sende med 2 ikoner i samme kort.
Legger også til stories som viser hvordan det funker i storybook. 
<!-- Detaljert beskrivelse av endringene dine. Skjermskudd er lov. -->

## Motivasjon og kontekst
Det er veldig mange steder i Oversikt (og andre steder) der det brukes en variant av stippledCard og IconCard med 2 ikoner. 
Håper derfor vi kan få det inn i FFE, sånn at man slipper å gjøre spesial tilpasninger hver gang det dukker opp i designet.

Viser seg også at dette er mulig i figma allerede. 
<!-- Hvorfor trengs denne endringen, og hva løser den? -->

## Testing
Kjørt opp lokalt og sett at det funker i Storybook. 
<!-- Hvordan har du har testet endringene dine? Ta gjerne med systeminfo o.l -->

<!--

Helt til slutt, har du ..

.. lest retningslinjene våre for bidrag?
.. tatt en siste sjekk for kode og skrivefeil, debug informasjon o.l?
.. kjørt og eventuelt oppdatert testene?
.. kommentert og dokumentert det som trengs?
.. knyttet denne opp til relaterte issues?

-->
