### PR TITLE
fix(ffe-account-selector-react): do not mutate accounts passed in

### DIFF
--- a/packages/ffe-account-selector-react/src/account-selector/AccountDetails.tsx
+++ b/packages/ffe-account-selector-react/src/account-selector/AccountDetails.tsx
@@ -1,20 +1,22 @@
 import React from 'react';
-import { accountFormatter } from '../format';
-import { Account } from '../types';
+import { Account, Locale } from '../types';
 import classnames from 'classnames';
+import { balanceWithCurrency, accountFormatter } from '../format';
 
 interface AccountDetailsProps {
     account?: Account;
     showBalance: boolean;
     ariaInvalid: React.ComponentPropsWithoutRef<'div'>['aria-invalid'];
+    locale: Locale;
 }
 
 export function AccountDetails({
     account,
     showBalance = true,
     ariaInvalid,
+    locale,
 }: AccountDetailsProps) {
-    const { balance, accountNumber } = account ?? {};
+    const { balance, accountNumber, currencyCode } = account ?? {};
     const isInvalidWithNoAccount =
         !account && (ariaInvalid === 'true' || ariaInvalid === true);
 
@@ -36,7 +38,7 @@ export function AccountDetails({
                     </div>
                     {showBalance && (
                         <div className="ffe-account-selector-single__details--right">
-                            {balance}
+                            {balanceWithCurrency(balance, locale, currencyCode)}
                         </div>
                     )}
                 </>

--- a/packages/ffe-account-selector-react/src/account-selector/AccountOptionBody.tsx
+++ b/packages/ffe-account-selector-react/src/account-selector/AccountOptionBody.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { MicroText } from '@sb1/ffe-core-react';
+import classnames from 'classnames';
+import { balanceWithCurrency, accountFormatter } from '../format';
+import { Account, Locale } from '../types';
+
+interface Props<Item extends Account> {
+    item: Item;
+    isHighlighted: boolean;
+    showBalance: boolean;
+    locale: Locale;
+}
+
+export function AccountActionBody<Item extends Account>({
+    item,
+    isHighlighted,
+    showBalance,
+    locale,
+}: Props<Item>) {
+    return (
+        <div
+            className={classnames('ffe-searchable-dropdown__list-item-body', {
+                'ffe-searchable-dropdown__list-item-body--highlighted':
+                    isHighlighted,
+            })}
+        >
+            {item.name}
+            <div className="ffe-searchable-dropdown__list-item-body-details">
+                <MicroText className="ffe-searchable-dropdown__detail-text">
+                    {accountFormatter(item.accountNumber)}
+                </MicroText>
+                {showBalance && (
+                    <MicroText className="ffe-searchable-dropdown__detail-text">
+                        {balanceWithCurrency(
+                            item.balance,
+                            locale,
+                            item.currencyCode,
+                        )}
+                    </MicroText>
+                )}
+            </div>
+        </div>
+    );
+}

--- a/packages/ffe-account-selector-react/src/account-selector/AccountSelector.tsx
+++ b/packages/ffe-account-selector-react/src/account-selector/AccountSelector.tsx
@@ -2,15 +2,12 @@ import React, { AriaAttributes, useState } from 'react';
 import classNames from 'classnames';
 import { AccountDetails } from './AccountDetails';
 import { Account, Locale } from '../types';
-import {
-    balanceWithCurrency,
-    formatIncompleteAccountNumber,
-    accountFormatter,
-} from '../format';
+import { formatIncompleteAccountNumber } from '../format';
 import { SearchableDropdown } from '@sb1/ffe-searchable-dropdown-react';
 import { getAccountsWithCustomAccounts } from './getAccountsWithCustomAccounts';
 import { searchMatcherIgnoringAccountNumberFormatting } from '../searchMatcherIgnoringAccountNumberFormatting';
 import { texts } from '../texts';
+import { AccountActionBody } from './AccountOptionBody';
 
 export interface AccountSelectorProps<T extends Account = Account> {
     /**
@@ -131,14 +128,6 @@ export const AccountSelector = <T extends Account = Account>({
 
     const _ariaInvalid = rest['aria-invalid'] ?? ariaInvalid;
 
-    const dropdownListAccounts = accounts.map(it => ({
-        ...it,
-        accountNumber: accountFormatter(it.accountNumber),
-        balance: OptionBody
-            ? it.balance
-            : balanceWithCurrency(it.balance, locale, it.currencyCode),
-    }));
-
     return (
         <div
             className={classNames(
@@ -165,10 +154,10 @@ export const AccountSelector = <T extends Account = Account>({
                     allowCustomAccount
                         ? getAccountsWithCustomAccounts({
                               selectedAccount,
-                              accounts: dropdownListAccounts,
+                              accounts,
                               inputValue,
                           })
-                        : dropdownListAccounts
+                        : accounts
                 }
                 noMatch={
                     allowCustomAccount && inputValue.trim() !== ''
@@ -188,7 +177,26 @@ export const AccountSelector = <T extends Account = Account>({
                 onChange={handleAccountSelected}
                 searchAttributes={['name', 'accountNumber']}
                 locale={locale}
-                optionBody={OptionBody}
+                optionBody={({ item, isHighlighted, ...restOptionBody }) => {
+                    if (OptionBody) {
+                        return (
+                            <OptionBody
+                                item={item}
+                                isHighlighted={isHighlighted}
+                                {...restOptionBody}
+                            />
+                        );
+                    }
+
+                    return (
+                        <AccountActionBody
+                            item={item}
+                            isHighlighted={isHighlighted}
+                            locale={locale}
+                            showBalance={showBalance}
+                        />
+                    );
+                }}
                 ariaInvalid={_ariaInvalid}
                 searchMatcher={searchMatcherIgnoringAccountNumberFormatting}
                 selectedItem={selectedAccount}
@@ -209,6 +217,7 @@ export const AccountSelector = <T extends Account = Account>({
                             typeof selectedAccount?.balance,
                         )
                     }
+                    locale={locale}
                 />
             )}
         </div>


### PR DESCRIPTION
Opdaget en liten bugg når skulel ta i bruk i sparing. Man får tilbake ett annet konto en man sender in(formatert kontonummmer). Det er ikke heldig