### PR TITLE
chore: endre tidspunkt for publisering av pakker

### DIFF
--- a/.github/workflows/update-main.yml
+++ b/.github/workflows/update-main.yml
@@ -2,14 +2,14 @@ name: Update main
 
 on:
     schedule:
-        # Run every day at 6:00, 11:00, 16:00 and 21:00, Norwegian time.
+        # Run every day Monday-Friday at 09:00, 12:00, 14:00, 16:00 Norwegian time.
         # schedule uses UTC time, so this cron expression has to be adjusted twice a year
         # because of daylight saving time.
         #
-        # Central European Time (CET): '0 5-20/5 * * *'
-        # Central European Summer Time (CEST): '0 4-19/5 * * *'
+        # Central European Time (CET): '0 8,11,13,15 * * 1-5'
+        # Central European Summer Time (CEST): '0 7,10,12,14 * * 1-5'
         #
-        - cron: '0 5-20/5 * * *'
+        - cron: '0 8,11,13,15 * * 1-5'
 
 jobs:
     merge:


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse
Endrer tidspunktene for publisering av npm pakkene til Mandag-Fredag:
- 09:00
- 12:00
- 14:00
- 16:00 

Fra:
Hver dag: kl 06:00, 11:00, 16:00, 21:00

Var ingen krise at den kjørte i helgene, da den kun releaser ved endringer, men tenkte kanskje det var greit å ha som ett "sikkerhetstiltak" tilfelle noe skulle skje når alle har helg. 

<!-- Detaljert beskrivelse av endringene dine. Skjermskudd er lov. -->

## Motivasjon og kontekst
Det har vært en del kommentarer på at det var for få tidspunkt i løpet av arbeidsdagen der npm-pakkene ble publisert, som førte til at flere følte de måtte vente lenge på endringer. 

<!-- Hvorfor trengs denne endringen, og hva løser den? -->

## Testing

<!-- Hvordan har du har testet endringene dine? Ta gjerne med systeminfo o.l -->

<!--

Helt til slutt, har du ..

.. lest retningslinjene våre for bidrag?
.. tatt en siste sjekk for kode og skrivefeil, debug informasjon o.l?
.. kjørt og eventuelt oppdatert testene?
.. kommentert og dokumentert det som trengs?
.. knyttet denne opp til relaterte issues?

-->
