### PR TITLE
fix(ffe-modals): Add missing focus color for close button

### DIFF
--- a/packages/ffe-modals/less/theme.less
+++ b/packages/ffe-modals/less/theme.less
@@ -4,6 +4,7 @@
     --ffe-v-modal-bg-color: var(--ffe-farge-hvit);
     --ffe-v-modal-close-button-cross-color: var(--ffe-farge-vann);
     --ffe-v-modal-close-button-border-color: var(--ffe-farge-vann);
+    --ffe-v-modal-close-button-color: var(--ffe-farge-vann);
     --ffe-v-modal-border-radius: 24px;
 
     @media (prefers-color-scheme: dark) {
@@ -12,6 +13,7 @@
             --ffe-v-modal-bg-color: var(--ffe-farge-svart);
             --ffe-v-modal-close-button-cross-color: var(--ffe-farge-vann-30);
             --ffe-v-modal-close-button-border-color: var(--ffe-farge-vann-70);
+            --ffe-v-modal-close-button-color: var(--ffe-farge-vann-70);
         }
     }
 }


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse

Løser https://github.com/SpareBank1/designsystem/issues/2439 ved å legge til manglende CSS custom propertie med antatte verdier.

Etter å ha gravd litt mer ser det ut som det ville vært riktigere med `--ffe-farge-hvit` for dark mode? 

Uten fokus
![image](https://github.com/user-attachments/assets/7570a38b-eb50-4123-9f02-05696650540a)

Med fokus
![image](https://github.com/user-attachments/assets/06a052c9-8788-4f01-84aa-af132ca68704)



## Motivasjon og kontekst

UU

## Testing

Har bare kjørt det opp med storybook.
Prøvde å teste dark mode, men klarte ikke få det til med Storybook.
Er det noen måte jeg kan få testet det?
