### PR TITLE
fix(ffe-modals): Add missing focus color for close button - firefox

### DIFF
--- a/packages/ffe-modals/less/modal.less
+++ b/packages/ffe-modals/less/modal.less
@@ -43,7 +43,6 @@
     --background-color: var(--ffe-v-modal-bg-color);
     --border-color: var(--ffe-v-modal-close-button-border-color);
     --text-color: var(--ffe-v-modal-close-button-cross-color);
-    --outline-color: transparent;
 
     aspect-ratio: 1;
     background: var(--background-color);
@@ -51,7 +50,7 @@
     border: 2px solid var(--border-color);
     font: inherit;
     cursor: pointer;
-    outline: 2px solid var(--outline-color);
+    outline: 2px solid transparent;
     padding: var(--ffe-spacing-2xs);
     border-radius: 50%;
     float: right;
@@ -71,7 +70,7 @@
     }
 
     &:focus-visible {
-        --outline-color: var(--ffe-v-modal-close-button-color);
+        outline: 2px solid var(--ffe-v-modal-close-button-color);
     }
 
     @media (hover: hover) and (pointer: fine) {


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse

fortsettelse av https://github.com/SpareBank1/designsystem/pull/2440

Oppdaget at den siste fiksen jeg kom med ikke løste problemet for firefox. Håpet at det var fordi vi har en litt gammel versjon av firefox, men testet med nyere nå og hadde endå samme problemet.

Endre til å bruke custom propertiene direkte fremfor å overskrive verdien slik det var satt opp og det ser ut til å fungere.

<!-- Detaljert beskrivelse av endringene dine. Skjermskudd er lov. -->

