### PR TITLE
feat(ffe-form): move invalid styling to components

### DIFF
--- a/packages/ffe-form/less/input-field.less
+++ b/packages/ffe-form/less/input-field.less
@@ -43,10 +43,10 @@
     }
 
     &--condensed {
-        height: 38px;
+        height: 2.25rem;
     }
 
-    &--text-like {
+    &--text-like.ffe-input-field {
         border: none;
         border-bottom: 2px solid var(--ffe-g-border-color);
         border-radius: 4px 4px 0 0;
@@ -62,6 +62,14 @@
             box-shadow: none;
             border-color: var(--ffe-g-primary-color);
         }
+
+        &[aria-invalid='true'] {
+            border-bottom: 2px solid;
+            border-color: var(--ffe-g-error-color);
+            border-left-style: none;
+            border-right-style: none;
+            border-top-style: none;
+        }
     }
 
     &::-ms-clear {
@@ -71,5 +79,15 @@
     &::placeholder {
         color: var(--ffe-v-input-placeholder-color);
         opacity: 1;
+    }
+}
+.ffe-input-field--invalid,
+:where(input).ffe-input-field[aria-invalid='true'] {
+    border-color: var(--ffe-g-error-color);
+    border-style: solid;
+
+    &:focus {
+        border-color: var(--ffe-v-input-bg-color);
+        box-shadow: 0 0 0 2px var(--ffe-g-error-color);
     }
 }

--- a/packages/ffe-form/less/input-group.less
+++ b/packages/ffe-form/less/input-group.less
@@ -3,26 +3,6 @@
     position: relative;
     padding: 0 0 calc(1lh + var(--ffe-spacing-xs));
 
-    [aria-invalid='true'] {
-        border-color: var(--ffe-g-error-color);
-        border-style: solid;
-
-        &:focus {
-            border-color: var(--ffe-v-input-bg-color);
-            box-shadow: 0 0 0 2px var(--ffe-g-error-color);
-        }
-    }
-
-    .ffe-input-field--text-like {
-        &[aria-invalid='true'] {
-            border-bottom: 2px solid;
-            border-color: var(--ffe-g-error-color);
-            border-left-style: none;
-            border-right-style: none;
-            border-top-style: none;
-        }
-    }
-
     > * {
         margin-top: 0;
         margin-bottom: var(--ffe-spacing-xs);

--- a/packages/ffe-form/less/textarea.less
+++ b/packages/ffe-form/less/textarea.less
@@ -29,3 +29,14 @@
         opacity: 1;
     }
 }
+
+.ffe-textarea--invalid,
+:where(textarea).ffe-textarea[aria-invalid='true'] {
+    border-color: var(--ffe-g-error-color);
+    border-style: solid;
+
+    &:focus {
+        border-color: var(--ffe-v-input-bg-color);
+        box-shadow: 0 0 0 2px var(--ffe-g-error-color);
+    }
+}


### PR DESCRIPTION
BEAKING CHANGE: ffe-input-group does not apply any red borders to children with [aria-invalid='true'] any more. The children are responsible to apply their own invalid styles.

