### PR TITLE
feat(ffe-datepicker-react): tillater liming inn i datepicker-felte…

### DIFF
--- a/packages/ffe-datepicker-react/src/datepicker/DatepickerComp.tsx
+++ b/packages/ffe-datepicker-react/src/datepicker/DatepickerComp.tsx
@@ -29,7 +29,9 @@ export interface DatepickerCompProps {
     onBlur?: (evt: React.FocusEvent<HTMLElement>) => void;
     calendarAbove?: boolean;
     id?: string;
+    /* Latest allowed date. With format 'dd.mm.yyyy'*/
     maxDate?: string | null;
+    /* Earliest allowed date. With format 'dd.mm.yyyy'*/
     minDate?: string | null;
     onChange: (date: string) => void;
     fullWidth?: boolean;
@@ -116,6 +118,9 @@ export const DatepickerComp: React.FC<DatepickerCompProps> = ({
 
             if (formattedDate !== dateString) {
                 onChange(formattedDate);
+                setDay([date.date]);
+                setMonth([date.month + 1]);
+                setYear([date.year]);
             }
             setLastValidDate(formattedDate);
         });
@@ -224,6 +229,19 @@ export const DatepickerComp: React.FC<DatepickerCompProps> = ({
         return ariaDescribedbyTotal as unknown as React.ComponentPropsWithRef<'span'>['aria-describedby'];
     };
 
+    const handlePaste = (evt: React.ClipboardEvent) => {
+        evt.preventDefault();
+
+        const paste = (evt.clipboardData || window.Clipboard).getData('text');
+        const date = getSimpleDateFromString(paste);
+        if (date) {
+            setDay([date.date]);
+            setMonth([date.month + 1]);
+            setYear([date.year]);
+            onChange(`${day}.${month}.${year}`);
+        }
+    };
+
     return (
         // eslint-disable-next-line jsx-a11y/no-static-element-interactions,jsx-a11y/no-noninteractive-element-interactions
         <div
@@ -253,6 +271,7 @@ export const DatepickerComp: React.FC<DatepickerCompProps> = ({
                         elementReceivingFocus !== monthRef.current
                     ) {
                         onBlur?.(evt);
+                        validateDateIntervals();
                     }
                 }}
             >
@@ -261,6 +280,7 @@ export const DatepickerComp: React.FC<DatepickerCompProps> = ({
                     value={day ?? undefined}
                     min={1}
                     max={31}
+                    onPaste={handlePaste}
                     onSpinButtonChange={(newValue, allowFocusNext = true) => {
                         onChange(
                             `${padZero(toNumber(newValue))}.${month}.${year}`,
@@ -291,6 +311,7 @@ export const DatepickerComp: React.FC<DatepickerCompProps> = ({
                     value={month ?? undefined}
                     min={1}
                     max={12}
+                    onPaste={handlePaste}
                     onSpinButtonChange={(newValue, allowFocusNext = true) => {
                         onChange(
                             `${day}.${padZero(toNumber(newValue))}.${year}`,
@@ -328,6 +349,7 @@ export const DatepickerComp: React.FC<DatepickerCompProps> = ({
                     value={year ?? undefined}
                     min={1}
                     max={9999}
+                    onPaste={handlePaste}
                     onSpinButtonChange={newValue => {
                         onChange(`${day}.${month}.${newValue}`);
                         setYear(newValue);

--- a/packages/ffe-datepicker-react/src/datepicker/SpinButton.tsx
+++ b/packages/ffe-datepicker-react/src/datepicker/SpinButton.tsx
@@ -40,9 +40,14 @@ export const SpinButton = React.forwardRef<HTMLSpanElement, SpinButtonProps>(
                         ? (history.current = [parseInt(evt.key)])
                         : history.current.concat(parseInt(evt.key));
                 onSpinButtonChange(history.current);
-            } else if (evt.key === 'Backspace') {
+            } else if (evt.key === 'Backspace' || evt.key === 'Delete') {
                 history.current = [];
-                onSpinButtonChange(history.current);
+                if (value === 0) {
+                    prevSpinButton?.current?.focus();
+                    return;
+                }
+                const newValue = value?.toString().slice(0, -1);
+                onSpinButtonChange(newValue ? [parseInt(newValue)] : []);
             } else if (evt.key === 'ArrowUp') {
                 evt.preventDefault();
                 let newValue = (value ?? 0) + 1;


### PR DESCRIPTION
[#2459](https://github.com/SpareBank1/designsystem/issues/2459)
Diskutert på slack her: https://sb1-utvikling.slack.com/archives/CNS68BM1B/p1734448478075779

Flere fikser etter tilbakemelding fra utviklere. 

### Tillate å lime inn dato
Hvis man limer inn en tekst med riktig format, f.eks "12.04.2024", går det nå å lime det inn. Uavhengig av om man har fokus på dato, måned eller år

### Backspace og delete
Har endret litt på hvordan backspace funger. Hvis man trykker backspace 1 gang nå, så går det fra "2003" til "200". Før var det fra "2003" til "yyyy". 
I tillegg, hvis det ikke er noe verdi i feltet (0, eller "yyyy"), flyttes fokuset til neste felt hvis man trykker backspace en gang til. Dermed kan man fjerne hele datoen uten å bruke piltaster eller musepeker. 
Dette fungerer også med delete. Delete får riktignok samme funksjonalitet som backspace, ikke motsatt retning som det pleier å være. 

### Gjett år on blur
Tatt tilbake funksjonalitet som var der før - gjette årstallet hvis man bare har skrevet 2 sifre, onBlur. Dvs. at hvis bruker har skrevet inn "04.08.24", fylles det ut til "04.08.2024", og "04.08.87" blir til "04.08.1987".
