### PR TITLE
Modernisere skjemaelementer

### DIFF
--- a/packages/ffe-core/less/theme.less
+++ b/packages/ffe-core/less/theme.less
@@ -137,7 +137,9 @@
 
     /* Form element borders */
     --ffe-g-border-color: var(--ffe-farge-varmgraa);
-    --ffe-g-border-radius: 4px;
+    --ffe-g-border-radius: 8px;
+    --ffe-g-border-width: 1px;
+    --ffe-g-border-width-focus: 2px;
 
     /** Fonts */
 

--- a/packages/ffe-datepicker/less/calendar.less
+++ b/packages/ffe-datepicker/less/calendar.less
@@ -1,7 +1,7 @@
 @import (reference) '@sb1/ffe-core/less/typography';
 
 .ffe-calendar {
-    border: solid 2px var(--ffe-g-border-color);
+    border: var(--ffe-g-border-width) solid var(--ffe-g-border-color);
     border-radius: var(--ffe-g-border-radius);
     padding: var(--ffe-spacing-2xs);
     background: var(--ffe-v-datepicker-bg-color);

--- a/packages/ffe-datepicker/less/dateinput.less
+++ b/packages/ffe-datepicker/less/dateinput.less
@@ -10,24 +10,16 @@
     }
 
     &:focus-within {
-        border-color: var(--ffe-v-datepicker-bg-color);
-        box-shadow: 0 0 0 2px var(--ffe-g-primary-color);
+        border: var(--ffe-g-border-width-focus) solid var(--ffe-g-primary-color);
         outline: none;
 
         & + .ffe-datepicker__button {
             @media (hover: hover) and (pointer: fine) {
                 &:hover {
-                    border-color: var(--ffe-v-datepicker-bg-color);
-                    box-shadow: 0 0 0 2px var(--ffe-g-primary-color);
+                    border: var(--ffe-g-border-width-focus) solid var(--ffe-g-primary-color);
                     outline: none;
                 }
             }
-        }
-    }
-
-    @media (hover: hover) and (pointer: fine) {
-        &:focus-within:hover {
-            border-color: transparent;
         }
     }
 
@@ -36,22 +28,19 @@
         align-items: center;
 
         &--invalid {
-            border-color: var(--ffe-g-error-color);
-            border-style: solid;
+            border: var(--ffe-g-border-width) solid var(--ffe-g-error-color);
 
             @media (hover: hover) and (pointer: fine) {
                 &:hover {
                     border-color: var(--ffe-g-error-color);
-                    box-shadow: none;
                 }
                 &:focus-within:hover {
-                    border-color: var(--ffe-v-datepicker-bg-color);
+                    border: var(--ffe-g-border-width-focus) solid var(--ffe-g-error-color);
                 }
             }
 
             &:focus-within {
-                border-color: var(--ffe-v-datepicker-bg-color);
-                box-shadow: 0 0 0 2px var(--ffe-g-error-color);
+                border: var(--ffe-g-border-width-focus) solid var(--ffe-g-error-color);
                 outline: none;
             }
 
@@ -63,8 +52,7 @@
 
                 @media (hover: hover) and (pointer: fine) {
                     &:hover {
-                        border-color: var(--ffe-v-datepicker-bg-color);
-                        box-shadow: 0 0 0 2px var(--ffe-g-error-color);
+                        border: var(--ffe-g-border-width-focus) solid var(--ffe-g-error-color);
                         outline: none;
                     }
                 }
@@ -87,14 +75,6 @@
         &::-ms-clear {
             display: none;
         }
-
-        &[role='spinbutton'][aria-invalid='true'] {
-            border-color: transparent;
-            border-style: none;
-        }
-        &[role='spinbutton'][aria-invalid='true']:focus {
-            box-shadow: none;
-        }
     }
     &--message {
         padding-bottom: 0;
@@ -113,13 +93,12 @@
 
     &__button {
         background-color: transparent;
-        border: 2px solid transparent;
+        border: var(--ffe-g-border-width) solid transparent;
         grid-column: 2 e('/') 3;
         grid-row: 1 e('/') -1;
         outline: none;
-        border-top-right-radius: 4px;
-        border-bottom-right-radius: 4px;
-        transition: all var(--ffe-transition-duration) var(--ffe-ease);
+        border-radius: 0 var(--ffe-g-border-radius) var(--ffe-g-border-radius) 0;
+        transition: border-color var(--ffe-transition-duration) var(--ffe-ease);
         width: 56px;
         cursor: pointer;
         z-index: 1;
@@ -127,7 +106,7 @@
 
         &:focus,
         &:active {
-            border-color: var(--ffe-v-datepicker-border-hover-color);
+            border: var(--ffe-g-border-width-focus) solid var(--ffe-v-datepicker-border-hover-color);
         }
 
         @media (hover: hover) and (pointer: fine) {

--- a/packages/ffe-form-react/package.json
+++ b/packages/ffe-form-react/package.json
@@ -32,6 +32,7 @@
     },
     "devDependencies": {
         "@sb1/ffe-buildtool": "^0.9.0",
+        "@sb1/ffe-icons-react": "^11.0.14",
         "eslint": "^8.57.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"

--- a/packages/ffe-form-react/package.json
+++ b/packages/ffe-form-react/package.json
@@ -28,7 +28,6 @@
     "dependencies": {
         "@sb1/ffe-collapse-react": "^5.1.0",
         "@sb1/ffe-form": "^30.2.0",
-        "@sb1/ffe-icons-react": "^11.0.14",
         "classnames": "^2.3.1"
     },
     "devDependencies": {

--- a/packages/ffe-form-react/src/ToggleSwitch.stories.tsx
+++ b/packages/ffe-form-react/src/ToggleSwitch.stories.tsx
@@ -15,20 +15,41 @@ export const Standard: Story = {
         children: 'Jeg vil gjerne ha reklame',
     },
     render: function Render(args) {
-        return <ToggleSwitch {...args} />;
+        const [checked, setChecked] = React.useState(true);
+        return (
+            <ToggleSwitch
+                {...args}
+                checked={checked}
+                onChange={e => setChecked(e.target.checked)}
+            />
+        );
     },
 };
 
 export const HideOnOff: Story = {
     args: { ...Standard.args, hideOnOff: true },
     render: function Render(args) {
-        return <ToggleSwitch {...args} />;
+        const [checked, setChecked] = React.useState(true);
+        return (
+            <ToggleSwitch
+                {...args}
+                checked={checked}
+                onChange={e => setChecked(e.target.checked)}
+            />
+        );
     },
 };
 
 export const Description: Story = {
     args: { ...Standard.args, description: 'Send meg spam' },
     render: function Render(args) {
-        return <ToggleSwitch {...args} />;
+        const [checked, setChecked] = React.useState(true);
+        return (
+            <ToggleSwitch
+                {...args}
+                checked={checked}
+                onChange={e => setChecked(e.target.checked)}
+            />
+        );
     },
 };

--- a/packages/ffe-form/less/checkbox.less
+++ b/packages/ffe-form/less/checkbox.less
@@ -40,13 +40,13 @@
         content: '';
         grid-column: 1 e('/') 2;
         grid-row: 1 e('/') 2;
-        transition: all var(--ffe-transition-duration) var(--ffe-ease);
+        transition: border-color var(--ffe-transition-duration) var(--ffe-ease);
     }
 
     &::before {
         background: var(--square-background-color);
-        border: solid 2px var(--square-color);
-        border-radius: var(--ffe-g-border-radius);
+        border: var(--ffe-g-border-width) solid var(--square-color);
+        border-radius: calc(var(--ffe-g-border-radius) / 2);
         height: 20px;
         width: 20px;
     }
@@ -99,9 +99,7 @@
     }
 
     &:focus-visible + .ffe-checkbox::before {
-        box-shadow:
-            0 0 0 3px var(--ffe-v-input-bg-color),
-            0 0 0 5px var(--ffe-v-checkbox-focus-outline-color);
+        border: var(--ffe-g-border-width-focus) solid var(--ffe-v-checkbox-focus-outline-color);
     }
 
     &:checked + .ffe-checkbox {

--- a/packages/ffe-form/less/input-field.less
+++ b/packages/ffe-form/less/input-field.less
@@ -1,14 +1,14 @@
 .ffe-input-field {
     display: block;
     height: 2.8125rem;
-    padding: 0 var(--ffe-spacing-sm);
+    padding: var(--ffe-v-input-padding);
     font-family: var(--ffe-g-font);
     font-variant-numeric: tabular-nums;
     background-color: var(--ffe-v-input-bg-color);
     color: var(--ffe-v-input-color);
     border-radius: var(--ffe-g-border-radius);
-    border: 2px solid var(--ffe-g-border-color);
-    transition: all var(--ffe-transition-duration) var(--ffe-ease);
+    border: var(--ffe-g-border-width) solid var(--ffe-g-border-color);
+    transition: border-color var(--ffe-transition-duration) var(--ffe-ease);
     width: 100%;
     font-size: var(--ffe-fontsize-form-input);
 
@@ -28,8 +28,7 @@
 
     &:focus,
     &:active {
-        border-color: var(--ffe-v-input-bg-color);
-        box-shadow: 0 0 0 2px var(--ffe-g-primary-color);
+        border: var(--ffe-g-border-width-focus) solid var(--ffe-g-primary-color);
         outline: none;
     }
 
@@ -48,19 +47,24 @@
 
     &--text-like.ffe-input-field {
         border: none;
-        border-bottom: 2px solid var(--ffe-g-border-color);
-        border-radius: 4px 4px 0 0;
+        border-bottom: var(--ffe-g-border-width) solid var(--ffe-g-border-color);
+        border-radius: var(--ffe-g-border-width) var(--ffe-g-border-width) 0 0;
         box-shadow: none;
         text-align: center;
         padding: 0;
         display: inline-block;
         height: 2em;
-        transition: all var(--ffe-transition-duration) var(--ffe-ease);
+        transition: border-color var(--ffe-transition-duration) var(--ffe-ease);
         background-color: transparent;
 
+        @media (hover: hover) and (pointer: fine) {
+            &:hover {
+                border-color: var(--ffe-g-primary-color);
+            }
+        }
+
         &:focus {
-            box-shadow: none;
-            border-color: var(--ffe-g-primary-color);
+            border-bottom: var(--ffe-g-border-width-focus) solid var(--ffe-g-primary-color);
         }
 
         &[aria-invalid='true'] {
@@ -87,7 +91,6 @@
     border-style: solid;
 
     &:focus {
-        border-color: var(--ffe-v-input-bg-color);
-        box-shadow: 0 0 0 2px var(--ffe-g-error-color);
+        border: var(--ffe-g-border-width-focus) solid var(--ffe-g-error-color);
     }
 }

--- a/packages/ffe-form/less/phone-number.less
+++ b/packages/ffe-form/less/phone-number.less
@@ -41,12 +41,12 @@
     &__plus {
         font-weight: 400;
         line-height: 1;
-        padding: 12px var(--ffe-spacing-xs);
+        padding: var(--ffe-v-input-padding);
         background-color: var(--ffe-v-input-bg-color);
-        border: 2px solid var(--ffe-g-border-color);
+        border: var(--ffe-g-border-width) solid var(--ffe-g-border-color);
         border-radius: var(--ffe-g-border-radius) 0 0 var(--ffe-g-border-radius);
         border-right: 0;
-        transition: all var(--ffe-transition-duration) var(--ffe-ease);
+        transition: border-color var(--ffe-transition-duration) var(--ffe-ease);
         color: var(--ffe-v-input-color);
         display: flex;
         align-items: center;

--- a/packages/ffe-form/less/radio-block.less
+++ b/packages/ffe-form/less/radio-block.less
@@ -24,7 +24,8 @@
         display: inline-grid;
         grid-template-columns: auto 1fr;
         position: relative;
-        border: 2px solid var(--ffe-radio-block-border-color);
+        border: var(--ffe-g-border-width) solid
+            var(--ffe-radio-block-border-color);
         border-radius: var(--ffe-g-border-radius);
         margin-right: var(--ffe-spacing-xs);
         color: var(--ffe-v-input-color);
@@ -38,7 +39,8 @@
             left: 20px;
             z-index: 1;
             background-color: var(--ffe-v-input-bg-color);
-            border: 2px solid var(--ffe-radio-block-border-color);
+            border: var(--ffe-g-border-width) solid
+                var(--ffe-radio-block-border-color);
             width: 20px;
             height: 20px;
             border-radius: 50%;
@@ -53,9 +55,9 @@
         display: block;
         padding: var(--ffe-spacing-xs) var(--ffe-spacing-3xl)
             var(--ffe-spacing-xs);
-        border-bottom: thin solid var(--ffe-radio-block-border-color);
         color: var(--ffe-radio-block-header-color);
         background-color: var(--ffe-radio-block-header-bg-color);
+        border-radius: var(--ffe-g-border-radius) var(--ffe-g-border-radius) 0 0;
     }
 
     &__wrapper {

--- a/packages/ffe-form/less/radio-button.less
+++ b/packages/ffe-form/less/radio-button.less
@@ -78,9 +78,9 @@
 
     &::after {
         background-color: var(--ffe-v-input-bg-color);
-        border: 2px solid var(--outer-circle-color);
-        width: 20px;
-        height: 20px;
+        border: var(--ffe-g-border-width) solid var(--outer-circle-color);
+        width: 24px;
+        height: 24px;
     }
 }
 

--- a/packages/ffe-form/less/radio-switch.less
+++ b/packages/ffe-form/less/radio-switch.less
@@ -1,13 +1,14 @@
 @import (reference) '@sb1/ffe-core/less/breakpoints';
 
 .ffe-radio-switch {
-    padding: 6px var(--ffe-spacing-sm);
+    padding: var(--ffe-spacing-xs) var(--ffe-spacing-md) var(--ffe-spacing-xs)
+        var(--ffe-spacing-xs);
     grid-template-columns: auto 1fr;
     grid-column-gap: var(--ffe-spacing-xs);
     position: relative;
     background-color: var(--ffe-v-input-bg-color);
-    border: 2px solid var(--ffe-g-border-color);
-    border-radius: 22px;
+    border: var(--ffe-g-border-width) solid var(--ffe-g-border-color);
+    border-radius: 48px;
     display: inline-grid;
     place-items: center;
     min-width: 100px;
@@ -16,8 +17,7 @@
     font-family: var(--ffe-g-font-strong);
     font-variant-numeric: tabular-nums;
     cursor: pointer;
-    transition: all var(--ffe-transition-duration) var(--ffe-ease);
-    box-shadow: 0 1px 2px 1px rgba(0, 0, 0, 0.05);
+    transition: border-color var(--ffe-transition-duration) var(--ffe-ease);
     margin-bottom: var(--ffe-spacing-2xs);
     margin-top: var(--ffe-spacing-sm);
     line-height: 1.5;
@@ -28,9 +28,9 @@
         left: 12px;
         top: 8px;
         background-color: var(--ffe-v-input-bg-color);
-        border: 2px solid var(--ffe-g-border-color);
-        width: 20px;
-        height: 20px;
+        border: var(--ffe-g-border-width) solid var(--ffe-g-border-color);
+        width: 24px;
+        height: 24px;
         border-radius: 50%;
         pointer-events: none;
     }
@@ -68,6 +68,7 @@
         box-shadow:
             0 0 0 3px var(--ffe-v-input-bg-color),
             0 0 0 5px var(--ffe-v-checkbox-focus-outline-color);
+        outline: none;
     }
 
     &:checked + .ffe-radio-switch::before {

--- a/packages/ffe-form/less/textarea.less
+++ b/packages/ffe-form/less/textarea.less
@@ -1,14 +1,14 @@
 .ffe-textarea {
     display: block;
     width: 100%;
-    padding: var(--ffe-spacing-sm);
+    padding: var(--ffe-v-input-padding);
     font-family: var(--ffe-g-font);
     font-variant-numeric: tabular-nums;
     border-radius: var(--ffe-g-border-radius);
-    border: 2px solid var(--ffe-g-border-color);
+    border: var(--ffe-g-border-width) solid var(--ffe-g-border-color);
     background-color: var(--ffe-v-input-bg-color);
     color: var(--ffe-v-input-color);
-    transition: all var(--ffe-transition-duration) var(--ffe-ease);
+    transition: border-color var(--ffe-transition-duration) var(--ffe-ease);
     font-size: var(--ffe-fontsize-form-input);
 
     @media (hover: hover) and (pointer: fine) {
@@ -19,8 +19,7 @@
 
     &:focus,
     &:active {
-        border-color: var(--ffe-v-input-bg-color);
-        box-shadow: 0 0 0 2px var(--ffe-g-primary-color);
+        border: var(--ffe-g-border-width-focus) solid var(--ffe-g-primary-color);
         outline: none;
     }
 
@@ -36,7 +35,6 @@
     border-style: solid;
 
     &:focus {
-        border-color: var(--ffe-v-input-bg-color);
-        box-shadow: 0 0 0 2px var(--ffe-g-error-color);
+        border: var(--ffe-g-border-width-focus) solid var(--ffe-g-error-color);
     }
 }

--- a/packages/ffe-form/less/theme.less
+++ b/packages/ffe-form/less/theme.less
@@ -3,6 +3,7 @@
     --ffe-v-input-color: var(--ffe-farge-svart);
     --ffe-v-input-bg-color: var(--ffe-farge-hvit);
     --ffe-v-input-placeholder-color: var(--ffe-farge-moerkgraa);
+    --ffe-v-input-padding: 12px var(--ffe-spacing-sm);
     --ffe-v-info-message-icon-color: var(--ffe-g-secondary-color);
     --ffe-v-info-message-icon-fill: var(--ffe-farge-hvit);
     --ffe-v-dropdown-bg-color: var(--ffe-farge-hvit);
@@ -17,7 +18,7 @@
     --ffe-v-checkbox-focus-outline-color: var(--ffe-g-primary-color);
     --ffe-v-radio-button-label-color: var(--ffe-g-primary-color);
     --ffe-v-toggle-switch-box-shadow: 0 0 0 3px var(--ffe-farge-hvit),
-        0 0 0 5px var(--ffe-g-primary-color);
+    0 0 0 5px var(--ffe-g-primary-color);
     --ffe-v-toggle-switch-hover-color: var(--ffe-farge-moerkgraa);
     --ffe-v-tooltip-icon-color: var(--ffe-g-primary-color);
     --ffe-v-tooltip-border-color: var(--ffe-g-border-color);

--- a/packages/ffe-form/less/toggle-switch.less
+++ b/packages/ffe-form/less/toggle-switch.less
@@ -52,7 +52,7 @@
             width: 56px;
             height: 30px;
             background: var(--ffe-g-border-color);
-            border-radius: 15px;
+            border-radius: 52px;
             left: auto;
             right: 0;
             transition:
@@ -68,8 +68,8 @@
             background: var(--ffe-v-input-bg-color);
             border-radius: 50%;
             position: absolute;
-            left: 2px;
-            transition: transform var(--ffe-transition-duration) var(--ffe-ease)-in-out-back;
+            left: 4px;
+            transition: transform var(--ffe-transition-duration) var(--ffe-ease);
         }
 
         @media (hover: hover) and (pointer: fine) {
@@ -80,7 +80,7 @@
     }
 
     &__input:checked + &__label &__switch::after {
-        transform: translateX(27px);
+        transform: translateX(24px);
     }
 
     &__input:checked + &__label &__switch::before {


### PR DESCRIPTION
Som en del av å få et mer moderne utseende i Sparebank1, har vi jobbet med å modernisere komponenter. Denne PRen er for modernisering av skjemaelementer. Kan finnes i DS 2.0 Core i Figma. 
https://www.figma.com/design/0trRkHBkdZ6emkhwPJAJMy/DS-2.0-Core---semantiske-farger?node-id=18547-40423

Man kan ignorere fargebruken siden den blir oppdatert med semantiske farger. 

Ting å tenke på når man skal teste
- Focus, hover, Hover on focus, focus med tastatur
- Error (fieldmessage), error focus osv. 
- Darkmode med alle disse modsene 

Alle skjemaelementer er med i denne committen. 
![image](https://github.com/user-attachments/assets/72219264-a197-416a-a108-981e0d5d0c10)

Tooltip er her en del av Form, men det har kommet inn endringsønsker og det anses som en større greie å endre denne. 

Checkbox har ikke fått helt riktig ikon, men det kan også endres på senere. 

fixes #[#2448](https://github.com/SpareBank1/designsystem/issues/2448)