### PR TITLE
chore: Kjør lint før build

### DIFF
--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -15,8 +15,8 @@ jobs:
               with:
                   node-version: 18
             - run: npm install
-            - run: npm run build
             - run: npm run lint
+            - run: npm run build
             - run: npm test -- --ci
             - name: Build component overview page
               if: ${{ !github.event.pull_request.head.repo.fork }}


### PR DESCRIPTION
Kjør lint før build for å få semantisk farger til å bygge riktig da vi ikke genererer fargene med formatering som lintingen støtter
