### PR TITLE
chore: fix tokens file path

### DIFF
--- a/.github/workflows/sync-figma-to-tokens.yml
+++ b/.github/workflows/sync-figma-to-tokens.yml
@@ -29,7 +29,7 @@ jobs:
               run: npm install
 
             - name: Sync variables in Figma file to tokens
-              run: npm run sync-figma-to-tokens -- --output tokens
+              run: npm run sync-figma-to-tokens -- --output packages/ffe-core/tokens
               env:
                   FILE_KEY: ${{ github.event.inputs.file_key }}
                   PERSONAL_ACCESS_TOKEN: ${{ secrets.GH_ACTION_VARIABLES_SYNC_FIGMA_TOKEN }}


### PR DESCRIPTION
Workflowen vi lastet opp her https://github.com/SpareBank1/designsystem/pull/2463 hadde ikke helt riktig path. 

Oppdatert til å legge seg inn i ffe-core/tokens
