### PR TITLE
Oppdater klassenavnet for å skru på accent mode

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -65,7 +65,7 @@ const preview: Preview = {
                         )}
                     {(scheme === 'both' || scheme === 'light') &&
                         (accent === 'both' || accent === 'accent') && (
-                            <div className="ffe-docs-content-container accent">
+                            <div className="ffe-docs-content-container ffe-accent-mode">
                                 <Story />
                             </div>
                         )}
@@ -77,7 +77,7 @@ const preview: Preview = {
                         )}
                     {(scheme === 'both' || scheme === 'dark') &&
                         (accent === 'both' || accent === 'accent') && (
-                            <div className="ffe-docs-content-container dark-mode regard-color-scheme-preference accent">
+                            <div className="ffe-docs-content-container dark-mode regard-color-scheme-preference ffe-accent-mode">
                                 <Story />
                             </div>
                         )}

--- a/packages/ffe-core/scripts/generate-semantic-colors.js
+++ b/packages/ffe-core/scripts/generate-semantic-colors.js
@@ -138,7 +138,7 @@ function filePath(filename) {
 
 function generateSemanticColors() {
     let cssContent = '// Generated from Figma tokens';
-    cssContent += `\n\n// Context accent \n.accent {\n${convertContextJsonToCss(filePath(files.contextAccent)).join('\n')}}\n`;
+    cssContent += `\n\n// Context accent \n.ffe-accent-mode {\n${convertContextJsonToCss(filePath(files.contextAccent)).join('\n')}}\n`;
     cssContent += `\n\n// Context \n:root,\n:host {\n${convertContextJsonToCss(filePath(files.context)).join('\n')}}\n`;
     cssContent += `\n\n${convertSemanticJsonToCss(filePath(files.semanticLight))}`;
     cssContent += `\n\n${convertSemanticJsonToCss(filePath(files.semanticDark), filePath(files.context), filePath(files.contextAccent))}`;


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse
Endrer klassenavnet som brukes for å skru på accent mode fra `accent` til `ffe-accent-mode`. 

Det er egentlig en breaking change, men kommer så raskt etter sist release at ingen vil ha rukket å oppdatere. 

Hvem enn leser dette, tilgi oss for våre versjoneringssynder.