### PR TITLE
fix(ffe-messages): add mask image css variable on icon inside ffe-messages

### DIFF
--- a/buildtool/config/stylelint.config.js
+++ b/buildtool/config/stylelint.config.js
@@ -9,7 +9,7 @@ module.exports = {
             },
         ],
         'media-feature-name-no-vendor-prefix': true,
-        'property-no-vendor-prefix': true,
+        'property-no-vendor-prefix': null,
         'selector-max-specificity': [
             '0,3,0',
             {

--- a/packages/ffe-messages/less/common.less
+++ b/packages/ffe-messages/less/common.less
@@ -68,7 +68,6 @@
         color: var(--text-color);
     }
 
-
     &__background {
         background: var(--background);
         border-radius: var(--ffe-g-border-radius-lg);
@@ -76,19 +75,19 @@
     }
 
     &--context {
-         --icon-size: var(--ffe-v-icons-size-lg);
-         --icon-padding: var(--ffe-spacing-xs);
+        --icon-size: var(--ffe-v-icons-size-lg);
+        --icon-padding: var(--ffe-spacing-xs);
 
-         .ffe-message__heading {
-             font-size: var(--ffe-fontsize-h6);
-             margin: 0 0 var(--ffe-spacing-2xs);
-         }
+        .ffe-message__heading {
+            font-size: var(--ffe-fontsize-h6);
+            margin: 0 0 var(--ffe-spacing-2xs);
+        }
 
         &.ffe-message--context-compact {
             --icon-size: var(--ffe-v-icons-size-md);
             --icon-padding: var(--ffe-spacing-2xs);
         }
-     }
+    }
 }
 
 .ffe-message__icon-container {
@@ -200,6 +199,7 @@
     mask-position: center;
     background-color: currentcolor;
     mask-image: var(--mask-image);
+    -webkit-mask-image: var(--mask-image);
     height: var(--icon-size);
     aspect-ratio: 1;
     mask-size: contain;


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse

<!-- Detaljert beskrivelse av endringene dine. Skjermskudd er lov. -->

<MessageBox type="info"> har ikke ikon på eldre versjoner av chrome.

## Motivasjon og kontekst

<!-- Hvorfor trengs denne endringen, og hva løser den? -->

Ved å legge til webkit-mask-image vil vi være bakoverkompatible.

## Testing

<!-- Hvordan har du har testet endringene dine? Ta gjerne med systeminfo o.l -->

<!--

Helt til slutt, har du ..

.. lest retningslinjene våre for bidrag?
.. tatt en siste sjekk for kode og skrivefeil, debug informasjon o.l?
.. kjørt og eventuelt oppdatert testene?
.. kommentert og dokumentert det som trengs?
.. knyttet denne opp til relaterte issues?

-->
