### PR TITLE
chore(buildtool): ignorer genererte fargefiler fra linting

### DIFF
--- a/buildtool/config/stylelint.config.js
+++ b/buildtool/config/stylelint.config.js
@@ -1,5 +1,42 @@
 module.exports = {
     extends: ['stylelint-config-standard', '@sb1/stylelint-config-ffe'],
+    ignoreFiles: [
+        '**/colors-semantic.less',
+        '**/colors-semantic-storybook.less',
+    ],
+    overrides: [
+        {
+            files: [
+                '**/colors-semantic.less',
+                '**/colors-semantic-storybook.less',
+            ],
+            rules: {
+                'selector-class-pattern': null,
+                'no-duplicate-selectors': null,
+                'color-hex-length': null,
+            },
+        },
+        {
+            files: ['**/*.less'],
+            customSyntax: 'postcss-less',
+            rules: {
+                'color-function-notation': null,
+                'import-notation': 'string',
+                '@sb1/ffe-no-deprecated-color-vars': [
+                    true,
+                    {
+                        severity: 'warning',
+                    },
+                ],
+                'function-no-unknown': [
+                    true,
+                    {
+                        ignoreFunctions: ['extend', 'fade', 'data-uri', 'e'],
+                    },
+                ],
+            },
+        },
+    ],
     rules: {
         'at-rule-no-vendor-prefix': true,
         'max-nesting-depth': [
@@ -56,26 +93,4 @@ module.exports = {
             },
         ],
     },
-    overrides: [
-        {
-            files: ['**/*.less'],
-            customSyntax: 'postcss-less',
-            rules: {
-                'color-function-notation': null,
-                'import-notation': 'string',
-                '@sb1/ffe-no-deprecated-color-vars': [
-                    true,
-                    {
-                        severity: 'warning',
-                    },
-                ],
-                'function-no-unknown': [
-                    true,
-                    {
-                        ignoreFunctions: ['extend', 'fade', 'data-uri', 'e'],
-                    },
-                ],
-            },
-        },
-    ],
 };


### PR DESCRIPTION
Ignorerer colors-semantic.less og -storybook.less fra stylelint siden de er generert fra Figma.

<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse

<!-- Detaljert beskrivelse av endringene dine. Skjermskudd er lov. -->

Dette var nødvendig for å få linting til å fungere lokalt.

## Motivasjon og kontekst

<!-- Hvorfor trengs denne endringen, og hva løser den? -->

## Testing

<!-- Hvordan har du har testet endringene dine? Ta gjerne med systeminfo o.l -->

<!--

Helt til slutt, har du ..

.. lest retningslinjene våre for bidrag?
.. tatt en siste sjekk for kode og skrivefeil, debug informasjon o.l?
.. kjørt og eventuelt oppdatert testene?
.. kommentert og dokumentert det som trengs?
.. knyttet denne opp til relaterte issues?

-->
