### PR TITLE
Eksporter SizeModifier i ffe-grid-react

### DIFF
--- a/packages/ffe-grid-react/src/GridCol.tsx
+++ b/packages/ffe-grid-react/src/GridCol.tsx
@@ -4,42 +4,8 @@ import {
     BackgroundColor,
     BackgroundColorDark,
     ComponentWithoutRefAsPropParams,
+    SizeModifier,
 } from './types';
-
-type ColumnsRange =
-    | 0
-    | 1
-    | 2
-    | 3
-    | 4
-    | 5
-    | 6
-    | 7
-    | 8
-    | 9
-    | 10
-    | 11
-    | 12
-    | '0'
-    | '1'
-    | '2'
-    | '3'
-    | '4'
-    | '5'
-    | '6'
-    | '7'
-    | '8'
-    | '9'
-    | '10'
-    | '11'
-    | '12';
-
-interface GridColSize {
-    cols: ColumnsRange;
-    offset?: ColumnsRange;
-}
-
-type SizeModifier = ColumnsRange | GridColSize;
 
 export type GridColProps<As extends ElementType = any> =
     ComponentWithoutRefAsPropParams<As> & {

--- a/packages/ffe-grid-react/src/types.ts
+++ b/packages/ffe-grid-react/src/types.ts
@@ -52,3 +52,38 @@ export type BackgroundColor =
     | 'hvit';
 
 export type BackgroundColorDark = 'svart' | 'natt' | 'koksgraa';
+
+type ColumnsRange =
+    | 0
+    | 1
+    | 2
+    | 3
+    | 4
+    | 5
+    | 6
+    | 7
+    | 8
+    | 9
+    | 10
+    | 11
+    | 12
+    | '0'
+    | '1'
+    | '2'
+    | '3'
+    | '4'
+    | '5'
+    | '6'
+    | '7'
+    | '8'
+    | '9'
+    | '10'
+    | '11'
+    | '12';
+
+interface GridColSize {
+    cols: ColumnsRange;
+    offset?: ColumnsRange;
+}
+
+export type SizeModifier = ColumnsRange | GridColSize;


### PR DESCRIPTION
## Beskrivelse

Flyttet SizeModifier og støtte typene den trenger til types.ts i ffe-grid-react

## Motivasjon og kontekst

I kundefronten vår trenger vi å bruke SizeModifier typen, og det ville vært mye enklere for oss å bare kunne importere den fra designsystemet enn å måtte lage en kopi i vår egen kodebase.

## Testing

Ikke gjort noe testing på dette, men det er ingen funksjonelle endringer. Jeg har bare flyttet på noen typer/interfaces :smile: 

