### PR TITLE
fix(ffe-cards-react): Reverter endring av bgColor property name

### DIFF
--- a/packages/ffe-cards-react/src/CardBase.tsx
+++ b/packages/ffe-cards-react/src/CardBase.tsx
@@ -15,7 +15,7 @@ export type CardBaseProps<As extends ElementType = 'div'> = Omit<
     /** No margin on card */
     noMargin?: boolean;
     textCenter?: boolean;
-    backgroundColor?: BackgroundColor;
+    bgColor?: BackgroundColor;
     noPadding?: boolean;
     children: WithCardActionProps['children'] | React.ReactNode;
 };
@@ -28,7 +28,7 @@ function CardBaseWithForwardRef<As extends ElementType>(
         className,
         noMargin,
         textCenter,
-        backgroundColor = 'primary',
+        bgColor = 'primary',
         noPadding,
         children,
         ...rest
@@ -38,7 +38,7 @@ function CardBaseWithForwardRef<As extends ElementType>(
         <WithCardAction
             baseClassName="ffe-card-base"
             className={classNames('ffe-card-base', className, {
-                [`ffe-card-base--bg-${backgroundColor}`]: backgroundColor,
+                [`ffe-card-base--bg-${bgColor}`]: bgColor,
                 'ffe-card-base--no-margin': noMargin,
                 'ffe-card-base--text-center': textCenter,
                 'ffe-card-base--no-padding': noPadding,

--- a/packages/ffe-cards-react/src/GroupCard/GroupCard.tsx
+++ b/packages/ffe-cards-react/src/GroupCard/GroupCard.tsx
@@ -8,7 +8,7 @@ export interface GroupCardProps
     /** The children of the GroupCard component */
     children: React.ReactNode;
     /** The background color of the whole groupcard element */
-    backgroundColor?: BackgroundColor;
+    bgColor?: BackgroundColor;
     /** No margin on card */
     noMargin?: boolean;
 }
@@ -17,7 +17,7 @@ function GroupCardWithForwardRef(
     {
         className,
         children,
-        backgroundColor = 'primary',
+        bgColor = 'primary',
         noMargin,
         ...rest
     }: GroupCardProps,
@@ -29,7 +29,7 @@ function GroupCardWithForwardRef(
                 'ffe-group-card',
                 {
                     'ffe-group-card--no-margin': noMargin,
-                    [`ffe-group-card--bg-${backgroundColor}`]: backgroundColor,
+                    [`ffe-group-card--bg-${bgColor}`]: bgColor,
                 },
                 className,
             )}


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse

`backgroundColor` -> `bgColor` for consistent property navngiving

<!-- Detaljert beskrivelse av endringene dine. Skjermskudd er lov. -->

## Motivasjon og kontekst

<!-- Hvorfor trengs denne endringen, og hva løser den? -->

## Testing

<!-- Hvordan har du har testet endringene dine? Ta gjerne med systeminfo o.l -->

<!--

Helt til slutt, har du ..

.. lest retningslinjene våre for bidrag?
.. tatt en siste sjekk for kode og skrivefeil, debug informasjon o.l?
.. kjørt og eventuelt oppdatert testene?
.. kommentert og dokumentert det som trengs?
.. knyttet denne opp til relaterte issues?

-->
