### PR TITLE
fix(ffe-cards-react): retter oppdatert prop i test

### DIFF
--- a/packages/ffe-cards-react/src/CardBase.spec.tsx
+++ b/packages/ffe-cards-react/src/CardBase.spec.tsx
@@ -28,7 +28,7 @@ describe('<CardBase/>', () => {
 
     it('should set bgColor-prop correctly', () => {
         render(
-            <CardBase data-testid={TEST_ID} backgroundColor="secondary">
+            <CardBase data-testid={TEST_ID} bgColor="secondary">
                 <div />
             </CardBase>,
         );


### PR DESCRIPTION
Denne brakk bygget i `semantiske-farger`-branchen