### PR TITLE
Legg til displayAttribute til SearchableDropdown og AccountSelector

### DIFF
--- a/packages/ffe-account-selector-react/src/account-selector/AccountSelector.mdx
+++ b/packages/ffe-account-selector-react/src/account-selector/AccountSelector.mdx
@@ -35,3 +35,7 @@ Dersom du ønsker å skjule kontodetaljer, kan du bruke `hideAccountDetails`.
 Dersom du ønsker å ha ekstra tekst på bunnen av lista, kan du bruke `postListElement`.
 
 <Canvas of={AccountSelectorStories.PostListElement} />
+
+Dersom du ønsker å vise en annen informasjon enn kontonavn i inputen, så kan du velge hvilken attribute som brukes med `displayAttribute`.
+
+<Canvas of={AccountSelectorStories.CustomDisplayAttribute} />

--- a/packages/ffe-account-selector-react/src/account-selector/AccountSelector.stories.tsx
+++ b/packages/ffe-account-selector-react/src/account-selector/AccountSelector.stories.tsx
@@ -3,6 +3,7 @@ import { AccountSelector } from './AccountSelector';
 import { InputGroup } from '@sb1/ffe-form-react';
 import type { StoryObj, Meta } from '@storybook/react';
 import { SmallText } from '@sb1/ffe-core-react';
+import { accountFormatter } from '../format';
 
 const meta: Meta<typeof AccountSelector> = {
     title: 'Komponenter/Account-selector/AccountSelector',
@@ -246,6 +247,44 @@ export const InitialValue: Story = {
                 labelId={args.labelledById}
             >
                 <AccountSelector
+                    {...args}
+                    selectedAccount={selectedAccount}
+                    onAccountSelected={setSelectedAccount}
+                />
+            </InputGroup>
+        );
+    },
+};
+
+type PrettyAccount = Account & { prettyName: string };
+
+const prettyAccounts: PrettyAccount[] = accounts.map(account => ({
+    ...account,
+    prettyName: `${account.name} - ${accountFormatter(account.accountNumber)}`,
+}));
+export const CustomDisplayAttribute: StoryObj<
+    typeof AccountSelector<PrettyAccount>
+> = {
+    args: {
+        id: 'input-id',
+        labelledById: 'label-id',
+        locale: 'nb',
+        formatAccountNumber: true,
+        allowCustomAccount: false,
+        displayAttribute: 'prettyName',
+        accounts: prettyAccounts,
+    },
+    render: function Render(args) {
+        const [selectedAccount, setSelectedAccount] = useState<PrettyAccount>(
+            prettyAccounts[2],
+        );
+        return (
+            <InputGroup
+                label="Velg konto"
+                inputId={args.id}
+                labelId={args.labelledById}
+            >
+                <AccountSelector<PrettyAccount>
                     {...args}
                     selectedAccount={selectedAccount}
                     onAccountSelected={setSelectedAccount}

--- a/packages/ffe-account-selector-react/src/account-selector/AccountSelector.tsx
+++ b/packages/ffe-account-selector-react/src/account-selector/AccountSelector.tsx
@@ -40,6 +40,8 @@ export interface AccountSelectorProps<T extends Account = Account> {
     formatAccountNumber?: boolean;
     /** id of element that labels input field */
     labelledById?: string;
+    /** Attribute used in the input when an item is selected. **/
+    displayAttribute?: keyof T;
     /**
      * Allows selecting the text the user writes even if it does not match anything in the accounts array.
      * Useful e.g. if you want to pay to account that is not in yur recipients list.
@@ -91,6 +93,7 @@ export const AccountSelector = <T extends Account = Account>({
     ariaInvalid,
     onOpen,
     onClose,
+    displayAttribute,
     ...rest
 }: AccountSelectorProps<T>) => {
     const [inputValue, setInputValue] = useState(selectedAccount?.name || '');
@@ -119,6 +122,7 @@ export const AccountSelector = <T extends Account = Account>({
             onAccountSelected({
                 name: value.name,
                 accountNumber: value.name,
+                ...(displayAttribute ? { [displayAttribute]: value.name } : {}),
             } as T);
             setInputValue(value.name);
         } else {
@@ -137,6 +141,7 @@ export const AccountSelector = <T extends Account = Account>({
             <SearchableDropdown<T>
                 id={id}
                 labelledById={labelledById}
+                displayAttribute={displayAttribute}
                 inputProps={{
                     ...inputProps,
                     onChange: onInputChange,
@@ -165,6 +170,13 @@ export const AccountSelector = <T extends Account = Account>({
                                           ? formatter(inputValue)
                                           : inputValue,
                                       accountNumber: '',
+                                      ...(displayAttribute
+                                          ? {
+                                                [displayAttribute]: formatter
+                                                    ? formatter(inputValue)
+                                                    : inputValue,
+                                            }
+                                          : {}),
                                   } as T,
                               ],
                           }
@@ -172,7 +184,11 @@ export const AccountSelector = <T extends Account = Account>({
                 }
                 formatter={formatter}
                 onChange={handleAccountSelected}
-                searchAttributes={['name', 'accountNumber']}
+                searchAttributes={[
+                    'name',
+                    'accountNumber',
+                    ...(displayAttribute ? [displayAttribute] : []),
+                ]}
                 locale={locale}
                 optionBody={({ item, isHighlighted, ...restOptionBody }) => {
                     if (OptionBody) {

--- a/packages/ffe-searchable-dropdown-react/src/getListToRender.ts
+++ b/packages/ffe-searchable-dropdown-react/src/getListToRender.ts
@@ -35,7 +35,7 @@ export const getListToRender = <Item extends Record<string, any>>({
     searchMatcher?: SearchMatcher<Item>;
     showAllItemsInDropdown: boolean;
 }): { noMatch: boolean; listToRender: Item[] } => {
-    const trimmedInput = inputValue ? inputValue.trim() : '';
+    const trimmedInput = inputValue ? String(inputValue).trim() : '';
 
     const shouldFilter = trimmedInput.length > 0;
 

--- a/packages/ffe-searchable-dropdown-react/src/single/SearchableDropdown.spec.tsx
+++ b/packages/ffe-searchable-dropdown-react/src/single/SearchableDropdown.spec.tsx
@@ -1026,4 +1026,33 @@ describe('SearchableDropdown', () => {
         await user.click(input);
         await screen.findByText('Dette er et postListElement!');
     });
+
+    it('allows passing a custom display attribute', async () => {
+        const onChange = jest.fn();
+        const user = userEvent.setup();
+
+        render(
+            <SearchableDropdown
+                id="id"
+                labelledById="labelId"
+                dropdownAttributes={['organizationName', 'organizationNumber']}
+                displayAttribute={'organizationNumber'}
+                dropdownList={companies}
+                onChange={onChange}
+                searchAttributes={['organizationName', 'organizationNumber']}
+                locale="nb"
+            />,
+        );
+
+        const input = screen.getByRole('combobox');
+
+        expect(input.getAttribute('value')).toBe('');
+        await user.type(input, 'Be');
+
+        await user.click(screen.getByText('Beslag skytter'));
+
+        expect(onChange).toHaveBeenCalledTimes(1);
+        expect(onChange).toHaveBeenCalledWith(companies[2]);
+        expect(input.getAttribute('value')).toEqual('812602552');
+    });
 });

--- a/packages/ffe-searchable-dropdown-react/src/single/SearchableDropdown.stories.tsx
+++ b/packages/ffe-searchable-dropdown-react/src/single/SearchableDropdown.stories.tsx
@@ -227,3 +227,27 @@ export const PostListElement: Story = {
         );
     },
 };
+
+export const CustomDisplayAttribute: Story = {
+    args: {
+        ...Standard.args,
+        displayAttribute: 'organizationNumber',
+        dropdownAttributes: ['organizationName', 'organizationNumber'],
+        searchAttributes: ['organizationNumber', 'organizationName'],
+    },
+    render: function Render({ id, labelledById, ...args }) {
+        return (
+            <InputGroup
+                label="Velg bedrift"
+                labelId={labelledById}
+                inputId={id}
+            >
+                <SearchableDropdown
+                    id={id}
+                    labelledById={labelledById}
+                    {...args}
+                />
+            </InputGroup>
+        );
+    },
+};

--- a/packages/ffe-searchable-dropdown-react/src/single/SearchableDropdown.tsx
+++ b/packages/ffe-searchable-dropdown-react/src/single/SearchableDropdown.tsx
@@ -51,6 +51,8 @@ export interface SearchableDropdownProps<Item extends Record<string, any>> {
     dropdownAttributes: (keyof Item)[];
     /** Array of attributes used when filtering search */
     searchAttributes: (keyof Item)[];
+    /** Attribute used in the input when an item is selected. Defaults to first in searchAttributes **/
+    displayAttribute?: keyof Item;
     /** Props used on input field */
     inputProps?: React.ComponentProps<'input'>;
     /** Limits number of rendered dropdown elements */
@@ -105,6 +107,7 @@ function SearchableDropdownWithForwardRef<Item extends Record<string, any>>(
         dropdownList,
         dropdownAttributes,
         searchAttributes,
+        displayAttribute = searchAttributes[0],
         maxRenderedDropdownElements = Number.MAX_SAFE_INTEGER,
         onChange,
         inputProps,
@@ -127,6 +130,7 @@ function SearchableDropdownWithForwardRef<Item extends Record<string, any>>(
     const [state, dispatch] = useReducer(
         createReducer({
             dropdownList,
+            displayAttribute: displayAttribute,
             searchAttributes,
             maxRenderedDropdownElements,
             noMatchDropdownList: noMatch?.dropdownList,
@@ -137,7 +141,8 @@ function SearchableDropdownWithForwardRef<Item extends Record<string, any>>(
             isExpanded: false,
             selectedItems: [],
             highlightedIndex: -1,
-            inputValue: selectedItem ? selectedItem[dropdownAttributes[0]] : '',
+            formattedInputValue: '',
+            inputValue: selectedItem ? selectedItem[displayAttribute] : '',
         },
         initialState => {
             return {
@@ -189,7 +194,7 @@ function SearchableDropdownWithForwardRef<Item extends Record<string, any>>(
         isLoading,
         locale,
         resultCount: state.listToRender.length,
-        selectedValue: state.selectedItem?.[searchAttributes[0]],
+        selectedValue: state.selectedItem?.[displayAttribute],
     });
 
     useLayoutEffect(() => {

--- a/packages/ffe-searchable-dropdown-react/src/single/reducer.ts
+++ b/packages/ffe-searchable-dropdown-react/src/single/reducer.ts
@@ -24,6 +24,7 @@ export const createReducer =
     <Item extends Record<string, any>>({
         searchAttributes,
         dropdownList,
+        displayAttribute,
         noMatchDropdownList,
         maxRenderedDropdownElements,
         searchMatcher,
@@ -31,6 +32,7 @@ export const createReducer =
     }: {
         dropdownList: Item[];
         searchAttributes: Array<keyof Item>;
+        displayAttribute: keyof Item;
         noMatchDropdownList: Item[] | undefined;
         maxRenderedDropdownElements: number;
         searchMatcher: SearchMatcher<Item> | undefined;
@@ -38,16 +40,17 @@ export const createReducer =
     }) =>
     (state: State<Item>, action: Action<Item>): State<Item> => {
         switch (action.type) {
-            case 'InputKeyDownEscape':
+            case 'InputKeyDownEscape': {
                 return {
                     ...state,
                     noMatch: false,
                     isExpanded: false,
                     highlightedIndex: -1,
                     inputValue: state.selectedItem
-                        ? state.selectedItem[searchAttributes[0]]
+                        ? state.selectedItem[displayAttribute]
                         : '',
                 };
+            }
             case 'InputClick': {
                 const { noMatch, listToRender } = getListToRender({
                     inputValue: state.inputValue,
@@ -90,23 +93,24 @@ export const createReducer =
                     noMatch,
                 };
             }
-            case 'ToggleButtonPressed':
+            case 'ToggleButtonPressed': {
                 return {
                     ...state,
                     isExpanded: !state.isExpanded,
                 };
+            }
             case 'ItemSelectedProgrammatically':
             case 'ItemOnClick':
-            case 'InputKeyDownEnter':
+            case 'InputKeyDownEnter': {
                 return {
                     ...state,
                     isExpanded: false,
                     highlightedIndex: -1,
                     selectedItem: action.payload?.selectedItem,
                     inputValue:
-                        action.payload?.selectedItem?.[searchAttributes[0]] ||
-                        '',
+                        action.payload?.selectedItem?.[displayAttribute] || '',
                 };
+            }
 
             case 'InputKeyDownArrowDown':
             case 'InputKeyDownArrowUp': {
@@ -153,7 +157,7 @@ export const createReducer =
                 }
 
                 const inputValue = selectedItem
-                    ? selectedItem[searchAttributes[0]]
+                    ? selectedItem[displayAttribute]
                     : '';
                 return {
                     ...state,


### PR DESCRIPTION
## Beskrivelse
Legger til en prop kalt `displayAttribute` i `SearchableDropdown` og `AccountSelector`.
Denne propen lar deg overstyre hvilket element i objektene sendt inn (`Item/T extends Account`) som er brukt til visning i input elementet. 

Defaulten før var det første elementet i `searchAttributes` (ble navn), det er fortsatt samme default

Disse endringene burde ikke har noe å si for eksisterende bruk, kun for nye. 

Viktig å få med seg endringen i `AccountSelector` på søk. Jeg ble nød til å legge til den nye `displayAttribute` propen til `searchAttributes` sendt videre til `SearchableDropdown` komponenten, for å ikke få "Ingen konto funnet" når man prøver å endre inputen etter det er valgt et element.

Skjermbilde på `SearchableDropdown`:
 ![Screenshot 2025-02-26 at 12 44 30](https://github.com/user-attachments/assets/a4490841-18a7-452d-b1dc-6d02c1cde6a5)

Skjermbilde på `AccountSelector`:
![Screenshot 2025-02-26 at 12 45 10](https://github.com/user-attachments/assets/dc98eddf-571f-4d54-b5ad-0912f9fd6bce)

Lagt inn ny story i StoryBook-en til` AccountSelector` for å vise bruk.
Også lagt til nye tester på begge komponenter som verifiserer at dette funker.

## Motivasjon og kontekst
Vi i team sparing ønsker å vise mer enn bare konto navn på Spareoversikt konto velgeren. Er flere brukere som har samme navn på flere kontoer. Vi ønsker at det skal vises slik i `AccountSelector-en`: "Kontonavn - Kontonummer" 

Se skjermbilde
![Screenshot 2025-02-26 at 13 00 30](https://github.com/user-attachments/assets/d5be3b80-5e42-4ba3-a2e0-1ebde5b0ae32)

Men vi ønsker ikke å bytte navn på kontoene i nedtrekksmenyen. 
Så dette viser seg å være vanskelig med dagens løsning. 

Disse endringene gjør det mulig å få til det som er ønsket

## Testing
Lagt til jest tester
Lagt inn nye stories i StoryBook-en som viser bruk og eksempler
