### PR TITLE
Searchabledropdown: Fikser semantiske farger. Fjerner at chevronen oppfører seg som en knapp

### DIFF
--- a/packages/ffe-searchable-dropdown-react/less/searchable-dropdown.less
+++ b/packages/ffe-searchable-dropdown-react/less/searchable-dropdown.less
@@ -1,6 +1,6 @@
 .ffe-searchable-dropdown {
     --button-width: 40px;
-    --border-width: 2px;
+    --border-width: var(--ffe-g-border-width);
     --border-color: var(--ffe-color-border-primary-default);
     --detail-text-color: var(
         --ffe-color-component-form-input-foreground-on-fill-subtle
@@ -17,25 +17,24 @@
     border-radius: var(--ffe-g-border-radius);
     transition: all var(--ffe-transition-duration) var(--ffe-ease);
     color: var(--text-color);
+    border: var(--border-width) solid var(--border-color);
+    transition: all var(--ffe-transition-duration) var(--ffe-ease);
+
     :where(.ffe-searchable-dropdown__button) {
         all: unset;
     }
-    &__input,
-    &__button {
-        border: var(--border-width) solid var(--border-color);
-        transition: all var(--ffe-transition-duration) var(--ffe-ease);
-        @media (hover: hover) and (pointer: fine) {
-            &:hover {
-                --border-color: var(--ffe-color-border-primary-hover);
-            }
+    @media (hover: hover) and (pointer: fine) {
+        &:hover {
+            --border-color: var(--ffe-color-border-primary-hover);
+            box-shadow: 0 0 0 1px var(--ffe-color-border-primary-hover);
         }
     }
-    &:has(input:focus-visible, input:active) {
-        .ffe-searchable-dropdown__button,
-        .ffe-searchable-dropdown__input {
-            --border-color: var(--ffe-color-border-primary-selected);
-        }
+
+    &:focus-within {
+        --border-color: var(--ffe-color-border-primary-selected);
+        box-shadow: 0 0 0 1px var(--ffe-color-border-primary-selected);
     }
+
     &__input {
         display: grid;
         border-radius: var(--ffe-g-border-radius) 0 0 var(--ffe-g-border-radius);
@@ -46,12 +45,6 @@
                 --border-color: var(--ffe-color-border-primary-hover);
             }
         }
-        &:focus-within {
-            --border-color: var(--ffe-color-border-primary-selected);
-            & + .ffe-searchable-dropdown__button {
-                --border-color: var(--ffe-color-border-primary-selected);
-            }
-        }
     }
     &__button {
         cursor: pointer;
@@ -60,21 +53,8 @@
         border-left: none;
         border-radius: 0 var(--ffe-g-border-radius) var(--ffe-g-border-radius) 0;
         .ffe-icons {
-            color: var(--ffe-g-primary-color);
+            color: var(--ffe-color-foreground-default);
             display: block;
-        }
-        &--hidden {
-            display: none;
-        }
-        &:focus-visible {
-            --border-color: var(--ffe-color-border-primary--selected);
-            border-left: var(--border-width) solid var(--border-color);
-        }
-        @media (hover: hover) and (pointer: fine) {
-            &:hover {
-                --border-color: var(--ffe-color-border-primary-hover);
-                border-left: var(--border-width) solid var(--border-color);
-            }
         }
         &-icon {
             transition:
@@ -150,7 +130,7 @@
             }
         }
         &--highlighted {
-            background: var(--ffe-color-surface-primary-default);
+            background: var(--ffe-color-surface-primary-default-hover);
         }
     }
     &__list-item-body-details {

--- a/packages/ffe-searchable-dropdown-react/src/ToggleButton.tsx
+++ b/packages/ffe-searchable-dropdown-react/src/ToggleButton.tsx
@@ -1,28 +1,19 @@
 import React from 'react';
-import { getButtonLabelClose, getButtonLabelOpen } from './translations';
 import classNames from 'classnames';
 import { Spinner } from '@sb1/ffe-spinner-react';
 import { Icon } from '@sb1/ffe-icons-react';
-import { Locale } from './types';
 
 interface Props {
-    locale: Locale;
     isExpanded: boolean;
     onClick: () => void;
     isLoading: boolean;
 }
 
 export const ToggleButton = React.forwardRef<HTMLButtonElement, Props>(
-    ({ locale, isExpanded, onClick, isLoading }, ref) => {
+    ({ isExpanded, onClick, isLoading }, ref) => {
         return (
-            <button
-                type="button"
-                ref={ref}
-                aria-label={
-                    isExpanded
-                        ? getButtonLabelClose(locale)
-                        : getButtonLabelOpen(locale)
-                }
+            <div
+                aria-hidden="true"
                 className={classNames('ffe-searchable-dropdown__button', {
                     'ffe-searchable-dropdown__button--flip': isExpanded,
                 })}
@@ -37,7 +28,7 @@ export const ToggleButton = React.forwardRef<HTMLButtonElement, Props>(
                         className="ffe-searchable-dropdown__button-icon"
                     />
                 )}
-            </button>
+            </div>
         );
     },
 );

--- a/packages/ffe-searchable-dropdown-react/src/moveFocusOutside.ts
+++ b/packages/ffe-searchable-dropdown-react/src/moveFocusOutside.ts
@@ -1,0 +1,64 @@
+import { SearchMatcher, State } from './types';
+import { getListToRender } from './getListToRender';
+
+export const moveFocusOutside = <Item extends Record<string, any>>({
+    state,
+    searchAttributes,
+    maxRenderedDropdownElements,
+    dropdownList,
+    noMatchDropdownList,
+    searchMatcher,
+    displayAttribute,
+    onChange,
+}: {
+    state: State<Item>;
+    searchAttributes: Array<keyof Item>;
+    maxRenderedDropdownElements: number;
+    dropdownList: Item[];
+    noMatchDropdownList: Item[] | undefined;
+    searchMatcher: SearchMatcher<Item> | undefined;
+    displayAttribute: keyof Item;
+    onChange: ((item: Item | null) => void) | undefined;
+}): {
+    inputValue: string;
+    selectedItem: Item | undefined;
+    listToRender: Item[];
+} => {
+    const { listToRender } = getListToRender({
+        inputValue: state.inputValue,
+        searchAttributes,
+        maxRenderedDropdownElements,
+        dropdownList,
+        noMatchDropdownList,
+        searchMatcher,
+        showAllItemsInDropdown: true,
+    });
+
+    const shouldEmptySelectedItem =
+        state.inputValue === '' && !!state.selectedItem;
+
+    const shouldAutomaticallySetSelectedItem =
+        state.listToRender.length === 1 &&
+        searchAttributes
+            .map(
+                searchAttribute =>
+                    state.listToRender[0][searchAttribute] ===
+                    state.selectedItem?.[searchAttribute],
+            )
+            .includes(false) &&
+        state.highlightedIndex !== -1;
+
+    let selectedItem = state.selectedItem;
+
+    if (shouldEmptySelectedItem) {
+        onChange?.(null);
+        selectedItem = undefined;
+    } else if (shouldAutomaticallySetSelectedItem) {
+        onChange?.(state.listToRender[0]);
+        selectedItem = state.listToRender[0];
+    }
+
+    const inputValue = selectedItem ? selectedItem[displayAttribute] : '';
+
+    return { inputValue, selectedItem, listToRender };
+};

--- a/packages/ffe-searchable-dropdown-react/src/multi/SearchableDropdownMultiSelect.spec.tsx
+++ b/packages/ffe-searchable-dropdown-react/src/multi/SearchableDropdownMultiSelect.spec.tsx
@@ -193,7 +193,7 @@ describe('SearchableDropdownMultiSelect', () => {
 
         const input = screen.getByRole('combobox');
         await user.click(input);
-        await user.type(input, 'some thing without a match');
+        await user.type(input, 'something without a match');
 
         expect(screen.getByText(noMatchText)).toBeInTheDocument();
         expect(screen.getByText('Rør og sånt')).toBeInTheDocument();
@@ -208,6 +208,66 @@ describe('SearchableDropdownMultiSelect', () => {
         expect(screen.queryByText('812602399')).toBeNull();
         expect(screen.queryByText('Kaffekoppen')).toBeNull();
         expect(screen.queryByText('812602222')).toBeNull();
+    });
+
+    it('should open and close using tab', async function () {
+        const user = userEvent.setup();
+        const onChangeMultiSelect = jest.fn();
+
+        render(
+            <SearchableDropdownMultiSelect
+                id="id"
+                labelledById="labelId"
+                dropdownAttributes={['organizationName', 'organizationNumber']}
+                dropdownList={companies}
+                searchAttributes={['organizationName', 'organizationNumber']}
+                locale="nb"
+                onChange={onChangeMultiSelect}
+                selectedItems={[]}
+            />,
+        );
+
+        await user.tab();
+
+        expect(screen.getByText('Bedriften')).toBeInTheDocument();
+        expect(screen.getByText('912602370')).toBeInTheDocument();
+        expect(screen.queryByText('Sønn & co')).toBeInTheDocument();
+        expect(screen.queryByText('812602372')).toBeInTheDocument();
+        expect(screen.getByText('Beslag skytter')).toBeInTheDocument();
+        expect(screen.getByText('812602552')).toBeInTheDocument();
+
+        await user.tab();
+
+        expect(screen.queryByText('Bedriften')).toBeNull();
+        expect(screen.queryByText('912602370')).toBeNull();
+        expect(screen.queryByText('Beslag skytter')).toBeNull();
+        expect(screen.queryByText('812602552')).toBeNull();
+    });
+
+    it('should navigate to selected items using tab', async function () {
+        const user = userEvent.setup();
+        const onChangeMultiSelect = jest.fn();
+
+        render(
+            <SearchableDropdownMultiSelect
+                id="id"
+                labelledById="labelId"
+                dropdownAttributes={['organizationName', 'organizationNumber']}
+                dropdownList={companies}
+                searchAttributes={['organizationName', 'organizationNumber']}
+                locale="nb"
+                onChange={onChangeMultiSelect}
+                selectedItems={[companies[0], companies[1]]}
+            />,
+        );
+
+        const input = screen.getByRole('combobox');
+        await user.click(input);
+        expect(input).toHaveFocus();
+
+        await userEvent.keyboard('{Shift>}{Tab}{/Shift}');
+
+        expect(screen.getByLabelText('Sønn & co, fjern valg')).toHaveFocus();
     });
 
     it('should be a wai-aria 1.0 combobox', async () => {

--- a/packages/ffe-searchable-dropdown-react/src/multi/SearchableDropdownMultiSelect.tsx
+++ b/packages/ffe-searchable-dropdown-react/src/multi/SearchableDropdownMultiSelect.tsx
@@ -174,13 +174,11 @@ function SearchableDropdownMultiSelectWithForwardRef<
     const refs = useRefs({ listToRender: state.listToRender });
     const [hasFocus, setHasFocus] = useState(false);
     const inputRef = useRef<HTMLInputElement>(null);
-    const toggleButtonRef = useRef<HTMLButtonElement>(null);
     const containerRef = useRef<HTMLDivElement>(null);
 
     const OptionBody = CustomOptionBody || MultiselectOptionBody;
     const listBoxRef = useRef<HTMLDivElement>(null);
     const noMatchMessageId = useId();
-    const shouldFocusToggleButton = useRef(false);
     const shouldFocusInput = useRef(false);
     const [showChips, setShowChips] = useState(true);
 
@@ -208,10 +206,7 @@ function SearchableDropdownMultiSelectWithForwardRef<
     });
 
     useLayoutEffect(() => {
-        if (shouldFocusToggleButton.current) {
-            toggleButtonRef.current?.focus();
-            shouldFocusToggleButton.current = false;
-        } else if (shouldFocusInput.current) {
+        if (shouldFocusInput.current) {
             inputRef.current?.focus();
             shouldFocusInput.current = false;
         }
@@ -225,7 +220,7 @@ function SearchableDropdownMultiSelectWithForwardRef<
 
     useIsExpandedCallbacks({ isExpanded: state.isExpanded, onClose, onOpen });
 
-    const handelFocusMovedOutside = useCallback(
+    const handleFocusMovedOutside = useCallback(
         () =>
             dispatch({
                 type: 'FocusMovedOutSide',
@@ -256,7 +251,7 @@ function SearchableDropdownMultiSelectWithForwardRef<
     useHandleContainerFocus({
         id,
         containerRef,
-        handelFocusMovedOutside,
+        handleFocusMovedOutside,
     });
 
     const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
@@ -345,8 +340,7 @@ function SearchableDropdownMultiSelectWithForwardRef<
             }
         } else if (event.key === TAB) {
             dispatch({
-                type: 'TabPressed',
-                payload: { highlightedIndex: -1 },
+                type: 'FocusMovedOutSide',
             });
             return;
         }
@@ -429,7 +423,10 @@ function SearchableDropdownMultiSelectWithForwardRef<
                             payload: { inputValue: e.target.value },
                         });
                     }}
-                    onFocus={() => setHasFocus(true)}
+                    onFocus={() => {
+                        setHasFocus(true);
+                        dispatch({ type: 'InputClick' });
+                    }}
                     onBlur={handleInputBlur}
                     aria-describedby={
                         [
@@ -462,17 +459,14 @@ function SearchableDropdownMultiSelectWithForwardRef<
                 />
             </div>
             <ToggleButton
-                ref={toggleButtonRef}
                 isExpanded={state.isExpanded}
                 onClick={() =>
                     dispatch({
                         type: 'ToggleButtonPressed',
                     })
                 }
-                locale={locale}
                 isLoading={isLoading}
             />
-
             <ListBox ref={listBoxRef} isExpanded={state.isExpanded}>
                 {state.isExpanded && (
                     <Results

--- a/packages/ffe-searchable-dropdown-react/src/multi/reducer.ts
+++ b/packages/ffe-searchable-dropdown-react/src/multi/reducer.ts
@@ -168,13 +168,6 @@ export const createReducer =
                 }
                 return state;
             }
-            case 'TabPressed': {
-                return {
-                    ...state,
-                    highlightedIndex: -1,
-                };
-            }
-
             case 'FocusMovedOutSide': {
                 return {
                     ...state,

--- a/packages/ffe-searchable-dropdown-react/src/single/SearchableDropdown.spec.tsx
+++ b/packages/ffe-searchable-dropdown-react/src/single/SearchableDropdown.spec.tsx
@@ -246,11 +246,9 @@ describe('SearchableDropdown', () => {
             />,
         );
 
-        const openButton = screen.getByRole('button', {
-            name: /åpne alternativer/i,
-        });
+        const input = screen.getByRole('combobox');
 
-        await user.click(openButton);
+        await user.click(input);
 
         expect(screen.getByText('Bedriften')).toBeInTheDocument();
         expect(screen.getByText('912602370')).toBeInTheDocument();
@@ -259,11 +257,43 @@ describe('SearchableDropdown', () => {
         expect(screen.getByText('Beslag skytter')).toBeInTheDocument();
         expect(screen.getByText('812602552')).toBeInTheDocument();
 
-        const closeButton = screen.getByRole('button', {
-            name: /lukk alternativer/i,
-        });
-
+        const closeButton = document.getElementsByClassName(
+            'ffe-searchable-dropdown__button',
+        )[0];
         await user.click(closeButton);
+
+        expect(screen.queryByText('Bedriften')).toBeNull();
+        expect(screen.queryByText('912602370')).toBeNull();
+        expect(screen.queryByText('Sønn & co')).toBeNull();
+        expect(screen.queryByText('812602372')).toBeNull();
+        expect(screen.queryByText('Beslag skytter')).toBeNull();
+        expect(screen.queryByText('812602552')).toBeNull();
+    });
+
+    it('should open and close using tab', async function () {
+        const user = userEvent.setup();
+
+        render(
+            <SearchableDropdown
+                id="id"
+                labelledById="labelId"
+                dropdownAttributes={['organizationName', 'organizationNumber']}
+                dropdownList={companies}
+                searchAttributes={['organizationName', 'organizationNumber']}
+                locale="nb"
+            />,
+        );
+
+        await user.tab();
+
+        expect(screen.getByText('Bedriften')).toBeInTheDocument();
+        expect(screen.getByText('912602370')).toBeInTheDocument();
+        expect(screen.getByText('Sønn & co')).toBeInTheDocument();
+        expect(screen.getByText('812602372')).toBeInTheDocument();
+        expect(screen.getByText('Beslag skytter')).toBeInTheDocument();
+        expect(screen.getByText('812602552')).toBeInTheDocument();
+
+        await user.tab();
 
         expect(screen.queryByText('Bedriften')).toBeNull();
         expect(screen.queryByText('912602370')).toBeNull();
@@ -582,29 +612,6 @@ describe('SearchableDropdown', () => {
         await user.keyboard('{Esc}');
 
         expect(input.getAttribute('value')).toEqual('Bedriften');
-    });
-
-    it('should move focus to toggle button when selecting from dropdown', async () => {
-        const onChange = jest.fn();
-        const user = userEvent.setup();
-        render(
-            <SearchableDropdown
-                id="id"
-                labelledById="labelId"
-                dropdownAttributes={['organizationName', 'organizationNumber']}
-                dropdownList={companies}
-                onChange={onChange}
-                searchAttributes={['organizationName', 'organizationNumber']}
-                locale="nb"
-            />,
-        );
-
-        const input = screen.getByRole('combobox');
-        await user.click(input);
-        await user.click(screen.getByText('Bedriften'));
-
-        const toggleButton = screen.getByLabelText('åpne alternativer');
-        expect(document.activeElement).toEqual(toggleButton);
     });
 
     it('should select item when losing focus if there is one single match', async () => {

--- a/packages/ffe-searchable-dropdown-react/src/single/SearchableDropdown.tsx
+++ b/packages/ffe-searchable-dropdown-react/src/single/SearchableDropdown.tsx
@@ -35,6 +35,7 @@ const ARROW_UP = 'ArrowUp';
 const ARROW_DOWN = 'ArrowDown';
 const ESCAPE = 'Escape';
 const ENTER = 'Enter';
+const TAB = 'Tab';
 
 export interface SearchableDropdownProps<Item extends Record<string, any>> {
     /** Id of drop down */
@@ -162,13 +163,11 @@ function SearchableDropdownWithForwardRef<Item extends Record<string, any>>(
     const refs = useRefs({ listToRender: state.listToRender });
     const [hasFocus, setHasFocus] = useState(false);
     const inputRef = useRef<HTMLInputElement>(null);
-    const toggleButtonRef = useRef<HTMLButtonElement>(null);
     const containerRef = useRef<HTMLDivElement>(null);
 
     const ListItemBodyElement = CustomOptionBody || OptionBody;
     const listBoxRef = useRef<HTMLDivElement>(null);
     const noMatchMessageId = useId();
-    const shouldFocusToggleButton = useRef(false);
     const shouldFocusInput = useRef(false);
 
     const handleInputClick = () => {
@@ -198,10 +197,7 @@ function SearchableDropdownWithForwardRef<Item extends Record<string, any>>(
     });
 
     useLayoutEffect(() => {
-        if (shouldFocusToggleButton.current) {
-            toggleButtonRef.current?.focus();
-            shouldFocusToggleButton.current = false;
-        } else if (shouldFocusInput.current) {
+        if (shouldFocusInput.current) {
             inputRef.current?.focus();
             shouldFocusInput.current = false;
         }
@@ -215,7 +211,7 @@ function SearchableDropdownWithForwardRef<Item extends Record<string, any>>(
 
     useIsExpandedCallbacks({ isExpanded: state.isExpanded, onClose, onOpen });
 
-    const handelFocusMovedOutside = useCallback(
+    const handleFocusMovedOutside = useCallback(
         () =>
             dispatch({
                 type: 'FocusMovedOutSide',
@@ -226,7 +222,7 @@ function SearchableDropdownWithForwardRef<Item extends Record<string, any>>(
     useHandleContainerFocus({
         id,
         containerRef,
-        handelFocusMovedOutside,
+        handleFocusMovedOutside,
     });
 
     const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
@@ -294,6 +290,10 @@ function SearchableDropdownWithForwardRef<Item extends Record<string, any>>(
                 );
             }
         }
+
+        if (event.key === TAB) {
+            dispatch({ type: 'FocusMovedOutSide' });
+        }
     };
 
     return (
@@ -327,7 +327,10 @@ function SearchableDropdownWithForwardRef<Item extends Record<string, any>>(
                             payload: { inputValue: e.target.value },
                         });
                     }}
-                    onFocus={() => setHasFocus(true)}
+                    onFocus={() => {
+                        setHasFocus(true);
+                        dispatch({ type: 'InputClick' });
+                    }}
                     onBlur={handleInputBlur}
                     aria-describedby={
                         [
@@ -360,14 +363,12 @@ function SearchableDropdownWithForwardRef<Item extends Record<string, any>>(
                 />
             </div>
             <ToggleButton
-                ref={toggleButtonRef}
                 isExpanded={state.isExpanded}
-                onClick={() =>
+                onClick={() => {
                     dispatch({
                         type: 'ToggleButtonPressed',
-                    })
-                }
-                locale={locale}
+                    });
+                }}
                 isLoading={isLoading}
             />
             <ListBox ref={listBoxRef} isExpanded={state.isExpanded}>
@@ -381,7 +382,6 @@ function SearchableDropdownWithForwardRef<Item extends Record<string, any>>(
                         locale={locale}
                         refs={refs}
                         onChange={item => {
-                            shouldFocusToggleButton.current = true;
                             dispatch({
                                 type: 'ItemOnClick',
                                 payload: { selectedItem: item },

--- a/packages/ffe-searchable-dropdown-react/src/translations.ts
+++ b/packages/ffe-searchable-dropdown-react/src/translations.ts
@@ -1,27 +1,5 @@
 import { Locale } from './types';
 
-export const getButtonLabelClose = (locale: Locale) => {
-    switch (locale) {
-        case 'nn':
-            return 'lukk alternativer';
-        case 'en':
-            return 'close alternatives';
-        default:
-            return 'lukk alternativer';
-    }
-};
-
-export const getButtonLabelOpen = (locale: Locale) => {
-    switch (locale) {
-        case 'nn':
-            return 'åpne alternativer';
-        case 'en':
-            return 'open alternatives';
-        default:
-            return 'åpne alternativer';
-    }
-};
-
 export const getSelectedLabel = (locale: Locale, amountSelected: number) => {
     switch (locale) {
         case 'en':

--- a/packages/ffe-searchable-dropdown-react/src/types.ts
+++ b/packages/ffe-searchable-dropdown-react/src/types.ts
@@ -24,3 +24,13 @@ export type SearchMatcher<Item extends Record<string, any>> = (
 ) => (item: Item) => boolean;
 
 export type ActionType = 'selected' | 'removed';
+
+export type State<Item extends Record<string, any>> = {
+    noMatch: boolean;
+    isExpanded: boolean;
+    highlightedIndex: number;
+    selectedItem?: Item;
+    inputValue: string;
+    listToRender: Item[];
+    noMatchDropdownList?: Item[] | undefined;
+};

--- a/packages/ffe-searchable-dropdown-react/src/useHandleContainerFocus.ts
+++ b/packages/ffe-searchable-dropdown-react/src/useHandleContainerFocus.ts
@@ -3,13 +3,13 @@ import { RefObject, useEffect } from 'react';
 interface Params {
     id: string;
     containerRef: RefObject<HTMLDivElement>;
-    handelFocusMovedOutside: () => void;
+    handleFocusMovedOutside: () => void;
 }
 
 export const useHandleContainerFocus = ({
     id,
     containerRef,
-    handelFocusMovedOutside,
+    handleFocusMovedOutside,
 }: Params) => {
     useEffect(() => {
         /**
@@ -25,7 +25,7 @@ export const useHandleContainerFocus = ({
                 e.__eventFromFFESearchableDropdownId === id;
 
             if (!isFocusInside) {
-                handelFocusMovedOutside();
+                handleFocusMovedOutside();
             }
         };
 
@@ -35,5 +35,5 @@ export const useHandleContainerFocus = ({
             document.removeEventListener('mousedown', handleContainerFocus);
             document.removeEventListener('focusin', handleContainerFocus);
         };
-    }, [id, containerRef, handelFocusMovedOutside]);
+    }, [id, containerRef, handleFocusMovedOutside]);
 };


### PR DESCRIPTION
# Opprydding SearchableDropdown, SearchableDropdownMultiSelect og Accountselector

## Beskrivelse

Små fikser: 
- Riktig farge på chevron
- Highlighted styling ved piltastnavigering er fikset
- Lagt til 1px i border-størrelse i stedet for 2px, og box-shadow ved hover og fokus

Større endring i hvordan searchabledropdown fungerer: 
- `ToggleButton`, altså chevronen, oppfører seg ikke lenger som en knapp. Den er skjult for skjermleser og brukes kun med mus til å åpne og lukke nedtrekkslista. 
- Forbedret Tab-navigasjon. Nå åpnes nedtrekkslista når man fokuserer på elementet med tab, samme oppførsel som ved musepeker. 

## Motivasjon og kontekst

Hovedårsaken til denne endringen er at vi ønsket endring i stylingen, altså å gå fra dette på hover
![image](https://github.com/user-attachments/assets/968127b4-169e-4185-b7c9-714205623609)
til en mer helhetlig komponent
![image](https://github.com/user-attachments/assets/489dae5b-a63f-461b-956d-6e6b37d40011)

Det gjør komponenten mer simplistisk, enklere i stilen og kanskje enklere å navigere. 
Det er fortsatt mulig å trykke på chevronen for å lukke nedtrekkslista når den er åpnet, men den kan ikke nås ved tastaturnavigasjon.

## Testing

Endringene må testes med skjermleser @SindreSafvenbom og med Firefox @dagfrode 
Endringene burde testes med mange varianter av bruk med tastatur og mus sammen. Jeg har testet manuelt etter beste evne, men gjerne prøv forskjellige scenarioer for å dobbeltsjekke. 
