### PR TITLE
fix(ffe-tables): legger til riktig bakgrunnsfarge på table header og cell, ved selected og pressed

### DIFF
--- a/packages/ffe-tables/less/tables.less
+++ b/packages/ffe-tables/less/tables.less
@@ -116,13 +116,27 @@
         transition: background var(--ffe-transition-duration) var(--ffe-ease);
         border-radius: var(--border-radius) var(--border-radius) 0 0;
 
-        &-ascending,
-        &-descending {
+        &:hover {
+            background: var(--ffe-color-surface-primary-default-hover);
+        }
+
+        &:active {
             background: var(--ffe-color-surface-primary-default-pressed);
         }
 
-        &:hover {
-            background: var(--ffe-color-surface-primary-default-hover);
+        &-ascending,
+        &-descending {
+            background: var(--ffe-color-fill-primary-selected);
+            color: var(--ffe-color-foreground-inverse);
+
+            &:hover {
+                background: var(--ffe-color-fill-primary-selected);
+                color: var(--ffe-color-foreground-inverse);
+            }
+
+            &:active {
+                background: var(--ffe-color-fill-primary-pressed);
+            }
         }
 
         @media (hover: hover) and (pointer: fine) {
@@ -149,6 +163,10 @@
             &:hover {
                 background: var(--ffe-color-surface-primary-default-hover);
             }
+        }
+
+        &:active {
+            background: var(--ffe-color-surface-primary-default-pressed);
         }
     }
 


### PR DESCRIPTION
Legger til: 
- Riktig blåfarge ved selected header
- Pressed-farge ved selected header og expandable row
- Pressed-farge ved hover header
- 
![image](https://github.com/user-attachments/assets/33cb957a-df83-49ae-8823-3eebf6914c68)
