### PR TITLE
Datepicker test

### DIFF
--- a/packages/ffe-datepicker-react/src/datepicker/Datepicker.mdx
+++ b/packages/ffe-datepicker-react/src/datepicker/Datepicker.mdx
@@ -11,10 +11,10 @@ import * as DatepickerStories from './Datepicker.stories.tsx';
 
 ## Testing med React Testing Library
 
-Testing av datepicker komponenten krever litt ekstra kode så vi har gjort det enklere ved å tilby en funksjon som 
+Testing av `Datepicker` krever litt ekstra kode, så vi har gjort det enklere ved å tilby en funksjon som 
 skal gjøre det enklere å teste komponenten med React Testing Library.
 
-Funksjonen er avhengig av `@testing-library/react` så dette bilbioteket må innstalleres.
+Funksjonen er avhengig av `@testing-library/react`, så dette biblioteket må installeres.
 
 ```sh
 npm i --save-dev @testing-library/react

--- a/packages/ffe-datepicker-react/src/datepicker/Datepicker.mdx
+++ b/packages/ffe-datepicker-react/src/datepicker/Datepicker.mdx
@@ -7,3 +7,50 @@ import * as DatepickerStories from './Datepicker.stories.tsx';
 
 <Canvas of={DatepickerStories.Standard} />
 <Controls of={DatepickerStories.Standard} />
+
+
+## Testing med React Testing Library
+
+Testing av datepicker komponenten krever litt ekstra kode så vi har gjort det enklere ved å tilby en funksjon som 
+skal gjøre det enklere å teste komponenten med React Testing Library.
+
+Funksjonen er avhengig av `@testing-library/react` så dette bilbioteket må innstalleres.
+
+```sh
+npm i --save-dev @testing-library/react
+```
+
+```tsx
+function getDatepickerByLabelText(
+    label: string,
+    index = 0,
+): {
+    /** The datepicker element */
+    element: Element;
+    /** Function to get the value of the datepicker
+     * @returns string in the format 'dd.mm.yyyy' or null if the datepicker is empty */
+    getValue: () => string | null;
+    /**Function to set the value of the datepicker
+     * @param value string in the format 'dd.mm.yyyy'
+     * @returns void
+     */
+    setValue: (value: string) => Promise<void>;
+};
+```
+
+```tsx
+describe('Datepicker test', () => {
+    it('datepicker provides methods to simplify testing', async () => {
+        
+        // Code for rendering your page / component
+
+        const datepicker = getDatepickerByLabelText('Dato velger');
+
+        expect(datepicker.getValue()).toStrictEqual('01.02.2024');
+    
+        await datepicker.setValue('6.5.2024');
+        expect(datepicker.getValue()).toStrictEqual('06.05.2024');
+    });
+});
+
+```

--- a/packages/ffe-datepicker-react/src/datepicker/Datepicker.tsx
+++ b/packages/ffe-datepicker-react/src/datepicker/Datepicker.tsx
@@ -1,17 +1,23 @@
-import React from 'react';
-import { DatepickerProvider } from './DatepickerContext';
-import { DatepickerComp, DatepickerCompProps } from './DatepickerComp';
+import React, { useEffect } from 'react';
 import { Locale } from '../datelogic/types';
+import { DatepickerComp, DatepickerCompProps } from './DatepickerComp';
+import { DatepickerProvider } from './DatepickerContext';
 
 export interface DatepickerProps extends DatepickerCompProps {
     value: string;
     locale: Locale;
+    /** Hack that changes InputGroups label to a span to be wcag complient  */
+    setInputGroupLabelAsSpan?: () => void;
 }
 export const Datepicker: React.FC<DatepickerProps> = ({
     locale = 'nb' as const,
     value,
+    setInputGroupLabelAsSpan,
     ...props
 }: DatepickerProps) => {
+    useEffect(() => {
+        setInputGroupLabelAsSpan?.();
+    }, [setInputGroupLabelAsSpan]);
     return (
         <DatepickerProvider locale={locale} value={value}>
             <DatepickerComp {...props} />

--- a/packages/ffe-datepicker-react/src/datepicker/DatepickerInContext.spec.tsx
+++ b/packages/ffe-datepicker-react/src/datepicker/DatepickerInContext.spec.tsx
@@ -13,7 +13,7 @@ const defaultProps = {
 
 const renderDatePicker = (props?: Partial<DatepickerProps>) =>
     render(
-        <InputGroup label="Dato velger">
+        <InputGroup label="Datovelger">
             <Datepicker {...defaultProps} {...props} />
         </InputGroup>,
     );
@@ -22,7 +22,7 @@ describe('<InputGroup><Datepicker /></InputGroup>', () => {
     it('empty datepicker returns null from testing functions', () => {
         renderDatePicker();
 
-        const datepicker = getDatepickerByLabelText('Dato velger');
+        const datepicker = getDatepickerByLabelText('Datovelger');
         expect(
             datepicker.element.classList.contains('ffe-datepicker'),
         ).toBeTruthy();
@@ -32,7 +32,7 @@ describe('<InputGroup><Datepicker /></InputGroup>', () => {
     it('datepicker returns value from testing functions', () => {
         renderDatePicker({ value: '01.02.2024' });
 
-        const datepicker = getDatepickerByLabelText('Dato velger');
+        const datepicker = getDatepickerByLabelText('Datovelger');
 
         expect(datepicker.getValue()).toStrictEqual('01.02.2024');
     });
@@ -40,7 +40,7 @@ describe('<InputGroup><Datepicker /></InputGroup>', () => {
     it('datepicker can be updated by testing functions', async () => {
         renderDatePicker({ value: '01.01.2024' });
 
-        const datepicker = getDatepickerByLabelText('Dato velger');
+        const datepicker = getDatepickerByLabelText('Datovelger');
         await datepicker.setValue('6.5.2024');
 
         expect(datepicker.getValue()).toStrictEqual('06.05.2024');

--- a/packages/ffe-datepicker-react/src/datepicker/DatepickerInContext.spec.tsx
+++ b/packages/ffe-datepicker-react/src/datepicker/DatepickerInContext.spec.tsx
@@ -1,0 +1,57 @@
+import { render } from '@testing-library/react';
+import React from 'react';
+import { InputGroup } from '../../../ffe-form-react/src/InputGroup';
+import { Datepicker, DatepickerProps } from './Datepicker';
+import { getDatepickerByLabelText } from './testHelper';
+
+const defaultProps = {
+    value: '',
+    onChange: () => {},
+    locale: 'nb' as const,
+    labelId: 'datepicker-label',
+};
+
+const renderDatePicker = (props?: Partial<DatepickerProps>) =>
+    render(
+        <InputGroup label="Dato velger">
+            <Datepicker {...defaultProps} {...props} />
+        </InputGroup>,
+    );
+
+describe('<InputGroup><Datepicker /></InputGroup>', () => {
+    it('empty datepicker returns null from testing functions', () => {
+        renderDatePicker();
+
+        const datepicker = getDatepickerByLabelText('Dato velger');
+        expect(
+            datepicker.element.classList.contains('ffe-datepicker'),
+        ).toBeTruthy();
+        expect(datepicker.getValue()).toBe(null);
+    });
+
+    it('datepicker returns value from testing functions', () => {
+        renderDatePicker({ value: '01.02.2024' });
+
+        const datepicker = getDatepickerByLabelText('Dato velger');
+
+        expect(datepicker.getValue()).toStrictEqual('01.02.2024');
+    });
+
+    it('datepicker can be updated by testing functions', async () => {
+        renderDatePicker({ value: '01.01.2024' });
+
+        const datepicker = getDatepickerByLabelText('Dato velger');
+        await datepicker.setValue('6.5.2024');
+
+        expect(datepicker.getValue()).toStrictEqual('06.05.2024');
+    });
+});
+
+/**
+ * todo
+ * x get datepicker with index
+ * x change to string
+ * x remove need for library
+ * better types
+ * own file
+ */

--- a/packages/ffe-datepicker-react/src/datepicker/index.ts
+++ b/packages/ffe-datepicker-react/src/datepicker/index.ts
@@ -1,2 +1,4 @@
 export { Datepicker, DatepickerProps } from './Datepicker';
 export type { DatepickerCompProps } from './DatepickerComp';
+export { getDatepickerByLabelText } from './testHelper';
+export type { DatepickerTestHelper } from './testHelper';

--- a/packages/ffe-datepicker-react/src/datepicker/testHelper.ts
+++ b/packages/ffe-datepicker-react/src/datepicker/testHelper.ts
@@ -1,0 +1,115 @@
+import { act, screen } from '@testing-library/react';
+
+async function simulateTyping(element: Element, text: string, delay = 100) {
+    return new Promise<void>(resolve => {
+        let index = 0;
+
+        function typeCharacter() {
+            if (index < text.length) {
+                const char = text[index];
+                const eventOptions = {
+                    key: char,
+                    keyCode: char.charCodeAt(0),
+                    which: char.charCodeAt(0),
+                    bubbles: true,
+                };
+                act(() => {
+                    element.dispatchEvent(
+                        new KeyboardEvent('keydown', eventOptions),
+                    );
+                    element.dispatchEvent(
+                        new Event('input', { bubbles: true }),
+                    );
+                    element.dispatchEvent(
+                        new KeyboardEvent('keyup', eventOptions),
+                    );
+                });
+
+                index++;
+                setTimeout(typeCharacter, delay);
+            } else {
+                resolve(); // Resolve the promise when done
+            }
+        }
+
+        typeCharacter();
+    });
+}
+
+function leftPad(str: string, len = 2, ch = '0') {
+    let newStr = str;
+    while (newStr.length < len) {
+        newStr = ch + newStr;
+    }
+    return newStr;
+}
+
+export type DatepickerTestHelper = {
+    /**
+     * The datepicker element
+     */
+    element: Element;
+    /**
+     * Function to get the value of the datepicker
+     *
+     * @returns string in the format 'dd.mm.yyyy' or null if the datepicker is empty
+     */
+    getValue: () => string | null;
+    /**
+     * Function to set the value of the datepicker
+     *
+     * @param value string in the format 'dd.mm.yyyy'
+     * @returns void
+     */
+    setValue: (value: string) => Promise<void>;
+};
+
+/**
+ * Get a datepicker with helper functions by label
+ *
+ * @param label label of the datepicker element you want to get
+ * @param index if there are multiple datepicker elements with the same label, you can specify which one you want to get
+ * @returns DatepickerTestHelper
+ */
+export function getDatepickerByLabelText(
+    label: string,
+    index = 0,
+): DatepickerTestHelper {
+    const elements = screen
+        .getAllByText(label)
+        .map(element => element.parentElement?.querySelector('.ffe-datepicker'))
+        .filter(element => element !== null && element !== undefined);
+
+    function getValue(element: Element): string | null {
+        const [dayElement, monthElement, yearElement] = Array.from(
+            element.querySelectorAll('[role="spinbutton"]'),
+        );
+
+        const day = dayElement.getAttribute('aria-valuenow') || '';
+        const month = monthElement.getAttribute('aria-valuenow') || '';
+        const year = yearElement.getAttribute('aria-valuenow') || '';
+        return year !== '' && month !== '' && day !== ''
+            ? `${leftPad(day)}.${leftPad(month)}.${year}`
+            : null;
+    }
+
+    async function setValue(element: Element, value: string) {
+        const [dayElement, monthElement, yearElement] = Array.from(
+            element.querySelectorAll('[role="spinbutton"]'),
+        );
+        // eslint-disable-next-line prefer-const
+        let [dayValue, monthValue, yearValue] = value.split('.');
+        dayValue = dayValue.length === 1 ? `0${dayValue}` : dayValue;
+        monthValue = monthValue.length === 1 ? `0${monthValue}` : monthValue;
+
+        await simulateTyping(dayElement, dayValue);
+        await simulateTyping(monthElement, monthValue);
+        await simulateTyping(yearElement, yearValue);
+    }
+
+    return {
+        element: elements[index],
+        getValue: () => getValue(elements[index]),
+        setValue: (value: string) => setValue(elements[index], value),
+    };
+}

--- a/packages/ffe-form-react/src/Checkbox.stories.tsx
+++ b/packages/ffe-form-react/src/Checkbox.stories.tsx
@@ -15,7 +15,6 @@ export const Standard: Story = {
         noMargins: false,
         hiddenLabel: false,
         inline: true,
-        onColoredBg: false,
     },
     render: args => (
         <fieldset className="ffe-input-group">

--- a/packages/ffe-form-react/src/InputGroup.tsx
+++ b/packages/ffe-form-react/src/InputGroup.tsx
@@ -8,6 +8,8 @@ type ChildrenExtraProps = {
     id: string;
     'aria-invalid': 'true' | 'false';
     'aria-describedby': string | undefined;
+    /** Hack that changes label to a span to be wcag complient  */
+    setInputGroupLabelAsSpan?: () => void;
 };
 
 export interface InputGroupProps
@@ -85,6 +87,7 @@ export const InputGroup: React.FC<InputGroupProps> = ({
     labelId,
     ...rest
 }) => {
+    const [labelAsSpan, setLabelAsSpan] = React.useState(false);
     const generatedInputId = useId();
     const id = inputId ?? generatedInputId;
     const descriptionId = description ? `${id}-description` : undefined;
@@ -139,6 +142,7 @@ export const InputGroup: React.FC<InputGroupProps> = ({
         id,
         'aria-invalid': isInvalid ? 'true' : 'false',
         'aria-describedby': ariaDescribedBy,
+        setInputGroupLabelAsSpan: () => setLabelAsSpan(true),
     } as const;
 
     const modifiedChildren = getChildrenWithExtraProps(children, extraProps);
@@ -156,7 +160,11 @@ export const InputGroup: React.FC<InputGroupProps> = ({
             {...rest}
         >
             {typeof label === 'string' ? (
-                <Label htmlFor={id} id={labelId}>
+                <Label
+                    as={labelAsSpan ? 'span' : 'label'}
+                    htmlFor={id}
+                    id={labelId}
+                >
                     {label}
                 </Label>
             ) : (

--- a/packages/ffe-form-react/src/Label.tsx
+++ b/packages/ffe-form-react/src/Label.tsx
@@ -1,7 +1,8 @@
-import React from 'react';
+import React, { ElementType } from 'react';
 import classNames from 'classnames';
 
 export interface LabelProps extends React.ComponentPropsWithoutRef<'label'> {
+    as?: ElementType;
     /**
      * Labels default to `display: inline-block;` to have tooltips appear immediately to the right.
      * Set this to `true` if you don't use tooltips and need the label to be `display: block;`.
@@ -15,13 +16,14 @@ export interface LabelProps extends React.ComponentPropsWithoutRef<'label'> {
 }
 
 export const Label: React.FC<LabelProps> = ({
+    as: Comp = 'label',
     block,
     children,
     className,
     htmlFor,
     ...rest
 }) => (
-    <label
+    <Comp
         className={classNames('ffe-form-label', className, {
             'ffe-form-label--block': block,
         })}
@@ -29,5 +31,5 @@ export const Label: React.FC<LabelProps> = ({
         {...rest}
     >
         {children}
-    </label>
+    </Comp>
 );


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse

- Gjør det mulig å endre label i input group til span for å ikke bryte wcag når en bruker den med datepicker
- [Lager testhelper til datepicker](https://black-beach-0d62d0d03-2614.westeurope.2.azurestaticapps.net/?path=/docs/komponenter-datepicker-datepicker--docs#testing-med-react-testing-library) for å gjøre den enklere å teste med react testing library


<!-- Detaljert beskrivelse av endringene dine. Skjermskudd er lov. -->

## Motivasjon og kontekst

<!-- Hvorfor trengs denne endringen, og hva løser den? -->

## Testing

<!-- Hvordan har du har testet endringene dine? Ta gjerne med systeminfo o.l -->

<!--

Helt til slutt, har du ..

.. lest retningslinjene våre for bidrag?
.. tatt en siste sjekk for kode og skrivefeil, debug informasjon o.l?
.. kjørt og eventuelt oppdatert testene?
.. kommentert og dokumentert det som trengs?
.. knyttet denne opp til relaterte issues?

-->
