### PR TITLE
Ordner slik at Datepicker oppfører seg som en kontrollert komponent

### DIFF
--- a/packages/ffe-datepicker-react/src/datepicker/Datepicker.spec.tsx
+++ b/packages/ffe-datepicker-react/src/datepicker/Datepicker.spec.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Datepicker, DatepickerProps } from './Datepicker';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -10,8 +10,30 @@ const defaultProps = {
     labelId: 'datepicker-label',
 };
 
+const DatepickerWithChangeButton: React.FC<DatepickerProps> = ({
+    value,
+    ...props
+}: DatepickerProps) => {
+    const [date, setDate] = useState(value);
+    return (
+        <>
+            <button
+                data-testid="change-date-input"
+                onClick={() => {
+                    setDate('02.02.2022');
+                }}
+            />
+            <Datepicker value={date} {...props} />
+        </>
+    );
+};
+
 const renderDatePicker = (props?: Partial<DatepickerProps>) =>
     render(<Datepicker {...defaultProps} {...props} />);
+
+const renderDatePickerWithChangeButton = (props?: Partial<DatepickerProps>) => {
+    return render(<DatepickerWithChangeButton {...defaultProps} {...props} />);
+};
 
 describe('<Datepicker />', () => {
     describe('with empty value', () => {
@@ -150,9 +172,22 @@ describe('<Datepicker />', () => {
             renderDatePicker({ value: '01.01.2021' });
 
             const [date, month, year] = screen.getAllByRole('spinbutton');
+
             expect(date).toHaveValue(1);
             expect(month).toHaveValue(1);
             expect(year).toHaveValue(2021);
+        });
+
+        it('input field changes when value changes', async () => {
+            const user = userEvent.setup();
+            renderDatePickerWithChangeButton({ value: '01.01.2021' });
+
+            await user.click(screen.getByTestId('change-date-input'));
+
+            const [date, month, year] = screen.getAllByRole('spinbutton');
+            expect(date).toHaveValue(2);
+            expect(month).toHaveValue(2);
+            expect(year).toHaveValue(2022);
         });
     });
 });

--- a/packages/ffe-datepicker-react/src/datepicker/DatepickerContext.tsx
+++ b/packages/ffe-datepicker-react/src/datepicker/DatepickerContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useState } from 'react';
+import React, { createContext, useEffect, useState } from 'react';
 import { Locale } from '../datelogic/types';
 import { validateDate } from '../util/dateUtil';
 import { getSimpleDateFromString } from '../datelogic/simpledate';
@@ -52,9 +52,17 @@ export const DatepickerProvider: React.FC<Props> = ({
     const [year, setYear] = useState<number | null>(
         newDate ? newDate.year : null,
     );
+
     const [calendarActiveDate, setCalendarActiveDate] = useState<string>(
         newDate?.toString() ?? '',
     );
+
+    useEffect(() => {
+        setDay(newDate ? newDate.date : null);
+        setMonth(newDate ? newDate.month + 1 : null);
+        setYear(newDate ? newDate.year : null);
+        setCalendarActiveDate(newDate?.toString() ?? '');
+    }, [newDate]);
 
     return (
         <DatepickerContext.Provider


### PR DESCRIPTION

## Beskrivelse

Legger til en useEffect i datepickers provider slik at den plukker opp endringer på value

## Motivasjon og kontekst

Komponenten ser ut som en kontrollert komponent men endringer i value ignoreres

## Testing

Enkel test med input som endrer value på en mountet komponent

