### PR TITLE
fix(ffe-core): Export chevron less variables

### DIFF
--- a/packages/ffe-core/.gitignore
+++ b/packages/ffe-core/.gitignore
@@ -2,3 +2,4 @@ css/
 gen-src/
 less/colors-semantic.less
 less/colors-semantic-storybook.less
+less/colors-semantic-chevron.less

--- a/packages/ffe-core/less/ffe.less
+++ b/packages/ffe-core/less/ffe.less
@@ -5,6 +5,7 @@
 @import 'breakpoints';
 @import 'colors';
 @import 'colors-semantic';
+@import 'colors-semantic-chevron';
 @import 'dimensions';
 @import 'motion';
 @import 'spacing';

--- a/packages/ffe-core/scripts/chevron.js
+++ b/packages/ffe-core/scripts/chevron.js
@@ -1,0 +1,118 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+const writeToFile = require('./lib/writeToFile');
+
+const chevron = {
+    default: {
+        variable: '',
+        light: {
+            variable: '',
+            value: '',
+        },
+        dark: {
+            variable: '',
+            value: '',
+        },
+    },
+    accent: {
+        variable: '',
+        light: {
+            variable: '',
+            value: '',
+        },
+        dark: {
+            variable: '',
+            value: '',
+        },
+    },
+};
+function filePath(filename) {
+    return path.resolve('tokens', filename);
+}
+
+const loadFile = file => {
+    return JSON.parse(fs.readFileSync(filePath(file), 'utf8'));
+};
+
+const files = {
+    primitive: loadFile('01 Primitive.value.json'),
+    semanticLight: loadFile('02 Semantic.Light.json'),
+    semanticDark: loadFile('02 Semantic.Dark.json'),
+    context: loadFile('03 Context.Default.json'),
+    contextAccent: loadFile('03 Context.Accent.json'),
+};
+
+function getValueRecursive(obj, p, addColor) {
+    const keys = p.slice(1, -1).split('.');
+    return keys.reduce((acc, key) => acc[key], obj).$value;
+}
+
+module.exports = () => {
+    // The variables to change
+    chevron.default.variable = files.context.color.foreground.default.$value;
+    chevron.accent.variable =
+        files.contextAccent.color.foreground.default.$value;
+
+    // default
+
+    chevron.default.light.variable = getValueRecursive(
+        files.semanticLight,
+        chevron.default.variable,
+    );
+
+    chevron.default.light.value = getValueRecursive(
+        files.primitive,
+        chevron.default.light.variable,
+        true,
+    );
+
+    chevron.default.dark.variable = getValueRecursive(
+        files.semanticDark,
+        chevron.default.variable,
+    );
+    chevron.default.dark.value = getValueRecursive(
+        files.primitive,
+        chevron.default.dark.variable,
+        true,
+    );
+    // accent
+
+    chevron.accent.light.variable = getValueRecursive(
+        files.semanticLight,
+        chevron.accent.variable,
+    );
+
+    chevron.accent.light.value = getValueRecursive(
+        files.primitive,
+        chevron.accent.light.variable,
+        true,
+    );
+
+    chevron.accent.dark.variable = getValueRecursive(
+        files.semanticDark,
+        chevron.accent.variable,
+    );
+    chevron.accent.dark.value = getValueRecursive(
+        files.primitive,
+        chevron.accent.dark.variable,
+        true,
+    );
+
+    const semanticChevron = {
+        lightDefault: chevron.default.light.value,
+        darkDefault: chevron.default.dark.value,
+        lightAccent: chevron.accent.light.value,
+        darkAccent: chevron.accent.dark.value,
+    };
+
+    const chevronLess = `
+// Chevron colors to make it work with semantic colors
+@ffe-color-chevron-light-default: ${semanticChevron.lightDefault};
+@ffe-color-chevron-dark-default: ${semanticChevron.darkDefault};
+@ffe-color-chevron-light-accent: ${semanticChevron.lightAccent};
+@ffe-color-chevron-dark-accent: ${semanticChevron.darkAccent};
+`;
+
+    writeToFile('less/colors-semantic-chevron.less')(chevronLess);
+};

--- a/packages/ffe-core/scripts/generate-semantic-colors.js
+++ b/packages/ffe-core/scripts/generate-semantic-colors.js
@@ -2,6 +2,7 @@
 const fs = require('fs');
 const path = require('path');
 const writeToFile = require('./lib/writeToFile');
+const generateChevronColors = require('./chevron');
 
 const usedPrimitive = {};
 const usedSemantic = {};
@@ -192,6 +193,8 @@ function generateSemanticColors() {
     const semanticColorModuleContent =
         generateSemanticColorModule(semanticColorNames);
     writeToFile('lib/semanticColors.js')(semanticColorModuleContent);
+
+    generateChevronColors();
 }
 
 generateSemanticColors();


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse

genererer 

`colors-semantic-chevron.less`
```less
// Chevron colors to make it work with semantic colors
@ffe-color-chevron-light-default: #292929;
@ffe-color-chevron-dark-default: #ffffff;
@ffe-color-chevron-light-accent: #ffffff;
@ffe-color-chevron-dark-accent: #ffffff;
```

<!-- Detaljert beskrivelse av endringene dine. Skjermskudd er lov. -->

## Motivasjon og kontekst

<!-- Hvorfor trengs denne endringen, og hva løser den? -->

## Testing

<!-- Hvordan har du har testet endringene dine? Ta gjerne med systeminfo o.l -->

<!--

Helt til slutt, har du ..

.. lest retningslinjene våre for bidrag?
.. tatt en siste sjekk for kode og skrivefeil, debug informasjon o.l?
.. kjørt og eventuelt oppdatert testene?
.. kommentert og dokumentert det som trengs?
.. knyttet denne opp til relaterte issues?

-->
