### PR TITLE
fix(ffe-cards): pirk på styling av action cards/group cards

### DIFF
--- a/packages/ffe-cards/less/common-card-styling.less
+++ b/packages/ffe-cards/less/common-card-styling.less
@@ -33,7 +33,9 @@
     @media (hover: hover) and (pointer: fine) {
         &:hover {
             cursor: pointer;
-            border-color: var(--ffe-color-border-primary-hover);
+            border-color: transparent;
+            box-shadow: var(--ffe-g-border-focus-box-shadow)
+                var(--ffe-color-border-primary-hover);
             background: var(--ffe-color-surface-primary-default-hover);
             &
                 :where(
@@ -47,7 +49,9 @@
         }
     }
     &:focus-within {
-        border-color: var(--ffe-color-border-primary-hover);
+        border-color: transparent;
+        box-shadow: var(--ffe-g-border-focus-box-shadow)
+            var(--ffe-color-border-primary-pressed);
 
         &
             :where(


### PR DESCRIPTION
Fikser denne lille stylingfeilen: 
![image](https://github.com/user-attachments/assets/42b7dc06-7e2a-427d-831c-19b2a89db550)

Bruker box shadow i stedet: 
![image](https://github.com/user-attachments/assets/0ca281d5-64ac-4b92-bfd4-63d23660cf92)
