### PR TITLE
fix(ffe-pagination): fix semantiske farger og knappehøyde pagniering

### DIFF
--- a/packages/ffe-pagination/less/pagination.less
+++ b/packages/ffe-pagination/less/pagination.less
@@ -14,6 +14,7 @@
         justify-content: space-between;
         align-items: center;
         gap: var(--ffe-spacing-sm);
+        color: var(--ffe-color-foreground-default);
 
         @media (min-width: @breakpoint-sm) {
             flex-direction: row;
@@ -107,6 +108,7 @@
         .ffe-button {
             width: var(--circular-button-size);
             aspect-ratio: 1;
+            padding-block: 12px; //Mellomløsning til vi har forskjellige knappestørrelser
         }
     }
 


### PR DESCRIPTION
Liten fiks i semantiske farger. Fra:
![image](https://github.com/user-attachments/assets/633acdf0-fb89-473e-9215-4bbbc9ea9d6d)
Til
![image](https://github.com/user-attachments/assets/90457f05-2504-42e9-a9ac-9f3bd7afbf67)


Har også oppdatert knappe-paddingen slik at det ser ok ut. Vi får ulike knappehøyder senere (som en del av moderniseringa av komponenter), så dette er bare en midlertidig fix. 