### PR TITLE
fix(ffe-form): riktige semantiske farger for radio-switch

### DIFF
--- a/packages/ffe-form/less/radio-switch.less
+++ b/packages/ffe-form/less/radio-switch.less
@@ -1,6 +1,6 @@
 .ffe-radio-switch {
     --outer-circle-color: var(--ffe-color-border-primary-default);
-    --inner-circle-color: var(--ffe-color-fill-primary-pressed);
+    --inner-circle-color: transparent;
     --circle-background: var(--ffe-color-surface-primary-default);
     color: var(--ffe-color-foreground-default);
 
@@ -36,6 +36,22 @@
         pointer-events: none;
     }
 
+    @media (hover: hover) and (pointer: fine) {
+        &:hover {
+            background-color: var(--ffe-color-surface-primary-default-hover);
+            border-color: var(--ffe-color-border-primary-hover);
+
+            &::before {
+                background-color: var(--ffe-color-surface-primary-default);
+            }
+        }
+    }
+
+    &:focus,
+    &:active {
+        background-color: var(--ffe-color-surface-primary-default-pressed);
+    }
+
     @media (min-width: @breakpoint-sm) {
         margin-bottom: 0;
     }
@@ -64,13 +80,28 @@
         --outer-circle-color: var(--ffe-color-fill-primary-selected);
         --inner-circle-color: var(--ffe-color-fill-primary-pressed);
 
-        background-color: var(--ffe-color-fill-primary-pressed);
+        background-color: var(--ffe-color-fill-primary-selected);
         color: var(--ffe-color-foreground-on-fill-default);
+        border-color: var(--ffe-color-border-primary-emphasis);
+        box-shadow: var(--ffe-g-border-focus-box-shadow) var(--ffe-color-border-primary-emphasis);
 
         &::before {
             border: 5px solid var(--ffe-color-surface-primary-default);
+            outline: 2px solid var(--ffe-color-border-primary-emphasis);
             background-color: var(--ffe-color-fill-primary-selected);
         }
+
+        @media (hover: hover) and (pointer: fine) {
+            &:hover {
+                background-color: var(--ffe-color-fill-primary-selected-hover);
+            }
+        }
+
+        &:focus,
+        &:active {
+            background-color: var(--ffe-color-fill-primary-selected-pressed);
+        }
+
     }
 
     &:focus + .ffe-radio-switch {


### PR DESCRIPTION
Eksisterende RadioSwitch hadde en feil og manglet litt hover-styling: 
![image](https://github.com/user-attachments/assets/140b23be-7086-496c-bce0-9b48a4d1a37c)

Ny: 
![image](https://github.com/user-attachments/assets/0dff5138-cc70-428b-a276-d168061906fa)

