### PR TITLE
Flere knappestørrelser

### DIFF
--- a/.storybook/preview.less
+++ b/.storybook/preview.less
@@ -2,3 +2,9 @@
     padding: var(--ffe-spacing-sm);
     background: var(--ffe-color-background-default);
 }
+
+.ffe-button-display-group {
+    display: flex;
+    gap: var(--ffe-spacing-xs);
+    align-items: flex-end;
+}

--- a/packages/ffe-buttons-react/src/ActionButton.mdx
+++ b/packages/ffe-buttons-react/src/ActionButton.mdx
@@ -12,3 +12,10 @@ Brukes for svært høyt prioriterte handlinger (call to action), og der du treng
 
 <Canvas of={ActionButtonStories.Standard} />
 <Controls of={ActionButtonStories.Standard} />
+
+## Forskjellige størrelser
+
+Primary Button tilbys i tre størrelser: `sm`, `md` og `lg`. Standardstørrelsen er `md`. Du kan endre størrelsen ved å
+sette `size`-propen til en av disse verdiene, altså `size="sm"`. Hvis du ikke sender inn noe, er størrelsen md.
+
+<Canvas of={ActionButtonStories.DifferentSizes} />

--- a/packages/ffe-buttons-react/src/ActionButton.stories.tsx
+++ b/packages/ffe-buttons-react/src/ActionButton.stories.tsx
@@ -22,6 +22,11 @@ const meta: Meta<typeof ActionButton<any>> = {
                 custom: Custom,
             },
         },
+        size: {
+            options: ['lg', 'md', 'sm'],
+            control: { type: 'radio' },
+            description: "Størrelse på knappen, 'md' default",
+        },
     },
 };
 export default meta;
@@ -34,5 +39,32 @@ export const Standard: Story = {
         ariaLoadingMessage: 'Vennligst vent...',
         isLoading: false,
     },
-    render: args => <ActionButton {...args}>Actionknapp</ActionButton>,
+    render: args => {
+        return (
+            <div className="ffe-button-display-group">
+                <ActionButton {...args}>Actionknapp</ActionButton>
+            </div>
+        );
+    },
+};
+
+export const DifferentSizes: Story = {
+    args: {
+        as: 'button',
+        ariaLoadingMessage: 'Vennligst vent...',
+        isLoading: false,
+    },
+    render: args => {
+        return (
+            <div className="ffe-button-display-group">
+                <ActionButton {...args} size="lg">
+                    Actionknapp
+                </ActionButton>
+                <ActionButton {...args}>Actionknapp</ActionButton>
+                <ActionButton {...args} size="sm">
+                    Actionknapp
+                </ActionButton>
+            </div>
+        );
+    },
 };

--- a/packages/ffe-buttons-react/src/BaseButton.tsx
+++ b/packages/ffe-buttons-react/src/BaseButton.tsx
@@ -11,6 +11,8 @@ export type BaseButtonProps<As extends ElementType = 'button'> =
         isLoading?: boolean;
         leftIcon?: ReactElement;
         rightIcon?: ReactElement;
+        /** Default md. */
+        size?: 'sm' | 'md' | 'lg';
     };
 /**
  * Internal component
@@ -29,6 +31,7 @@ function BaseButtonWithForwardRef<As extends ElementType>(
         onClick,
         leftIcon,
         rightIcon,
+        size = 'md',
         ariaLoadingMessage,
         children,
         ...rest
@@ -44,10 +47,11 @@ function BaseButtonWithForwardRef<As extends ElementType>(
             className={classNames(
                 'ffe-button',
                 `ffe-button--${buttonType}`,
+                `ffe-button--${size}`,
                 { 'ffe-button--loading': isLoading && supportsSpinner },
                 className,
             )}
-            onClick={event => {
+            onClick={(event: React.MouseEvent) => {
                 if (isLoading && supportsSpinner) {
                     event.preventDefault();
                     event.stopPropagation();

--- a/packages/ffe-buttons-react/src/ExpandButton.mdx
+++ b/packages/ffe-buttons-react/src/ExpandButton.mdx
@@ -12,3 +12,11 @@ Brukes i spesifikke situasjoner der du vil ekspandere/kollapse en seksjon.
 
 <Canvas of={ExpandButtonStories.Standard} />
 <Controls of={ExpandButtonStories.Standard} />
+
+## Forskjellige størrelser
+
+Primary Button tilbys i tre størrelser: `sm`, `md` og `lg`. Standardstørrelsen er `md`. Du kan endre størrelsen ved å
+sette `size`-propen til en av disse verdiene, altså `size="sm"`. Hvis du ikke sender inn noe, er størrelsen md.
+
+<Canvas of={ExpandButtonStories.DifferentSizes} />
+

--- a/packages/ffe-buttons-react/src/ExpandButton.stories.tsx
+++ b/packages/ffe-buttons-react/src/ExpandButton.stories.tsx
@@ -5,7 +5,13 @@ import { ExpandButton } from './ExpandButton';
 const meta: Meta<typeof ExpandButton> = {
     title: 'Komponenter/Buttons/ExpandButton',
     component: ExpandButton,
-    argTypes: {},
+    argTypes: {
+        size: {
+            options: ['lg', 'md', 'sm'],
+            control: { type: 'radio' },
+            description: "Størrelse på knappen, 'md' default",
+        },
+    },
 };
 export default meta;
 
@@ -20,13 +26,55 @@ export const Standard: Story = {
         const [isExpanded, setExpanded] = useState(args.isExpanded);
 
         return (
-            <ExpandButton
-                {...args}
-                isExpanded={isExpanded}
-                onClick={() => setExpanded(!isExpanded)}
-            >
-                Vis mer
-            </ExpandButton>
+            <div className="ffe-button-display-group">
+                <ExpandButton
+                    {...args}
+                    isExpanded={isExpanded}
+                    onClick={() => setExpanded(!isExpanded)}
+                >
+                    Vis mer
+                </ExpandButton>
+            </div>
+        );
+    },
+};
+
+export const DifferentSizes: Story = {
+    args: {
+        isExpanded: false,
+        as: 'button',
+    },
+    render: function Render(args) {
+        const [isExpandedLg, setExpandedLg] = useState(args.isExpanded);
+        const [isExpandedMd, setExpandedMd] = useState(args.isExpanded);
+        const [isExpandedSm, setExpandedSm] = useState(args.isExpanded);
+
+        return (
+            <div className="ffe-button-display-group">
+                <ExpandButton
+                    {...args}
+                    isExpanded={isExpandedLg}
+                    onClick={() => setExpandedLg(!isExpandedLg)}
+                    size={'lg'}
+                >
+                    Vis mer
+                </ExpandButton>
+                <ExpandButton
+                    {...args}
+                    isExpanded={isExpandedMd}
+                    onClick={() => setExpandedMd(!isExpandedMd)}
+                >
+                    Vis mer
+                </ExpandButton>
+                <ExpandButton
+                    {...args}
+                    isExpanded={isExpandedSm}
+                    onClick={() => setExpandedSm(!isExpandedSm)}
+                    size={'sm'}
+                >
+                    Vis mer
+                </ExpandButton>
+            </div>
         );
     },
 };

--- a/packages/ffe-buttons-react/src/ExpandButton.tsx
+++ b/packages/ffe-buttons-react/src/ExpandButton.tsx
@@ -10,6 +10,7 @@ export type ExpandButtonProps<As extends ElementType = 'button'> =
         closeLabel?: string;
         /** When true the component will render a circle with an X indicating whatever is controlled is in an expanded state. */
         isExpanded: boolean;
+        size?: 'sm' | 'md' | 'lg';
     };
 
 function ExpandButtonWithForwardRef<As extends ElementType>(
@@ -22,18 +23,26 @@ function ExpandButtonWithForwardRef<As extends ElementType>(
         closeLabel = 'Lukk',
         as: Comp = 'button',
         isExpanded,
+        size = 'md',
         ...rest
     } = props;
 
-    const closeIcon =
+    const closeIconMd =
         'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGhlaWdodD0iMjQiIHZpZXdCb3g9IjAgLTk2MCA5NjAgOTYwIiB3aWR0aD0iMjQiPjxwYXRoIGQ9Ik00ODAtNDM3Ljg0NyAyNzcuMDc2LTIzNC45MjRxLTguMzA3IDguMzA4LTIwLjg4NCA4LjUtMTIuNTc2LjE5My0yMS4yNjgtOC41LTguNjkzLTguNjkyLTguNjkzLTIxLjA3NnQ4LjY5My0yMS4wNzZMNDM3Ljg0Ny00ODAgMjM0LjkyNC02ODIuOTI0cS04LjMwOC04LjMwNy04LjUtMjAuODg0LS4xOTMtMTIuNTc2IDguNS0yMS4yNjggOC42OTItOC42OTMgMjEuMDc2LTguNjkzdDIxLjA3NiA4LjY5M0w0ODAtNTIyLjE1M2wyMDIuOTI0LTIwMi45MjNxOC4zMDctOC4zMDggMjAuODg0LTguNSAxMi41NzYtLjE5MyAyMS4yNjggOC41IDguNjkzIDguNjkyIDguNjkzIDIxLjA3NnQtOC42OTMgMjEuMDc2TDUyMi4xNTMtNDgwbDIwMi45MjMgMjAyLjkyNHE4LjMwOCA4LjMwNyA4LjUgMjAuODg0LjE5MyAxMi41NzYtOC41IDIxLjI2OC04LjY5MiA4LjY5My0yMS4wNzYgOC42OTN0LTIxLjA3Ni04LjY5M0w0ODAtNDM3Ljg0N1oiLz48L3N2Zz4=';
+    const closeIconSm =
+        'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGhlaWdodD0iMjAiIHZpZXdCb3g9IjAgLTk2MCA5NjAgOTYwIiB3aWR0aD0iMjAiPjxwYXRoIGQ9Ik00ODAtNDQyLjg1IDMwOS4wOC0yNzEuOTJxLTguMzEgOC4zLTE3Ljg5IDgtOS41Ny0uMzEtMTguMjctOS04LjY5LTguNy04LjY5LTE4LjU4IDAtOS44OCA4LjY5LTE4LjU4TDQ0Mi44NS00ODAgMjcxLjkyLTY1MC45MnEtOC4zLTguMzEtOC0xOC4zOS4zMS0xMC4wNyA5LTE4Ljc3IDguNy04LjY5IDE4LjU4LTguNjkgOS44OCAwIDE4LjU4IDguNjlMNDgwLTUxNy4xNWwxNzAuOTItMTcwLjkzcTguMzEtOC4zIDE4LjM5LTguNSAxMC4wNy0uMTkgMTguNzcgOC41IDguNjkgOC43IDguNjkgMTguNTggMCA5Ljg4LTguNjkgMTguNThMNTE3LjE1LTQ4MGwxNzAuOTMgMTcwLjkycTguMyA4LjMxIDguNSAxNy44OS4xOSA5LjU3LTguNSAxOC4yNy04LjcgOC42OS0xOC41OCA4LjY5LTkuODggMC0xOC41OC04LjY5TDQ4MC00NDIuODVaIi8+PC9zdmc+';
+
+    const closeIcon = size === 'sm' ? closeIconSm : closeIconMd;
+
     return (
         <Comp
             aria-expanded={isExpanded}
             aria-label={isExpanded ? closeLabel : undefined}
             className={classNames(
                 'ffe-button',
+                'ffe-button--secondary',
                 'ffe-button--expand',
+                `ffe-button--${size}`,
                 { 'ffe-button--expanded': isExpanded },
                 className,
             )}
@@ -44,7 +53,7 @@ function ExpandButtonWithForwardRef<As extends ElementType>(
                 <Icon
                     className="ffe-button__icon"
                     fileUrl={closeIcon}
-                    size="md"
+                    size={size === 'sm' ? 'sm' : 'md'} //Det store ikonet er for stort, ikke behov for å bruke det
                 />
             )}
             {!isExpanded && <span>{children}</span>}

--- a/packages/ffe-buttons-react/src/PrimaryButton.mdx
+++ b/packages/ffe-buttons-react/src/PrimaryButton.mdx
@@ -12,3 +12,10 @@ For høyt prioriterte handlinger, som det også kan finnes flere av på en side/
 
 <Canvas of={PrimaryButtonStories.Standard} />
 <Controls of={PrimaryButtonStories.Standard} />
+
+## Forskjellige størrelser
+
+Primary Button tilbys i tre størrelser: `sm`, `md` og `lg`. Standardstørrelsen er `md`. Du kan endre størrelsen ved å
+sette `size`-propen til en av disse verdiene, altså `size="sm"`. Hvis du ikke sender inn noe, er størrelsen md.
+
+<Canvas of={PrimaryButtonStories.DifferentSizes} />

--- a/packages/ffe-buttons-react/src/PrimaryButton.stories.tsx
+++ b/packages/ffe-buttons-react/src/PrimaryButton.stories.tsx
@@ -22,6 +22,11 @@ const meta: Meta<typeof PrimaryButton<any>> = {
                 custom: Custom,
             },
         },
+        size: {
+            options: ['lg', 'md', 'sm'],
+            control: { type: 'radio' },
+            description: "Størrelse på knappen, 'md' default",
+        },
     },
 };
 export default meta;
@@ -34,5 +39,24 @@ export const Standard: Story = {
         ariaLoadingMessage: 'Vennligst vent...',
         isLoading: false,
     },
-    render: args => <PrimaryButton {...args}>Primærknapp</PrimaryButton>,
+    render: args => <PrimaryButton {...args}>Primary Button</PrimaryButton>,
+};
+
+export const DifferentSizes: Story = {
+    args: {
+        as: 'button',
+        ariaLoadingMessage: 'Vennligst vent...',
+        isLoading: false,
+    },
+    render: args => (
+        <div className="ffe-button-display-group">
+            <PrimaryButton {...args} size="lg">
+                Stor knapp
+            </PrimaryButton>
+            <PrimaryButton {...args}>Default knapp</PrimaryButton>
+            <PrimaryButton {...args} size="sm">
+                Liten knapp
+            </PrimaryButton>
+        </div>
+    ),
 };

--- a/packages/ffe-buttons-react/src/SecondaryButton.mdx
+++ b/packages/ffe-buttons-react/src/SecondaryButton.mdx
@@ -1,6 +1,6 @@
 import { Canvas, Meta, Controls } from '@storybook/blocks';
 import * as SecondaryButtonStories from './SecondaryButton.stories.tsx';
-import { SecondaryButton } from '@sb1/ffe-buttons-react';
+import { SecondaryButton } from "@sb1/ffe-buttons-react";
 
 <Meta of={SecondaryButtonStories} />
 
@@ -13,3 +13,10 @@ SecondaryButtons kan ha ikon.
 
 <Canvas of={SecondaryButtonStories.Standard} />
 <Controls of={SecondaryButtonStories.Standard} />
+
+## Forskjellige størrelser
+
+Primary Button tilbys i tre størrelser: `sm`, `md` og `lg`. Standardstørrelsen er `md`. Du kan endre størrelsen ved å
+sette `size`-propen til en av disse verdiene, altså `size="sm"`. Hvis du ikke sender inn noe, er størrelsen md.
+
+<Canvas of={SecondaryButtonStories.DifferentSizes} />

--- a/packages/ffe-buttons-react/src/SecondaryButton.stories.tsx
+++ b/packages/ffe-buttons-react/src/SecondaryButton.stories.tsx
@@ -22,6 +22,11 @@ const meta: Meta<typeof SecondaryButton<any>> = {
                 custom: Custom,
             },
         },
+        size: {
+            options: ['lg', 'md', 'sm'],
+            control: { type: 'radio' },
+            description: "Størrelse på knappen, 'md' default",
+        },
     },
 };
 export default meta;
@@ -34,5 +39,30 @@ export const Standard: Story = {
         ariaLoadingMessage: 'Vennligst vent...',
         isLoading: false,
     },
-    render: args => <SecondaryButton {...args}>Sekundærknapp</SecondaryButton>,
+    render: args => {
+        return (
+            <div className="ffe-button-display-group">
+                <SecondaryButton {...args}>Sekundærknapp</SecondaryButton>
+            </div>
+        );
+    },
+};
+
+export const DifferentSizes: Story = {
+    args: {
+        as: 'button',
+        ariaLoadingMessage: 'Vennligst vent...',
+        isLoading: false,
+    },
+    render: args => (
+        <div className="ffe-button-display-group">
+            <SecondaryButton {...args} size="lg">
+                Sekundærknapp
+            </SecondaryButton>
+            <SecondaryButton {...args}>Sekundærknapp</SecondaryButton>
+            <SecondaryButton {...args} size="sm">
+                Sekundærknapp
+            </SecondaryButton>
+        </div>
+    ),
 };

--- a/packages/ffe-buttons/less/base-button.less
+++ b/packages/ffe-buttons/less/base-button.less
@@ -1,9 +1,14 @@
 @import (reference) '@sb1/ffe-core/less/breakpoints';
 
 .ffe-button {
+    --border-width: 2px;
+    --padding-sm: calc(var(--ffe-spacing-2xs) - var(--border-width));
+    --padding-md: calc(var(--ffe-spacing-xs) - var(--border-width));
+    --padding-lg: calc(12px - var(--border-width));
+
     align-items: center;
     appearance: none;
-    border: 2px solid transparent;
+    border: var(--border-width) solid transparent;
     border-radius: 6em;
     color: var(--ffe-color-component-button-primary-foreground-default);
     cursor: pointer;
@@ -12,7 +17,6 @@
     justify-content: center;
     line-height: 1.5; // 16 * 1.5 = 24(height of ffe-icons size md)
     overflow: hidden;
-    padding: var(--ffe-spacing-xs) var(--ffe-spacing-md);
     position: relative;
     text-align: center;
     text-decoration: none;
@@ -67,125 +71,168 @@
     .ffe-icons {
         display: block;
     }
-}
 
-.ffe-button--action {
-    background-color: var(--ffe-color-component-button-action-fill-default);
-    color: var(--ffe-color-component-button-action-foreground-default);
-    border: none;
+    &--sm {
+        padding: var(--padding-sm) 12px;
+        font-size: var(--ffe-fontsize-button-sm);
+    }
 
-    :where(.ffe-button__icon) {
+    &--md {
+        padding: var(--padding-md) var(--ffe-spacing-sm);
+    }
+
+    &--lg {
+        padding: var(--padding-lg) var(--ffe-spacing-md);
+    }
+
+    &--action {
+        background-color: var(--ffe-color-component-button-action-fill-default);
         color: var(--ffe-color-component-button-action-foreground-default);
-    }
 
-    &:active {
-        transform: scale(0.97);
-        background-color: var(--ffe-color-component-button-action-fill-pressed);
-    }
+        :where(.ffe-button__icon) {
+            color: var(--ffe-color-component-button-action-foreground-default);
+        }
 
-    @media (hover: hover) and (pointer: fine) {
-        &:hover:not(:active):not(.ffe-button--pressed) {
+        &:active {
+            transform: scale(0.97);
             background-color: var(
-                --ffe-color-component-button-action-fill-hover
+                --ffe-color-component-button-action-fill-pressed
             );
         }
-    }
-}
 
-.ffe-button--primary {
-    --background-color: var(--ffe-color-component-button-primary-fill-default);
-    --text-color: var(--ffe-color-component-button-primary-foreground-default);
-
-    background-color: var(--background-color);
-    color: var(--text-color);
-
-    :where(.ffe-button__icon) {
-        color: var(--text-color);
+        @media (hover: hover) and (pointer: fine) {
+            &:hover:not(:active):not(.ffe-button--pressed) {
+                background-color: var(
+                    --ffe-color-component-button-action-fill-hover
+                );
+            }
+        }
     }
 
-    &:active {
-        transform: scale(0.97);
-
+    &--primary {
         --background-color: var(
-            --ffe-color-component-button-primary-fill-pressed
+            --ffe-color-component-button-primary-fill-default
         );
-    }
+        --text-color: var(
+            --ffe-color-component-button-primary-foreground-default
+        );
 
-    @media (hover: hover) and (pointer: fine) {
-        &:hover {
-            --background-color: var(
-                --ffe-color-component-button-primary-fill-hover
-            );
-        }
-    }
-}
-
-.ffe-button--secondary,
-.ffe-button--expand {
-    --background-color: var(
-        --ffe-color-component-button-secondary-fill-default
-    );
-    --border-color: var(--ffe-color-component-button-secondary-border-default);
-    --text-color: var(
-        --ffe-color-component-button-secondary-foreground-default
-    );
-
-    background-color: var(--background-color);
-    border: solid 2px var(--border-color);
-    color: var(--text-color);
-
-    :where(.ffe-button__label, .ffe-button__icon) {
+        background-color: var(--background-color);
         color: var(--text-color);
-    }
 
-    @media (hover: hover) and (pointer: fine) {
-        &:hover {
+        :where(.ffe-button__icon) {
+            color: var(--text-color);
+        }
+
+        &:active {
+            transform: scale(0.97);
+
             --background-color: var(
-                --ffe-color-component-button-secondary-fill-hover
+                --ffe-color-component-button-primary-fill-pressed
             );
-            --border-color: var(
-                --ffe-color-component-button-secondary-border-hover
-            );
-            --text-color: var(
-                --ffe-color-component-button-secondary-foreground-hover
-            );
+        }
+
+        @media (hover: hover) and (pointer: fine) {
+            &:hover {
+                --background-color: var(
+                    --ffe-color-component-button-primary-fill-hover
+                );
+            }
         }
     }
 
-    &:focus,
-    &:visited {
-        color: var(--ffe-color-component-button-secondary-foreground-default);
-        background-color: var(
-            --ffe-color-component-button-secondary-fill-hover
+    &--secondary,
+    &--expand {
+        --background-color: var(
+            --ffe-color-component-button-secondary-fill-default
         );
-    }
-
-    &:active {
-        transform: scale(0.97);
-        background-color: var(
-            --ffe-color-component-button-secondary-fill-pressed
+        --border-color: var(
+            --ffe-color-component-button-secondary-border-default
         );
-        border-color: var(
-            --ffe-color-component-button-secondary-border-pressed
+        --text-color: var(
+            --ffe-color-component-button-secondary-foreground-default
         );
-        color: var(--ffe-color-component-button-secondary-foreground-hover);
-    }
-}
 
-.ffe-button--shortcut {
-    background-color: var(--ffe-color-component-button-secondary-fill-default);
-    border: solid 2px var(--ffe-color-component-button-secondary-border-default);
-    color: var(--ffe-color-component-button-secondary-foreground-default);
+        background-color: var(--background-color);
+        border: solid 2px var(--border-color);
+        color: var(--text-color);
 
-    .ffe-button__icon {
-        color: var(--ffe-color-component-button-secondary-foreground-default);
-        transition: transform var(--ffe-transition-duration) var(--ffe-ease);
-    }
+        :where(.ffe-button__label, .ffe-button__icon) {
+            color: var(--text-color);
+        }
 
-    @media (hover: hover) and (pointer: fine) {
-        &:hover {
+        @media (hover: hover) and (pointer: fine) {
+            &:hover {
+                --background-color: var(
+                    --ffe-color-component-button-secondary-fill-hover
+                );
+                --border-color: var(
+                    --ffe-color-component-button-secondary-border-hover
+                );
+                --text-color: var(
+                    --ffe-color-component-button-secondary-foreground-hover
+                );
+            }
+        }
+
+        &:focus,
+        &:visited {
+            color: var(
+                --ffe-color-component-button-secondary-foreground-default
+            );
             background-color: var(
                 --ffe-color-component-button-secondary-fill-hover
+            );
+        }
+
+        &:active {
+            transform: scale(0.97);
+            background-color: var(
+                --ffe-color-component-button-secondary-fill-pressed
+            );
+            border-color: var(
+                --ffe-color-component-button-secondary-border-pressed
+            );
+            color: var(--ffe-color-component-button-secondary-foreground-hover);
+        }
+    }
+
+    &--shortcut {
+        background-color: var(
+            --ffe-color-component-button-secondary-fill-default
+        );
+        border: solid var(--border-width)
+            var(--ffe-color-component-button-secondary-border-default);
+        color: var(--ffe-color-component-button-secondary-foreground-default);
+
+        .ffe-button__icon {
+            color: var(
+                --ffe-color-component-button-secondary-foreground-default
+            );
+            transition: transform var(--ffe-transition-duration) var(--ffe-ease);
+        }
+
+        @media (hover: hover) and (pointer: fine) {
+            &:hover {
+                background-color: var(
+                    --ffe-color-component-button-secondary-fill-hover
+                );
+                color: var(
+                    --ffe-color-component-button-secondary-foreground-hover
+                );
+
+                .ffe-button__icon {
+                    color: var(
+                        --ffe-color-component-button-secondary-foreground-hover
+                    );
+                }
+            }
+        }
+
+        &:active {
+            transform: scale(0.97);
+            background-color: var(
+                --ffe-color-component-button-secondary-fill-pressed
             );
             color: var(--ffe-color-component-button-secondary-foreground-hover);
 
@@ -195,154 +242,151 @@
                 );
             }
         }
-    }
 
-    &:active {
-        transform: scale(0.97);
-        background-color: var(
-            --ffe-color-component-button-secondary-fill-pressed
-        );
-        color: var(--ffe-color-component-button-secondary-foreground-hover);
-
-        .ffe-button__icon {
-            color: var(--ffe-color-component-button-secondary-foreground-hover);
-        }
-    }
-
-    &:focus,
-    &:visited {
-        color: var(--ffe-color-component-button-secondary-foreground-default);
-        background-color: var(
-            --ffe-color-component-button-secondary-fill-hover
-        );
-    }
-
-    &:hover,
-    &:focus {
-        .ffe-button__icon {
-            transform: translateX(4px);
-        }
-    }
-}
-
-.ffe-button--expanded {
-    padding: var(--ffe-spacing-xs);
-    width: 45px;
-}
-
-.ffe-button--task {
-    --text-color: var(--ffe-color-foreground-emphasis);
-    background: transparent;
-    border-radius: 1.75rem;
-    border: none;
-    box-shadow: none;
-    color: var(--text-color);
-    display: inline-block;
-    padding: var(--ffe-spacing-2xs) var(--ffe-spacing-sm) var(--ffe-spacing-2xs)
-        var(--ffe-spacing-2xs);
-    text-align: left;
-    transition: all var(--ffe-transition-duration) var(--ffe-ease);
-    width: auto;
-
-    :where(.ffe-button__icon) {
-        --icon-border-color: var(--ffe-color-foreground-emphasis);
-        --icon-background-color: transparent;
-        --icon-color: var(--ffe-color-foreground-emphasis);
-
-        border: 2px solid var(--icon-border-color);
-        background-color: var(--icon-background-color);
-        border-radius: 50%;
-        height: 45px;
-        width: 45px;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        transition: all var(--ffe-transition-duration) var(--ffe-ease);
-
-        :where(.ffe-icons) {
-            color: var(--icon-color);
-        }
-    }
-
-    &:focus {
-        &::after {
-            box-shadow: 0 0 0 2px var(--ffe-color-border-interactive-focus);
-        }
-    }
-
-    &:active {
-        transform: scale(0.97);
-        background-color: transparent;
-
-        .ffe-button__icon {
-            background-color: var(
-                --ffe-color-component-button-secondary-fill-pressed
+        &:focus,
+        &:visited {
+            color: var(
+                --ffe-color-component-button-secondary-foreground-default
             );
+            background-color: var(
+                --ffe-color-component-button-secondary-fill-hover
+            );
+        }
 
-            --icon-border-color: var(--ffe-color-foreground-emphasis);
+        &:hover,
+        &:focus {
+            .ffe-button__icon {
+                transform: translateX(4px);
+            }
         }
     }
 
-    @media (hover: hover) and (pointer: fine) {
-        &:hover {
+    &--expanded {
+        &.ffe-button--sm {
+            padding: var(--padding-sm);
+        }
+        &.ffe-button--md {
+            padding: var(--padding-md);
+        }
+        &.ffe-button--lg {
+            padding: var(--padding-lg);
+        }
+    }
+
+    &--task {
+        --text-color: var(--ffe-color-foreground-emphasis);
+        background: transparent;
+        border-radius: 1.75rem;
+        border: none;
+        box-shadow: none;
+        color: var(--text-color);
+        display: inline-block;
+        padding: var(--ffe-spacing-2xs) var(--ffe-spacing-sm)
+            var(--ffe-spacing-2xs) var(--ffe-spacing-2xs);
+        text-align: left;
+        transition: all var(--ffe-transition-duration) var(--ffe-ease);
+        width: auto;
+
+        :where(.ffe-button__icon) {
+            --icon-border-color: var(--ffe-color-foreground-emphasis);
+            --icon-background-color: transparent;
+            --icon-color: var(--ffe-color-foreground-emphasis);
+
+            border: 2px solid var(--icon-border-color);
+            background-color: var(--icon-background-color);
+            border-radius: 50%;
+            height: 45px;
+            width: 45px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            transition: all var(--ffe-transition-duration) var(--ffe-ease);
+
+            :where(.ffe-icons) {
+                color: var(--icon-color);
+            }
+        }
+
+        &:focus {
+            &::after {
+                box-shadow: 0 0 0 2px var(--ffe-color-border-interactive-focus);
+            }
+        }
+
+        &:active {
+            transform: scale(0.97);
+            background-color: transparent;
+
             .ffe-button__icon {
-                --icon-background-color: var(
-                    --ffe-color-component-button-secondary-fill-hover
+                background-color: var(
+                    --ffe-color-component-button-secondary-fill-pressed
                 );
+
                 --icon-border-color: var(--ffe-color-foreground-emphasis);
             }
         }
-    }
-}
 
-.ffe-button--loading {
-    pointer-events: none;
-
-    .ffe-button__label {
-        transform: translateY(-32px);
-        opacity: 0;
-    }
-
-    .ffe-button__spinner {
-        opacity: 1;
-        transform: none;
-        visibility: visible;
-    }
-}
-
-.ffe-button__label {
-    align-items: center;
-    display: flex;
-    transition: transform var(--ffe-transition-duration) var(--ffe-ease);
-    gap: var(--ffe-spacing-xs);
-}
-
-.ffe-button__spinner {
-    inset: 0;
-    opacity: 0;
-    position: absolute;
-    transform: translateY(24px);
-    transition: all var(--ffe-transition-duration) var(--ffe-ease);
-    visibility: hidden;
-    display: grid;
-    place-items: center;
-
-    &::after {
-        animation: 1s linear infinite button-loading-spin;
-        border: 3px solid currentcolor;
-        border-radius: 50%;
-        border-top-color: transparent;
-        content: '';
-        display: block;
-        height: 1.375rem;
-        aspect-ratio: 1;
-
-        @keyframes button-loading-spin {
-            from {
-                transform: none;
+        @media (hover: hover) and (pointer: fine) {
+            &:hover {
+                .ffe-button__icon {
+                    --icon-background-color: var(
+                        --ffe-color-component-button-secondary-fill-hover
+                    );
+                    --icon-border-color: var(--ffe-color-foreground-emphasis);
+                }
             }
-            to {
-                transform: rotate(360deg);
+        }
+    }
+
+    &--loading {
+        pointer-events: none;
+
+        .ffe-button__label {
+            transform: translateY(-32px);
+            opacity: 0;
+        }
+
+        .ffe-button__spinner {
+            opacity: 1;
+            transform: none;
+            visibility: visible;
+        }
+    }
+
+    &__label {
+        align-items: center;
+        display: flex;
+        transition: transform var(--ffe-transition-duration) var(--ffe-ease);
+        gap: var(--ffe-spacing-xs);
+    }
+
+    &__spinner {
+        inset: 0;
+        opacity: 0;
+        position: absolute;
+        transform: translateY(24px);
+        transition: all var(--ffe-transition-duration) var(--ffe-ease);
+        visibility: hidden;
+        display: grid;
+        place-items: center;
+
+        &::after {
+            animation: 1s linear infinite button-loading-spin;
+            border: 3px solid currentcolor;
+            border-radius: 50%;
+            border-top-color: transparent;
+            content: '';
+            display: block;
+            height: 1.375rem;
+            aspect-ratio: 1;
+
+            @keyframes button-loading-spin {
+                from {
+                    transform: none;
+                }
+                to {
+                    transform: rotate(360deg);
+                }
             }
         }
     }

--- a/packages/ffe-buttons/less/inline-base-button.less
+++ b/packages/ffe-buttons/less/inline-base-button.less
@@ -36,11 +36,11 @@
         }
 
         &--left {
-            margin-right: 6px;
+            margin-right: var(--ffe-spacing-2xs);
         }
 
         &--right {
-            margin-left: 6px;
+            margin-left: var(--ffe-spacing-2xs);
         }
     }
 }
@@ -90,7 +90,7 @@
 
     color: var(--text-color);
     background-color: var(--background-color);
-    padding: 0 var(--ffe-spacing-xs);
+    padding: 0 12px;
     margin: 0;
     align-items: center;
 
@@ -123,12 +123,12 @@
 
 .ffe-inline-button--tertiary {
     --icon-size-md: 1.5rem; // 24px
-    --border-width: 1px;
+    --border-width: 2px;
 
     align-content: center;
     color: var(--ffe-color-component-button-tertiary-foreground-default);
     flex-wrap: wrap;
-    padding: var(--ffe-spacing-xs) calc(var(--ffe-spacing-sm));
+    padding: calc(var(--ffe-spacing-xs) - var(--border-width)) var(--ffe-spacing-sm);
     border: 2px solid transparent;
     line-height: calc(var(--icon-size-md) - var(--border-width));
 

--- a/packages/ffe-core/less/theme.less
+++ b/packages/ffe-core/less/theme.less
@@ -79,6 +79,7 @@
     --ffe-fontsize-form-input: 1rem;
     --ffe-fontsize-form-dropdown: 1rem;
     --ffe-fontsize-button: 1rem;
+    --ffe-fontsize-button-sm: 0.875rem;
 
     /** Breakpoints */
     --breakpoint-sm: @breakpoint-sm;


### PR DESCRIPTION
Flere knappestørrelser!

Som en del av oppgradering, semantiske farger og modernisering av komponentene våre. Og, så har det kommet inn som et [ønske i ønskelista](https://www.figma.com/design/uSg1Lz02to7HEZNzqBqi3p/%C3%98nskeliste?node-id=113-10181). 

![image](https://github.com/user-attachments/assets/851f8ecc-36a4-428c-90eb-51b9ea2fd650)

Det gjelder PrimaryButton, SecondaryButton, ActionButton og ExpandButton. 

