### PR TITLE
Semantiske opprydding del 1

### DIFF
--- a/packages/ffe-chips-react/src/ChipSelectable.tsx
+++ b/packages/ffe-chips-react/src/ChipSelectable.tsx
@@ -1,7 +1,11 @@
+import { Icon } from '@sb1/ffe-icons-react';
 import React, { ElementType, ForwardedRef } from 'react';
 import { Chip, type ChipProps } from './Chip';
 import { fixedForwardRef } from './fixedForwardRef';
 import classNames from 'classnames';
+
+const checkOpen400Sm =
+    'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGhlaWdodD0iMjAiIHZpZXdCb3g9IjAgLTk2MCA5NjAgOTYwIiB3aWR0aD0iMjAiPjxwYXRoIGQ9Im0zODktMzY5IDI5OS0yOTlxMTAuOTA5LTExIDI1LjQ1NS0xMVE3MjgtNjc5IDczOS02NjhxMTEgMTEgMTEgMjUuNTgyIDAgMTQuNTgzLTEwLjYwNyAyNS4xODhMNDE1LTI5MnEtMTAuOTA5IDExLTI1LjQ1NSAxMVEzNzUtMjgxIDM2NC0yOTJMMjIxLTQzNXEtMTEtMTEtMTEtMjUuNXQxMS0yNS41cTExLTExIDI1LjY2Ny0xMSAxNC42NjYgMCAyNS4zMzMgMTFsMTE3IDExN1oiLz48L3N2Zz4=';
 
 export type ChipSelectableProps<As extends ElementType = 'button'> =
     ChipProps<As> & {
@@ -18,6 +22,7 @@ function ChipSelectableForwardRef<As extends ElementType>(
     return (
         <Chip
             ref={ref}
+            leftIcon={<Icon size="sm" fileUrl={checkOpen400Sm} />}
             className={classNames(className, {
                 'ffe-chip--selected': isSelected,
             })}

--- a/packages/ffe-chips/less/chip.less
+++ b/packages/ffe-chips/less/chip.less
@@ -50,7 +50,7 @@
     }
 
     &:active {
-        --background-color: var(var(--ffe-color-fill-primary-subtle-pressed));
+        --background-color: var(--ffe-color-fill-primary-subtle-pressed);
         --border-color: var(--ffe-color-border-primary-pressed);
 
         transform: scale(0.97);

--- a/packages/ffe-feedback/less/feedback.less
+++ b/packages/ffe-feedback/less/feedback.less
@@ -12,7 +12,6 @@
         flex-direction: column;
         align-items: center;
         color: var(--ffe-color-foreground-default);
-        text-align: center; // Add text alignment for better heading display
     }
 
     &__heading {

--- a/packages/ffe-form/less/checkbox.less
+++ b/packages/ffe-form/less/checkbox.less
@@ -51,7 +51,7 @@
 
     &::before {
         background: var(--ffe-color-surface-primary-default);
-        border: 1px solid var(--ffe-color-foreground-subtle);
+        border: var(--ffe-g-border-width) solid var(--ffe-color-foreground-subtle);
         border-radius: calc(var(--ffe-g-border-radius) / 2);
         height: 20px;
         width: 20px;
@@ -100,14 +100,21 @@
 
     &:focus + .ffe-checkbox::before,
     &:focus-visible + .ffe-checkbox::before {
-        border: 1px solid var(--ffe-color-border-primary-selected); // Changed border width to 1px
-        box-shadow: 0 0 0 1px var(--ffe-color-border-primary-selected); // Changed box-shadow width to 1px
+        border: var(--ffe-g-border-width) solid var(--ffe-color-border-primary-selected);
+        box-shadow: var(--ffe-g-border-focus-box-shadow) var(--ffe-color-border-primary-selected);
     }
 
     &:active + .ffe-checkbox {
         &::before {
             border-color: var(--ffe-color-border-primary-default);
             background: var(--ffe-color-surface-primary-default-pressed);
+        }
+    }
+
+    &:active:checked + .ffe-checkbox {
+        &::before {
+            border-color: var(--ffe-color-border-primary-selected);
+            background: var(--ffe-color-fill-primary-pressed);
         }
     }
 

--- a/packages/ffe-form/less/dropdown.less
+++ b/packages/ffe-form/less/dropdown.less
@@ -56,7 +56,7 @@
 
     &:focus,
     &:active {
-        border-color: var(--ffe-color-border-primary-pressed);
+        border-color: var(--ffe-color-border-interactive-focus);
         box-shadow: var(--ffe-g-border-focus-box-shadow)
             var(--ffe-color-border-interactive-focus);
         outline: none;

--- a/packages/ffe-messages/less/common.less
+++ b/packages/ffe-messages/less/common.less
@@ -18,7 +18,6 @@
         --icon-background: var(--ffe-v-messages-icon-background-color-info);
         --icon-color: var(--ffe-v-messages-icon-color-info);
         --close-button: var(--ffe-v-messages-close-button-color-info);
-        --link-text-color: var(--ffe-v-messages-link-color-info);
         --mask-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGhlaWdodD0iMjAiIHZpZXdCb3g9IjAgLTk2MCA5NjAgOTYwIiB3aWR0aD0iMjAiPjxwYXRoIGQ9Ik00NzkuNzg4LTY3MnEtMjUuOTQyIDAtNDMuODY0LTE4LjEzNS0xNy45MjMtMTguMTM2LTE3LjkyMy00NC4wNzd0MTguMTM1LTQzLjg2NHExOC4xMzUtMTcuOTIzIDQ0LjA3Ni0xNy45MjMgMjUuOTQyIDAgNDMuODY0IDE4LjEzNiAxNy45MjMgMTguMTM1IDE3LjkyMyA0NC4wNzZ0LTE4LjEzNSA0My44NjRRNTA1LjcyOS02NzIgNDc5Ljc4OC02NzJabS4yNTcgNTA3Ljk5OXEtMjAuODE0IDAtMzUuNDI5LTE0LjU4NC0xNC42MTUtMTQuNTgzLTE0LjYxNS0zNS40MTZ2LTI5Ni42MTRxMC0yMC44MzMgMTQuNTctMzUuNDE2IDE0LjU3LTE0LjU4MyAzNS4zODQtMTQuNTgzdDM1LjQyOSAxNC41ODNxMTQuNjE1IDE0LjU4MyAxNC42MTUgMzUuNDE2djI5Ni42MTRxMCAyMC44MzMtMTQuNTcgMzUuNDE2LTE0LjU3IDE0LjU4NC0zNS4zODQgMTQuNTg0WiIvPjwvc3ZnPg==');
     }
 
@@ -59,7 +58,6 @@
         --icon-background: var(--ffe-v-messages-icon-background-color-error);
         --icon-color: var(--ffe-v-messages-icon-color-error);
         --close-button: var(--ffe-v-messages-close-button-color-error);
-        --link-text-color: var(--ffe-v-messages-link-color-error);
         --mask-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGhlaWdodD0iMjAiIHZpZXdCb3g9IjAgLTk2MCA5NjAgOTYwIiB3aWR0aD0iMjAiPjxwYXRoIGQ9Ik00NzkuNzg4LTE4Ny4wOHEtMjEuNTM3IDAtMzYuNjYyLTE1LjMzN3QtMTUuMTI1LTM2Ljg3NHEwLTIxLjUzNyAxNS4zMzctMzYuNjYyIDE1LjMzNy0xNS4xMjQgMzYuODc0LTE1LjEyNCAyMS41MzcgMCAzNi42NjIgMTUuMzM3dDE1LjEyNSAzNi44NzRxMCAyMS41MzctMTUuMzM3IDM2LjY2MS0xNS4zMzcgMTUuMTI1LTM2Ljg3NCAxNS4xMjVabS0uMDYyLTE5Ni4xNTFxLTE5LjM0MSAwLTMyLjg0LTEzLjcwOS0xMy41LTEzLjcwOS0xMy41LTMyLjk2di0zMTYuNjg1cTAtMTkuMjUxIDEzLjc3NC0zMi43OTQgMTMuNzczLTEzLjU0MiAzMy4xMTQtMTMuNTQyIDE5LjM0MSAwIDMyLjg0IDEzLjcwOSAxMy41IDEzLjcwOSAxMy41IDMyLjk2djMxNi42ODVxMCAxOS4yNTEtMTMuNzc0IDMyLjc5NC0xMy43NzMgMTMuNTQyLTMzLjExNCAxMy41NDJaIi8+PC9zdmc+');
     }
 
@@ -121,7 +119,7 @@
         display: grid;
         grid-template-columns: auto 1fr auto;
         gap: var(--ffe-spacing-sm);
-        align-items: center;
+        align-items: flex-start;
         grid-template-rows: 1fr;
     }
 }

--- a/packages/ffe-messages/less/theme.less
+++ b/packages/ffe-messages/less/theme.less
@@ -4,7 +4,7 @@
     --ffe-v-messages-text-color-info: var(--ffe-color-foreground-feedback-info);
     --ffe-v-messages-border-color-info: var(--ffe-color-border-feedback-info);
     --ffe-v-messages-icon-background-color-info: var(--ffe-color-fill-feedback-info);
-    --ffe-v-messages-icon-color-info: var(--ffe-color-foreground-on-fill-default);
+    --ffe-v-messages-icon-color-info: var(--ffe-color-foreground-inverse);
     --ffe-v-messages-close-button-color-info: var(--ffe-color-foreground-feedback-info);
 
     /** Tips */
@@ -12,7 +12,7 @@
     --ffe-v-messages-text-color-tip: var(--ffe-color-foreground-feedback-tip);
     --ffe-v-messages-border-color-tip: var(--ffe-color-border-feedback-tip);
     --ffe-v-messages-icon-background-color-tip: var(--ffe-color-fill-feedback-tip);
-    --ffe-v-messages-icon-color-tip: var(--ffe-color-foreground-on-fill-default);
+    --ffe-v-messages-icon-color-tip: var(--ffe-color-foreground-inverse);
     --ffe-v-messages-close-button-color-tip: var(--ffe-color-foreground-feedback-tip);
 
     /** Success */
@@ -20,7 +20,7 @@
     --ffe-v-messages-text-color-success: var(--ffe-color-foreground-feedback-success);
     --ffe-v-messages-border-color-success: var(--ffe-color-border-feedback-success);
     --ffe-v-messages-icon-background-color-success: var(--ffe-color-fill-feedback-success);
-    --ffe-v-messages-icon-color-success: var(--ffe-color-foreground-on-fill-default);
+    --ffe-v-messages-icon-color-success: var(--ffe-color-foreground-inverse);
     --ffe-v-messages-close-button-color-success: var(--ffe-color-foreground-feedback-success);
 
     /** Warning */
@@ -28,7 +28,7 @@
     --ffe-v-messages-text-color-warning: var(--ffe-color-foreground-feedback-warning);
     --ffe-v-messages-border-color-warning: var(--ffe-color-border-feedback-warning);
     --ffe-v-messages-icon-background-color-warning: var(--ffe-color-fill-feedback-warning);
-    --ffe-v-messages-icon-color-warning: var(--ffe-color-foreground-on-fill-default);
+    --ffe-v-messages-icon-color-warning: var(--ffe-color-foreground-inverse);
     --ffe-v-messages-close-button-color-warning: var(--ffe-color-foreground-feedback-warning);
 
     /** Error */
@@ -36,7 +36,7 @@
     --ffe-v-messages-text-color-error: var(--ffe-color-foreground-feedback-critical);
     --ffe-v-messages-border-color-error: var(--ffe-color-border-feedback-critical);
     --ffe-v-messages-icon-background-color-error: var(--ffe-color-fill-feedback-critical);
-    --ffe-v-messages-icon-color-error: var(--ffe-color-foreground-on-fill-default);
+    --ffe-v-messages-icon-color-error: var(--ffe-color-foreground-inverse);
     --ffe-v-messages-close-button-color-error: var(--ffe-color-foreground-feedback-critical);
     --ffe-v-messages-link-color-error: var(--ffe-foreground-feedback-critical);
 

--- a/packages/ffe-spinner-react/src/Spinner.mdx
+++ b/packages/ffe-spinner-react/src/Spinner.mdx
@@ -15,5 +15,9 @@ Spinneren finnes i liten og stor versjon.
 ## Forhåndsvisning
 
 <Canvas of={SpinnerStories.Standard} />
-<Canvas of={SpinnerStories.Large} />
 <Controls of={SpinnerStories.Standard} />
+
+## Størrelser
+
+<Canvas of={SpinnerStories.Large} />
+<Controls of={SpinnerStories.Large} />

--- a/packages/ffe-spinner-react/src/Spinner.stories.tsx
+++ b/packages/ffe-spinner-react/src/Spinner.stories.tsx
@@ -32,6 +32,7 @@ export const Large: Story = {
     args: {
         ...Standard.args,
         large: true,
+        loadingText: 'Større loading',
     },
     render: args => <Spinner {...args} />,
 };

--- a/packages/ffe-spinner-react/src/Spinner.tsx
+++ b/packages/ffe-spinner-react/src/Spinner.tsx
@@ -25,7 +25,7 @@ export const Spinner: React.FC<SpinnerProps> = ({
 }) => (
     <div
         aria-live="assertive"
-        className={className}
+        className={classNames('ffe-loading-spinner-container', className)}
         {...rest}
         data-testid="spinner-container"
     >

--- a/packages/ffe-spinner/less/spinner.less
+++ b/packages/ffe-spinner/less/spinner.less
@@ -1,3 +1,10 @@
+.ffe-loading-spinner-container {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    color: var(--ffe-color-foreground-default);
+}
+
 .ffe-loading-spinner {
     display: inline-block;
     vertical-align: middle;
@@ -5,10 +12,10 @@
     &::before {
         content: ' ';
         display: inline-block;
-        width: 20px;
-        height: 20px;
-        border: 3px solid var(--ffe-color-foreground-emphasis);
-        border-top-color: transparent;
+        width: 30px;
+        height: 30px;
+        border: 3px solid var(--ffe-color-fill-primary-default);
+        border-top-color: var(--ffe-color-fill-primary-subtle);
         border-radius: 50%;
         animation: spin 1s linear infinite;
 
@@ -35,9 +42,9 @@
     }
 
     &--large::before {
-        border-width: 3px;
-        height: 40px;
-        width: 40px;
+        border-width: 5px;
+        height: 60px;
+        width: 60px;
     }
 
     &--immediate::before {

--- a/packages/ffe-tabs/less/tab-group.less
+++ b/packages/ffe-tabs/less/tab-group.less
@@ -5,7 +5,7 @@
     flex-direction: column;
     border-radius: 25px;
     background-color: var(--ffe-color-surface-primary-default);
-    border: 2px solid var(--ffe-color-border-primary-subtle);
+    border: var(--ffe-g-border-width) solid var(--ffe-color-border-primary-subtle);
 
     align-items: center;
 


### PR DESCRIPTION
Har gått igjennom Figma og sett om det stemmer med koden i forbedredelse på å gi A-ok på at alle kan bruke semantiske farger. Her er det mange små fikses i en commit, gjerne se nøye på om alt stemmer, også om commitmeldingene ble riktige

## Form 
### Dropdown
Fikser feil fokusfarge på border
Fra 
![image](https://github.com/user-attachments/assets/f6b76fc5-c4db-48f1-8e4d-89c96019cc4e)
Til 
<img width="456" alt="image" src="https://github.com/user-attachments/assets/76ca24f7-38a6-4786-a44d-89d8431ccabb" />

### Checkbox
Lagt til riktig Selected pressed state - men selected hover state tror jeg det er noe feil med fra Figma

## Chip 
Button - hadde feil pressed styling
Selected - har lagt til checked ikon 

## Feedback 
Har venstrestilt teksten, slik som det var før. Venstrestilling av header og bedre padding på knappen under er en større omsrkivningsjobb, så har ikke gjort det nå. 

## Messages
Oppdaterte til riktig variabel for ikonfargene. 
ContextMessage: Alignment på ikonet er nå på toppen 
Fixes https://github.com/SpareBank1/designsystem/issues/2651 

## Tabgroup
Endret fra 2px til 1px på gruppen

## Spinner
Endret til riktige farger, midstilling, riktig størrelse og tykkelse og forbedret dokumentasjonen bittelitt. 

