### PR TITLE
chore: oppdater react-custom-scrollbars (#2661)

### DIFF
--- a/packages/ffe-account-selector-react/package.json
+++ b/packages/ffe-account-selector-react/package.json
@@ -35,7 +35,7 @@
         "@sb1/ffe-icons-react": "^11.0.20",
         "@sb1/ffe-searchable-dropdown-react": "^23.1.15",
         "classnames": "^2.3.1",
-        "react-custom-scrollbars-2": "^4.3.0"
+        "react-custom-scrollbars-4": "^4.5.1"
     },
     "devDependencies": {
         "@sb1/ffe-buildtool": "^0.10.0",


### PR DESCRIPTION
ffe-account selector bruker react-custom-scrollbars-2 som ikke støtter React 19. Se ellers issue #2661 
