### PR TITLE
Wave undepricate

### DIFF
--- a/packages/ffe-core-react/src/Wave.tsx
+++ b/packages/ffe-core-react/src/Wave.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import classNames from 'classnames';
+
+type Color =
+    | 'hvit'
+    | 'frost-30'
+    | 'sand-30'
+    | 'sand-70'
+    | 'syrin-30'
+    | 'syrin-70'
+    | 'vann'
+    | 'vann-30'
+    | 'fjell';
+
+type ColorDarkMode = 'svart' | 'natt';
+
+export interface WaveProps {
+    /** Adds additional class */
+    className?: string;
+    /** Sets the mask-position property, setting a px/rem value will move the starting position of the wave */
+    position?: string;
+    /** Rotate the wave 180 degrees :*/
+    flip?: boolean;
+    /** Sets the color of the wave. Accepts ffe-color variables without the "ffe-farge-" bit of the name. */
+    color: Color;
+    /** Set the background color of the wave container. Accepts ffe-color variables without the "ffe-farge-" bit of the name. */
+    bgColor?: Color;
+    /** Set the wave color in darkmode */
+    darkmodeColor?: ColorDarkMode;
+    /** Set the background color of wave container in darkmode */
+    bgDarkmodeColor?: ColorDarkMode;
+    children?: React.ReactNode;
+}
+
+/**
+ * @deprecated Use the Wave component in `ffe-shapes-react` instead.
+ */
+export function Wave({
+    position,
+    flip,
+    color,
+    darkmodeColor,
+    bgColor,
+    bgDarkmodeColor,
+    children,
+    className,
+    ...rest
+}: WaveProps) {
+    return (
+        <div
+            className={classNames('ffe-wave', className, {
+                [`ffe-wave--bg-${bgColor}`]: bgColor,
+                [`ffe-wave--dm-bg-${bgDarkmodeColor}`]: bgDarkmodeColor,
+            })}
+        >
+            {children ? (
+                <div className="ffe-wave__content">{children}</div>
+            ) : null}
+            <div
+                className={classNames(
+                    'ffe-wave__wave',
+                    `ffe-wave--bg-${color}`,
+                    {
+                        [`ffe-wave--dm-bg-${darkmodeColor}`]: darkmodeColor,
+                        'ffe-wave__wave--flip': flip,
+                    },
+                )}
+                aria-hidden="true"
+                style={{
+                    maskPosition: position,
+                    WebkitMaskPosition: position,
+                }}
+                {...rest}
+            />
+        </div>
+    );
+}

--- a/packages/ffe-core-react/src/index.ts
+++ b/packages/ffe-core-react/src/index.ts
@@ -22,3 +22,4 @@ export {
 } from './typography/PreformattedText';
 export { SmallText, SmallTextProps } from './typography/SmallText';
 export { StrongText, StrongTextProps } from './typography/StrongText';
+export { Wave, WaveProps } from './Wave';

--- a/packages/ffe-core/less/colors.less
+++ b/packages/ffe-core/less/colors.less
@@ -2,7 +2,7 @@
 // ======== Ny visuell identitet ========
 //
 
-/* DEPRICATED. Skal ikke brukes lenger. Fargene fra colors-semantic skal brukes. */
+/* DEPRECATED. Skal ikke brukes lenger. Fargene fra colors-semantic skal brukes. */
 // Primærpalett
 @ffe-farge-fjell: #002776;
 @ffe-farge-fjell-70: tint(@ffe-farge-fjell, 30%);

--- a/packages/ffe-core/less/ffe.less
+++ b/packages/ffe-core/less/ffe.less
@@ -18,3 +18,4 @@
 @import 'body';
 @import 'accessibility';
 @import 'variables';
+@import 'waves';

--- a/packages/ffe-core/less/theme.less
+++ b/packages/ffe-core/less/theme.less
@@ -5,7 +5,7 @@
  */
 :root,
 :host {
-    /* DEPRICATED, bruk colors-semantic i stedet for */
+    /* DEPRECATED, bruk colors-semantic i stedet for */
 
     /** Primærpalett */
     --ffe-farge-fjell: @ffe-farge-fjell;
@@ -62,7 +62,7 @@
     --ffe-farge-lysvarmgraa: @ffe-farge-lysvarmgraa;
     --ffe-farge-hvit: @ffe-farge-hvit;
 
-    /* END depricated */
+    /* END deprecated */
 
     /** Font sizes */
     --ffe-fontsize-body-text: 1rem;
@@ -129,16 +129,16 @@
     /** Theme base colors */
 
     /* Links, buttons and similar */
-    --ffe-g-primary-color: var(--ffe-color-fill-primary-default); //Depricated
+    --ffe-g-primary-color: var(--ffe-color-fill-primary-default); //Deprecated
 
     /* Headings, labels, hover, etc */
-    --ffe-g-secondary-color: var(--ffe-color-foreground-emphasis); //Depricated
+    --ffe-g-secondary-color: var(--ffe-color-foreground-emphasis); //Deprecated
 
     /* Error messages, invalid inputs, etc  */
-    --ffe-g-error-color: var(--ffe-color-fill-feedback-critical); //Depricated
+    --ffe-g-error-color: var(--ffe-color-fill-feedback-critical); //Deprecated
 
     /* Form element borders */
-    --ffe-g-border-color: var(--ffe-color-border-primary-default); //Depricated
+    --ffe-g-border-color: var(--ffe-color-border-primary-default); //Deprecated
 
     /* Default font */
     --ffe-g-font: 'SpareBank1-regular', arial, sans-serif;

--- a/packages/ffe-core/less/waves.less
+++ b/packages/ffe-core/less/waves.less
@@ -1,0 +1,90 @@
+//DEPRECATED: Use ffe-core/less/waves.less instead
+@import (reference) 'breakpoints';
+@import 'colors';
+
+.ffe-wave {
+    position: relative;
+    width: 100%;
+
+    &__content {
+        position: absolute;
+        z-index: 1;
+        width: 100%;
+    }
+
+    &__wave {
+        mask-repeat: repeat-x;
+        min-height: 60px;
+        mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 479.9 60' style='enable-background:new 0 0 479.9 148' xml:space='preserve'%3E%3Cpath d='M0 530V0c60.7 0 91.6 13.8 121.4 27.1 30.4 13.6 59.1 26.4 118.1 26.4s87.7-12.8 118.1-26.4C387.4 13.8 418.2 0 478.9 0s91.6 13.8 121.4 27.1c30.4 13.6 59.1 26.4 118.1 26.4s87.7-12.8 118.1-26.4C866.3 13.8 897.1 0 957.8 0s91.6 13.8 121.4 27.1c30.4 13.6 59.1 26.4 118.1 26.4s87.7-12.8 118.1-26.4C1345.2 13.8 1376 0 1436.7 0c60.7 0 91.6 13.8 121.4 27.1 30.4 13.6 59.1 26.4 118.1 26.4s87.7-12.8 118.1-26.4C1824.1 13.8 1854.9 0 1915.7 0v530'/%3E%3C/svg%3E");
+        mask-size: 480px;
+
+        @media (min-width: @breakpoint-sm) {
+            min-height: 119px;
+            mask-position: 812px;
+            mask-size: 950px;
+        }
+
+        @media (min-width: @breakpoint-lg) {
+            min-height: 250px;
+            mask-position: 1931px;
+            mask-size: 2004px;
+        }
+
+        &--flip {
+            rotate: 180deg;
+        }
+    }
+
+    // Tilgjengelige farger
+    &--bg-hvit {
+        background-color: var(--ffe-farge-hvit);
+    }
+
+    &--bg-frost-30 {
+        background-color: @ffe-farge-frost-30;
+    }
+
+    &--bg-sand-30 {
+        background-color: @ffe-farge-sand-30;
+    }
+
+    &--bg-sand-70 {
+        background-color: @ffe-farge-sand-70;
+    }
+
+    &--bg-syrin-30 {
+        background-color: @ffe-farge-syrin-30;
+    }
+
+    &--bg-syrin-70 {
+        background-color: @ffe-farge-syrin-70;
+    }
+
+    &--bg-vann {
+        background-color: @ffe-farge-vann;
+    }
+
+    &--bg-vann-30 {
+        background-color: @ffe-farge-vann-30;
+    }
+
+    &--bg-fjell {
+        background-color: @ffe-farge-fjell;
+    }
+
+    &--dm-bg-svart {
+        .regard-color-scheme-preference & {
+            @media (prefers-color-scheme: dark) {
+                background-color: var(--ffe-farge-svart);
+            }
+        }
+    }
+
+    &--dm-bg-natt {
+        .regard-color-scheme-preference & {
+            @media (prefers-color-scheme: dark) {
+                background-color: @ffe-farge-natt;
+            }
+        }
+    }
+}

--- a/packages/ffe-shapes-react/src/Wave.mdx
+++ b/packages/ffe-shapes-react/src/Wave.mdx
@@ -32,13 +32,6 @@ Bølgen kan forskyves horisontalt ved hjelp av `position`-propertyen.
 <Canvas of={WaveStories.Position} />
 <Controls of={WaveStories.Position} />
 
-## Skjul i darkmode
-
-Det er ikke alltid det ser like dekorativt ut med bølgen i dark mode. Bruk `hideInDarkMode=true` for å skjule bølgen i dark mode.
-
-<Canvas of={WaveStories.HideInDarkMode} />
-<Controls of={WaveStories.HideInDarkMode} />
-
 ## Eksempel på bruk
 
 Under ser du et eksempel på hvordan bølgen kan brukes i sammenheng med grid for å bygge en layout.

--- a/packages/ffe-shapes-react/src/Wave.stories.tsx
+++ b/packages/ffe-shapes-react/src/Wave.stories.tsx
@@ -36,13 +36,6 @@ export const Position: Story = {
     render: args => <Wave {...args} />,
 };
 
-export const HideInDarkMode: Story = {
-    args: {
-        hideInDarkMode: true,
-    },
-    render: args => <Wave {...args} />,
-};
-
 export const LayoutExample: Story = {
     render: args => <WaveExample />,
 };

--- a/packages/ffe-shapes-react/src/Wave.tsx
+++ b/packages/ffe-shapes-react/src/Wave.tsx
@@ -10,8 +10,6 @@ export interface WaveProps {
     flip?: boolean;
     /** Set the background color of the wave container. */
     bgColor?: Color;
-    //** Hide the wave in dark mode */
-    hideInDarkMode?: boolean;
     /** Adds additional class */
     className?: string;
     children?: React.ReactNode;
@@ -21,7 +19,6 @@ export function Wave({
     position,
     flip,
     bgColor = 'default',
-    hideInDarkMode = false,
     children,
     className,
     ...rest
@@ -31,10 +28,11 @@ export function Wave({
             className={classNames(
                 'ffe-wave',
                 className,
-                { 'ffe-wave--hide-in-dark-mode': hideInDarkMode },
+                { 'ffe-accent-mode': flip },
+                { 'ffe-default-mode': !flip },
                 {
                     [`ffe-wave--bg-${bgColor}`]:
-                        bgColor && bgColor !== 'default',
+                        bgColor && bgColor !== 'default' && !flip,
                 },
             )}
         >
@@ -42,9 +40,15 @@ export function Wave({
                 <div className="ffe-wave__content">{children}</div>
             ) : null}
             <div
-                className={classNames('ffe-wave__wave', 'ffe-accent-mode', {
-                    'ffe-wave__wave--flip': flip,
-                })}
+                className={classNames(
+                    'ffe-wave__wave',
+                    { 'ffe-accent-mode': !flip },
+                    { 'ffe-default-mode': flip },
+                    {
+                        [`ffe-wave__wave--bg-${bgColor}`]:
+                            bgColor && bgColor !== 'default' && flip,
+                    },
+                )}
                 aria-hidden="true"
                 style={{
                     maskPosition: position,

--- a/packages/ffe-shapes/less/wave.less
+++ b/packages/ffe-shapes/less/wave.less
@@ -15,16 +15,6 @@
         width: 100%;
     }
 
-    &--hide-in-dark-mode {
-        @media (prefers-color-scheme: dark) {
-            .regard-color-scheme-preference & {
-                .ffe-wave__wave {
-                    display: none;
-                }
-            }
-        }
-    }
-
     &__wave {
         background-color: var(--ffe-color-background-default);
         mask-repeat: repeat-x;
@@ -44,19 +34,8 @@
             mask-size: 2004px;
         }
 
-        &--flip {
-            rotate: 180deg;
+        &--bg-subtle {
+            background-color: var(--ffe-color-background-subtle);
         }
     }
 }
-
-/* stylelint-disable selector-class-pattern */
-.dark-mode {
-    //Storybook specific
-    .ffe-wave--hide-in-dark-mode {
-        .ffe-wave__wave {
-            visibility: hidden;
-        }
-    }
-}
-/* stylelint-enable selector-class-pattern */


### PR DESCRIPTION
Legger tilbake bølgen i ffe-core som depricated for å fikse byggfeil hos andre team mens de oppdaterer til semantiske farger. 

Fjerner `hideInDarkMode` som ble lagt til forrige uke. 
Gjør funksjonaliteten mer lik den var før, at "flipped" swapper bakgrunnsfarge og bølgefarge, ikke at den snur alt opp ned.  Det gjør det lettere for team å få en høyere "bølge" (det som nå er bakgrunnsfarge i flipped) ved å sende inn klasse. 
