### PR TITLE
Semantiske datepicker

### DIFF
--- a/packages/ffe-datepicker-react/src/datepicker/DatepickerComp.tsx
+++ b/packages/ffe-datepicker-react/src/datepicker/DatepickerComp.tsx
@@ -262,6 +262,7 @@ export const DatepickerComp: React.FC<DatepickerCompProps> = ({
             className={classNames('ffe-datepicker', {
                 'ffe-datepicker--full-width': fullWidth,
                 'ffe-input-group--message': hasMessage,
+                'ffe-datepicker--invalid': ariaInvalid(),
             })}
             data-testid="date-picker"
             onClick={e => {

--- a/packages/ffe-datepicker/less/calendar.less
+++ b/packages/ffe-datepicker/less/calendar.less
@@ -1,11 +1,11 @@
 @import (reference) '@sb1/ffe-core/less/typography';
 
 .ffe-calendar {
-    border: 1px solid var(--ffe-color-foreground-default);
+    border: var(--ffe-g-border-width) solid
+        var(--ffe-color-border-primary-default);
     border-radius: var(--ffe-g-border-radius);
-    padding: var(--ffe-spacing-2xs);
     background: var(--ffe-color-background-default);
-    color: var(--ffe-color-foreground);
+    color: var(--ffe-color-foreground-default);
     overflow-y: auto;
 
     &--datepicker {
@@ -17,7 +17,7 @@
 
         &--above {
             top: inherit;
-            bottom: 55px;
+            bottom: 56px;
             min-height: 339px;
         }
     }
@@ -25,15 +25,14 @@
     &__header {
         text-align: center;
         color: var(--ffe-color-foreground-emphasis);
-        padding: var(--ffe-spacing-sm) var(--ffe-spacing-2xs)
-            var(--ffe-spacing-2xs);
+        padding: var(--ffe-spacing-sm);
         width: 100%;
         margin-bottom: var(--ffe-spacing-xs);
     }
 
     &__header-inner-wrapper {
         display: flex;
-        justify-content: center;
+        justify-content: space-between;
         align-items: center;
     }
 
@@ -56,20 +55,11 @@
         border-radius: 4px;
         display: grid;
         place-items: center;
+        padding: 4px;
 
-        &:focus,
-        &:active {
-            box-shadow:
-                0 0 0 2px var(--ffe-v-datepicker-bg-color),
-                0 0 0 4px var(--ffe-v-datepicker-border-hover-color);
-        }
-
-        @media (hover: hover) and (pointer: fine) {
-            &:hover {
-                box-shadow:
-                    0 0 0 2px var(--ffe-v-datepicker-bg-color),
-                    0 0 0 4px var(--ffe-v-datepicker-border-hover-color);
-            }
+        &:focus-visible {
+            box-shadow: var(--ffe-g-border-focus-box-shadow)
+                var(--ffe-color-border-primary-emphasis);
         }
     }
 
@@ -90,11 +80,10 @@
     &__grid {
         width: 100%;
         border-spacing: 0.5em 0;
+        padding: 12px;
 
         &:focus {
             outline: none;
-            box-shadow: 0 0 0 2px var(--ffe-v-datepicker-date-color-focus);
-            border-radius: 4px;
         }
     }
 
@@ -109,9 +98,10 @@
 
     thead {
         display: block;
-        border-bottom: 1px solid var(--ffe-color-foreground-emphasis);
+        border-bottom: var(--ffe-g-border-width) solid
+            var(--ffe-color-border-primary-default);
         margin-bottom: var(--ffe-spacing-2xs);
-        padding-bottom: var(--ffe-spacing-3xs);
+        padding-bottom: var(--ffe-spacing-sm);
     }
 
     tr {
@@ -126,7 +116,7 @@
     }
 
     &__day {
-        padding: var(--ffe-spacing-2xs) 0;
+        padding: var(--ffe-spacing-2xs);
         text-align: center;
         outline: none;
     }
@@ -135,129 +125,73 @@
         .ffe-small-text();
 
         font-size: 1rem;
-        background-color: var();
         width: 2.1875rem;
         aspect-ratio: 1;
         color: var(--ffe-color-foreground-default);
-        border-radius: 4px;
+        border: var(--ffe-g-border-width) solid transparent;
+        border-radius: var(--ffe-g-border-radius);
         display: inline-block;
         line-height: 2.1875;
         cursor: pointer;
 
         &--today {
-            border: 1px solid var(--ffe-v-datepicker-date-color-today);
+            border: var(--ffe-g-border-width) solid
+                var(--ffe-color-border-primary-emphasis);
         }
 
         @media (hover: hover) and (pointer: fine) {
             &:hover {
-                background: var(--ffe-color-fill-primary-hover);
-                color: var(--ffe-color-foreground-inverse);
+                background: var(--ffe-color-fill-primary-subtle-hover);
+                color: var(--ffe-color-foreground-default);
             }
         }
 
         &:active {
-            background: var(--ffe-color-fill-primary-pressed);
+            background: var(--ffe-color-fill-primary-subtle-pressed);
+            color: var(--ffe-color-foreground-default);
+        }
+
+        &:focus-visible,
+        &--focus {
+            border: var(--ffe-g-border-width) solid
+                var(--ffe-color-border-primary-default);
+            outline: none;
         }
 
         &--selected {
             background: var(--ffe-color-fill-primary-selected);
             color: var(--ffe-color-foreground-inverse);
 
+            &.ffe-calendar__date--focus {
+                border-color: var(--ffe-color-border-primary-emphasis);
+            }
+
             @media (hover: hover) and (pointer: fine) {
                 &:hover {
-                    color: var(--ffe-v-datepicker-bg-color);
+                    background: var(--ffe-color-fill-primary-selected-hover);
+                    color: var(--ffe-color-foreground-inverse);
                 }
             }
         }
 
         &--disabled {
-            color: var(--ffe-v-datepicker-date-color-disabled);
+            color: var(--ffe-color-foreground-subtle);
 
-            &:focus {
-                border: 2px solid var(--ffe-v-datepicker-date-color-disabled);
-                color: var(--ffe-v-datepicker-date-color-disabled);
+            &.ffe-calendar__date--selected {
+                background: var(--ffe-color-fill-tertiary-subtle);
+                color: var(--ffe-color-foreground-subtle);
             }
 
             @media (hover: hover) and (pointer: fine) {
                 &:hover {
-                    border: 2px solid
-                        var(--ffe-v-datepicker-date-color-disabled);
-                    color: var(--ffe-v-datepicker-date-color-disabled);
+                    background: var(--ffe-color-fill-tertiary-subtle);
+                    color: var(--ffe-color-foreground-subtle);
                 }
             }
-        }
 
-        &--disabled-focus {
-            border: 2px solid var(--ffe-v-datepicker-date-color-disabled);
-        }
-    }
-}
-
-:root,
-:host {
-    --ffe-v-datepicker-bg-color: var(
-        --ffe-color-component-form-input-fill-default
-    );
-    --ffe-v-datepicker-border-hover-color: var(
-        --ffe-color-border-primary-hover
-    );
-    --ffe-v-datepicker-icon-color: var(--ffe-color-foreground-interactive-link);
-    --ffe-v-datepicker-icon-color-hover: var(
-        --ffe-color-foreground-interactive-link-hover
-    );
-    --ffe-v-datepicker-title-color: var(--ffe-color-foreground-default);
-    --ffe-v-datepicker-weekday-color: var(--ffe-color-foreground-subtle);
-    --ffe-v-datepicker-weekday-border-color: var(
-        --ffe-color-border-primary-subtle
-    );
-    --ffe-v-datepicker-date-color: var(--ffe-color-foreground-default);
-    --ffe-v-datepicker-date-color-today: var(
-        --ffe-color-border-primary-emphasis
-    );
-    --ffe-v-datepicker-date-color-hover: var(--ffe-color-fill-primary-hover);
-    --ffe-v-datepicker-date-color-focus: var(
-        --ffe-color-border-interactive-focus
-    );
-    --ffe-v-datepicker-date-color-disabled: var(--ffe-color-foreground-subtle);
-    --ffe-v-datepicker-spinbutton-hover-color: var(
-        --ffe-color-surface-primary-default-hover
-    );
-
-    @media (prefers-color-scheme: dark) {
-        .regard-color-scheme-preference {
-            --ffe-v-datepicker-bg-color: var(--ffe-color-background-default);
-            --ffe-v-datepicker-border-hover-color: var(
-                --ffe-color-border-primary-hover
-            );
-            --ffe-v-datepicker-icon-color: var(
-                --ffe-color-foreground-interactive-link
-            );
-            --ffe-v-datepicker-icon-color-hover: var(
-                --ffe-color-foreground-interactive-link-hover
-            );
-            --ffe-v-datepicker-title-color: var(--ffe-color-foreground-default);
-            --ffe-v-datepicker-weekday-color: var(
-                --ffe-color-foreground-subtle
-            );
-            --ffe-v-datepicker-weekday-border-color: var(
-                --ffe-color-border-primary-subtle
-            );
-            --ffe-v-datepicker-date-color: var(--ffe-color-foreground-default);
-            --ffe-v-datepicker-date-color-today: var(
-                --ffe-color-border-primary-emphasis
-            );
-            --ffe-v-datepicker-date-color-hover: var(
-                --ffe-color-fill-primary-hover
-            );
-            --ffe-v-datepicker-date-color-focus: var(
-                --ffe-color-border-interactive-focus
-            );
-            --ffe-v-datepicker-date-color-disabled: var(
-                --ffe-color-foreground-subtle
-            );
-            --ffe-v-datepicker-spinbutton-hover-color: var(
-                --ffe-color-surface-primary-default-hover
-            );
+            &-focus {
+                border-color: var(--ffe-color-foreground-subtle);
+            }
         }
     }
 }

--- a/packages/ffe-datepicker/less/dateinput.less
+++ b/packages/ffe-datepicker/less/dateinput.less
@@ -3,120 +3,31 @@
         color: var(--ffe-color-foreground-default) !important;
     }
 }
-
-.ffe-dateinput {
-    position: relative;
-    display: inline-block;
-    grid-column: 1 e('/') 3;
-    grid-row: 1 e('/') -1;
-    min-width: 210px;
-    color: var(--ffe-color-foreground-default);
-
-    &--full-width {
-        display: block;
-    }
-
-    &:focus-within {
-        border: 2px solid var(--ffe-color-border-interactive-focus);
-        outline: none;
-
-        & + .ffe-datepicker__button {
-            @media (hover: hover) and (pointer: fine) {
-                &:hover {
-                    border: 2px solid var(--ffe-color-border-interactive-focus);
-                    outline: none;
-                }
-            }
-        }
-    }
-
-    &.ffe-input-field {
-        display: flex;
-        align-items: center;
-        border: 2px solid var(--ffe-color-border-primary-default);
-        background-color: var(--ffe-color-component-form-input-fill-default);
-
-        @media (hover: hover) and (pointer: fine) {
-            &:hover,
-            &:has(+ .ffe-datepicker__button:hover) {
-                border-color: var(--ffe-color-border-primary-hover);
-
-                & + .ffe-datepicker__button {
-                    border-color: var(--ffe-color-border-primary-hover);
-                }
-            }
-        }
-
-        &--invalid {
-            border: 2px solid var(--ffe-color-border-feedback-critical);
-
-            @media (hover: hover) and (pointer: fine) {
-                &:hover {
-                    border-color: var(--ffe-color-border-feedback-critical);
-                }
-                &:focus-within:hover {
-                    border: 2px solid var(--ffe-color-border-feedback-critical);
-                }
-            }
-
-            &:focus-within {
-                border: 2px solid var(--ffe-color-border-feedback-critical);
-                outline: none;
-            }
-
-            & + .ffe-datepicker__button {
-                &:focus-visible {
-                    border-color: var(--ffe-color-border-feedback-critical);
-                    border-style: solid;
-                }
-
-                @media (hover: hover) and (pointer: fine) {
-                    &:hover {
-                        border: 2px solid
-                            var(--ffe-color-border-feedback-critical);
-                        outline: none;
-                    }
-                }
-            }
-        }
-    }
-
-    &__field {
-        padding-block: var(--ffe-spacing-2xs);
-        color: var(--ffe-color-foreground-default);
-        background-color: transparent;
-
-        &-year {
-            min-width: 4ch;
-        }
-
-        &:focus {
-            background-color: var(--ffe-color-surface-secondary-default);
-            outline: none;
-        }
-
-        &::-ms-clear {
-            display: none;
-        }
-    }
-    &--message {
-        padding-bottom: 0;
-    }
-}
-
 .ffe-datepicker {
     position: relative;
     display: grid;
     grid-template-columns: 1fr auto;
     width: fit-content;
+    border: var(--ffe-g-border-width) solid
+        var(--ffe-color-border-primary-default);
+    border-radius: var(--ffe-g-border-radius);
+    transition: all var(--ffe-transition-duration) var(--ffe-ease);
 
     &--full-width {
         width: 100%;
     }
 
+    @media (hover: hover) and (pointer: fine) {
+        &:hover {
+            border-color: var(--ffe-color-border-primary-hover);
+            box-shadow: var(--ffe-g-border-focus-box-shadow)
+                var(--ffe-color-border-primary-hover);
+        }
+    }
+
     &__button {
         background-color: var(--ffe-color-background-default);
-        border: 2px solid var(--ffe-color-border-primary-default);
+        border: none;
         grid-column: 2 e('/') 3;
         grid-row: 1 e('/') -1;
         outline: none;
@@ -125,31 +36,126 @@
         width: 56px;
         cursor: pointer;
         isolation: isolate;
+    }
 
-        &:focus,
-        &:active {
-            border: 2px solid var(--ffe-color-border-interactive-focus);
-        }
+    .ffe-input-field:focus {
+        border: none;
+    }
 
-        @media (hover: hover) and (pointer: fine) {
-            &:hover {
-                border-color: var(--ffe-color-border-primary-hover);
-
-                & ~ .ffe-input-field {
-                    border-color: var(--ffe-color-border-primary-hover);
-                }
-            }
-        }
+    &:focus-within {
+        outline: none;
+        box-shadow: var(--ffe-g-border-focus-box-shadow)
+            var(--ffe-color-border-interactive-focus);
+        border-color: var(--ffe-color-border-interactive-focus);
     }
 
     &__icon.ffe-icons {
         vertical-align: middle;
-        color: var(--ffe-color-foreground-interactive-link);
+        color: var(--ffe-color-foreground-default);
         transition: color var(--ffe-transition-duration) var(--ffe-ease);
 
         @media (hover: hover) and (pointer: fine) {
             &:hover {
                 color: var(--ffe-color-foreground-interactive-link-hover);
+            }
+        }
+    }
+
+    .ffe-dateinput {
+        position: relative;
+        grid-column: 1 e('/') 3;
+        grid-row: 1 e('/') -1;
+        min-width: 210px;
+        color: var(--ffe-color-foreground-default);
+        background-color: var(--ffe-color-background-default);
+
+        &--full-width {
+            display: block;
+        }
+
+        &.ffe-input-field {
+            display: flex;
+            align-items: center;
+            border: none;
+
+            &:focus-within {
+                border: none;
+                box-shadow: none;
+                outline: none;
+            }
+
+            @media (hover: hover) and (pointer: fine) {
+                &:hover {
+                    border: none;
+                    box-shadow: none;
+                }
+            }
+
+            &--invalid {
+                border: none;
+            }
+        }
+
+        &__field {
+            padding-block: var(--ffe-spacing-2xs);
+            color: var(--ffe-color-foreground-default);
+            background-color: transparent;
+
+            &-year {
+                min-width: 4ch;
+            }
+
+            &:focus {
+                background-color: var(--ffe-color-surface-secondary-default);
+                outline: none;
+            }
+
+            &::-ms-clear {
+                display: none;
+            }
+        }
+
+        &--message {
+            padding-bottom: 0;
+        }
+    }
+
+    &--invalid {
+        border: var(--ffe-g-border-width) solid
+            var(--ffe-color-border-feedback-critical);
+
+        @media (hover: hover) and (pointer: fine) {
+            &:hover {
+                border-color: var(--ffe-color-border-feedback-critical);
+                box-shadow: var(--ffe-g-border-focus-box-shadow)
+                    var(--ffe-color-border-feedback-critical);
+            }
+            &:focus-within:hover {
+                border-color: var(--ffe-color-border-feedback-critical);
+            }
+        }
+
+        &:focus-within {
+            border-color: var(--ffe-color-border-feedback-critical);
+            outline: none;
+            box-shadow: var(--ffe-g-border-focus-box-shadow)
+                var(--ffe-color-border-feedback-critical);
+        }
+
+        .ffe-input-field {
+            &:focus {
+                border: none;
+                box-shadow: none;
+            }
+
+            @media (hover: hover) and (pointer: fine) {
+                &:hover {
+                    border: none;
+                    box-shadow: none;;
+                }
+                &:focus-within:hover {
+                    border: none;
+                }
             }
         }
     }


### PR DESCRIPTION
Styler datepicker med semantiske farger og modernisering, i henhold til Figma. 
Feil jeg vet om: 
I figma er streken mellom dager og datoene helt ut til sidene, men det er ikke mulig sånn koden er lagt opp nå. 
![image](https://github.com/user-attachments/assets/4f15d966-8b3f-429b-ac9b-9d585f71d5a9)
![image](https://github.com/user-attachments/assets/e7c4ae4b-a1e8-4097-ae09-f381051f443a)

Ellers har jeg endret så stylingen ligger på det ytterste elementet, `ffe-datepicker` i stedet for på knappen og `ffe-input-field`. Om det er den beste løsningen vet jeg ikke, i og med at det ble mye overskriving av alt som skjer på ffe-input-field, men det stemmer i alle fall bedre med sånn det ser ut i figma. 

relatert til [#2623](https://github.com/SpareBank1/designsystem/issues/2623)
