### PR TITLE
Legger til muligheten til å velge HTML-element på GroupCard

### DIFF
--- a/packages/ffe-cards-react/src/GroupCard/GroupCard.stories.tsx
+++ b/packages/ffe-cards-react/src/GroupCard/GroupCard.stories.tsx
@@ -7,16 +7,36 @@ import { GroupCardElement } from './GroupCardElement';
 import { GroupCardFooter } from './GroupCardFooter';
 import { GroupCardTitle } from './GroupCardTitle';
 
-const meta: Meta<typeof GroupCard> = {
+const Custom: React.FC<React.ComponentProps<'div'>> = props => (
+    <div {...props}>
+        {`Custom `}
+        {props.children}
+    </div>
+);
+
+const meta: Meta<typeof GroupCard<any>> = {
     title: 'Komponenter/Cards/GroupCard',
     component: GroupCard,
+    argTypes: {
+        as: {
+            options: ['span', 'div', 'custom'],
+            mapping: {
+                div: 'div',
+                span: 'span',
+                custom: Custom,
+            },
+        },
+    },
 };
+
 export default meta;
 
-type Story = StoryObj<typeof GroupCard>;
+type Story = StoryObj<typeof GroupCard<any>>;
 
 export const Standard: Story = {
-    args: {},
+    args: {
+        as: 'div',
+    },
     render: args => (
         <GroupCard {...args}>
             <GroupCardTitle>
@@ -55,6 +75,55 @@ export const NoSeparator: Story = {
                 Dette er et element i GroupCard en linje mellom elementene
             </GroupCardElement>
             <GroupCardFooter>Footer</GroupCardFooter>
+        </GroupCard>
+    ),
+};
+
+export const AsList: Story = {
+    args: {
+        as: 'ul',
+    },
+    render: args => (
+        <GroupCard {...args}>
+            <GroupCardElement as={'li'}>
+                {({ CardAction, CardName, Title }: CardRenderProps) => (
+                    <>
+                        <CardName>Kortnavn</CardName>
+                        <Title>
+                            <CardAction href="https://design.sparebank1.no">
+                                Lenke men hele kortet er klikkbart
+                            </CardAction>
+                        </Title>
+                    </>
+                )}
+            </GroupCardElement>
+            <GroupCardElement as={'li'}>
+                Dette er ett ikke-klikkbart liste element i GroupCard
+            </GroupCardElement>
+            <GroupCardElement as={'li'}>
+                {({ CardAction, CardName, Title }: CardRenderProps) => (
+                    <>
+                        <CardName>Kortnavn</CardName>
+                        <Title>
+                            <CardAction href="https://design.sparebank1.no">
+                                Lenke men hele kortet er klikkbart
+                            </CardAction>
+                        </Title>
+                    </>
+                )}
+            </GroupCardElement>
+            <GroupCardElement as={'li'}>
+                {({ CardAction, CardName, Title }: CardRenderProps) => (
+                    <>
+                        <CardName>Kortnavn</CardName>
+                        <Title>
+                            <CardAction href="https://design.sparebank1.no">
+                                Lenke men hele kortet er klikkbart
+                            </CardAction>
+                        </Title>
+                    </>
+                )}
+            </GroupCardElement>
         </GroupCard>
     ),
 };

--- a/packages/ffe-cards-react/src/GroupCard/GroupCard.tsx
+++ b/packages/ffe-cards-react/src/GroupCard/GroupCard.tsx
@@ -1,10 +1,12 @@
 import classNames from 'classnames';
-import React, { ForwardedRef } from 'react';
+import React, { ElementType, ForwardedRef } from 'react';
 import { fixedForwardRef } from '../fixedForwardRef';
-import { BackgroundColor } from '../types';
+import { ComponentAsPropParams, BackgroundColor } from '../types';
 
-export interface GroupCardProps
-    extends Omit<React.ComponentPropsWithoutRef<'div'>, 'children'> {
+export type GroupCardProps<As extends ElementType = 'div'> = Omit<
+    ComponentAsPropParams<As>,
+    'children'
+> & {
     /** The children of the GroupCard component */
     children: React.ReactNode;
     /**
@@ -22,20 +24,22 @@ export interface GroupCardProps
     bgDarkmodeColor?: never;
     /** No margin on card */
     noMargin?: boolean;
-}
+};
 
-function GroupCardWithForwardRef(
-    {
+function GroupCardWithForwardRef<As extends ElementType>(
+    props: GroupCardProps<As>,
+    ref: ForwardedRef<any>,
+) {
+    const {
         className,
         children,
         bgColor = 'primary',
         noMargin,
+        as: Comp = 'div',
         ...rest
-    }: GroupCardProps,
-    ref: ForwardedRef<any>,
-) {
+    } = props;
     return (
-        <div
+        <Comp
             className={classNames(
                 'ffe-group-card',
                 {
@@ -44,12 +48,12 @@ function GroupCardWithForwardRef(
                 },
                 className,
             )}
-            role="group"
+            role={Comp === 'div' && 'group'}
             {...rest}
             ref={ref}
         >
             {children}
-        </div>
+        </Comp>
     );
 }
 export const GroupCard = fixedForwardRef(GroupCardWithForwardRef);

--- a/packages/ffe-cards/less/group-card.less
+++ b/packages/ffe-cards/less/group-card.less
@@ -17,6 +17,10 @@
         margin: 0;
     }
 
+    &:is(ul) {
+        padding-inline-start: 0;
+        list-style: none;
+    }
     & > :first-child {
         border-radius: var(--ffe-v-cards-common-card-border-radius)
             var(--ffe-v-cards-common-card-border-radius) 0 0;


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse
Legger til muligheten til å sende med "as"- prop til groupCard for å kunne bestemme 
HTML elementet på hele kortet. 

Siden det blir feil med `role="group"` på en liste, så har jeg valgt å heller kun legge det på, dersom `as` er satt til å være en div. 

Legger til Styling som fjerner padding og setter list-style: none, ved default dersom GroupCard er satt til å være `ul` 

Legger også til en Storybook story som viser GroupCard som liste i praksis. 

## Motivasjon og kontekst
I Team Oversikt ønsker vi å bruke GroupCard komponenten til f.eks å vise liste over kontoer, semantisk blir det mer riktig for oss at GroupCard er en `ul`.  Legger derfor til muligheten for å gjøre det på en måte som ikke gir oss visuelle bugs som at border-radius ikke settes riktig på `:hover` og at man får en ekstra strek på siste liste-element. 

<!-- Hvorfor trengs denne endringen, og hva løser den? -->

## Testing
Kjørt opp lokalt, og testet i Storybook .
<!-- Hvordan har du har testet endringene dine? Ta gjerne med systeminfo o.l -->

<!--

Helt til slutt, har du ..

.. lest retningslinjene våre for bidrag?
.. tatt en siste sjekk for kode og skrivefeil, debug informasjon o.l?
.. kjørt og eventuelt oppdatert testene?
.. kommentert og dokumentert det som trengs?
.. knyttet denne opp til relaterte issues?

-->
