### PR TITLE
fix(ffe-datepicker-react): Improve backspace behaviour of year

### DIFF
--- a/packages/ffe-datepicker-react/src/datepicker/SpinButton.tsx
+++ b/packages/ffe-datepicker-react/src/datepicker/SpinButton.tsx
@@ -47,7 +47,10 @@ export const SpinButton = React.forwardRef<HTMLSpanElement, SpinButtonProps>(
                     return;
                 }
                 const newValue = value?.toString().slice(0, -1);
-                onSpinButtonChange(newValue ? [parseInt(newValue)] : []);
+                history.current = newValue
+                    ? newValue.split('').map(Number)
+                    : [];
+                onSpinButtonChange(history.current);
             } else if (evt.key === 'ArrowUp') {
                 evt.preventDefault();
                 let newValue = (value ?? 0) + 1;


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse

Gjør det mulig å bruke backspace på år for så å skrive inn mer. Feks hvis en skal bytte ut 2024 til 2025.
Delete og backspace fungerer enda likt. Lar det være. Tror ikke nok bruker delete til at det skal være et problem, blir fort tweakenede på denne komponenten resten av sesesongen hvis ikke :sweat_smile: 

Fixes https://github.com/SpareBank1/designsystem/issues/2697

<!-- Detaljert beskrivelse av endringene dine. Skjermskudd er lov. -->

## Motivasjon og kontekst

<!-- Hvorfor trengs denne endringen, og hva løser den? -->

## Testing

<!-- Hvordan har du har testet endringene dine? Ta gjerne med systeminfo o.l -->

<!--

Helt til slutt, har du ..

.. lest retningslinjene våre for bidrag?
.. tatt en siste sjekk for kode og skrivefeil, debug informasjon o.l?
.. kjørt og eventuelt oppdatert testene?
.. kommentert og dokumentert det som trengs?
.. knyttet denne opp til relaterte issues?

-->
