### PR TITLE
Tertiary button icon

### DIFF
--- a/packages/ffe-buttons-react/src/ActionButton.mdx
+++ b/packages/ffe-buttons-react/src/ActionButton.mdx
@@ -15,7 +15,7 @@ Brukes for svært høyt prioriterte handlinger (call to action), og der du treng
 
 ## Forskjellige størrelser
 
-Primary Button tilbys i tre størrelser: `sm`, `md` og `lg`. Standardstørrelsen er `md`. Du kan endre størrelsen ved å
+Action Button tilbys i tre størrelser: `sm`, `md` og `lg`. Standardstørrelsen er `md`. Du kan endre størrelsen ved å
 sette `size`-propen til en av disse verdiene, altså `size="sm"`. Hvis du ikke sender inn noe, er størrelsen md.
 
 <Canvas of={ActionButtonStories.DifferentSizes} />
@@ -24,6 +24,7 @@ sette `size`-propen til en av disse verdiene, altså `size="sm"`. Hvis du ikke s
 
 Hvis du kun vil bruke ikon på knappen, og ikke tekst, kan du sende inn `iconOnly="true"`. Det gjelder for alle størrelser,
 men du må selv sørge for å ha riktig størrelse på ikonet.
+**OBS: Legg ved `aria-label` når du bruker ikon uten tekst.**
 
 <Canvas of={ActionButtonStories.IconOnly} />
 <Controls of={ActionButtonStories.IconOnly} />

--- a/packages/ffe-buttons-react/src/ActionButton.stories.tsx
+++ b/packages/ffe-buttons-react/src/ActionButton.stories.tsx
@@ -64,11 +64,11 @@ export const DifferentSizes: Story = {
         return (
             <div className="ffe-button-display-group">
                 <ActionButton {...args} size="lg">
-                    Actionknapp
+                    Stor Actionknapp
                 </ActionButton>
                 <ActionButton {...args}>Actionknapp</ActionButton>
                 <ActionButton {...args} size="sm">
-                    Actionknapp
+                    Liten Actionknapp
                 </ActionButton>
             </div>
         );
@@ -84,13 +84,25 @@ export const IconOnly: Story = {
     },
     render: args => (
         <div className="ffe-button-display-group">
-            <ActionButton {...args} size="lg">
+            <ActionButton
+                {...args}
+                size="lg"
+                aria-label="Stor actionknapp med ikon"
+            >
                 <Icon fileUrl={addReactionIconLg} size="lg" />
             </ActionButton>
-            <ActionButton {...args} size="md">
+            <ActionButton
+                {...args}
+                size="md"
+                aria-label="Vanlig actionknapp med ikon"
+            >
                 <Icon fileUrl={addReactionIconMd} size="md" />
             </ActionButton>
-            <ActionButton {...args} size="sm">
+            <ActionButton
+                {...args}
+                size="sm"
+                aria-label="Liten actionknapp med ikon"
+            >
                 <Icon fileUrl={addReactionIconSm} size="sm" />
             </ActionButton>
         </div>

--- a/packages/ffe-buttons-react/src/BaseButton.tsx
+++ b/packages/ffe-buttons-react/src/BaseButton.tsx
@@ -11,8 +11,9 @@ export type BaseButtonProps<As extends ElementType = 'button'> =
         isLoading?: boolean;
         leftIcon?: ReactElement;
         rightIcon?: ReactElement;
-        /** Default md. */
+        /** Size of the button, default md. */
         size?: 'sm' | 'md' | 'lg';
+        /** Using only an icon, no label */
         iconOnly?: boolean;
     };
 /**

--- a/packages/ffe-buttons-react/src/InlineBaseButton.tsx
+++ b/packages/ffe-buttons-react/src/InlineBaseButton.tsx
@@ -14,6 +14,10 @@ export type InlineBaseButtonProps<As extends ElementType = 'button'> =
         leftIcon?: ReactElement;
         /** Icon shown to the right of the label */
         rightIcon?: ReactElement;
+        /** Size of the button, default md. */
+        size?: 'sm' | 'md' | 'lg';
+        /** Using only an icon, no label */
+        iconOnly?: boolean;
     };
 
 /**
@@ -30,6 +34,8 @@ function InlineBaseButtonWithForwardRef<As extends ElementType>(
         className,
         leftIcon,
         rightIcon,
+        size = 'md',
+        iconOnly = false,
         children,
         ...rest
     } = props;
@@ -38,8 +44,10 @@ function InlineBaseButtonWithForwardRef<As extends ElementType>(
         <Comp
             className={classNames(
                 'ffe-inline-button',
-                `ffe-inline-button--${buttonType}`,
                 className,
+                `ffe-inline-button--${size}`,
+                `ffe-inline-button--${buttonType}`,
+                { 'ffe-inline-button--icon-only': iconOnly },
             )}
             {...rest}
             ref={ref}

--- a/packages/ffe-buttons-react/src/PrimaryButton.mdx
+++ b/packages/ffe-buttons-react/src/PrimaryButton.mdx
@@ -24,6 +24,7 @@ sette `size`-propen til en av disse verdiene, altså `size="sm"`. Hvis du ikke s
 
 Hvis du kun vil bruke ikon på knappen, og ikke tekst, kan du sende inn `iconOnly="true"`. Det gjelder for alle størrelser,
 men du må selv sørge for å ha riktig størrelse på ikonet.
+**OBS: Legg ved `aria-label` når du bruker ikon uten tekst.**
 
 <Canvas of={PrimaryButtonStories.IconOnly} />
 <Controls of={PrimaryButtonStories.IconOnly} />

--- a/packages/ffe-buttons-react/src/PrimaryButton.stories.tsx
+++ b/packages/ffe-buttons-react/src/PrimaryButton.stories.tsx
@@ -76,13 +76,25 @@ export const IconOnly: Story = {
     },
     render: args => (
         <div className="ffe-button-display-group">
-            <PrimaryButton {...args} size="lg">
+            <PrimaryButton
+                {...args}
+                size="lg"
+                aria-label="Stor primærknapp med ikon"
+            >
                 <Icon fileUrl={addReactionIconLg} size="lg" />
             </PrimaryButton>
-            <PrimaryButton {...args} size="md">
+            <PrimaryButton
+                {...args}
+                size="md"
+                aria-label="Vanlig primærknapp med ikon"
+            >
                 <Icon fileUrl={addReactionIconMd} size="md" />
             </PrimaryButton>
-            <PrimaryButton {...args} size="sm">
+            <PrimaryButton
+                {...args}
+                size="sm"
+                aria-label="Liten primærknapp med ikon"
+            >
                 <Icon fileUrl={addReactionIconSm} size="sm" />
             </PrimaryButton>
         </div>

--- a/packages/ffe-buttons-react/src/SecondaryButton.mdx
+++ b/packages/ffe-buttons-react/src/SecondaryButton.mdx
@@ -1,6 +1,6 @@
 import { Canvas, Meta, Controls } from '@storybook/blocks';
 import * as SecondaryButtonStories from './SecondaryButton.stories.tsx';
-import { SecondaryButton } from "@sb1/ffe-buttons-react";
+import { SecondaryButton } from '@sb1/ffe-buttons-react';
 
 <Meta of={SecondaryButtonStories} />
 
@@ -16,7 +16,7 @@ SecondaryButtons kan ha ikon.
 
 ## Forskjellige størrelser
 
-Primary Button tilbys i tre størrelser: `sm`, `md` og `lg`. Standardstørrelsen er `md`. Du kan endre størrelsen ved å
+Secondary Button tilbys i tre størrelser: `sm`, `md` og `lg`. Standardstørrelsen er `md`. Du kan endre størrelsen ved å
 sette `size`-propen til en av disse verdiene, altså `size="sm"`. Hvis du ikke sender inn noe, er størrelsen md.
 
 <Canvas of={SecondaryButtonStories.DifferentSizes} />
@@ -25,7 +25,7 @@ sette `size`-propen til en av disse verdiene, altså `size="sm"`. Hvis du ikke s
 
 Hvis du kun vil bruke ikon på knappen, og ikke tekst, kan du sende inn `iconOnly="true"`. Det gjelder for alle størrelser,
 men du må selv sørge for å ha riktig størrelse på ikonet.
+**OBS: Legg ved `aria-label` når du bruker ikon uten tekst.**
 
 <Canvas of={SecondaryButtonStories.IconOnly} />
 <Controls of={SecondaryButtonStories.IconOnly} />
-

--- a/packages/ffe-buttons-react/src/SecondaryButton.stories.tsx
+++ b/packages/ffe-buttons-react/src/SecondaryButton.stories.tsx
@@ -82,13 +82,25 @@ export const IconOnly: Story = {
     },
     render: args => (
         <div className="ffe-button-display-group">
-            <SecondaryButton {...args} size="lg">
+            <SecondaryButton
+                {...args}
+                size="lg"
+                aria-label="Stor sekundærknapp med ikon"
+            >
                 <Icon fileUrl={addReactionIconLg} size="lg" />
             </SecondaryButton>
-            <SecondaryButton {...args} size="md">
+            <SecondaryButton
+                {...args}
+                size="md"
+                aria-label="Vanlig sekundærknapp med ikon"
+            >
                 <Icon fileUrl={addReactionIconMd} size="md" />
             </SecondaryButton>
-            <SecondaryButton {...args} size="sm">
+            <SecondaryButton
+                {...args}
+                size="sm"
+                aria-label="Liten sekundærknapp med ikon"
+            >
                 <Icon fileUrl={addReactionIconSm} size="sm" />
             </SecondaryButton>
         </div>

--- a/packages/ffe-buttons-react/src/TertiaryButton.mdx
+++ b/packages/ffe-buttons-react/src/TertiaryButton.mdx
@@ -12,3 +12,21 @@ For lavt prioriterte handlinger, eller i situasjoner der du trenger å «linke»
 
 <Canvas of={TertiaryButtonStories.Standard} />
 <Controls of={TertiaryButtonStories.Standard} />
+
+
+## Forskjellige størrelser
+
+TertiaryButton tilbys i tre størrelser: `sm`, `md` og `lg`. Standardstørrelsen er `md`. Du kan endre størrelsen ved å
+sette `size`-propen til en av disse verdiene, altså `size="sm"`. Hvis du ikke sender inn noe, er størrelsen md.
+
+<Canvas of={TertiaryButtonStories.DifferentSizes} />
+
+## Ikon i stedet for tekst
+
+Hvis du kun vil bruke ikon på knappen, og ikke tekst, kan du sende inn `iconOnly="true"`. Det gjelder for alle størrelser,
+men du må selv sørge for å ha riktig størrelse på ikonet.
+**OBS: Legg ved `aria-label` når du bruker ikon uten tekst.**
+
+<Canvas of={TertiaryButtonStories.IconOnly} />
+<Controls of={TertiaryButtonStories.IconOnly} />
+

--- a/packages/ffe-buttons-react/src/TertiaryButton.stories.tsx
+++ b/packages/ffe-buttons-react/src/TertiaryButton.stories.tsx
@@ -1,6 +1,12 @@
 import React from 'react';
 import { TertiaryButton } from './TertiaryButton';
 import type { StoryObj, Meta } from '@storybook/react';
+import { Icon } from '@sb1/ffe-icons-react';
+import {
+    addReactionIconLg,
+    addReactionIconMd,
+    addReactionIconSm,
+} from './assets/IconExamples';
 
 const Custom: React.FC<React.ComponentProps<'a'>> = props => (
     <a {...props}>
@@ -33,4 +39,55 @@ export const Standard: Story = {
         as: 'button',
     },
     render: args => <TertiaryButton {...args}>Tertiærknapp</TertiaryButton>,
+};
+
+export const DifferentSizes: Story = {
+    args: {
+        as: 'button',
+    },
+    render: args => {
+        return (
+            <div className="ffe-button-display-group">
+                <TertiaryButton {...args} size="lg">
+                    Stor tertiærknapp
+                </TertiaryButton>
+                <TertiaryButton {...args}>Tertiærknapp</TertiaryButton>
+                <TertiaryButton {...args} size="sm">
+                    Liten tertiærknapp
+                </TertiaryButton>
+            </div>
+        );
+    },
+};
+
+export const IconOnly: Story = {
+    args: {
+        as: 'button',
+        iconOnly: true,
+    },
+    render: args => (
+        <div className="ffe-button-display-group">
+            <TertiaryButton
+                {...args}
+                size="lg"
+                aria-label="Stor tertiærknapp med ikon"
+            >
+                <Icon fileUrl={addReactionIconLg} size="lg" />
+            </TertiaryButton>
+            <TertiaryButton
+                {...args}
+                size="md"
+                aria-label="Vanlig tertiærknapp med ikon"
+            >
+                <Icon fileUrl={addReactionIconMd} size="md" />
+            </TertiaryButton>
+            <TertiaryButton
+                {...args}
+                size="sm"
+                aria-label="Liten tertiærknapp med ikon"
+            >
+                <Icon fileUrl={addReactionIconSm} size="sm" />
+            </TertiaryButton>
+        </div>
+    ),
 };

--- a/packages/ffe-buttons/less/inline-base-button.less
+++ b/packages/ffe-buttons/less/inline-base-button.less
@@ -124,6 +124,9 @@
 .ffe-inline-button--tertiary {
     --icon-size-md: 1.5rem; // 24px
     --border-width: 2px;
+    --padding-sm: calc(var(--ffe-spacing-2xs) - var(--border-width));
+    --padding-md: calc(var(--ffe-spacing-xs) - var(--border-width));
+    --padding-lg: calc(12px - var(--border-width));
 
     align-content: center;
     color: var(--ffe-color-component-button-tertiary-foreground-default);
@@ -131,6 +134,31 @@
     padding: calc(var(--ffe-spacing-xs) - var(--border-width)) var(--ffe-spacing-sm);
     border: 2px solid transparent;
     line-height: calc(var(--icon-size-md) - var(--border-width));
+
+    &.ffe-inline-button--sm {
+        padding: var(--padding-sm) 12px;
+        font-size: var(--ffe-fontsize-button-sm);
+
+        &.ffe-inline-button--icon-only {
+            padding: var(--padding-sm);
+        }
+    }
+
+    &.ffe-inline-button--md {
+        padding: var(--padding-md) var(--ffe-spacing-sm);
+
+        &.ffe-inline-button--icon-only {
+            padding: var(--padding-md);
+        }
+    }
+
+    &.ffe-inline-button--lg {
+        padding: var(--padding-lg) var(--ffe-spacing-md);
+
+        &.ffe-inline-button--icon-only {
+            padding: var(--padding-md); //Md for å kompansere for hvor stort lg-ikonet er i forhold til lg-knappen
+        }
+    }
 
     .ffe-inline-button__icon {
         color: var(--ffe-color-component-button-tertiary-foreground-default);
@@ -142,6 +170,18 @@
             content: ' ';
             display: block;
             width: 100%;
+        }
+    }
+
+    &.ffe-inline-button--icon-only {
+        .ffe-inline-button__label {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+
+            &::after {
+                display: none;
+            }
         }
     }
 


### PR DESCRIPTION
fixes #2659 
Flere knappestørrelser og IconOnly funksjonalitet på tertiarybutton 
![image](https://github.com/user-attachments/assets/a7831ccd-225a-4a6d-9e00-facdd2f53ab9)
![image](https://github.com/user-attachments/assets/6db407a8-f808-424b-9cd6-da5ca1189280)
