### PR TITLE
fix(ffe-pagination): justerer knappestørrelsene

### DIFF
--- a/packages/ffe-pagination/less/pagination.less
+++ b/packages/ffe-pagination/less/pagination.less
@@ -108,7 +108,6 @@
         .ffe-button {
             width: var(--circular-button-size);
             aspect-ratio: 1;
-            padding-block: 12px; //Mellomløsning til vi har forskjellige knappestørrelser
         }
     }
 


### PR DESCRIPTION
Fra 
![image](https://github.com/user-attachments/assets/be671315-a1f4-4c85-8f74-2c0b559d6943)
til 
![image](https://github.com/user-attachments/assets/c56f78eb-2212-4928-afc8-249db402dd9a)

fixes #2688 

Jeg så på å få `paginationControls` dokumentasjonen bedre, men det var ikke så lett med storybook, eller jeg fant i alle fall ikke en løsning. En løsning senere kan være å splitte opp, så det ikke er et object. 

![image](https://github.com/user-attachments/assets/72552c10-467e-4cd4-849c-f4363d47add5)

