### PR TITLE
fix(ffe-header): Remove old design

### DIFF
--- a/packages/ffe-header/Header.stories.tsx
+++ b/packages/ffe-header/Header.stories.tsx
@@ -6,7 +6,6 @@ import classNames from 'classnames';
 
 type PagePropsAndCustomArgs = React.Component & {
     showNotificationBubbles: boolean;
-    enableLinkToProfile: boolean;
 };
 
 const meta: Meta<PagePropsAndCustomArgs> = {
@@ -16,10 +15,6 @@ const meta: Meta<PagePropsAndCustomArgs> = {
         showNotificationBubbles: {
             control: { type: 'boolean' },
             name: 'show notification bubbles',
-        },
-        enableLinkToProfile: {
-            control: { type: 'boolean' },
-            name: 'user name links to profile page',
         },
     },
 };
@@ -105,65 +100,11 @@ const LogoutListItem = () => {
     );
 };
 
-interface UserNavProps {
-    visible?: boolean;
-    showNotificationBubbles?: boolean;
-}
-
-const UserNav = ({ visible, showNotificationBubbles }: UserNavProps) => {
-    return (
-        <nav
-            className={classNames('ffe-header__user-nav', {
-                'ffe-header__user-nav--visible': visible,
-            })}
-        >
-            <ul
-                className={classNames(
-                    'ffe-header__list ffe-header__user-nav-list',
-                )}
-            >
-                <li className="ffe-header__list-item">
-                    <a className="ffe-header__link" href="#">
-                        Huskeliste{' '}
-                        {showNotificationBubbles && (
-                            <span className="ffe-header__notification-bubble">
-                                1
-                            </span>
-                        )}
-                    </a>
-                </li>
-                <li className="ffe-header__list-item">
-                    <a className="ffe-header__link" href="#">
-                        Postkasse{' '}
-                        {showNotificationBubbles && (
-                            <span className="ffe-header__notification-bubble">
-                                22
-                            </span>
-                        )}
-                    </a>
-                </li>
-                <li className="ffe-header__list-item">
-                    <a className="ffe-header__link" href="#">
-                        Innstillinger
-                    </a>
-                </li>
-                <li className="ffe-header__list-item">
-                    <div className="ffe-header__link ffe-header__link--disabled">
-                        Chat - stengt
-                    </div>
-                </li>
-                <LogoutListItem />
-            </ul>
-        </nav>
-    );
-};
-
 interface SiteNavProps {
     visible?: boolean;
-    includeLogoutButton?: boolean;
 }
 
-const SiteNav = ({ visible, includeLogoutButton }: SiteNavProps) => {
+const SiteNav = ({ visible }: SiteNavProps) => {
     return (
         <nav className="ffe-header__site-nav" role="navigation">
             <ul
@@ -213,7 +154,7 @@ const SiteNav = ({ visible, includeLogoutButton }: SiteNavProps) => {
                         Kundeservice
                     </a>
                 </li>
-                {includeLogoutButton && <LogoutListItem />}
+                <LogoutListItem />
             </ul>
         </nav>
     );
@@ -267,146 +208,71 @@ const DummyArticle = () => {
 export const Standard: Story = {
     args: {
         showNotificationBubbles: true,
-        enableLinkToProfile: false,
     },
-    render: function Render({ enableLinkToProfile, showNotificationBubbles }) {
-        const [isUserNavOpen, setIsUserNavOpen] = useState(false);
+    render: function Render({ showNotificationBubbles }) {
         const [isSiteNavOpen, setIsSiteNavOpen] = useState(false);
 
         return (
             <div>
-                <header
-                    className={classNames('ffe-header', {
-                        'ffe-header--enable-link-to-profile':
-                            enableLinkToProfile,
-                    })}
-                >
+                <header className={classNames('ffe-header')}>
                     <div className="ffe-header__wrapper">
                         <SecondaryNav />
 
                         <Logo />
 
                         <div className="ffe-header__user-nav-toggle">
-                            {enableLinkToProfile ? (
-                                <a
-                                    className="ffe-header__icon-button ffe-header__icon-button--user-nav"
-                                    href="#"
-                                >
-                                    <span className="ffe-header__user-name">
-                                        Jomar Beate Skrothaug
-                                    </span>
-                                    <span
-                                        className={classNames(
-                                            'ffe-header__svg-icon',
-                                            'ffe-header__user-icon',
-                                            {
-                                                'ffe-header__user-icon--with-notification':
-                                                    showNotificationBubbles,
-                                            },
-                                        )}
-                                    >
-                                        <Icon
-                                            fileUrl="./icons/open/400/md/account_circle.svg"
-                                            aria-label="profil"
-                                        />
-                                    </span>
-                                    {showNotificationBubbles && (
-                                        <span className="ffe-header__notification-bubble">
-                                            5
-                                        </span>
+                            <a
+                                className="ffe-header__icon-button ffe-header__icon-button--user-nav"
+                                href="#"
+                            >
+                                <span className="ffe-header__user-name">
+                                    Jomar Beate Skrothaug
+                                </span>
+                                <span
+                                    className={classNames(
+                                        'ffe-header__svg-icon',
+                                        'ffe-header__user-icon',
+                                        {
+                                            'ffe-header__user-icon--with-notification':
+                                                showNotificationBubbles,
+                                        },
                                     )}
-                                </a>
-                            ) : (
-                                <button
-                                    className="ffe-header__icon-button ffe-header__icon-button--user-nav"
-                                    onClick={() => {
-                                        setIsUserNavOpen(prev => !prev);
-                                        setIsSiteNavOpen(false);
-                                    }}
                                 >
-                                    <span className="ffe-header__user-name">
-                                        Jomar Beate Skrothaug
-                                        <span className="ffe-header__user-chevron">
-                                            <Icon
-                                                fileUrl="./icons/open/300/md/expand_more.svg"
-                                                size="md"
-                                                className={classNames(
-                                                    'ffe-header__user-chevron-icon',
-                                                    {
-                                                        'ffe-header__user-chevron--expanded':
-                                                            isUserNavOpen,
-                                                    },
-                                                )}
-                                            />
-                                        </span>
+                                    <Icon
+                                        fileUrl="./icons/open/400/md/account_circle.svg"
+                                        aria-label="profil"
+                                    />
+                                </span>
+                                {showNotificationBubbles && (
+                                    <span className="ffe-header__notification-bubble">
+                                        5
                                     </span>
-                                    <span className="ffe-header__svg-icon ffe-header__user-icon">
-                                        <Icon
-                                            fileUrl="./icons/open/300/xl/person.svg"
-                                            aria-label="bruker"
-                                            size="xl"
-                                        />
-                                    </span>
-                                    {showNotificationBubbles && (
-                                        <span className="ffe-header__notification-bubble">
-                                            5
-                                        </span>
-                                    )}
-                                </button>
-                            )}
+                                )}
+                            </a>
                         </div>
                         <div className="ffe-header__site-nav-toggle">
                             <button
                                 className="ffe-header__icon-button ffe-header__icon-button--site-nav"
                                 type="button"
                                 onClick={() => {
-                                    setIsUserNavOpen(false);
                                     setIsSiteNavOpen(prev => !prev);
                                 }}
                             >
-                                {enableLinkToProfile ? (
-                                    <Icon
-                                        fileUrl={
-                                            isSiteNavOpen
-                                                ? './icons/open/400/md/close.svg'
-                                                : './icons/open/400/md/menu.svg'
-                                        }
-                                        aria-label={
-                                            isSiteNavOpen ? 'lukk' : 'meny'
-                                        }
-                                    />
-                                ) : (
-                                    <span
-                                        className={classNames(
-                                            'ffe-header__site-nav-hamburger',
-                                            {
-                                                'ffe-header__site-nav-hamburger--expanded':
-                                                    isSiteNavOpen,
-                                            },
-                                        )}
-                                    >
-                                        <span className="ffe-header__site-nav-hamburger-bar" />
-                                    </span>
-                                )}
+                                <Icon
+                                    fileUrl={
+                                        isSiteNavOpen
+                                            ? './icons/open/400/md/close.svg'
+                                            : './icons/open/400/md/menu.svg'
+                                    }
+                                    aria-label={isSiteNavOpen ? 'lukk' : 'meny'}
+                                />
                             </button>
                         </div>
                     </div>
 
                     <div className="ffe-header__border">
                         <div className="ffe-header__wrapper">
-                            {!enableLinkToProfile && (
-                                <UserNav
-                                    visible={isUserNavOpen}
-                                    showNotificationBubbles={
-                                        showNotificationBubbles
-                                    }
-                                />
-                            )}
-
-                            <SiteNav
-                                visible={isSiteNavOpen}
-                                includeLogoutButton={enableLinkToProfile}
-                            />
+                            <SiteNav visible={isSiteNavOpen} />
                         </div>
                     </div>
                 </header>

--- a/packages/ffe-header/less/ffe-header.less
+++ b/packages/ffe-header/less/ffe-header.less
@@ -9,10 +9,6 @@
     position: relative;
     z-index: 999;
 
-    &__user-chevron--expanded {
-        transform: rotate(180deg);
-    }
-
     &__border:first-child {
         position: relative;
     }
@@ -50,11 +46,6 @@
         @media (hover: hover) and (pointer: fine) {
             &:hover {
                 color: var(--ffe-color-foreground-interactive-link-hover);
-
-                .ffe-header__user-nav & {
-                    background: var(--ffe-color-surface-primary-default-hover);
-                    color: var(--ffe-color-foreground-default);
-                }
             }
         }
 
@@ -82,13 +73,6 @@
             border-radius: 1rem;
             box-shadow: 0 0 0 2px var(--ffe-color-border-interactive-focus);
             outline: none;
-
-            .ffe-header__user-nav & {
-                border-radius: 0;
-                background-color: var(
-                    --ffe-color-surface-primary-default-pressed
-                );
-            }
         }
 
         &:focus:not(:focus-visible) {
@@ -196,43 +180,11 @@
     }
 
     &__user-icon,
-    &__user-chevron-icon,
     &__site-nav-icon {
+        vertical-align: middle;
         color: var(--ffe-color-foreground-emphasis);
     }
 
-    &__user-icon,
-    &__site-nav-icon {
-        vertical-align: middle;
-    }
-
-    &__user-chevron-icon {
-        vertical-align: middle;
-        margin-left: var(--ffe-spacing-xs);
-        transition: transform var(--ffe-transition-duration)
-            var(--ffe-ease-in-out-back);
-        color: var(--ffe-color-foreground-default);
-    }
-
-    &__user-chevron--expanded &__user-chevron-icon {
-        transform: rotate(180deg);
-    }
-
-    &__user-nav {
-        transition:
-            transform var(--ffe-transition-duration) var(--ffe-ease),
-            opacity 0.1s;
-        overflow: hidden;
-
-        &:not(.ffe-header__user-nav--visible) {
-            visibility: hidden;
-            height: 1px;
-            overflow: hidden;
-            transform: translateY(-25px);
-            opacity: 0;
-        }
-    }
-    &__user-nav,
     &__site-nav {
         .ffe-header__link {
             display: flex;
@@ -331,6 +283,16 @@
             display: none;
         }
 
+        &__user-name {
+            transition:
+                color var(--ffe-transition-duration) var(--ffe-ease),
+                background-color var(--ffe-transition-duration) var(--ffe-ease);
+        }
+
+        &__user-name:hover {
+            color: var(--ffe-color-foreground-emphasis);
+        }
+
         &__icon-button {
             .ffe-header__notification-bubble {
                 transform: unset;
@@ -341,7 +303,7 @@
         &__icon-button--user-nav {
             .ffe-header__notification-bubble {
                 grid-area: 1 e('/') 1 e('/') span 1 e('/') span 1;
-                margin-right: var(--ffe-spacing-sm);
+                margin-right: var(--ffe-spacing-xs);
             }
         }
 
@@ -400,29 +362,7 @@
             text-align: right;
             flex: 1;
         }
-
-        &__user-nav {
-            position: absolute;
-            right: 20px;
-            top: -16px;
-            min-width: 225px;
-            background: var(--ffe-color-background-default);
-            border-radius: 24px;
-            box-shadow: var(--ffe-shadow-md);
-            border: 2px solid var(--ffe-color-border-primary-default);
-            padding: var(--ffe-spacing-md) 0;
-        }
     }
-
-    // === Override styles for new header ===
-    .ffe-header--enable-link-to-profile {
-        .ffe-header__icon-button--user-nav {
-            .ffe-header__notification-bubble {
-                margin-right: var(--ffe-spacing-xs);
-            }
-        }
-    }
-    // === End override styles for new header ===
 }
 
 @media (max-width: (@breakpoint-md)) {
@@ -437,15 +377,28 @@
             display: none;
         }
 
-        &__user-nav {
-            margin-right: var(--ffe-spacing-sm);
-        }
-
         &__user-nav-toggle {
+            display: inline-flex;
             order: -1;
+            & .ffe-header__svg-icon {
+                display: inline-flex;
+            }
         }
 
-        &__user-nav,
+        &__user-icon--with-notification::after {
+            display: block;
+            position: absolute;
+            width: 10px;
+            aspect-ratio: 1;
+            background: var(--ffe-color-fill-feedback-critical);
+            border-radius: 50%;
+            content: '';
+        }
+
+        &__notification-bubble {
+            display: none;
+        }
+
         &__site-nav-list {
             visibility: hidden;
             height: 1px;
@@ -466,46 +419,19 @@
                 background-color: var(--ffe-color-background-default);
             }
         }
+
+        &__site-nav-toggle {
+            display: inline-flex;
+
+            & .ffe-header__svg-icon {
+                display: inline-flex;
+            }
+        }
+
         &__list-item--logout {
             display: block;
         }
     }
-
-    // === Override styles for new header ===
-    .ffe-header--enable-link-to-profile {
-        .ffe-header {
-            &__notification-bubble {
-                display: none;
-            }
-
-            &__user-icon--with-notification::after {
-                display: block;
-                position: absolute;
-                width: 10px;
-                aspect-ratio: 1;
-                background: var(--ffe-color-fill-feedback-critical);
-                border-radius: 50%;
-                content: '';
-            }
-
-            &__user-nav-toggle {
-                display: inline-flex;
-
-                & .ffe-header__svg-icon {
-                    display: inline-flex;
-                }
-            }
-
-            &__site-nav-toggle {
-                display: inline-flex;
-
-                & .ffe-header__svg-icon {
-                    display: inline-flex;
-                }
-            }
-        }
-    }
-    // === End override styles for new header ===
 }
 
 @media print {
@@ -514,9 +440,7 @@
             text-align: left;
         }
 
-        &__user-nav,
         &__user-icon,
-        &__user-chevron,
         &__site-nav,
         &__site-nav-toggle,
         &__notification-bubble {

--- a/packages/ffe-header/package.json
+++ b/packages/ffe-header/package.json
@@ -16,7 +16,9 @@
         "build": "lessc less/ffe-header-nodeps.less css/ffe-header.css --autoprefix",
         "build:examples": "lessc less/ffe-header-nodeps.less examples/ffe-header.css --autoprefix && lessc examples/examples.less examples/examples.css",
         "lint": "ffe-buildtool stylelint less/*.less",
-        "test": "npm run lint"
+        "test": "npm run lint",
+        "prettier": "prettier --check './Header.stories.tsx' './less/*'",
+        "prettier:fix": "prettier --write './Header.stories.tsx' './less/*'"
     },
     "devDependencies": {
         "@sb1/ffe-buildtool": "^0.10.0",


### PR DESCRIPTION
For a while, we supported both new and old header design. This commit will remove the old header design,
as all frontends now use the new header.

- Remove everything related to "usernav" list, which no longer exists.
- Make link to Profile behave like other links with hover effect.
- Remove styles related to removed chevron.

-----

# Fjerner gammel styling av header

## Beskrivelse

I en overgangsfase hadde vi dobbelt opp med styling av headeren liggende, slik at vi raskt kunne rulle tilbake hvis det ikke ble godt mottatt. Vi har nå landet på å gå for det nye designet, så kan nå trygt fjerne den gamle stylingen.

## Motivasjon og kontekst

Klikk på brukerens navn peker nå til Profilsiden istedet for å åpne en meny. For å få til dette måtte vi gjøre noen stylingendringer.

## Testing

Sjekk ut headeren i storybook :) Ingen html er endret, bare fjernet.

Standard:
![Screenshot from 2025-03-25 12-33-51](https://github.com/user-attachments/assets/844f1a61-f9aa-41e8-b837-bf5881850663)
Med hoved over navn:
![Screenshot from 2025-03-25 12-33-54](https://github.com/user-attachments/assets/50bd25c2-b48c-4b00-a3be-ceb3c5ed325c)
Med tab over navn:
![Screenshot from 2025-03-25 12-33-59](https://github.com/user-attachments/assets/f4c0987a-9f56-43e4-a934-6e62704f28ee)

