### PR TITLE
fix(ffe-searchable-dropdown-react): Improve screen reader of dropdoww actions

### DIFF
--- a/packages/ffe-searchable-dropdown-react/src/multi/MultiselectOptionBody.tsx
+++ b/packages/ffe-searchable-dropdown-react/src/multi/MultiselectOptionBody.tsx
@@ -2,11 +2,14 @@ import React from 'react';
 import classnames from 'classnames';
 import { SmallText } from '@sb1/ffe-core-react';
 import { Icon } from '@sb1/ffe-icons-react';
+import { getBalanceAriaLabel } from '../translations';
+import { Locale } from '../types';
 
 interface MultiselectOptionBodyProps<Item extends Record<string, any>> {
     item: Item;
     dropdownAttributes: (keyof Item)[];
     isHighlighted: boolean;
+    locale: Locale;
 }
 
 const checkIcon =
@@ -16,11 +19,20 @@ export function MultiselectOptionBody<Item extends Record<string, any>>({
     item,
     dropdownAttributes,
     isHighlighted,
+    locale,
 }: MultiselectOptionBodyProps<Item>) {
     const [titleAttribute, ...restAttributes] = dropdownAttributes;
     const title = item[titleAttribute];
     const rest = restAttributes.map((attribute, index) => (
-        <SmallText className="ffe-searchable-dropdown__detail-text" key={index}>
+        <SmallText
+            aria-label={
+                attribute === 'balance'
+                    ? getBalanceAriaLabel(locale, item[attribute])
+                    : undefined
+            }
+            className="ffe-searchable-dropdown__detail-text"
+            key={index}
+        >
             {item[attribute]}
         </SmallText>
     ));

--- a/packages/ffe-searchable-dropdown-react/src/multi/SearchableDropdownMultiSelect.stories.tsx
+++ b/packages/ffe-searchable-dropdown-react/src/multi/SearchableDropdownMultiSelect.stories.tsx
@@ -49,6 +49,27 @@ const fruits: Fruit[] = [
     },
 ] as const;
 
+const companies = [
+    {
+        organizationName: 'Bedriften',
+        organizationNumber: '912602370',
+        quantityUnprocessedMessages: 5,
+        balance: '12 345 678,00 kr',
+    },
+    {
+        organizationName: 'Sønn & co',
+        organizationNumber: '812602372',
+        quantityUnprocessedMessages: 3,
+        balance: '12 345,00 kr',
+    },
+    {
+        organizationName: 'Beslag skytter',
+        organizationNumber: '812602552',
+        quantityUnprocessedMessages: 1,
+        balance: '34 234 343,00 kr',
+    },
+];
+
 const CustomOptionBody = ({
     item,
     isHighlighted,
@@ -141,6 +162,25 @@ export const MultipleDataResults: Story = {
     render: function Render({ id, labelledById, ...args }) {
         return (
             <InputGroup label="Velg frukt" labelId={labelledById} inputId={id}>
+                <SearchableDropdownMultiSelect
+                    id={id}
+                    labelledById={labelledById}
+                    {...args}
+                />
+            </InputGroup>
+        );
+    },
+};
+
+export const DropdownAttributes: Story = {
+    args: {
+        ...Standard.args,
+        dropdownList: companies,
+        dropdownAttributes: ['organizationName', 'balance'],
+    },
+    render: function Render({ id, labelledById, ...args }) {
+        return (
+            <InputGroup label="Velg" labelId={labelledById} inputId={id}>
                 <SearchableDropdownMultiSelect
                     id={id}
                     labelledById={labelledById}

--- a/packages/ffe-searchable-dropdown-react/src/single/OptionBody.tsx
+++ b/packages/ffe-searchable-dropdown-react/src/single/OptionBody.tsx
@@ -1,22 +1,34 @@
 import React from 'react';
 import classnames from 'classnames';
 import { MicroText } from '@sb1/ffe-core-react';
+import { Locale } from '../types';
+import { getBalanceAriaLabel } from '../translations';
 
 interface ListItemBodyProps<Item extends Record<string, any>> {
     item: Item;
     dropdownAttributes: Array<keyof Item>;
     isHighlighted: boolean;
+    locale: Locale;
 }
 
 export function OptionBody<Item extends Record<string, any>>({
     item,
     dropdownAttributes,
     isHighlighted,
+    locale,
 }: ListItemBodyProps<Item>) {
     const [titleAttribute, ...restAttributes] = dropdownAttributes;
     const title = item[titleAttribute];
     const rest = restAttributes.map((attribute, index) => (
-        <MicroText className="ffe-searchable-dropdown__detail-text" key={index}>
+        <MicroText
+            aria-label={
+                attribute === 'balance'
+                    ? getBalanceAriaLabel(locale, item[attribute])
+                    : undefined
+            }
+            className="ffe-searchable-dropdown__detail-text"
+            key={index}
+        >
             {item[attribute]}
         </MicroText>
     ));

--- a/packages/ffe-searchable-dropdown-react/src/single/SearchableDropdown.stories.tsx
+++ b/packages/ffe-searchable-dropdown-react/src/single/SearchableDropdown.stories.tsx
@@ -10,16 +10,19 @@ const companies = [
         organizationName: 'Bedriften',
         organizationNumber: '912602370',
         quantityUnprocessedMessages: 5,
+        balance: '12 345 678,00 kr',
     },
     {
         organizationName: 'Sønn & co',
         organizationNumber: '812602372',
         quantityUnprocessedMessages: 3,
+        balance: '12 345,00 kr',
     },
     {
         organizationName: 'Beslag skytter',
         organizationNumber: '812602552',
         quantityUnprocessedMessages: 1,
+        balance: '34 234 343,00 kr',
     },
 ];
 
@@ -109,7 +112,11 @@ export const Standard: Story = {
 export const DropdownAttributes: Story = {
     args: {
         ...Standard.args,
-        dropdownAttributes: ['organizationName', 'organizationNumber'],
+        dropdownAttributes: [
+            'organizationName',
+            'organizationNumber',
+            'balance',
+        ],
     },
     render: function Render({ id, labelledById, ...args }) {
         return (

--- a/packages/ffe-searchable-dropdown-react/src/translations.ts
+++ b/packages/ffe-searchable-dropdown-react/src/translations.ts
@@ -82,3 +82,14 @@ export const getIsLoadingItemsA11yStatus = (locale: Locale) => {
             return 'Laster inn alternativer.';
     }
 };
+
+export const getBalanceAriaLabel = (locale: Locale, balance: number) => {
+    switch (locale) {
+        case 'nn':
+            return `Saldo: ${balance}`;
+        case 'en':
+            return `Balance: ${balance}`;
+        default:
+            return `Saldo: ${balance}`;
+    }
+};


### PR DESCRIPTION

<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse

Legger til `Saldo:` før saldo i account dropdown ved å oppdatere searchable dropdown.
Slik at det blir `Skattetrekkskonto 4202 59 72303 Saldo: 271 677,46 kr`

Idielt burde vi ha en mer generisk måte å fikse skermlesing av `dropdownAttributes` men retter det for det mest brukte scenario for nå.

Fix https://github.com/SpareBank1/designsystem/issues/2522

<!-- Detaljert beskrivelse av endringene dine. Skjermskudd er lov. -->

## Motivasjon og kontekst

<!-- Hvorfor trengs denne endringen, og hva løser den? -->

## Testing

Tester ved å sjekke select dropdown med dropdown attributes exemplene i single og multi og chrome og accessability.

Eksempel
![image](https://github.com/user-attachments/assets/6195a932-e003-4401-ab47-f50d038044b7)

Storybene å teste med: https://black-beach-0d62d0d03-2714.westeurope.2.azurestaticapps.net/?path=/story/komponenter-searchable-dropdown-searchabledropdown--dropdown-attributes

https://black-beach-0d62d0d03-2714.westeurope.2.azurestaticapps.net/?path=/story/komponenter-searchable-dropdown-searchabledropdownmultiselect--dropdown-attributes

Får ikke teste i account selectoren før det er merget og pakkene er bumper så det må testes post merge. Inkluderer Sindre på den testingen


