### PR TITLE
Context messages fixes

### DIFF
--- a/packages/ffe-messages/less/common.less
+++ b/packages/ffe-messages/less/common.less
@@ -84,6 +84,16 @@
         &.ffe-message--context-compact {
             --icon-size: var(--ffe-v-icons-size-md);
             --icon-padding: var(--ffe-spacing-2xs);
+
+            .ffe-message__icon-container {
+                margin-top: var(--ffe-spacing-2xs);
+            }
+        }
+    }
+
+     &--system {
+        .ffe-message__icon-container {
+            margin-top: var(--ffe-spacing-2xs);
         }
     }
 }
@@ -108,6 +118,7 @@
         grid-column: 2 e('/') 3;
         grid-row: 1 e('/') 2;
         color: var(--text-color);
+        align-self: center;
     }
 
     .ffe-message__close {


### PR DESCRIPTION
Justerer ikon-alignmenten på systemmessages og contextmessages. 

## årsak
Tidligere la vi inn en fix for å få ikonet til å være på linje med toppen, ikke sentrert. Men det så ikke så bra ut med `compact=true`. 
Lagt til margin og self-align for å få justert riktig. 

Burde skjekkes for alle messages, compact mode av og på, med og uten tittel, med og uten lukkeknapp, og med én eller flere linjer av innhold. 
Feilen: 
![image](https://github.com/user-attachments/assets/9481a2a8-b217-45d4-879b-ea7129514aac)

Løsning: 
![image](https://github.com/user-attachments/assets/771b2714-6801-4239-96a9-04971ea8c041)

Meldt inn av team PM Betaling

