### PR TITLE
chore: småjusteringer på storybook dokumentasjon

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -102,15 +102,15 @@ const preview: Preview = {
             description: 'Select light or dark theme',
             table: {
                 defaultValue: {
-                    detail: 'both',
+                    detail: 'light',
                 },
             },
-            defaultValue: 'both',
+            defaultValue: 'light',
             toolbar: {
                 items: [
-                    { icon: 'sun', value: 'light', title: 'Light' },
-                    { icon: 'moon', value: 'dark', title: 'Dark' },
-                    { icon: 'stacked', value: 'both', title: 'Both modes' },
+                    { icon: 'sun', value: 'light', title: 'Lys' },
+                    { icon: 'moon', value: 'dark', title: 'Mørk' },
+                    { icon: 'stacked', value: 'both', title: 'Begge moduser' },
                 ],
                 dynamicTitle: true,
             },
@@ -127,12 +127,12 @@ const preview: Preview = {
             toolbar: {
                 items: [
                     {
-                        icon: 'lightningoff',
+                        icon: 'circlehollow',
                         value: 'default',
-                        title: 'Default',
+                        title: 'Vanlig',
                     },
-                    { icon: 'lightning', value: 'accent', title: 'Accent' },
-                    { icon: 'stacked', value: 'both', title: 'Both accents' },
+                    { icon: 'circle', value: 'accent', title: 'Accent' },
+                    { icon: 'mirror', value: 'both', title: 'Begge kontekster' },
                 ],
                 dynamicTitle: true,
             },


### PR DESCRIPTION
## Endring 
Endrer til bruk av norsk i brytere i storybook, og fjerner dark mode som default synlig. 

## Årsak
#2656 Syntes dette var en sykt god idé, men etter å ha snakket med martin ble vi enige om at det kanskje tok litt vekk fra komponenten, og at det kanskje ble litt vel rotete. Konkluderte heller med at vi kan fjerne at dark mode er default synlig, sånn at det blir mindre støy. Vi kan etterhvert fjerne accent, når folk har vendt seg til det tenker vi. Prøvde også å justere språket, få inn "kontekst", og gjøre det norskt siden mye annet er på norsk. 

Betyr at #2656 kan lukkes hvis vi fortsetter med denne. 