### PR TITLE
fix(ffe-shapes-react): Add missing dependency classnames

### DIFF
--- a/packages/ffe-cards-react/package.json
+++ b/packages/ffe-cards-react/package.json
@@ -26,7 +26,8 @@
         "test:watch": "ffe-buildtool jest --watch"
     },
     "dependencies": {
-        "@sb1/ffe-cards": "^22.1.1"
+        "@sb1/ffe-cards": "^22.1.1",
+        "classnames": "^2.3.1"
     },
     "devDependencies": {
         "@sb1/ffe-buildtool": "^0.10.0",

--- a/packages/ffe-shapes-react/package.json
+++ b/packages/ffe-shapes-react/package.json
@@ -25,7 +25,8 @@
         "test:watch": "ffe-buildtool jest --watch"
     },
     "dependencies": {
-        "@sb1/ffe-shapes": "^1.1.3"
+        "@sb1/ffe-shapes": "^1.1.3",
+        "classnames": "^2.3.1"
     },
     "devDependencies": {
         "@sb1/ffe-buildtool": "^0.10.0",


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse

Legger til manglende dep `classnames`

fixes #2723 