### PR TITLE
fix(ffe-core): fikser linktext focus styling og fjerner visited styling

### DIFF
--- a/packages/ffe-core-react/src/typography/LinkText.stories.tsx
+++ b/packages/ffe-core-react/src/typography/LinkText.stories.tsx
@@ -14,6 +14,7 @@ export const Standard: Story = {
     args: {
         underline: true,
         children: 'Some text',
+        href: 'https://design.sparebank1.no/',
     },
     render: args => <LinkText {...args} />,
 };

--- a/packages/ffe-core/less/typography.less
+++ b/packages/ffe-core/less/typography.less
@@ -172,23 +172,16 @@
         }
     }
 
-    &:visited {
-        border-bottom-color: var(--ffe-color-foreground-interactive-link-pressed);
-        color: var(--ffe-color-foreground-interactive-link-pressed);
-        text-decoration: none;
-    }
-
     &--no-underline {
         border-bottom: none;
     }
 
     &:focus {
-        border-color: var(--ffe-color-foreground-interactive-link-pressed);
         color: var(--ffe-color-foreground-interactive-link-pressed);
         border-radius: 1px;
-        background-color: var(--ffe-color-foreground-interactive-link);
-        box-shadow: 0 0 0 2px var(--ffe-color-foreground-interactive-link);
+        box-shadow: 0 0 0 2px var(--ffe-color-border-interactive-focus);
         outline: none;
+        border-bottom-color: transparent;
     }
 }
 


### PR DESCRIPTION
fixes #2734 

Har fjernet visited-styling fra `LinkText`. Testet i Safari og Chrome, test gjerne på Firefox også. 

Har oppdatert Focus-stylinga fra 
![image](https://github.com/user-attachments/assets/bcaab11b-bbe5-43b5-8345-88e55268dc67)
til
![image](https://github.com/user-attachments/assets/a1b1cd8f-bf07-4e5f-a10c-65b183991025)
og 
![image](https://github.com/user-attachments/assets/df1b9e4e-918d-4bc8-9bca-61b53f180f4f)

