### PR TITLE
Fix/forms/setinputgrouplabelasspan

### DIFF
--- a/packages/ffe-datepicker-react/src/datelogic/simpledate.ts
+++ b/packages/ffe-datepicker-react/src/datelogic/simpledate.ts
@@ -163,7 +163,7 @@ export const getSimpleDateFromString = (
     let month = match[3];
     let year = match[4];
 
-    if (year.length === 1 || year.length === 2) {
+    if ((year.length === 1 && year !== '0') || year.length === 2) {
         // @ts-ignore
         year = deriveOneOrTwoDigitYear(year);
     }
@@ -178,7 +178,7 @@ export const getSimpleDateFromString = (
         // @ts-ignore
         month = today.getMonth() + 1;
     }
-    if (!year) {
+    if (!year || year === '0') {
         // @ts-ignore
         year = today.getFullYear();
     }

--- a/packages/ffe-datepicker-react/src/datepicker/Datepicker.tsx
+++ b/packages/ffe-datepicker-react/src/datepicker/Datepicker.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { Locale } from '../datelogic/types';
 import { DatepickerComp, DatepickerCompProps } from './DatepickerComp';
 import { DatepickerProvider } from './DatepickerContext';
@@ -6,19 +6,13 @@ import { DatepickerProvider } from './DatepickerContext';
 export interface DatepickerProps extends DatepickerCompProps {
     value: string;
     locale: Locale;
-    /** Hack that changes InputGroups label to a span to be wcag complient  */
-    setInputGroupLabelAsSpan?: () => void;
 }
 
 export const Datepicker: React.FC<DatepickerProps> = ({
     locale = 'nb' as const,
     value,
-    setInputGroupLabelAsSpan,
     ...props
 }: DatepickerProps) => {
-    useEffect(() => {
-        setInputGroupLabelAsSpan?.();
-    }, [setInputGroupLabelAsSpan]);
     return (
         <DatepickerProvider locale={locale} value={value}>
             <DatepickerComp {...props} />

--- a/packages/ffe-datepicker-react/src/datepicker/DatepickerInContext.spec.tsx
+++ b/packages/ffe-datepicker-react/src/datepicker/DatepickerInContext.spec.tsx
@@ -9,6 +9,7 @@ const defaultProps = {
     onChange: () => {},
     locale: 'nb' as const,
     labelId: 'datepicker-label',
+    maxDate: '31.12.2128',
 };
 
 const renderDatePicker = (props?: Partial<DatepickerProps>) =>
@@ -44,5 +45,43 @@ describe('<InputGroup><Datepicker /></InputGroup>', () => {
         await datepicker.setValue('6.5.2024');
 
         expect(datepicker.getValue()).toStrictEqual('06.05.2024');
+    });
+
+    it('datepicker can be cleared by testing function', async () => {
+        renderDatePicker({ value: '01.01.2024' });
+
+        const datepicker = getDatepickerByLabelText('Datovelger');
+        await datepicker.setValue('');
+
+        expect(datepicker.getValue()).toBeNull();
+    });
+
+    it('2 number year date is updated to correct 4 number year', async () => {
+        renderDatePicker({ value: '01.01.2024' });
+
+        const datepicker = getDatepickerByLabelText('Datovelger');
+        await datepicker.setValue('02.02.28');
+
+        expect(datepicker.getValue()).toStrictEqual('02.02.2028');
+    });
+
+    it('3 number year date is updated to correct 4 number year', async () => {
+        renderDatePicker({ value: '01.01.2024' });
+
+        const datepicker = getDatepickerByLabelText('Datovelger');
+        await datepicker.setValue('02.02.128');
+
+        expect(datepicker.getValue()).toStrictEqual('02.02.2128');
+    });
+
+    it('no year is updated to correct 4 number year', async () => {
+        renderDatePicker({ value: '01.01.2023' });
+
+        const datepicker = getDatepickerByLabelText('Datovelger');
+        await datepicker.setValue('02.02.');
+        const date = new Date();
+        expect(datepicker.getValue()).toStrictEqual(
+            `02.02.${date.getFullYear()}`,
+        );
     });
 });

--- a/packages/ffe-datepicker-react/src/datepicker/index.ts
+++ b/packages/ffe-datepicker-react/src/datepicker/index.ts
@@ -1,4 +1,6 @@
 export { Datepicker, DatepickerProps } from './Datepicker';
 export type { DatepickerCompProps } from './DatepickerComp';
-export { getDatepickerByLabelText } from './testHelper';
-export type { DatepickerTestHelper } from './testHelper';
+export {
+    getDatepickerByLabelText,
+    type DatepickerTestHelper,
+} from './testHelper';

--- a/packages/ffe-datepicker-react/src/index.ts
+++ b/packages/ffe-datepicker-react/src/index.ts
@@ -1,3 +1,8 @@
-export { Datepicker, DatepickerProps } from './datepicker';
+export {
+    Datepicker,
+    DatepickerProps,
+    getDatepickerByLabelText,
+    type DatepickerTestHelper,
+} from './datepicker';
 export { DateInput, DateInputProps } from './input';
 export { Calendar, CalendarProps } from './calendar';

--- a/packages/ffe-form-react/src/InputGroup.tsx
+++ b/packages/ffe-form-react/src/InputGroup.tsx
@@ -1,17 +1,13 @@
-import React, { useId } from 'react';
-import { Tooltip, TooltipProps } from './Tooltip';
-import { Label } from './Label';
 import classNames from 'classnames';
+import React, { useId } from 'react';
+import { Label } from './Label';
 import { ErrorFieldMessage } from './message';
+import { Tooltip, TooltipProps } from './Tooltip';
 
 type ChildrenExtraProps = {
     id: string;
     'aria-invalid': 'true' | 'false';
     'aria-describedby': string | undefined;
-};
-
-type FunctionExtraProps = {
-    setInputGroupLabelAsSpan: () => void;
 };
 
 export interface InputGroupProps
@@ -67,10 +63,9 @@ export interface InputGroupProps
 const getChildrenWithExtraProps = (
     children: InputGroupProps['children'],
     extraProps: ChildrenExtraProps,
-    functionExtraProps: FunctionExtraProps,
 ) => {
     if (typeof children === 'function') {
-        return children({ ...extraProps, ...functionExtraProps });
+        return children(extraProps);
     } else if (React.isValidElement(children)) {
         return React.cloneElement(children, extraProps);
     }
@@ -90,7 +85,6 @@ export const InputGroup: React.FC<InputGroupProps> = ({
     labelId,
     ...rest
 }) => {
-    const [labelAsSpan, setLabelAsSpan] = React.useState(false);
     const generatedInputId = useId();
     const id = inputId ?? generatedInputId;
     const descriptionId = description ? `${id}-description` : undefined;
@@ -147,17 +141,7 @@ export const InputGroup: React.FC<InputGroupProps> = ({
         'aria-describedby': ariaDescribedBy,
     } as const;
 
-    const extraFunctionProps = {
-        setInputGroupLabelAsSpan: () => {
-            setLabelAsSpan(true);
-        },
-    } as const;
-
-    const modifiedChildren = getChildrenWithExtraProps(
-        children,
-        extraProps,
-        extraFunctionProps,
-    );
+    const modifiedChildren = getChildrenWithExtraProps(children, extraProps);
 
     return (
         <div
@@ -172,11 +156,7 @@ export const InputGroup: React.FC<InputGroupProps> = ({
             {...rest}
         >
             {typeof label === 'string' ? (
-                <Label
-                    as={labelAsSpan ? 'span' : 'label'}
-                    htmlFor={id}
-                    id={labelId}
-                >
+                <Label htmlFor={id} id={labelId}>
                     {label}
                 </Label>
             ) : (


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse

Teamene får enda `setinputgrouplabelasspan` siden de bruker 

```tsx

<InputGroup>
{(inputProps) => (
    <>
        <Input
            value={formatAmountV2(estateValue)}
            name="estateValue"
            {...inputProps}
        />
    </>
)}
</InputGroup>
```

fremfor

```tsx
<InputGroup>
        <Input
            value={formatAmountV2(estateValue)}
            name="estateValue"
        />
</InputGroup>
```

Ikke sikker på hvorfor de gjør det, men de gjør det.

Fjerner derfor hacken. Det gjør den muligens litt mindre UU vennlig, men fjerner warningen og er ikke nødvendig for testene lenger heller pga egne testhelpers.

Fixes [#2738](https://github.com/SpareBank1/designsystem/issues/2738)

Oppdaterer og testhelper slik at den støtter å sende inn tomme eller delvis tomme datoer og on blur etter year slik at hvis en sender inn en delvis dato blir den satt riktig.

Gjør og et par små endringer for å få le date ting å fungere riktig igjen etter at vi gjorde datepicker om til konntrollert komponent.

Gikk fra å være en liten quick fix til flere problemer betaling oppllevde her.
