### PR TITLE
fix(ffe-core): Improve tailwind colors by kebab casing variables

### DIFF
--- a/documentation/Changelog.mdx
+++ b/documentation/Changelog.mdx
@@ -32,10 +32,10 @@ Farger i `ffe-core/less/colors-deprecated.less` fjernes også. Dette er gamle Le
 
 #### Tailwind
 
-For de som bruker Tailwind kan en oppdatere importen fra `@sb1/ffe-core/lib/colors` til `@sb1/ffe-core/lib/senamticColors`.
+For de som bruker Tailwind kan en oppdatere importen fra `@sb1/ffe-core/lib/colors` til `@sb1/ffe-core/lib/semanticColorsTailwind`.
 
 ```tsx
-import * as colors from '@sb1/ffe-core/lib/senamticColors';
+import * as colors from '@sb1/ffe-core/lib/semanticColorsTailwind';
 module.exports = {
     theme: {
         colors: {
@@ -45,4 +45,4 @@ module.exports = {
 };
 ```
 
-Da blir fargene tilgjengelige i camelCase uten `--ffe-color`. Feks `--ffe-color-background-default` -> `backgroundDefault`
+Da blir fargene tilgjengelige i kebab-case uten `--ffe-color`. Feks `--ffe-color-background-default` -> `background-default`

--- a/packages/ffe-core/documentation/Colors.mdx
+++ b/packages/ffe-core/documentation/Colors.mdx
@@ -20,10 +20,10 @@ containeren til elementet. Se mer om accent mode på [siden om accent mode](./?p
 
 ## Tailwind
 
-For å bruke semantiske farger i Tailwind importerer en `@sb1/ffe-core/lib/senamticColors`.
+For å bruke semantiske farger i Tailwind importerer en `@sb1/ffe-core/lib/semanticColorsTailwind`.
 
 ```tsx
-import * as colors from '@sb1/ffe-core/lib/senamticColors';
+import * as colors from '@sb1/ffe-core/lib/semanticColorsTailwind';
 module.exports = {
     theme: {
         colors: {
@@ -33,7 +33,7 @@ module.exports = {
 };
 ```
 
-Da blir fargene tilgjengelige i camelCase uten `--ffe-color`. Feks `--ffe-color-background-default` -> `backgroundDefault`
+Da blir fargene tilgjengelige i kebab-case uten `--ffe-color`. Feks `--ffe-color-background-default` -> `background-default`
 
 ## Liste over de semantiske fargene
 

--- a/packages/ffe-core/scripts/generate-semantic-colors.js
+++ b/packages/ffe-core/scripts/generate-semantic-colors.js
@@ -149,6 +149,10 @@ function transformColorName(colorName) {
         .join('');
 }
 
+function transformColorNameTW(colorName) {
+    return colorName.replace('--ffe-color-', '');
+}
+
 function generateSemanticColorModule(_semanticColorNames) {
     let moduleContent = `"use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
@@ -160,6 +164,25 @@ Object.defineProperty(exports, "__esModule", { value: true });
         const transformedName = transformColorName(colorName);
         moduleVars += `exports.${transformedName} = 'var(${colorName})';\n`;
         moduleContent += `exports.${transformedName} = `;
+    });
+
+    moduleContent += 'void 0\n';
+    moduleContent += moduleVars;
+
+    return moduleContent;
+}
+
+function generateSemanticColorTWModule(_semanticColorNames) {
+    let moduleContent = `"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+
+`;
+    let moduleVars = '';
+
+    _semanticColorNames.forEach(colorName => {
+        const transformedName = transformColorNameTW(colorName);
+        moduleVars += `exports['${transformedName}'] = 'var(${colorName})';\n`;
+        moduleContent += `exports['${transformedName}'] = `;
     });
 
     moduleContent += 'void 0\n';
@@ -193,6 +216,9 @@ function generateSemanticColors() {
     const semanticColorModuleContent =
         generateSemanticColorModule(semanticColorNames);
     writeToFile('lib/semanticColors.js')(semanticColorModuleContent);
+    const semanticColorTWModuleContent =
+        generateSemanticColorTWModule(semanticColorNames);
+    writeToFile('lib/semanticColorsTailwind.js')(semanticColorTWModuleContent);
 
     generateChevronColors();
 }


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse

Legger til en ny fil med js fargenavn rettet mot tailwind ved at de er kebab case
Adds a new file with js color names to tailor to Tailwind

den nåværende fila for semantiske farger er slik `semanticColors.js`
```js
exports.surfaceTertiaryDefault = 'var(--ffe-color-surface-tertiary-default)';
```
Den blir værende uendret, men er litt rar når en bruker det for da blir klassenavn 
```html
<div classname="background-color-surfaceTertiaryDefault"></div>
```

Legger derfor til fila `semanticColorsTailwind.js` på formatet
```js
exports['border-primary-selected'] = 'var(--ffe-color-border-primary-selected)';
```

Slik at når en bruker det med tailwind blir det slik
```html
<div classname="background-color-surface-tertiary-default"></div>
```

Sebastian har testet den nye fila som blir generert.

Oppdaterer og docken om tailwind til å bruke den nye fila. den gamle vil forstatt fungere, men er ikke like pen å bruke. Det er altså i stor grad en kosmetisk endring for variablene, men er jo noe som gnager på folk flere ganger hver dag når de bruker det.