### PR TITLE
fix(ffe-cards-react): fjern advarsel på at role er satt feil dersom groupcard ikke er div

### DIFF
--- a/packages/ffe-cards-react/src/GroupCard/GroupCard.tsx
+++ b/packages/ffe-cards-react/src/GroupCard/GroupCard.tsx
@@ -48,7 +48,7 @@ function GroupCardWithForwardRef<As extends ElementType>(
                 },
                 className,
             )}
-            role={Comp === 'div' && 'group'}
+            role={Comp === 'div' ? 'group' : undefined}
             {...rest}
             ref={ref}
         >


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse
Setter `role` til å være undefined dersom komponent typen ikke er div. 

<!-- Detaljert beskrivelse av endringene dine. Skjermskudd er lov. -->

## Motivasjon og kontekst
Da jeg la inn funksjonaliteten til å endre elementet på GroupCard med `as`- prop,
så la jeg også til at den ikke skulle sette `role="group"`dersom elementet er noe annet enn div. Da jeg ville ikke overstyre default HTML role i de tilfellene man valgte ett annet element. 

Måten jeg løste det på "fungerer" på en måte i praksis, da role ikke blir satt i tilfeller der GroupCard er noe annet enn div, men det trigget også en advarsel i konsollen om at role var satt til en ugyldig verdi.
Så håper denne fiksen fjerner advarselen, men gjør at det fungerer på samme måte! 

Helt konkret i tilfelle vi oppdaget advarselen, så var GroupCard satt til `as="ul" `

<!-- Hvorfor trengs denne endringen, og hva løser den? -->

## Testing

<!-- Hvordan har du har testet endringene dine? Ta gjerne med systeminfo o.l -->

<!--

Helt til slutt, har du ..

.. lest retningslinjene våre for bidrag?
.. tatt en siste sjekk for kode og skrivefeil, debug informasjon o.l?
.. kjørt og eventuelt oppdatert testene?
.. kommentert og dokumentert det som trengs?
.. knyttet denne opp til relaterte issues?

-->
