### PR TITLE
fix(ffe-cards): focus styling på cardaction

### DIFF
--- a/packages/ffe-cards/less/common-card-styling.less
+++ b/packages/ffe-cards/less/common-card-styling.less
@@ -48,10 +48,12 @@
             }
         }
     }
-    &:focus-within {
-        border-color: transparent;
+    &:focus,
+    &:active,
+    &:focus-within{
+        border-color: var(--ffe-color-border-interactive-focus);
         box-shadow: var(--ffe-g-border-focus-box-shadow)
-            var(--ffe-color-border-primary-pressed);
+            var(--ffe-color-border-interactive-focus);
 
         &
             :where(


### PR DESCRIPTION
fixes #2747 

Legger til focus styling på cards med cardAction i 
Fra: 
![image](https://github.com/user-attachments/assets/e0a03610-439d-45bf-bb57-44f4930fd770)
Til: 
![image](https://github.com/user-attachments/assets/d9d8a07f-48d4-4999-aee8-62945d42bf8d)

La også til at den får den samme tykke borderen når man klikker