### PR TITLE
feat(ffe-core-react): ny bodytext-komponent

### DIFF
--- a/packages/ffe-core-react/src/index.ts
+++ b/packages/ffe-core-react/src/index.ts
@@ -1,3 +1,4 @@
+export { BodyText, BodyTextProps } from './typography/BodyText';
 export { DividerLine, DividerLineProps } from './typography/DividerLine';
 export {
     EmphasizedText,

--- a/packages/ffe-core-react/src/typography/BodyText.mdx
+++ b/packages/ffe-core-react/src/typography/BodyText.mdx
@@ -1,0 +1,13 @@
+import { Canvas, Meta, Controls } from '@storybook/blocks';
+import * as BodyTextStories from './BodyText.stories';
+
+<Meta of={BodyTextStories} />
+
+# BodyText
+
+BodyText er vår default tekststyling for brødtekst. Komponenten gir deg SpareBank1-fonten og setter den opp med riktig fontstørrelse, linjehøyde og farge.
+
+Merk: For å sikre at SpareBank1-fonten settes som default på tekst også utenom disse komponentene må du passe på å ha klassen `.ffe-body` på eller nær `body`-elementet.
+
+<Canvas of={BodyTextStories.Standard} />
+<Controls of={BodyTextStories.Standard} />

--- a/packages/ffe-core-react/src/typography/BodyText.stories.tsx
+++ b/packages/ffe-core-react/src/typography/BodyText.stories.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { BodyText } from './BodyText';
+import type { StoryObj, Meta } from '@storybook/react';
+
+const meta: Meta<typeof BodyText> = {
+    title: 'Komponenter/Core/BodyText',
+    component: BodyText,
+};
+export default meta;
+
+type Story = StoryObj<typeof BodyText>;
+
+export const Standard: Story = {
+    args: {
+        children:
+            'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce in sem posuere, fringilla augue et, egestas magna. Sed dapibus, libero quis rutrum pharetra, lectus tortor bibendum quam, quis placerat urna lorem malesuada elit. Maecenas justo lorem, accumsan in leo non, pellentesque facilisis magna.',
+        as: 'p',
+        className: 'custom-class',
+    },
+    render: args => <BodyText {...args} />,
+};

--- a/packages/ffe-core-react/src/typography/BodyText.tsx
+++ b/packages/ffe-core-react/src/typography/BodyText.tsx
@@ -1,0 +1,19 @@
+import React, { ComponentProps, ElementType } from 'react';
+import classNames from 'classnames';
+import { DistributiveOmit } from './types';
+
+export type BodyTextProps<As extends ElementType = 'div'> = {
+    as?: As;
+    // ComponentPropsWithoutProps was missing class for some reason
+} & DistributiveOmit<
+    ComponentProps<ElementType extends As ? 'div' : As>,
+    'as' | 'ref'
+>;
+
+export function BodyText<As extends ElementType>(props: BodyTextProps<As>) {
+    const { as: Comp = 'div', className, ...rest } = props;
+
+    return (
+        <Comp className={classNames('ffe-body-text', className)} {...rest} />
+    );
+}

--- a/packages/ffe-core-react/src/typography/Heading1.mdx
+++ b/packages/ffe-core-react/src/typography/Heading1.mdx
@@ -13,7 +13,7 @@ En Heading 2 kan ikke komme uten at en heading 1 kommer først, siden Heading 2 
 
 Man kan ha flere headingnivåer av samme nivå etter hverandre. Det eneste dette betyr er at de presenterer en ny paragraf eller innhold som er relevant for den overordnede headingen, men ikke passer som en underparagraf for den tidligere headingen av samme nivå.
 
-Merk: For å sikre at SpareBank1-fonten settes som default på tekst også utenom disse komponentene må du passe på å ha klassen `.ffe-body` på eller nær `body-elementet`.
+Merk: For å sikre at SpareBank1-fonten settes som default på tekst også utenom disse komponentene må du passe på å ha klassen `.ffe-body` på eller nær `body`-elementet.
 
 <Canvas of={HeadingStories.Standard} />
 <Controls of={HeadingStories.Standard} />

--- a/packages/ffe-core-react/src/typography/Heading2.mdx
+++ b/packages/ffe-core-react/src/typography/Heading2.mdx
@@ -13,7 +13,7 @@ En Heading 2 kan ikke komme uten at en heading 1 kommer først, siden Heading 2 
 
 Man kan ha flere headingnivåer av samme nivå etter hverandre. Det eneste dette betyr er at de presenterer en ny paragraf eller innhold som er relevant for den overordnede headingen, men ikke passer som en underparagraf for den tidligere headingen av samme nivå.
 
-Merk: For å sikre at SpareBank1-fonten settes som default på tekst også utenom disse komponentene må du passe på å ha klassen `.ffe-body` på eller nær `body-elementet`.
+Merk: For å sikre at SpareBank1-fonten settes som default på tekst også utenom disse komponentene må du passe på å ha klassen `.ffe-body` på eller nær `body`-elementet.
 
 <Canvas of={HeadingStories.Standard} />
 <Controls of={HeadingStories.Standard} />

--- a/packages/ffe-core-react/src/typography/Heading3.mdx
+++ b/packages/ffe-core-react/src/typography/Heading3.mdx
@@ -13,7 +13,7 @@ En Heading 2 kan ikke komme uten at en heading 1 kommer først, siden Heading 2 
 
 Man kan ha flere headingnivåer av samme nivå etter hverandre. Det eneste dette betyr er at de presenterer en ny paragraf eller innhold som er relevant for den overordnede headingen, men ikke passer som en underparagraf for den tidligere headingen av samme nivå.
 
-Merk: For å sikre at SpareBank1-fonten settes som default på tekst også utenom disse komponentene må du passe på å ha klassen `.ffe-body` på eller nær `body-elementet`.
+Merk: For å sikre at SpareBank1-fonten settes som default på tekst også utenom disse komponentene må du passe på å ha klassen `.ffe-body` på eller nær `body`-elementet.
 
 <Canvas of={HeadingStories.Standard} />
 <Controls of={HeadingStories.Standard} />

--- a/packages/ffe-core-react/src/typography/Heading4.mdx
+++ b/packages/ffe-core-react/src/typography/Heading4.mdx
@@ -13,7 +13,7 @@ En Heading 2 kan ikke komme uten at en heading 1 kommer først, siden Heading 2 
 
 Man kan ha flere headingnivåer av samme nivå etter hverandre. Det eneste dette betyr er at de presenterer en ny paragraf eller innhold som er relevant for den overordnede headingen, men ikke passer som en underparagraf for den tidligere headingen av samme nivå.
 
-Merk: For å sikre at SpareBank1-fonten settes som default på tekst også utenom disse komponentene må du passe på å ha klassen `.ffe-body` på eller nær `body-elementet`.
+Merk: For å sikre at SpareBank1-fonten settes som default på tekst også utenom disse komponentene må du passe på å ha klassen `.ffe-body` på eller nær `body`-elementet.
 
 <Canvas of={HeadingStories.Standard} />
 <Controls of={HeadingStories.Standard} />

--- a/packages/ffe-core-react/src/typography/Heading5.mdx
+++ b/packages/ffe-core-react/src/typography/Heading5.mdx
@@ -13,7 +13,7 @@ En Heading 2 kan ikke komme uten at en heading 1 kommer først, siden Heading 2 
 
 Man kan ha flere headingnivåer av samme nivå etter hverandre. Det eneste dette betyr er at de presenterer en ny paragraf eller innhold som er relevant for den overordnede headingen, men ikke passer som en underparagraf for den tidligere headingen av samme nivå.
 
-Merk: For å sikre at SpareBank1-fonten settes som default på tekst også utenom disse komponentene må du passe på å ha klassen `.ffe-body` på eller nær `body-elementet`.
+Merk: For å sikre at SpareBank1-fonten settes som default på tekst også utenom disse komponentene må du passe på å ha klassen `.ffe-body` på eller nær `body`-elementet.
 
 <Canvas of={HeadingStories.Standard} />
 <Controls of={HeadingStories.Standard} />

--- a/packages/ffe-core-react/src/typography/Heading6.mdx
+++ b/packages/ffe-core-react/src/typography/Heading6.mdx
@@ -13,7 +13,7 @@ En Heading 2 kan ikke komme uten at en heading 1 kommer først, siden Heading 2 
 
 Man kan ha flere headingnivåer av samme nivå etter hverandre. Det eneste dette betyr er at de presenterer en ny paragraf eller innhold som er relevant for den overordnede headingen, men ikke passer som en underparagraf for den tidligere headingen av samme nivå.
 
-Merk: For å sikre at SpareBank1-fonten settes som default på tekst også utenom disse komponentene må du passe på å ha klassen `.ffe-body` på eller nær `body-elementet`.
+Merk: For å sikre at SpareBank1-fonten settes som default på tekst også utenom disse komponentene må du passe på å ha klassen `.ffe-body` på eller nær `body`-elementet.
 
 <Canvas of={HeadingStories.Standard} />
 <Controls of={HeadingStories.Standard} />


### PR DESCRIPTION
Legger til en ny komponent for BodyText.

BodyText har ikke hittil vært tilbudt som egen komponent, i motsetning til all annen tekststyling, til tross for at klassen gir default styling for brødtekst.

Fixes #2741
