### PR TITLE
Feedback improvements

### DIFF
--- a/packages/ffe-feedback-react/src/Feedback.spec.tsx
+++ b/packages/ffe-feedback-react/src/Feedback.spec.tsx
@@ -1,0 +1,220 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { Feedback } from './Feedback'; // Adjust the import path as needed
+
+describe('Feedback Component', () => {
+    it('should trigger onThumbClick when the thumb up is clicked', () => {
+        const onThumbClickMock = jest.fn();
+
+        render(
+            <Feedback
+                onThumbClick={onThumbClickMock}
+                onFeedbackSend={() => {}}
+            />,
+        );
+
+        const thumbButton = screen.getByLabelText('Gi tommel opp');
+        fireEvent.click(thumbButton);
+
+        expect(onThumbClickMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('should trigger onThumbClick when the thumb down is clicked', () => {
+        const onThumbClickMock = jest.fn();
+
+        render(
+            <Feedback
+                onThumbClick={onThumbClickMock}
+                onFeedbackSend={() => {}}
+            />,
+        );
+
+        const thumbButton = screen.getByLabelText('Gi tommel ned');
+        fireEvent.click(thumbButton);
+
+        expect(onThumbClickMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('should change the view when thumb up is clicked', () => {
+        render(<Feedback onThumbClick={() => {}} onFeedbackSend={() => {}} />);
+
+        const thumbButton = screen.getByLabelText('Gi tommel ned');
+        fireEvent.click(thumbButton);
+
+        expect(
+            screen.getByText('Takk for tilbakemeldingen!'),
+        ).toBeInTheDocument();
+    });
+
+    it('should not trigger onFeedbackSend if no text', () => {
+        const onFeedbackSendMock = jest.fn();
+        render(
+            <Feedback
+                onThumbClick={() => {}}
+                onFeedbackSend={onFeedbackSendMock}
+            />,
+        );
+
+        const thumbButton = screen.getByLabelText('Gi tommel opp');
+        fireEvent.click(thumbButton);
+
+        const sendButton = screen.getByText('Send tilbakemelding');
+        fireEvent.click(sendButton);
+
+        expect(onFeedbackSendMock).not.toHaveBeenCalled();
+    });
+
+    it('should trigger onFeedbackSend with text', () => {
+        const onFeedbackSendMock = jest.fn();
+        render(
+            <Feedback
+                onThumbClick={() => {}}
+                onFeedbackSend={onFeedbackSendMock}
+            />,
+        );
+
+        const thumbButton = screen.getByLabelText('Gi tommel opp');
+        fireEvent.click(thumbButton);
+
+        const feedbackInput = screen.getByLabelText(
+            'Har du noe mer på hjertet? (valgfritt)',
+        );
+        fireEvent.change(feedbackInput, { target: { value: 'Test feedback' } });
+
+        const sendButton = screen.getByText('Send tilbakemelding');
+        fireEvent.click(sendButton);
+
+        expect(onFeedbackSendMock).toHaveBeenCalledWith(
+            'Test feedback',
+            undefined,
+        );
+    });
+
+    it('should trigger onFeedbackSend with text and false consent if not ticked', () => {
+        const onFeedbackSendMock = jest.fn();
+        render(
+            <Feedback
+                onThumbClick={() => {}}
+                onFeedbackSend={onFeedbackSendMock}
+                includeConsent={true}
+            />,
+        );
+
+        const thumbButton = screen.getByLabelText('Gi tommel opp');
+        fireEvent.click(thumbButton);
+
+        const feedbackInput = screen.getByLabelText(
+            'Har du noe mer på hjertet? (valgfritt)',
+        );
+        fireEvent.change(feedbackInput, { target: { value: 'Test feedback' } });
+
+        const sendButton = screen.getByText('Send tilbakemelding');
+        fireEvent.click(sendButton);
+
+        expect(onFeedbackSendMock).toHaveBeenCalledWith('Test feedback', false);
+    });
+
+    it('should trigger onFeedbackSend with text and consent if ticked', () => {
+        const onFeedbackSendMock = jest.fn();
+        render(
+            <Feedback
+                onThumbClick={() => {}}
+                onFeedbackSend={onFeedbackSendMock}
+                includeConsent={true}
+            />,
+        );
+
+        const thumbButton = screen.getByLabelText('Gi tommel opp');
+        fireEvent.click(thumbButton);
+
+        const feedbackInput = screen.getByLabelText(
+            'Har du noe mer på hjertet? (valgfritt)',
+        );
+        fireEvent.change(feedbackInput, { target: { value: 'Test feedback' } });
+
+        const consent = screen.getByLabelText(
+            'Jeg samtykker til at jeg kan bli kontaktet angående tilbakemeldingen min.',
+        );
+        fireEvent.click(consent);
+
+        const sendButton = screen.getByText('Send tilbakemelding');
+        fireEvent.click(sendButton);
+
+        expect(onFeedbackSendMock).toHaveBeenCalledWith('Test feedback', true);
+    });
+
+    it('should render with custom heading', () => {
+        render(
+            <Feedback
+                onThumbClick={() => {}}
+                onFeedbackSend={() => {}}
+                texts={{ feedbackNotSentHeading: 'Custom Heading' }}
+            />,
+        );
+
+        const heading = screen.getByText('Custom Heading');
+        expect(heading).toBeInTheDocument();
+    });
+
+    it('should render with contact link', () => {
+        const contactLink = {
+            url: 'https://nav.no',
+            linkText: 'Kontakt oss',
+            onClick: jest.fn(),
+        };
+
+        render(
+            <Feedback
+                onThumbClick={() => {}}
+                onFeedbackSend={() => {}}
+                contactLink={contactLink}
+            />,
+        );
+
+        const thumbButton = screen.getByLabelText('Gi tommel opp');
+        fireEvent.click(thumbButton);
+
+        const link = screen.getByText('Kontakt oss');
+        expect(link).toBeInTheDocument();
+    });
+
+    it('should render with bgColor', () => {
+        render(
+            <Feedback
+                onThumbClick={() => {}}
+                onFeedbackSend={() => {}}
+                bgColor="secondary"
+            />,
+        );
+
+        const feedback = screen.getByText('Hva synes du om denne siden?');
+        const parent = feedback.parentElement?.parentElement;
+        expect(parent).toHaveClass('ffe-feedback--bg-secondary');
+    });
+
+    it('should render with large heading', () => {
+        render(
+            <Feedback
+                onThumbClick={() => {}}
+                onFeedbackSend={() => {}}
+                headingLevel={2}
+            />,
+        );
+
+        const heading = screen.getByRole('heading', { level: 2 });
+        expect(heading).toBeInTheDocument();
+    });
+
+    it('should render with correct language', () => {
+        render(
+            <Feedback
+                onThumbClick={() => {}}
+                onFeedbackSend={() => {}}
+                locale="en"
+            />,
+        );
+
+        const heading = screen.getByText('What do you think of this page?');
+        expect(heading).toBeInTheDocument();
+    });
+});

--- a/packages/ffe-feedback-react/src/Feedback.stories.tsx
+++ b/packages/ffe-feedback-react/src/Feedback.stories.tsx
@@ -11,19 +11,56 @@ export default meta;
 type Story = StoryObj<typeof Feedback>;
 export const Standard: Story = {
     args: {
-        // Removing the headingLevel property to use default value (5)
         onThumbClick: () => console.log('Thumb clicked'),
         onFeedbackSend: text => console.log('Feedback sent:', text),
     },
     render: args => <Feedback {...args} />,
 };
 
-// Adding an example with explicit heading level for comparison
 export const WithLargeHeading: Story = {
     args: {
+        ...Standard.args,
         headingLevel: 2,
-        onThumbClick: () => console.log('Thumb clicked'),
-        onFeedbackSend: text => console.log('Feedback sent:', text),
+    },
+    render: args => <Feedback {...args} />,
+};
+
+export const WithBGColor: Story = {
+    args: {
+        ...Standard.args,
+        bgColor: 'secondary',
+    },
+    render: args => <Feedback {...args} />,
+};
+
+export const WithContactLink: Story = {
+    args: {
+        ...Standard.args,
+        contactLink: {
+            url: 'https://nav.no',
+            linkText: 'Kontakt oss',
+            onClick: () => console.log('Contact link clicked'),
+        },
+    },
+    render: args => <Feedback {...args} />,
+};
+
+export const WithConsent: Story = {
+    args: {
+        ...Standard.args,
+        includeConsent: true,
+        onFeedbackSend: (text, consent) =>
+            console.log('Feedback sent:', text, 'Consent given:', consent),
+    },
+    render: args => <Feedback {...args} />,
+};
+
+export const WithCustomHeading: Story = {
+    args: {
+        includeConsent: true,
+        texts: {
+            feedbackNotSentHeading: 'Vil du se mer av slike endringer?',
+        },
     },
     render: args => <Feedback {...args} />,
 };

--- a/packages/ffe-feedback-react/src/Feedback.tsx
+++ b/packages/ffe-feedback-react/src/Feedback.tsx
@@ -14,17 +14,19 @@ export interface FeedbackProps {
     headingLevel?: HeadingLevel;
     locale?: Locale;
     onThumbClick: (thumb: Thumb) => void;
-    onFeedbackSend: (feedbackText: string) => void;
+    onFeedbackSend: (feedbackText: string, consent?: boolean) => void;
     bgColor?: BgColor;
     contactLink?: FeedbackExpandedProps['contactLink'];
     texts?: {
         feedbackNotSentHeading?: string;
+        consentText?: string;
     };
     className?: string;
+    includeConsent?: boolean;
 }
 
 export const Feedback = ({
-    headingLevel = 5,
+    headingLevel = 4,
     locale = 'nb',
     onThumbClick,
     onFeedbackSend,
@@ -32,12 +34,10 @@ export const Feedback = ({
     contactLink,
     texts,
     className,
+    includeConsent = false,
 }: FeedbackProps) => {
     const feedbackSentRef = useRef<HTMLHeadingElement>(null);
     const expandedRef = useRef<HTMLHeadingElement>(null);
-    const [feedbackThumbClicked, setFeedbackThumbClicked] = useState<
-        Thumb | undefined
-    >();
     const [expanded, setExpanded] = useState(false);
     const [feedbackSent, setFeedbackSent] = useState(false);
     const headingId = useId();
@@ -51,7 +51,6 @@ export const Feedback = ({
     );
 
     const handleThumbClicked = (thumb: Thumb) => {
-        setFeedbackThumbClicked(thumb);
         flushSync(() => {
             setExpanded(true);
         });
@@ -59,12 +58,17 @@ export const Feedback = ({
         onThumbClick(thumb);
     };
 
-    const handleFeedbackSent = (feedbackText: string) => {
+    const handleFeedbackSent = (
+        feedbackText?: string,
+        consentGiven?: boolean,
+    ) => {
         flushSync(() => {
             setFeedbackSent(true);
         });
         feedbackSentRef.current?.focus();
-        onFeedbackSend(feedbackText);
+        if (feedbackText && feedbackText.length > 0) {
+            onFeedbackSend(feedbackText, consentGiven);
+        }
     };
 
     const renderHeading = (
@@ -115,19 +119,17 @@ export const Feedback = ({
     if (expanded) {
         return (
             <div className={feedbackClassnames}>
-                <div className="ffe-feedback__content">
+                <div className="ffe-feedback__expanded">
                     {renderHeading(
                         headingLevel,
-                        feedbackThumbClicked === 'THUMB_UP'
-                            ? txt[locale].FEEDBACK_GOOD
-                            : txt[locale].FEEDBACK_IMPROVE,
+                        txt[locale].FEEDBACK_SENT_HEADING,
                         { ref: expandedRef, tabIndex: -1 },
                     )}
                     <FeedbackExpanded
                         locale={locale}
-                        onSend={handleFeedbackSent}
-                        onCancel={() => setExpanded(false)}
+                        handleFeedback={handleFeedbackSent}
                         contactLink={contactLink}
+                        includeConsent={includeConsent}
                     />
                 </div>
             </div>

--- a/packages/ffe-feedback-react/src/FeedbackExpanded.tsx
+++ b/packages/ffe-feedback-react/src/FeedbackExpanded.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
-import { Paragraph } from '@sb1/ffe-core-react';
+import { LinkText, Paragraph } from '@sb1/ffe-core-react';
 import { txt } from './i18n/texts';
-import { InputGroup, TextArea } from '@sb1/ffe-form-react';
+import { InputGroup, TextArea, Checkbox } from '@sb1/ffe-form-react';
 import {
     ActionButton,
     ButtonGroup,
@@ -10,42 +10,32 @@ import {
 
 export interface FeedbackExpandedProps {
     locale: 'nb' | 'nn' | 'en';
-    onSend: (feedbackText: string) => void;
-    onCancel: () => void;
+    handleFeedback: (feedbackText?: string, consentGiven?: boolean) => void;
     contactLink?: {
         url: string;
         onClick?: React.MouseEventHandler<HTMLAnchorElement>;
         linkText?: string;
     };
+    includeConsent?: boolean;
 }
 
 export const FeedbackExpanded: React.FC<FeedbackExpandedProps> = ({
     locale,
-    onSend,
-    onCancel,
+    handleFeedback,
     contactLink,
+    includeConsent = false,
 }) => {
     const [feedbackText, setFeedbackText] = useState<string>();
-    const [fieldMessage, setFieldMessage] = useState<string>();
-
-    const validateMessage = () => {
-        if (feedbackText && feedbackText?.length >= 3) {
-            setFieldMessage(undefined);
-            return true;
-        }
-        setFieldMessage(txt[locale].FEEDBACK_SHORT);
-        return false;
-    };
+    const [consentGiven, setConsentGiven] = useState<boolean>(false);
 
     const contactLinkElement = contactLink ? (
-        <TertiaryButton
-            as="a"
+        <LinkText
             href={contactLink.url}
             className="ffe-feedback__link-button"
             onClick={contactLink?.onClick}
         >
             {contactLink.linkText ?? txt[locale].FEEDBACK_LINK_TEXT}
-        </TertiaryButton>
+        </LinkText>
     ) : null;
 
     return (
@@ -55,17 +45,10 @@ export const FeedbackExpanded: React.FC<FeedbackExpandedProps> = ({
                 {contactLinkElement && txt[locale].QUESTIONS}
                 {contactLinkElement}
             </Paragraph>
-            <Paragraph>{txt[locale].FEEDBACK_SENSITIVE}</Paragraph>
             <InputGroup
                 className="ffe-feedback__textarea-container"
-                fieldMessage={fieldMessage}
-                label={
-                    // htmlFor kommer fra InputGroup
-                    // eslint-disable-next-line jsx-a11y/label-has-for
-                    <label className="ffe-screenreader-only">
-                        {txt[locale].FEEDBACK_IMPROVE}
-                    </label>
-                }
+                label={txt[locale].FEEDBACK_IMPROVE}
+                description={txt[locale].FEEDBACK_SENSITIVE}
             >
                 <TextArea
                     data-testid="feedbackTextArea"
@@ -73,23 +56,40 @@ export const FeedbackExpanded: React.FC<FeedbackExpandedProps> = ({
                     value={feedbackText}
                     rows={6}
                     maxLength={1000}
-                    onBlur={validateMessage}
+                    className="ffe-feedback__textarea"
                 />
             </InputGroup>
+            {includeConsent && (
+                <div className="ffe-feedback__consent">
+                    <Checkbox
+                        checked={consentGiven}
+                        onChange={event =>
+                            setConsentGiven(event.target.checked)
+                        }
+                    >
+                        {txt[locale].FEEDBACK_CONSENT}
+                    </Checkbox>
+                </div>
+            )}
+
             <ButtonGroup
                 className="ffe-feedback__button-group"
                 ariaLabel={txt[locale].FEEDBACK_BUTTON_GROUP}
+                thin={true}
             >
                 <ActionButton
                     onClick={() => {
-                        if (validateMessage() && feedbackText) {
-                            onSend(feedbackText);
+                        if (feedbackText) {
+                            handleFeedback(
+                                feedbackText,
+                                includeConsent ? consentGiven : undefined,
+                            );
                         }
                     }}
                 >
                     {txt[locale].FEEDBACK_BUTTON_SEND}
                 </ActionButton>
-                <TertiaryButton onClick={onCancel}>
+                <TertiaryButton onClick={() => handleFeedback()}>
                     {txt[locale].FEEDBACK_BUTTON_CANCEL}
                 </TertiaryButton>
             </ButtonGroup>

--- a/packages/ffe-feedback-react/src/FeedbackThumbs.tsx
+++ b/packages/ffe-feedback-react/src/FeedbackThumbs.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import { txt } from './i18n/texts';
+import { SecondaryButton } from '@sb1/ffe-buttons-react';
+import { Icon } from '@sb1/ffe-icons-react';
 
 export type Thumb = 'THUMB_UP' | 'THUMB_DOWN';
 
@@ -9,31 +11,37 @@ interface FeedbackThumbsProps {
     headingId: string;
 }
 
+const thumbUpIconLg =
+    'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgLTk2MCA5NjAgOTYwIiB3aWR0aD0iMzIiIGhlaWdodD0iMzIiPjxwYXRoIGQ9Ik04MzUuMTMtNjE2LjJxMjQuNjQgMCA0My42IDE4Ljk2dDE4Ljk2IDQzLjZ2NjUuNnEwIDYuMzktLjA1IDEzLjM4LS4wNSA2Ljk5LTIuNDYgMTMuMjJMNzc3LjgzLTE4Ny4xM3EtOC42MSAxOS44LTI4Ljg2IDMzLjQ2UTcyOC43MS0xNDAgNzA3LjE5LTE0MEgyODQuNjd2LTQ3Ni4ybDIyNS4yNS0yMzAuN3ExMC45OS0xMS4yNSAyNS45Mi0xMy41NiAxNC45My0yLjMxIDI4LjM5IDUuMjYgMTMuMzEgNy41NiAxOS43OSAyMS41MSA2LjQ5IDEzLjk1IDIuOTggMjkuMUw1NDYuOTctNjE2LjJoMjg4LjE2Wm0tNTAwLjIxIDIxLjMzdjQwNC42MWgzNzguNzdxMy45OCAwIDguNTMtMi4zIDQuNTUtMi4zMSA2Ljg2LTcuN2wxMTguMzYtMjc5LjMzdi03NC4wNXEwLTUuMTMtMy41OS04LjcyLTMuNTktMy41OS04LjcyLTMuNTlINDg0LjkybDQ5LjQ5LTIzMy4xOC0xOTkuNDkgMjA0LjI2Wk0xNjIuMTUtMTQwcS0yNS44IDAtNDQuMTgtMTguNDh0LTE4LjM4LTQ0LjA5di0zNTEuMDdxMC0yNS42MSAxOC4zOC00NC4wOSAxOC4zOC0xOC40NyA0NC4xOC0xOC40N2gxMjIuNTJ2NTAuMjVIMTYyLjE1cS01LjM4IDAtOC44NCAzLjU5dC0zLjQ2IDguNzJ2MzUxLjA3cTAgNS4zOSAzLjQ2IDguODV0OC44NCAzLjQ2aDEyMi41MlYtMTQwSDE2Mi4xNVptMTcyLjc3LTUwLjI2di00MDQuNjEgNDA0LjYxWiIvPjwvc3ZnPg==';
+
+const thumbDownIconLg =
+    'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgLTk2MCA5NjAgOTYwIiB3aWR0aD0iMzIiIGhlaWdodD0iMzIiPjxwYXRoIGQ9Ik0xMjUuMTMtMzQzLjhxLTI1IDAtNDMuNzgtMTguOTZ0LTE4Ljc4LTQzLjZ2LTY1LjZxMC02LjM5LS4wOC0xMy4zOC0uMDgtNi45OSAyLjMzLTEzLjIybDExNy42MS0yNzQuMzFxOC4yNi0xOS43NiAyOC41Ni0zMy40NFEyMzEuMjktODIwIDI1Mi44MS04MjBoNDIyLjUydjQ3Ni4yTDQ1MC4wOC0xMTMuMXEtMTAuOTkgMTEuMjUtMjUuOTIgMTMuNTYtMTQuOTMgMi4zMS0yOC4zOS01LjI2LTEzLjMxLTcuNTYtMTkuNzktMjEuNTEtNi40OS0xMy45NS0yLjk4LTI5LjFsNDAuMDMtMTg4LjM5aC0yODcuOVptNDk5Ljk1LTIxLjMzdi00MDQuNjFIMjQ2LjMxcS0zLjk4IDAtOC41MyAyLjMtNC41NSAyLjMxLTYuODYgNy43bC0xMTguMSAyNzkuMzN2NzQuMDVxMCA1LjEzIDMuNDYgOC43MiAzLjQ2IDMuNTkgOC44NSAzLjU5aDM0OS45NWwtNDkuNDkgMjMzLjE4IDE5OS40OS0yMDQuMjZaTTc5Ny44NS04MjBxMjUuOCAwIDQ0LjE4IDE4LjQ4dDE4LjM4IDQ0LjA5djM1MS4wN3EwIDI1LjYxLTE4LjM4IDQ0LjA5LTE4LjM4IDE4LjQ3LTQ0LjE4IDE4LjQ3SDY3NS4zM3YtNTAuMjVoMTIyLjUycTUuMzggMCA4Ljg0LTMuNTl0My40Ni04Ljcydi0zNTEuMDdxMC01LjM5LTMuNDYtOC44NXQtOC44NC0zLjQ2SDY3NS4zM1YtODIwaDEyMi41MlptLTE3Mi43NyA1MC4yNnY0MDQuNjEtNDA0LjYxWiIvPjwvc3ZnPg==';
+
 export const FeedbackThumbs: React.FC<FeedbackThumbsProps> = ({
     locale,
     onClick,
     headingId,
 }) => {
     return (
-        <div>
-            <button
+        <div className="ffe-feedback__thumbs">
+            <SecondaryButton
                 aria-label={txt[locale].ARIA_LABEL_THUMB_UP}
                 aria-describedby={headingId}
-                className="ffe-feedback__thumb"
                 onClick={() => onClick('THUMB_UP')}
-                type="button"
+                iconOnly={true}
+                size={'lg'}
             >
-                <span className="ffe-icons ffe-icons--xl" />
-            </button>
-            <button
+                <Icon size="lg" fileUrl={thumbUpIconLg} />
+            </SecondaryButton>
+            <SecondaryButton
                 aria-label={txt[locale].ARIA_LABEL_THUMB_DOWN}
                 aria-describedby={headingId}
-                className="ffe-feedback__thumb ffe-feedback__thumb--down"
                 onClick={() => onClick('THUMB_DOWN')}
-                type="button"
+                iconOnly={true}
+                size={'lg'}
             >
-                <span className="ffe-icons ffe-icons--xl" />
-            </button>
+                <Icon size="lg" fileUrl={thumbDownIconLg} />
+            </SecondaryButton>
         </div>
     );
 };

--- a/packages/ffe-feedback-react/src/i18n/en.ts
+++ b/packages/ffe-feedback-react/src/i18n/en.ts
@@ -4,16 +4,14 @@ export const en = {
     FEEDBACK_NOT_SENT_HEADING: 'What do you think of this page? ',
     FEEDBACK_SENT_HEADING: 'Thank you!',
     FEEDBACK_BUTTON_SEND: 'Send feedback',
-    FEEDBACK_BUTTON_CANCEL: 'Cancel',
+    FEEDBACK_BUTTON_CANCEL: 'Finish',
     FEEDBACK_BUTTON_GROUP: 'Button group',
-    FEEDBACK_GOOD: 'What was good?',
-    FEEDBACK_IMPROVE: 'How can we improve?',
+    FEEDBACK_IMPROVE: 'Do you have anything else on your mind?',
     FEEDBACK_ANSWER:
         'Your feedback will be used to improve this site and will not be replied.',
+    FEEDBACK_CONSENT: 'I consent to be contacted regarding my feedback.',
     QUESTIONS: ' If you have questions, ',
     FEEDBACK_LINK_TEXT: 'contact customer services.',
     FEEDBACK_SENSITIVE:
-        'Please do not send sensitive or personal information, for example: Health information, political affiliation, social security number, name, email or telephone number.',
-    FEEDBACK_SHORT: 'Feedback must be at least three characters.',
-    NATIVE_VIEW_HEADING: 'Customer service',
+        'Please do not send sensitive or personal information, for example: Health information, personal identification number, name or contact information.',
 } as const;

--- a/packages/ffe-feedback-react/src/i18n/nb.ts
+++ b/packages/ffe-feedback-react/src/i18n/nb.ts
@@ -4,16 +4,15 @@ export const nb = {
     FEEDBACK_NOT_SENT_HEADING: 'Hva synes du om denne siden? ',
     FEEDBACK_SENT_HEADING: 'Takk for tilbakemeldingen!',
     FEEDBACK_BUTTON_SEND: 'Send tilbakemelding',
-    FEEDBACK_BUTTON_CANCEL: 'Avbryt',
+    FEEDBACK_BUTTON_CANCEL: 'Avslutt',
     FEEDBACK_BUTTON_GROUP: 'Knappegruppe',
-    FEEDBACK_GOOD: 'Hva var bra?',
-    FEEDBACK_IMPROVE: 'Hva kan vi gjøre bedre?',
+    FEEDBACK_IMPROVE: 'Har du noe mer på hjertet? (valgfritt)',
     FEEDBACK_ANSWER:
         'Svaret ditt blir brukt til å forbedre denne siden og blir ikke besvart.',
+    FEEDBACK_CONSENT:
+        'Jeg samtykker til at jeg kan bli kontaktet angående tilbakemeldingen min.',
     QUESTIONS: ' Har du spørsmål, ',
     FEEDBACK_LINK_TEXT: 'kontakt kundeservice.',
     FEEDBACK_SENSITIVE:
-        'Unngå å oppgi sensitiv eller personlig informasjon, for eksempel helseopplysninger, politisk tilhørighet, personnummer, navn, e-post eller telefonnummer.',
-    FEEDBACK_SHORT: 'Tilbakemeldingen må være på minst tre tegn.',
-    NATIVE_VIEW_HEADING: 'Kundeservice',
+        'Unngå å oppgi sensitiv eller personlig informasjon, for eksempel helseopplysninger, personnummer, navn eller kontaktinfo.',
 } as const;

--- a/packages/ffe-feedback-react/src/i18n/nn.ts
+++ b/packages/ffe-feedback-react/src/i18n/nn.ts
@@ -4,16 +4,15 @@ export const nn = {
     FEEDBACK_NOT_SENT_HEADING: 'Kva synest du om denne sida? ',
     FEEDBACK_SENT_HEADING: 'Takk for tilbakemeldinga!',
     FEEDBACK_BUTTON_SEND: 'Send tilbakemelding',
-    FEEDBACK_BUTTON_CANCEL: 'Avbryt',
+    FEEDBACK_BUTTON_CANCEL: 'Avslutt',
     FEEDBACK_BUTTON_GROUP: 'Knappegruppe',
-    FEEDBACK_GOOD: 'Kva var bra?',
-    FEEDBACK_IMPROVE: 'Kva kan vi gjere betre?',
+    FEEDBACK_IMPROVE: 'Har du noko meir på hjartet? (valfritt)',
     FEEDBACK_ANSWER:
         'Svaret ditt vert brukt til å betre denne sida og vert ikkje svart på.',
+    FEEDBACK_CONSENT:
+        'Eg samtykkjer til at eg kan bli kontakta angåande tilbakemeldinga mi.',
     QUESTIONS: ' Har du spørsmål, ',
     FEEDBACK_LINK_TEXT: 'kontakt kundetenesta.',
     FEEDBACK_SENSITIVE:
-        'Unngå å oppgje sensitiv eller personleg informasjon, til dømes helseopplysingar, politisk tilhøyrsel, personnummer, namn, e-post eller telefonnummer.',
-    FEEDBACK_SHORT: 'Tilbakemeldinga må vere minst tre teikn.',
-    NATIVE_VIEW_HEADING: 'Kundetenest',
+        'Unngå å oppgje sensitiv eller personleg informasjon, til dømes helseopplysingar, personnummer, namn eller kontaktinfo.',
 } as const;

--- a/packages/ffe-feedback/less/feedback.less
+++ b/packages/ffe-feedback/less/feedback.less
@@ -14,26 +14,39 @@
         color: var(--ffe-color-foreground-default);
     }
 
+    &__expanded {
+        padding: var(--ffe-spacing-xs) 0 var(--ffe-spacing-xl);
+        margin-right: auto;
+        margin-left: auto;
+        max-width: 420px;
+        color: var(--ffe-color-foreground-default);
+
+        .ffe-feedback__textarea-container {
+            padding-bottom: var(--ffe-spacing-md);
+        }
+    }
+
     &__heading {
         color: var(--ffe-color-foreground-emphasis);
-        margin-bottom: var(--ffe-spacing-md); // Add margin below heading
-        max-width: 100%; // Ensure heading doesn't overflow container
+        margin-bottom: var(--ffe-spacing-sm); // Add margin below heading
         word-wrap: break-word; // Handle long words
     }
 
-    &__link-button {
-        border: none;
-        border-radius: 0;
-        padding: 0;
-        margin: 0;
+    &__thumbs {
+        display: flex;
+        gap: var(--ffe-spacing-sm);
+    }
+
+    &__consent {
+        margin-bottom: var(--ffe-spacing-sm);
     }
 
     &__textarea-container {
         width: 100%;
-    }
 
-    &__button-group {
-        padding: var(--ffe-spacing-sm) 0 0;
+        .ffe-feedback__textarea {
+            margin-bottom: 0;
+        }
     }
 
     &--bg-primary {
@@ -46,39 +59,5 @@
 
     &--bg-tertiary {
         background-color: var(--ffe-color-surface-tertiary-default);
-    }
-}
-
-.ffe-feedback__thumb {
-    --thumb-up-filled-xl: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGhlaWdodD0iNDAiIHZpZXdCb3g9IjAgLTk2MCA5NjAgOTYwIiB3aWR0aD0iNDAiPjxwYXRoIGQ9Ik04NDIuMzA2LTYxNC4zMDZxMjIuMjMxIDAgMzkuOTYyIDE3LjczIDE3LjczMSAxNy43MzEgMTcuNzMxIDM5Ljk2MnY2Ni4yMjlxMCA5LjQ2Mi0yLjExNiAyMS40NjItMi4xMTUgMTEuOTk5LTUuOTYxIDIwLjY5Mkw3ODAuMTUzLTE4Ny45MjRxLTguNjE2IDE5Ljg0Ni0yOC41MzkgMzMuODg0LTE5LjkyMyAxNC4wMzktNDEuNzY5IDE0LjAzOUgzMjUuNDYycS0yMy44NDYgMC00MC43NjktMTYuOTIzLTE2LjkyMy0xNi45MjQtMTYuOTIzLTQwLjc3di0zOTIuOTk3cTAtMTEgNC41LTIxLjYxNSA0LjUtMTAuNjE2IDEyLjExNS0xOC42MTZsMjA0LjMwOC0yMTEuNDYxcTEwLjkyMy0xMS4zMDcgMjUuOTk5LTEzLjkyMyAxNS4wNzctMi42MTUgMjguMjMgNC42OTIgMTIuNzY5IDcuMzA4IDE5LjE1NCAyMS40NjIgNi4zODQgMTQuMTUzIDMuMTU0IDMwLjA3NmwtMzggMTg1Ljc3aDMxOC4wNzZaTTE1NS40NjMtMTQwLjAwMXEtMjIuNjE1IDAtMzkuMDM5LTE2LjQyMy0xNi40MjMtMTYuNDI0LTE2LjQyMy0zOS4wMzl2LTM2My4zODJxMC0yMi4yMzEgMTYuNDIzLTM4Ljg0NiAxNi40MjQtMTYuNjE1IDM5LjAzOS0xNi42MTVoOC40NjJxMjIuNjE1IDAgMzkuMDM4IDE2LjYxNXQxNi40MjMgMzguODQ2djM2My43NjdxMCAyMi42MTUtMTYuNDIzIDM4Ljg0Ni0xNi40MjMgMTYuMjMxLTM5LjAzOCAxNi4yMzFoLTguNDYyWiIvPjwvc3ZnPg==');
-    --thumb-up-open-400-xl: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGhlaWdodD0iNDAiIHZpZXdCb3g9IjAgLTk2MCA5NjAgOTYwIiB3aWR0aD0iNDAiPjxwYXRoIGQ9Ik04NTUtNjMycTI0IDAgNDIgMTh0MTggNDJ2ODEuODM5cTAgNy4xNjEgMS41IDE0LjY2MVQ5MTUtNDYxTDc4OS0xNzFxLTguODc4IDIxLjI1LTI5LjU5NSAzNi4xMjVRNzM4LjY4OS0xMjAgNzE2LTEyMEgyNzJ2LTUxMmwyMjUtMjM4cTEzLjYtMTQgMzIuMTg3LTE2LjVRNTQ3Ljc3My04ODkgNTY1LTg3OXExNyAxMCAyNS41IDI3LjV0NC4yIDM2LjVMNTU2LTYzMmgyOTlabS01MjMgMjV2NDI3aDM5N2wxMjYtMjk5di05M0g0ODJsNTMtMjQ5LTIwMyAyMTRaTTEzOS0xMjBxLTI0Ljc1IDAtNDIuMzc1LTE3LjYyNVQ3OS0xODB2LTM5MnEwLTI0Ljc1IDE3LjYyNS00Mi4zNzVUMTM5LTYzMmgxMzN2NjBIMTM5djM5MmgxMzN2NjBIMTM5Wm0xOTMtNjB2LTQyNyA0MjdaIi8+PC9zdmc+');
-
-    all: unset;
-    margin: 0 var(--ffe-spacing-xs);
-    padding: var(--ffe-spacing-xs);
-    border-radius: 50%;
-    transition: all var(--ffe-transition-duration) var(--ffe-ease);
-    background: transparent;
-    display: inline-flex;
-    cursor: pointer;
-
-    .ffe-icons {
-        mask-image: var(--thumb-up-open-400-xl);
-        color: var(--ffe-color-component-button-tertiary-foreground-default);
-    }
-
-    &:focus-visible .ffe-icons,
-    &:active .ffe-icons {
-        mask-image: var(--thumb-up-filled-xl);
-    }
-
-    &:hover,
-    &:focus-visible,
-    &:active {
-        background: var(--ffe-color-component-button-tertiary-fill-hover);
-    }
-
-    &--down {
-        transform: rotate(180deg);
     }
 }


### PR DESCRIPTION
fixes #2660 
Etter mange diskusjoner og ønskeliste-forslag har vi kommet med noen forbedringer på feedback-komponenten. 

Det innebærer: 
- Samtykke. Mulighet for en checkbox på bunn som godkjenner samtykke av å bli kontaktet
- Forbedret styling. Vi har lagt til label for å få innholdet mer leselig. Samt flyttet litt rundt på tekster og skrevet om sånn at det er lettere for brukeren å forstå at det er valgfritt å sende inn tekst, og at tommel-svaret har blitt lagret. 
- Bruker secondary icon-only knapp på tomlene

Burde kanskje skrive tester før det merges, men her er i alle fall endringen
