### PR TITLE
fix(ffe-modals): Fix polifill so it does not overwrite safari dialog styling

### DIFF
--- a/packages/ffe-modals/less/modal-polyfill.less
+++ b/packages/ffe-modals/less/modal-polyfill.less
@@ -1,7 +1,7 @@
 /* vi har ikke laget denne klassen  derav slå av lint */
 /* stylelint-disable */
 dialog {
-    position: absolute;
+    position: fixed;
     left: 0;
     right: 0;
     width: -moz-fit-content;


### PR DESCRIPTION
Endra stylinga fra asolute til fixed. Siden det ikke fungerer for safari på mobil nå