### PR TITLE
fix(ffe-datepicker-react): Use dynamic imports in test helper to avoid making react testing library a dependency

### DIFF
--- a/packages/ffe-datepicker-react/src/datepicker/Datepicker.mdx
+++ b/packages/ffe-datepicker-react/src/datepicker/Datepicker.mdx
@@ -41,7 +41,7 @@ npm i --save-dev @testing-library/react
 ```
 
 ```tsx
-function getDatepickerByLabelText(
+async function getDatepickerByLabelText(
     label: string,
     index = 0,
 ): {
@@ -63,7 +63,7 @@ describe('Datepicker test', () => {
     it('datepicker provides methods to simplify testing', async () => {
         // Code for rendering your page / component
 
-        const datepicker = getDatepickerByLabelText('Dato velger');
+        const datepicker = await getDatepickerByLabelText('Dato velger');
 
         expect(datepicker.getValue()).toStrictEqual('01.02.2024');
 

--- a/packages/ffe-datepicker-react/src/datepicker/DatepickerInContext.spec.tsx
+++ b/packages/ffe-datepicker-react/src/datepicker/DatepickerInContext.spec.tsx
@@ -20,20 +20,20 @@ const renderDatePicker = (props?: Partial<DatepickerProps>) =>
     );
 
 describe('<InputGroup><Datepicker /></InputGroup>', () => {
-    it('empty datepicker returns null from testing functions', () => {
+    it('empty datepicker returns null from testing functions', async () => {
         renderDatePicker();
 
-        const datepicker = getDatepickerByLabelText('Datovelger');
+        const datepicker = await getDatepickerByLabelText('Datovelger');
         expect(
             datepicker.element.classList.contains('ffe-datepicker'),
         ).toBeTruthy();
         expect(datepicker.getValue()).toBe(null);
     });
 
-    it('datepicker returns value from testing functions', () => {
+    it('datepicker returns value from testing functions', async () => {
         renderDatePicker({ value: '01.02.2024' });
 
-        const datepicker = getDatepickerByLabelText('Datovelger');
+        const datepicker = await getDatepickerByLabelText('Datovelger');
 
         expect(datepicker.getValue()).toStrictEqual('01.02.2024');
     });
@@ -41,7 +41,7 @@ describe('<InputGroup><Datepicker /></InputGroup>', () => {
     it('datepicker can be updated by testing functions', async () => {
         renderDatePicker({ value: '01.01.2024' });
 
-        const datepicker = getDatepickerByLabelText('Datovelger');
+        const datepicker = await getDatepickerByLabelText('Datovelger');
         await datepicker.setValue('6.5.2024');
 
         expect(datepicker.getValue()).toStrictEqual('06.05.2024');
@@ -50,7 +50,7 @@ describe('<InputGroup><Datepicker /></InputGroup>', () => {
     it('datepicker can be cleared by testing function', async () => {
         renderDatePicker({ value: '01.01.2024' });
 
-        const datepicker = getDatepickerByLabelText('Datovelger');
+        const datepicker = await getDatepickerByLabelText('Datovelger');
         await datepicker.setValue('');
 
         expect(datepicker.getValue()).toBeNull();
@@ -59,7 +59,7 @@ describe('<InputGroup><Datepicker /></InputGroup>', () => {
     it('2 number year date is updated to correct 4 number year', async () => {
         renderDatePicker({ value: '01.01.2024' });
 
-        const datepicker = getDatepickerByLabelText('Datovelger');
+        const datepicker = await getDatepickerByLabelText('Datovelger');
         await datepicker.setValue('02.02.28');
 
         expect(datepicker.getValue()).toStrictEqual('02.02.2028');
@@ -68,7 +68,7 @@ describe('<InputGroup><Datepicker /></InputGroup>', () => {
     it('3 number year date is updated to correct 4 number year', async () => {
         renderDatePicker({ value: '01.01.2024' });
 
-        const datepicker = getDatepickerByLabelText('Datovelger');
+        const datepicker = await getDatepickerByLabelText('Datovelger');
         await datepicker.setValue('02.02.128');
 
         expect(datepicker.getValue()).toStrictEqual('02.02.2128');
@@ -77,7 +77,7 @@ describe('<InputGroup><Datepicker /></InputGroup>', () => {
     it('no year is updated to correct 4 number year', async () => {
         renderDatePicker({ value: '01.01.2023' });
 
-        const datepicker = getDatepickerByLabelText('Datovelger');
+        const datepicker = await getDatepickerByLabelText('Datovelger');
         await datepicker.setValue('02.02.');
         const date = new Date();
         expect(datepicker.getValue()).toStrictEqual(

--- a/packages/ffe-datepicker-react/src/datepicker/testHelper.ts
+++ b/packages/ffe-datepicker-react/src/datepicker/testHelper.ts
@@ -1,6 +1,5 @@
-import { act, screen } from '@testing-library/react';
-
 async function simulateTyping(element: HTMLElement, text: string, delay = 100) {
+    const { act } = await import('@testing-library/react');
     let _text = text;
     if (text.length === 0) {
         _text = '0';
@@ -69,10 +68,11 @@ export type DatepickerTestHelper = {
  * @param index if there are multiple datepicker elements with the same label, you can specify which one you want to get
  * @returns DatepickerTestHelper
  */
-export function getDatepickerByLabelText(
+export async function getDatepickerByLabelText(
     label: string,
     index = 0,
-): DatepickerTestHelper {
+): Promise<DatepickerTestHelper> {
+    const { screen } = await import('@testing-library/react');
     const elements = screen
         .getAllByText(label)
         .map(element => element.parentElement?.querySelector('.ffe-datepicker'))
@@ -99,6 +99,7 @@ export function getDatepickerByLabelText(
     }
 
     async function setValue(element: HTMLElement, value: string) {
+        const { act } = await import('@testing-library/react');
         const [dayElement, monthElement, yearElement] = Array.from(
             element.querySelectorAll('[role="spinbutton"]'),
         ) as HTMLElement[];


### PR DESCRIPTION
…

<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse

Importerer React Testing library dynamisk. Jeg er 90% sikker på at det vil si at en ikke får problemer med at en ikke har react library innstallert om en ikke kaller testhelperen.

Må verifisere når det er ute :) 

Samme måten vi gjør det i modalen