### PR TITLE
chore: Update node version used in publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,7 +24,7 @@ jobs:
 
             - uses: actions/setup-node@v3
               with:
-                  node-version: 18
+                  node-version: 20
                   registry-url: 'https://registry.npmjs.com'
 
             - run: |


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse

Det er noen forskjeller på node 18 og 20. Vi bruker node 20 ellers og node 18 har end of life om 2 uker. Vi sitter på node 22 lokalt gjerne derfor vi ikke fikk med oss at dette ikke fungerte og dev byggene bruker node 20. Så foreslår vi oppdaterer denne også. Det vil fikse publish.