### PR TITLE
fix(ffe-icons-react): fjern ubrukt weight-prop

### DIFF
--- a/packages/ffe-context-message-react/src/ContextMessage.tsx
+++ b/packages/ffe-context-message-react/src/ContextMessage.tsx
@@ -80,7 +80,6 @@ export const ContextMessage: React.FC<ContextMessageProps> = ({
                                     'ffe-context-message-content__icon-span',
                                     icon.props.className,
                                 ),
-                                weight: 300,
                             })}
                         </div>
                     )}
@@ -106,7 +105,7 @@ export const ContextMessage: React.FC<ContextMessageProps> = ({
                         onClick={() => setIsOpen(false)}
                         type="button"
                     >
-                        <Icon fileUrl={closeIcon} weight={300} size="sm" />
+                        <Icon fileUrl={closeIcon} size="sm" />
                     </button>
                 )}
             </div>

--- a/packages/ffe-icons-react/src/Icon.tsx
+++ b/packages/ffe-icons-react/src/Icon.tsx
@@ -6,8 +6,6 @@ export interface IconProps extends React.ComponentPropsWithoutRef<'span'> {
     fileUrl: string;
     /** Size of the icon, default is the closest defined font-size */
     size?: 'sm' | 'md' | 'lg' | 'xl';
-    /** Symbols stroke weight. This can affect overall size of symbol, 400 is default */
-    weight?: 300 | 500;
     /** Aria label text. If null/undefined, aria-hidden is automatically set to true */
     ariaLabel?: React.ComponentProps<'span'>['aria-label'];
 }


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse
Icons komponenten hadde en type definisjon på en `weight`-prop, denne brukes ikke. 
Gjør det til en breaking change,  den knekker ingenting hvis man ikke har sendt med `weight`-prop, men har man sendt med vil man nå få feilmelding
<!-- Detaljert beskrivelse av endringene dine. Skjermskudd er lov. -->

## Motivasjon og kontekst
Dukket opp under en samtale på Slack, der det ble litt forvirring om hvorfor `weight` måtte defineres både i `fileUrl` og i komponenten. 

<!-- Hvorfor trengs denne endringen, og hva løser den? -->

## Testing

<!-- Hvordan har du har testet endringene dine? Ta gjerne med systeminfo o.l -->

<!--

Helt til slutt, har du ..

.. lest retningslinjene våre for bidrag?
.. tatt en siste sjekk for kode og skrivefeil, debug informasjon o.l?
.. kjørt og eventuelt oppdatert testene?
.. kommentert og dokumentert det som trengs?
.. knyttet denne opp til relaterte issues?

-->
