### PR TITLE
fix(ffe-buttons): fiks farge ved fokus ved å endre klassenavn

### DIFF
--- a/packages/ffe-buttons/less/base-button.less
+++ b/packages/ffe-buttons/less/base-button.less
@@ -5,7 +5,9 @@
     --padding-sm: calc(var(--ffe-spacing-2xs) - var(--border-width));
     --padding-md: calc(var(--ffe-spacing-xs) - var(--border-width));
     --padding-lg: calc(12px - var(--border-width));
-    --icon-only-color: var(--ffe-color-component-button-action-foreground-default);
+    --icon-only-color: var(
+        --ffe-color-component-button-action-foreground-default
+    );
 
     align-items: center;
     appearance: none;
@@ -104,7 +106,9 @@
         padding: var(--padding-lg) var(--ffe-spacing-md);
 
         &.ffe-button--icon-only {
-            padding: var(--padding-md); //Md for å kompansere for hvor stort lg-ikonet er i forhold til lg-knappen
+            padding: var(
+                --padding-md
+            ); //Md for å kompansere for hvor stort lg-ikonet er i forhold til lg-knappen
         }
     }
 
@@ -210,9 +214,7 @@
 
         &:focus,
         &:visited {
-            color: var(
-                --ffe-color-component-button-secondary-foreground-default
-            );
+            color: var(--ffe-color-component-button-secondary-foreground-hover);
             background-color: var(
                 --ffe-color-component-button-secondary-fill-hover
             );


### PR DESCRIPTION
Vet ikke om dette regnes som en feil eller ikke, men i vår bruk av ffe så setter vi egne farger ved å bruke ffe-variabler.

For "button", så slår dette uheldig ut for oss på secondary button :focus, ved at en bruker:
tekst: --ffe-color-component-button-secondary-foreground-default
bakgrunn: --ffe-color-component-button-secondary-fill-hover

For vårt "theme" er det ikke god kontrast her.

<img width="198" alt="Skjermbilde 2025-04-24 kl  10 40 28" src="https://github.com/user-attachments/assets/132a6ed7-6d28-40f4-bee5-5733a80c2109" />
<img width="175" alt="Skjermbilde 2025-04-24 kl  09 58 52" src="https://github.com/user-attachments/assets/98f9b2a9-e90f-4bba-a685-af41f51e7dab" />
