### PR TITLE
Fix linting peer deps

### DIFF
--- a/linting/eslint-config-ffe-base/package.json
+++ b/linting/eslint-config-ffe-base/package.json
@@ -22,7 +22,7 @@
         "eslint-plugin-import": "^2.29.1"
     },
     "peerDependencies": {
-        "eslint": ">=2",
+        "eslint": ">=9.7.0",
         "eslint-plugin-import": ">=2.20.1"
     },
     "publishConfig": {

--- a/linting/eslint-config-ffe/package.json
+++ b/linting/eslint-config-ffe/package.json
@@ -27,9 +27,9 @@
         "eslint-plugin-react-hooks": "^5.2.0"
     },
     "peerDependencies": {
-        "eslint": "*",
-        "eslint-plugin-jsx-a11y": "*",
-        "eslint-plugin-react": "*",
+        "eslint": ">=9.7.0",
+        "eslint-plugin-jsx-a11y": ">=6.0.0",
+        "eslint-plugin-react": ">=7.0.0",
         "eslint-plugin-react-hooks": "^5.0.0"
     },
     "publishConfig": {


### PR DESCRIPTION
Det flate formatet som benyttes fra versjon 8.1.6 av denne pluginen støttes bare av eslint >= 9. Oppdaterer peerDependencies slik at `npm install` feiler dersom man prøver å bruke denne pluginen med eslint < 9
