### PR TITLE
Nye darkmode farger update

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,8 +33,8 @@
         "storybook:build": "storybook build",
         "storybook": "node count-stories.js && echo \"💡[INFO] If Storybook fails, try building the design system first with: npm run build\" && storybook dev -p 6006",
         "build-storybook": "run-s build storybook:build",
-        "sync-tokens-to-figma": "ts-node packages/ffe-core/scripts/figma-api/sync_tokens_to_figma.ts",
-        "sync-figma-to-tokens": "ts-node packages/ffe-core/scripts/figma-api/sync_figma_to_tokens.ts",
+        "sync-tokens-to-figma": "tsx packages/ffe-core/scripts/figma-api/sync_tokens_to_figma.ts",
+        "sync-figma-to-tokens": "tsx packages/ffe-core/scripts/figma-api/sync_figma_to_tokens.ts",
         "count": "node count-stories.js"
     },
     "lint-staged": {
@@ -90,6 +90,7 @@
         "rimraf": "^6.0.1",
         "storybook": "^8.6.0",
         "ts-node": "^10.9.2",
+        "tsx": "^4.19.3",
         "typescript": "^5.7.2"
     },
     "eslintConfig": {

--- a/packages/ffe-accordion-react/src/Accordion.tsx
+++ b/packages/ffe-accordion-react/src/Accordion.tsx
@@ -15,7 +15,11 @@ export const Accordion: React.FC<AccordionProps> = ({
     return (
         <AccordionProvider headingLevel={headingLevel}>
             <div
-                className={classNames(className, 'ffe-accordion')}
+                className={classNames(
+                    className,
+                    'ffe-accordion',
+                    'ffe-default-mode',
+                )}
                 role="group"
                 aria-label="Trekkspillmeny"
                 {...rest}

--- a/packages/ffe-accordion/less/ffe-accordion.less
+++ b/packages/ffe-accordion/less/ffe-accordion.less
@@ -3,7 +3,7 @@
         --ffe-color-surface-primary-default-hover
     );
     --ffe-v-accordion-border-color: var(--ffe-color-border-primary-subtle);
-    --ffe-v-accordion-border-hover-color: var(--ffe-color-border-primary-hover);
+    --ffe-v-accordion-border-hover-color: var(--ffe-color-border-primary-default-hover);
     --ffe-v-accordion-border-focus-color: var(
         --ffe-color-border-interactive-focus
     );

--- a/packages/ffe-cards-react/src/CardBase.tsx
+++ b/packages/ffe-cards-react/src/CardBase.tsx
@@ -27,6 +27,8 @@ export type CardBaseProps<As extends ElementType = 'div'> = Omit<
      * [Read more in the upgrade guide](https://sparebank1.github.io/designsystem/?path=/docs/introduksjon-changelog--docs#2025---februar---semantiske-farger) */
     bgDarkmodeColor?: never;
     noPadding?: boolean;
+    /** Avgjør utseende i kontekst accent. Hvis man ønsker et blått utseende i kontekst accent, velg appearance: 'accent' */
+    appearance?: 'default' | 'accent';
     children: WithCardActionProps['children'] | React.ReactNode;
 };
 
@@ -40,6 +42,7 @@ function CardBaseWithForwardRef<As extends ElementType>(
         textCenter,
         bgColor = 'primary',
         noPadding,
+        appearance = 'default',
         children,
         ...rest
     } = props;
@@ -52,6 +55,7 @@ function CardBaseWithForwardRef<As extends ElementType>(
                 'ffe-card-base--no-margin': noMargin,
                 'ffe-card-base--text-center': textCenter,
                 'ffe-card-base--no-padding': noPadding,
+                'ffe-default-mode': appearance === 'default',
             })}
             {...(rest as Record<string, unknown>)}
             ref={ref}

--- a/packages/ffe-cards-react/src/GroupCard/GroupCard.tsx
+++ b/packages/ffe-cards-react/src/GroupCard/GroupCard.tsx
@@ -24,6 +24,8 @@ export type GroupCardProps<As extends ElementType = 'div'> = Omit<
     bgDarkmodeColor?: never;
     /** No margin on card */
     noMargin?: boolean;
+    /** Avgjør utseende i kontekst accent. Hvis man ønsker et blått utseende i kontekst accent, velg appearance: 'accent' */
+    appearance?: 'default' | 'accent';
 };
 
 function GroupCardWithForwardRef<As extends ElementType>(
@@ -35,6 +37,7 @@ function GroupCardWithForwardRef<As extends ElementType>(
         children,
         bgColor = 'primary',
         noMargin,
+        appearance = 'default',
         as: Comp = 'div',
         ...rest
     } = props;
@@ -45,6 +48,7 @@ function GroupCardWithForwardRef<As extends ElementType>(
                 {
                     'ffe-group-card--no-margin': noMargin,
                     [`ffe-group-card--bg-${bgColor}`]: bgColor,
+                    'ffe-default-mode': appearance === 'default',
                 },
                 className,
             )}

--- a/packages/ffe-cards-react/src/IconCard/IconCard.tsx
+++ b/packages/ffe-cards-react/src/IconCard/IconCard.tsx
@@ -19,6 +19,8 @@ export type IconCardProps<As extends ElementType = 'div'> = Omit<
     condensed?: boolean;
     /** No margin on card */
     noMargin?: boolean;
+    /** Avgjør utseende i kontekst accent. Hvis man ønsker et blått utseende i kontekst accent, velg appearance: 'accent' */
+    appearance?: 'default' | 'accent';
     children:
         | React.ReactNode
         | ((cardRenderProps: CardRenderProps) => React.ReactNode);
@@ -34,6 +36,7 @@ function IconCardWithForwardRef<As extends ElementType>(
         icon,
         rightIcon,
         noMargin,
+        appearance = 'default',
         children,
         ...rest
     } = props;
@@ -45,6 +48,7 @@ function IconCardWithForwardRef<As extends ElementType>(
                 'ffe-icon-card',
                 { 'ffe-icon-card--condensed': condensed },
                 { 'ffe-icon-card--no-margin': noMargin },
+                { 'ffe-default-mode': appearance === 'default' },
                 className,
             )}
             {...(rest as Record<string, unknown>)}

--- a/packages/ffe-cards-react/src/IllustrationCard/IllustrationCard.tsx
+++ b/packages/ffe-cards-react/src/IllustrationCard/IllustrationCard.tsx
@@ -20,6 +20,8 @@ export type IllustrationCardProps<As extends ElementType = 'div'> = Omit<
     illustrationPosition?: 'right' | 'left';
     /** No margin on card */
     noMargin?: boolean;
+    /** Avgjør utseende i kontekst accent. Hvis man ønsker et blått utseende i kontekst accent, velg appearance: 'accent' */
+    appearance?: 'default' | 'accent';
     children:
         | React.ReactNode
         | ((cardRenderProps: CardRenderProps) => React.ReactNode);
@@ -35,6 +37,7 @@ function IllustrationCardWithForwardRef<As extends ElementType>(
         img,
         illustrationPosition,
         noMargin,
+        appearance = 'default',
         children,
         ...rest
     } = props;
@@ -49,6 +52,7 @@ function IllustrationCardWithForwardRef<As extends ElementType>(
                     'ffe-illustration-card--right':
                         illustrationPosition === 'right',
                 },
+                { ' ffe-default-mode': appearance === 'default' },
                 className,
             )}
             {...(rest as Record<string, unknown>)}

--- a/packages/ffe-cards-react/src/ImageCard/ImageCard.tsx
+++ b/packages/ffe-cards-react/src/ImageCard/ImageCard.tsx
@@ -18,6 +18,8 @@ export type ImageCardProps<As extends ElementType = 'div'> = Omit<
     imageAltText: string;
     /** No margin on card */
     noMargin?: boolean;
+    /** Avgjør utseende i kontekst accent. Hvis man ønsker et blått utseende i kontekst accent, velg appearance: 'accent' */
+    appearance?: 'default' | 'accent';
     children:
         | React.ReactNode
         | ((cardRenderProps: CardRenderProps) => React.ReactNode);
@@ -27,15 +29,25 @@ function ImageCardWithForwardRef<As extends ElementType>(
     props: ImageCardProps<As>,
     ref: ForwardedRef<any>,
 ) {
-    const { className, imageSrc, imageAltText, noMargin, children, ...rest } =
-        props;
+    const {
+        className,
+        imageSrc,
+        imageAltText,
+        noMargin,
+        appearance = 'default',
+        children,
+        ...rest
+    } = props;
 
     return (
         <WithCardAction
             baseClassName="ffe-image-card"
             className={classNames(
                 'ffe-image-card',
-                { 'ffe-image-card--no-margin': noMargin },
+                {
+                    'ffe-image-card--no-margin': noMargin,
+                    'ffe-default-mode': appearance === 'default',
+                },
                 className,
             )}
             {...(rest as Record<string, unknown>)}

--- a/packages/ffe-cards-react/src/TextCard/TextCard.tsx
+++ b/packages/ffe-cards-react/src/TextCard/TextCard.tsx
@@ -16,6 +16,8 @@ export type TextCardProps<As extends ElementType = 'div'> = Omit<
     leftAlign?: boolean;
     /** No margin on card */
     noMargin?: boolean;
+    /** Avgjør utseende i kontekst accent. Hvis man ønsker et blått utseende i kontekst accent, velg appearance: 'accent' */
+    appearance?: 'default' | 'accent';
     /** Function that's passed available subcomponents as arguments, or regular children */
     children:
         | React.ReactNode
@@ -26,15 +28,25 @@ function TextCardWithForwardRef<As extends ElementType>(
     props: TextCardProps<As>,
     ref: ForwardedRef<any>,
 ) {
-    const { className, leftAlign, noMargin, children, ...rest } = props;
+    const {
+        className,
+        leftAlign,
+        noMargin,
+        appearance = 'default',
+        children,
+        ...rest
+    } = props;
 
     return (
         <WithCardAction
             baseClassName="ffe-text-card"
             className={classNames(
                 'ffe-text-card',
-                { 'ffe-text-card--left-align': leftAlign },
-                { 'ffe-text-card--no-margin': noMargin },
+                {
+                    'ffe-text-card--left-align': leftAlign,
+                    'ffe-text-card--no-margin': noMargin,
+                    'ffe-default-mode': appearance === 'default',
+                },
                 className,
             )}
             {...(rest as Record<string, unknown>)}

--- a/packages/ffe-cards/less/common-card-styling.less
+++ b/packages/ffe-cards/less/common-card-styling.less
@@ -35,7 +35,7 @@
             cursor: pointer;
             border-color: transparent;
             box-shadow: var(--ffe-g-border-focus-box-shadow)
-                var(--ffe-color-border-primary-hover);
+                var(--ffe-color-border-primary-default-hover);
             background: var(--ffe-color-surface-primary-default-hover);
             &
                 :where(

--- a/packages/ffe-chips/less/chip.less
+++ b/packages/ffe-chips/less/chip.less
@@ -40,7 +40,7 @@
     @media (hover: hover) and (pointer: fine) {
         &:hover {
             --background-color: var(--ffe-color-fill-primary-subtle-hover);
-            --border-color: var(--ffe-color-border-primary-hover);
+            --border-color: var(--ffe-color-border-primary-default-hover);
         }
     }
 
@@ -51,14 +51,14 @@
 
     &:active {
         --background-color: var(--ffe-color-fill-primary-subtle-pressed);
-        --border-color: var(--ffe-color-border-primary-pressed);
+        --border-color: var(--ffe-color-border-primary-default-pressed);
 
         transform: scale(0.97);
     }
 
     &--selected {
-        --background-color: var(--ffe-color-fill-primary-selected);
-        --border-color: var(--ffe-color-border-primary-selected);
+        --background-color: var(--ffe-color-fill-primary-selected-default);
+        --border-color: var(--ffe-color-border-interactive-selected);
         --text-color: var(--ffe-color-foreground-inverse);
 
         @media (hover: hover) and (pointer: fine) {

--- a/packages/ffe-core/less/variables.less
+++ b/packages/ffe-core/less/variables.less
@@ -1,6 +1,7 @@
 :root,
 :host {
     /* Form element borders */
+    --ffe-g-border-radius-sm: 4px;
     --ffe-g-border-radius: 8px;
     --ffe-g-border-radius-lg: 16px;
     --ffe-g-border-width: 1px;

--- a/packages/ffe-core/scripts/generate-semantic-colors.cjs
+++ b/packages/ffe-core/scripts/generate-semantic-colors.cjs
@@ -99,14 +99,22 @@ const convertSemanticJsonToCss = (
                     .replace(/ø/g, 'oe')
                     .replace(/æ/g, 'ae')
                     .replace(/å/g, 'aa');
+                const newValue = value.$value
+                    .slice(1, -1)
+                    .replace(/\./g, '-')
+                    .replace(/ø/g, 'oe')
+                    .replace(/æ/g, 'ae')
+                    .replace(/å/g, 'aa');
+
+                if (!newValue.includes('color')) {
+                    throw new Error(
+                        'Fargevariabelen finnes ikke i primitive. Dobbeltsjekk Figma, kanskje en farge er referert til inad i det semantiske laget?',
+                    );
+                }
                 const cssVarValue = value.$value.startsWith('{')
-                    ? `var(--ffe-${value.$value
-                          .slice(1, -1)
-                          .replace(/\./g, '-')
-                          .replace(/ø/g, 'oe')
-                          .replace(/æ/g, 'ae')
-                          .replace(/å/g, 'aa')})`
+                    ? `var(--ffe-${newValue})`
                     : value.$value;
+
                 if (usedSemantic[`var(${cssVarName})`]) {
                     cssLines.push(`${cssVarName}: ${cssVarValue};`);
                     usedPrimitive[cssVarValue] = true;

--- a/packages/ffe-core/tokens/01 Primitive.value.json
+++ b/packages/ffe-core/tokens/01 Primitive.value.json
@@ -3665,7 +3665,7 @@
       },
       "100": {
         "$type": "color",
-        "$value": "#cccccc",
+        "$value": "#d6d6d6",
         "$description": "",
         "$extensions": {
           "com.figma": {
@@ -3749,7 +3749,7 @@
       },
       "450": {
         "$type": "color",
-        "$value": "#858585",
+        "$value": "#6b6b6b",
         "$description": "",
         "$extensions": {
           "com.figma": {
@@ -3906,105 +3906,9 @@
             }
           }
         },
-        "5": {
-          "$type": "color",
-          "$value": "#ffffff0d",
-          "$description": "",
-          "$extensions": {
-            "com.figma": {
-              "hiddenFromPublishing": true,
-              "scopes": [],
-              "codeSyntax": {}
-            }
-          }
-        },
-        "10": {
-          "$type": "color",
-          "$value": "#ffffff1a",
-          "$description": "",
-          "$extensions": {
-            "com.figma": {
-              "hiddenFromPublishing": true,
-              "scopes": [],
-              "codeSyntax": {}
-            }
-          }
-        },
-        "15": {
-          "$type": "color",
-          "$value": "#ffffff26",
-          "$description": "",
-          "$extensions": {
-            "com.figma": {
-              "hiddenFromPublishing": true,
-              "scopes": [],
-              "codeSyntax": {}
-            }
-          }
-        },
-        "20": {
-          "$type": "color",
-          "$value": "#ffffff33",
-          "$description": "",
-          "$extensions": {
-            "com.figma": {
-              "hiddenFromPublishing": true,
-              "scopes": [],
-              "codeSyntax": {}
-            }
-          }
-        },
         "25": {
           "$type": "color",
-          "$value": "#ffffff40",
-          "$description": "",
-          "$extensions": {
-            "com.figma": {
-              "hiddenFromPublishing": true,
-              "scopes": [],
-              "codeSyntax": {}
-            }
-          }
-        },
-        "30": {
-          "$type": "color",
-          "$value": "#ffffff4d",
-          "$description": "",
-          "$extensions": {
-            "com.figma": {
-              "hiddenFromPublishing": true,
-              "scopes": [],
-              "codeSyntax": {}
-            }
-          }
-        },
-        "35": {
-          "$type": "color",
-          "$value": "#ffffff59",
-          "$description": "",
-          "$extensions": {
-            "com.figma": {
-              "hiddenFromPublishing": true,
-              "scopes": [],
-              "codeSyntax": {}
-            }
-          }
-        },
-        "40": {
-          "$type": "color",
-          "$value": "#ffffff66",
-          "$description": "",
-          "$extensions": {
-            "com.figma": {
-              "hiddenFromPublishing": true,
-              "scopes": [],
-              "codeSyntax": {}
-            }
-          }
-        },
-        "45": {
-          "$type": "color",
-          "$value": "#ffffff73",
+          "$value": "#ffffff06",
           "$description": "",
           "$extensions": {
             "com.figma": {
@@ -4016,55 +3920,7 @@
         },
         "50": {
           "$type": "color",
-          "$value": "#ffffff80",
-          "$description": "",
-          "$extensions": {
-            "com.figma": {
-              "hiddenFromPublishing": true,
-              "scopes": [],
-              "codeSyntax": {}
-            }
-          }
-        },
-        "55": {
-          "$type": "color",
-          "$value": "#ffffff8c",
-          "$description": "",
-          "$extensions": {
-            "com.figma": {
-              "hiddenFromPublishing": true,
-              "scopes": [],
-              "codeSyntax": {}
-            }
-          }
-        },
-        "60": {
-          "$type": "color",
-          "$value": "#ffffff99",
-          "$description": "",
-          "$extensions": {
-            "com.figma": {
-              "hiddenFromPublishing": true,
-              "scopes": [],
-              "codeSyntax": {}
-            }
-          }
-        },
-        "65": {
-          "$type": "color",
-          "$value": "#ffffffa6",
-          "$description": "",
-          "$extensions": {
-            "com.figma": {
-              "hiddenFromPublishing": true,
-              "scopes": [],
-              "codeSyntax": {}
-            }
-          }
-        },
-        "70": {
-          "$type": "color",
-          "$value": "#ffffffb2",
+          "$value": "#ffffff0d",
           "$description": "",
           "$extensions": {
             "com.figma": {
@@ -4076,6 +3932,174 @@
         },
         "75": {
           "$type": "color",
+          "$value": "#ffffff13",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": true,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "100": {
+          "$type": "color",
+          "$value": "#ffffff1a",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": true,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "150": {
+          "$type": "color",
+          "$value": "#ffffff26",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": true,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "200": {
+          "$type": "color",
+          "$value": "#ffffff33",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": true,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "250": {
+          "$type": "color",
+          "$value": "#ffffff40",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": true,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "300": {
+          "$type": "color",
+          "$value": "#ffffff4d",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": true,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "350": {
+          "$type": "color",
+          "$value": "#ffffff59",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": true,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "400": {
+          "$type": "color",
+          "$value": "#ffffff66",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": true,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "450": {
+          "$type": "color",
+          "$value": "#ffffff73",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": true,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "500": {
+          "$type": "color",
+          "$value": "#ffffff80",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": true,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "550": {
+          "$type": "color",
+          "$value": "#ffffff8c",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": true,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "600": {
+          "$type": "color",
+          "$value": "#ffffff99",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": true,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "650": {
+          "$type": "color",
+          "$value": "#ffffffa6",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": true,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "700": {
+          "$type": "color",
+          "$value": "#ffffffb2",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": true,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "750": {
+          "$type": "color",
           "$value": "#ffffffbf",
           "$description": "",
           "$extensions": {
@@ -4086,7 +4110,7 @@
             }
           }
         },
-        "80": {
+        "800": {
           "$type": "color",
           "$value": "#ffffffcc",
           "$description": "",
@@ -4098,7 +4122,7 @@
             }
           }
         },
-        "85": {
+        "850": {
           "$type": "color",
           "$value": "#ffffffd9",
           "$description": "",
@@ -4110,7 +4134,7 @@
             }
           }
         },
-        "90": {
+        "900": {
           "$type": "color",
           "$value": "#ffffffe5",
           "$description": "",
@@ -4122,7 +4146,7 @@
             }
           }
         },
-        "95": {
+        "950": {
           "$type": "color",
           "$value": "#fffffff2",
           "$description": "",
@@ -4134,7 +4158,7 @@
             }
           }
         },
-        "100": {
+        "1000": {
           "$type": "color",
           "$value": "#ffffff",
           "$description": "",
@@ -4150,7 +4174,7 @@
       "black": {
         "0": {
           "$type": "color",
-          "$value": "#00000000",
+          "$value": "#020a0a00",
           "$description": "",
           "$extensions": {
             "com.figma": {
@@ -4160,57 +4184,9 @@
             }
           }
         },
-        "5": {
+        "25": {
           "$type": "color",
-          "$value": "#0000000d",
-          "$description": "",
-          "$extensions": {
-            "com.figma": {
-              "hiddenFromPublishing": true,
-              "scopes": [],
-              "codeSyntax": {}
-            }
-          }
-        },
-        "10": {
-          "$type": "color",
-          "$value": "#0000001a",
-          "$description": "",
-          "$extensions": {
-            "com.figma": {
-              "hiddenFromPublishing": true,
-              "scopes": [],
-              "codeSyntax": {}
-            }
-          }
-        },
-        "20": {
-          "$type": "color",
-          "$value": "#00000033",
-          "$description": "",
-          "$extensions": {
-            "com.figma": {
-              "hiddenFromPublishing": true,
-              "scopes": [],
-              "codeSyntax": {}
-            }
-          }
-        },
-        "30": {
-          "$type": "color",
-          "$value": "#0000004d",
-          "$description": "",
-          "$extensions": {
-            "com.figma": {
-              "hiddenFromPublishing": true,
-              "scopes": [],
-              "codeSyntax": {}
-            }
-          }
-        },
-        "40": {
-          "$type": "color",
-          "$value": "#00000066",
+          "$value": "#020a0a06",
           "$description": "",
           "$extensions": {
             "com.figma": {
@@ -4222,7 +4198,7 @@
         },
         "50": {
           "$type": "color",
-          "$value": "#00000080",
+          "$value": "#020a0a0d",
           "$description": "",
           "$extensions": {
             "com.figma": {
@@ -4232,45 +4208,9 @@
             }
           }
         },
-        "60": {
+        "75": {
           "$type": "color",
-          "$value": "#00000099",
-          "$description": "",
-          "$extensions": {
-            "com.figma": {
-              "hiddenFromPublishing": true,
-              "scopes": [],
-              "codeSyntax": {}
-            }
-          }
-        },
-        "70": {
-          "$type": "color",
-          "$value": "#000000b2",
-          "$description": "",
-          "$extensions": {
-            "com.figma": {
-              "hiddenFromPublishing": true,
-              "scopes": [],
-              "codeSyntax": {}
-            }
-          }
-        },
-        "80": {
-          "$type": "color",
-          "$value": "#000000cc",
-          "$description": "",
-          "$extensions": {
-            "com.figma": {
-              "hiddenFromPublishing": true,
-              "scopes": [],
-              "codeSyntax": {}
-            }
-          }
-        },
-        "90": {
-          "$type": "color",
-          "$value": "#000000e5",
+          "$value": "#020a0a13",
           "$description": "",
           "$extensions": {
             "com.figma": {
@@ -4281,6 +4221,222 @@
           }
         },
         "100": {
+          "$type": "color",
+          "$value": "#020a0a1a",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": true,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "150": {
+          "$type": "color",
+          "$value": "#020a0a26",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": true,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "200": {
+          "$type": "color",
+          "$value": "#020a0a33",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": true,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "250": {
+          "$type": "color",
+          "$value": "#020a0a40",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": true,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "300": {
+          "$type": "color",
+          "$value": "#020a0a4d",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": true,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "350": {
+          "$type": "color",
+          "$value": "#020a0a59",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": true,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "400": {
+          "$type": "color",
+          "$value": "#020a0a66",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": true,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "450": {
+          "$type": "color",
+          "$value": "#020a0a73",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": true,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "500": {
+          "$type": "color",
+          "$value": "#020a0a80",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": true,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "550": {
+          "$type": "color",
+          "$value": "#020a0a8c",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": true,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "600": {
+          "$type": "color",
+          "$value": "#020a0a99",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": true,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "650": {
+          "$type": "color",
+          "$value": "#020a0aa6",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": true,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "700": {
+          "$type": "color",
+          "$value": "#020a0ab2",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": true,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "750": {
+          "$type": "color",
+          "$value": "#020a0abf",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": true,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "800": {
+          "$type": "color",
+          "$value": "#020a0acc",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": true,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "850": {
+          "$type": "color",
+          "$value": "#020a0ad9",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": true,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "900": {
+          "$type": "color",
+          "$value": "#020a0ae5",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": true,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "950": {
+          "$type": "color",
+          "$value": "#020a0af2",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": true,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "1000": {
           "$type": "color",
           "$value": "#020a0a",
           "$description": "",
@@ -4294,7 +4450,7 @@
         }
       },
       "water": {
-        "5": {
+        "50": {
           "$type": "color",
           "$value": "#005aa40d",
           "$description": "",
@@ -4306,7 +4462,7 @@
             }
           }
         },
-        "10": {
+        "100": {
           "$type": "color",
           "$value": "#005aa41a",
           "$description": "",
@@ -4318,7 +4474,7 @@
             }
           }
         },
-        "15": {
+        "150": {
           "$type": "color",
           "$value": "#005aa426",
           "$description": "",
@@ -4330,7 +4486,7 @@
             }
           }
         },
-        "20": {
+        "200": {
           "$type": "color",
           "$value": "#005aa433",
           "$description": "",
@@ -4342,7 +4498,7 @@
             }
           }
         },
-        "25": {
+        "250": {
           "$type": "color",
           "$value": "#005aa440",
           "$description": "",
@@ -4354,7 +4510,7 @@
             }
           }
         },
-        "30": {
+        "300": {
           "$type": "color",
           "$value": "#005aa44d",
           "$description": "",
@@ -4366,7 +4522,7 @@
             }
           }
         },
-        "35": {
+        "350": {
           "$type": "color",
           "$value": "#005aa459",
           "$description": "",
@@ -4378,7 +4534,7 @@
             }
           }
         },
-        "40": {
+        "400": {
           "$type": "color",
           "$value": "#005aa466",
           "$description": "",
@@ -4390,7 +4546,7 @@
             }
           }
         },
-        "45": {
+        "450": {
           "$type": "color",
           "$value": "#005aa473",
           "$description": "",
@@ -4402,7 +4558,7 @@
             }
           }
         },
-        "50": {
+        "500": {
           "$type": "color",
           "$value": "#005aa480",
           "$description": "",
@@ -4414,7 +4570,7 @@
             }
           }
         },
-        "55": {
+        "550": {
           "$type": "color",
           "$value": "#005aa48c",
           "$description": "",
@@ -4426,7 +4582,7 @@
             }
           }
         },
-        "60": {
+        "600": {
           "$type": "color",
           "$value": "#005aa499",
           "$description": "",
@@ -4438,7 +4594,7 @@
             }
           }
         },
-        "65": {
+        "650": {
           "$type": "color",
           "$value": "#005aa4a6",
           "$description": "",
@@ -4450,7 +4606,7 @@
             }
           }
         },
-        "70": {
+        "700": {
           "$type": "color",
           "$value": "#005aa4b2",
           "$description": "",
@@ -4462,7 +4618,7 @@
             }
           }
         },
-        "75": {
+        "750": {
           "$type": "color",
           "$value": "#005aa4bf",
           "$description": "",
@@ -4474,7 +4630,7 @@
             }
           }
         },
-        "80": {
+        "800": {
           "$type": "color",
           "$value": "#005aa4cc",
           "$description": "",
@@ -4486,7 +4642,7 @@
             }
           }
         },
-        "85": {
+        "850": {
           "$type": "color",
           "$value": "#005aa4d9",
           "$description": "",
@@ -4498,7 +4654,7 @@
             }
           }
         },
-        "90": {
+        "900": {
           "$type": "color",
           "$value": "#005aa4e5",
           "$description": "",
@@ -4510,9 +4666,21 @@
             }
           }
         },
-        "95": {
+        "950": {
           "$type": "color",
           "$value": "#005aa4f2",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": true,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "1000": {
+          "$type": "color",
+          "$value": "#005aa4",
           "$description": "",
           "$extensions": {
             "com.figma": {

--- a/packages/ffe-core/tokens/02 Semantic.Dark.json
+++ b/packages/ffe-core/tokens/02 Semantic.Dark.json
@@ -1,2572 +1,3552 @@
 {
-    "default": {
-        "brand": {
-            "primary": {
-                "subtlest": {
-                    "$type": "color",
-                    "$value": "{color.natt.800}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "subtler": {
-                    "$type": "color",
-                    "$value": "{color.natt.700}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "subtle": {
-                    "$type": "color",
-                    "$value": "{color.natt.600}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "default": {
-                    "$type": "color",
-                    "$value": "{color.natt.500}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "medium": {
-                    "$type": "color",
-                    "$value": "{color.natt.400}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "strong": {
-                    "$type": "color",
-                    "$value": "{color.natt.300}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "stronger": {
-                    "$type": "color",
-                    "$value": "{color.natt.200}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "strongest": {
-                    "$type": "color",
-                    "$value": "{color.natt.100}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                }
-            },
-            "secondary": {
-                "subtlest": {
-                    "$type": "color",
-                    "$value": "{color.frost.800}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "subtler": {
-                    "$type": "color",
-                    "$value": "{color.frost.700}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "subtle": {
-                    "$type": "color",
-                    "$value": "{color.frost.600}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "default": {
-                    "$type": "color",
-                    "$value": "{color.frost.500}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "medium": {
-                    "$type": "color",
-                    "$value": "{color.frost.400}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "strong": {
-                    "$type": "color",
-                    "$value": "{color.frost.300}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "stronger": {
-                    "$type": "color",
-                    "$value": "{color.frost.200}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "strongest": {
-                    "$type": "color",
-                    "$value": "{color.frost.100}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                }
-            },
-            "tertiary": {
-                "subtlest": {
-                    "$type": "color",
-                    "$value": "{color.syrin.750}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "subtler": {
-                    "$type": "color",
-                    "$value": "{color.syrin.650}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "subtle": {
-                    "$type": "color",
-                    "$value": "{color.syrin.550}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "default": {
-                    "$type": "color",
-                    "$value": "{color.syrin.450}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "medium": {
-                    "$type": "color",
-                    "$value": "{color.syrin.350}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "strong": {
-                    "$type": "color",
-                    "$value": "{color.syrin.250}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "stronger": {
-                    "$type": "color",
-                    "$value": "{color.syrin.100}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "strongest": {
-                    "$type": "color",
-                    "$value": "{color.syrin.50}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                }
-            },
-            "emphasis": {
-                "sublest": {
-                    "$type": "color",
-                    "$value": "{color.vann.850}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "subtler": {
-                    "$type": "color",
-                    "$value": "{color.vann.750}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "subtle": {
-                    "$type": "color",
-                    "$value": "{color.vann.700}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "default": {
-                    "$type": "color",
-                    "$value": "{color.vann.600}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "medium": {
-                    "$type": "color",
-                    "$value": "{color.vann.500}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "strong": {
-                    "$type": "color",
-                    "$value": "{color.vann.300}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "stronger": {
-                    "$type": "color",
-                    "$value": "{color.vann.150}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "strongest": {
-                    "$type": "color",
-                    "$value": "{color.vann.75}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                }
-            },
-            "subtle": {
-                "subtlest": {
-                    "$type": "color",
-                    "$value": "{color.sand.900}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "subtler": {
-                    "$type": "color",
-                    "$value": "{color.sand.800}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "subtle": {
-                    "$type": "color",
-                    "$value": "{color.sand.700}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "default": {
-                    "$type": "color",
-                    "$value": "{color.sand.600}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "medium": {
-                    "$type": "color",
-                    "$value": "{color.sand.500}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "strong": {
-                    "$type": "color",
-                    "$value": "{color.sand.400}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "stronger": {
-                    "$type": "color",
-                    "$value": "{color.sand.300}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "strongest": {
-                    "$type": "color",
-                    "$value": "{color.sand.200}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                }
+  "default": {
+    "brand": {
+      "primary": {
+        "subtlest": {
+          "$type": "color",
+          "$value": "{color.vann.800}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
             }
+          }
         },
-        "feedback": {
-            "info": {
-                "subtlest": {
-                    "$type": "color",
-                    "$value": "{color.frost.800}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "subtler": {
-                    "$type": "color",
-                    "$value": "{color.frost.700}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "subtle": {
-                    "$type": "color",
-                    "$value": "{color.frost.600}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "default": {
-                    "$type": "color",
-                    "$value": "{color.frost.500}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "medium": {
-                    "$type": "color",
-                    "$value": "{color.frost.400}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "strong": {
-                    "$type": "color",
-                    "$value": "{color.frost.300}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "stronger": {
-                    "$type": "color",
-                    "$value": "{color.frost.200}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "strongest": {
-                    "$type": "color",
-                    "$value": "{color.frost.100}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                }
-            },
-            "success": {
-                "subtlest": {
-                    "$type": "color",
-                    "$value": "{color.skog.800}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "subtler": {
-                    "$type": "color",
-                    "$value": "{color.skog.700}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "subtle": {
-                    "$type": "color",
-                    "$value": "{color.skog.600}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "default": {
-                    "$type": "color",
-                    "$value": "{color.skog.500}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "medium": {
-                    "$type": "color",
-                    "$value": "{color.skog.400}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "strong": {
-                    "$type": "color",
-                    "$value": "{color.skog.300}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "stronger": {
-                    "$type": "color",
-                    "$value": "{color.skog.200}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "strongest": {
-                    "$type": "color",
-                    "$value": "{color.skog.100}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                }
-            },
-            "warning": {
-                "subtlest": {
-                    "$type": "color",
-                    "$value": "{color.sol.750}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "subtler": {
-                    "$type": "color",
-                    "$value": "{color.sol.650}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "subtle": {
-                    "$type": "color",
-                    "$value": "{color.sol.550}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "default": {
-                    "$type": "color",
-                    "$value": "{color.sol.450}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "medium": {
-                    "$type": "color",
-                    "$value": "{color.sol.350}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "strong": {
-                    "$type": "color",
-                    "$value": "{color.sol.250}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "stronger": {
-                    "$type": "color",
-                    "$value": "{color.sol.150}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "strongest": {
-                    "$type": "color",
-                    "$value": "{color.sol.100}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                }
-            },
-            "critical": {
-                "subtlest": {
-                    "$type": "color",
-                    "$value": "{color.bær.800}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "subtler": {
-                    "$type": "color",
-                    "$value": "{color.bær.700}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "subtle": {
-                    "$type": "color",
-                    "$value": "{color.bær.600}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "default": {
-                    "$type": "color",
-                    "$value": "{color.bær.500}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "medium": {
-                    "$type": "color",
-                    "$value": "{color.bær.400}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "strong": {
-                    "$type": "color",
-                    "$value": "{color.bær.300}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "stronger": {
-                    "$type": "color",
-                    "$value": "{color.bær.200}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "strongest": {
-                    "$type": "color",
-                    "$value": "{color.bær.100}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                }
-            },
-            "tip": {
-                "sublest": {
-                    "$type": "color",
-                    "$value": "{color.syrin.800}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "subtler": {
-                    "$type": "color",
-                    "$value": "{color.syrin.700}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "subtle": {
-                    "$type": "color",
-                    "$value": "{color.syrin.600}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "default": {
-                    "$type": "color",
-                    "$value": "{color.syrin.500}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "medium": {
-                    "$type": "color",
-                    "$value": "{color.syrin.400}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "strong": {
-                    "$type": "color",
-                    "$value": "{color.syrin.300}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "stronger": {
-                    "$type": "color",
-                    "$value": "{color.syrin.200}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "strongest": {
-                    "$type": "color",
-                    "$value": "{color.syrin.100}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                }
+        "subtler": {
+          "$type": "color",
+          "$value": "{color.vann.700}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
             }
+          }
         },
-        "neutral": {
-            "sublest": {
-                "$type": "color",
-                "$value": "{color.gray.900}",
-                "$description": "",
-                "$extensions": {
-                    "com.figma": {
-                        "hiddenFromPublishing": false,
-                        "scopes": [],
-                        "codeSyntax": {}
-                    }
-                }
-            },
-            "subtler": {
-                "$type": "color",
-                "$value": "{color.gray.750}",
-                "$description": "",
-                "$extensions": {
-                    "com.figma": {
-                        "hiddenFromPublishing": false,
-                        "scopes": [],
-                        "codeSyntax": {}
-                    }
-                }
-            },
-            "subtle": {
-                "$type": "color",
-                "$value": "{color.gray.650}",
-                "$description": "",
-                "$extensions": {
-                    "com.figma": {
-                        "hiddenFromPublishing": false,
-                        "scopes": [],
-                        "codeSyntax": {}
-                    }
-                }
-            },
-            "default": {
-                "$type": "color",
-                "$value": "{color.gray.450}",
-                "$description": "",
-                "$extensions": {
-                    "com.figma": {
-                        "hiddenFromPublishing": false,
-                        "scopes": [],
-                        "codeSyntax": {}
-                    }
-                }
-            },
-            "medium": {
-                "$type": "color",
-                "$value": "{color.gray.400}",
-                "$description": "",
-                "$extensions": {
-                    "com.figma": {
-                        "hiddenFromPublishing": false,
-                        "scopes": [],
-                        "codeSyntax": {}
-                    }
-                }
-            },
-            "strong": {
-                "$type": "color",
-                "$value": "{color.gray.250}",
-                "$description": "",
-                "$extensions": {
-                    "com.figma": {
-                        "hiddenFromPublishing": false,
-                        "scopes": [],
-                        "codeSyntax": {}
-                    }
-                }
-            },
-            "stronger": {
-                "$type": "color",
-                "$value": "{color.gray.150}",
-                "$description": "",
-                "$extensions": {
-                    "com.figma": {
-                        "hiddenFromPublishing": false,
-                        "scopes": [],
-                        "codeSyntax": {}
-                    }
-                }
-            },
-            "strongest": {
-                "$type": "color",
-                "$value": "{color.alpha.white.100}",
-                "$description": "",
-                "$extensions": {
-                    "com.figma": {
-                        "hiddenFromPublishing": false,
-                        "scopes": [],
-                        "codeSyntax": {}
-                    }
-                }
-            },
-            "inverted": {
-                "$type": "color",
-                "$value": "{color.gray.950}",
-                "$description": "",
-                "$extensions": {
-                    "com.figma": {
-                        "hiddenFromPublishing": false,
-                        "scopes": [],
-                        "codeSyntax": {}
-                    }
-                }
+        "subtle": {
+          "$type": "color",
+          "$value": "{color.vann.600}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
             }
+          }
         },
-        "interactive": {
-            "default": {
-                "$type": "color",
-                "$value": "{color.natt.200}",
-                "$description": "",
-                "$extensions": {
-                    "com.figma": {
-                        "hiddenFromPublishing": false,
-                        "scopes": [],
-                        "codeSyntax": {}
-                    }
-                }
-            },
-            "hover": {
-                "$type": "color",
-                "$value": "{color.natt.100}",
-                "$description": "",
-                "$extensions": {
-                    "com.figma": {
-                        "hiddenFromPublishing": false,
-                        "scopes": [],
-                        "codeSyntax": {}
-                    }
-                }
-            },
-            "pressed": {
-                "$type": "color",
-                "$value": "{color.natt.50}",
-                "$description": "",
-                "$extensions": {
-                    "com.figma": {
-                        "hiddenFromPublishing": false,
-                        "scopes": [],
-                        "codeSyntax": {}
-                    }
-                }
-            },
-            "focus": {
-                "$type": "color",
-                "$value": "{color.alpha.white.100}",
-                "$description": "",
-                "$extensions": {
-                    "com.figma": {
-                        "hiddenFromPublishing": false,
-                        "scopes": [],
-                        "codeSyntax": {}
-                    }
-                }
+        "default": {
+          "$type": "color",
+          "$value": "{color.vann.500}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
             }
+          }
+        },
+        "medium": {
+          "$type": "color",
+          "$value": "{color.vann.400}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "strong": {
+          "$type": "color",
+          "$value": "{color.vann.300}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "stronger": {
+          "$type": "color",
+          "$value": "{color.vann.200}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "strongest": {
+          "$type": "color",
+          "$value": "{color.vann.100}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
         }
+      },
+      "secondary": {
+        "subtlest": {
+          "$type": "color",
+          "$value": "{color.frost.900}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "subtler": {
+          "$type": "color",
+          "$value": "{color.frost.800}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "subtle": {
+          "$type": "color",
+          "$value": "{color.frost.700}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "default": {
+          "$type": "color",
+          "$value": "{color.frost.600}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "medium": {
+          "$type": "color",
+          "$value": "{color.frost.500}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "strong": {
+          "$type": "color",
+          "$value": "{color.frost.300}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "stronger": {
+          "$type": "color",
+          "$value": "{color.frost.200}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "strongest": {
+          "$type": "color",
+          "$value": "{color.frost.100}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        }
+      },
+      "tertiary": {
+        "subtlest": {
+          "$type": "color",
+          "$value": "{color.syrin.950}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "subtler": {
+          "$type": "color",
+          "$value": "{color.syrin.850}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "subtle": {
+          "$type": "color",
+          "$value": "{color.syrin.750}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "default": {
+          "$type": "color",
+          "$value": "{color.syrin.650}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "medium": {
+          "$type": "color",
+          "$value": "{color.syrin.550}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "strong": {
+          "$type": "color",
+          "$value": "{color.syrin.300}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "stronger": {
+          "$type": "color",
+          "$value": "{color.syrin.200}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "strongest": {
+          "$type": "color",
+          "$value": "{color.syrin.100}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        }
+      },
+      "emphasis": {
+        "sublest": {
+          "$type": "color",
+          "$value": "{color.vann.850}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "subtler": {
+          "$type": "color",
+          "$value": "{color.vann.750}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "subtle": {
+          "$type": "color",
+          "$value": "{color.vann.700}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "default": {
+          "$type": "color",
+          "$value": "{color.vann.600}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "medium": {
+          "$type": "color",
+          "$value": "{color.vann.500}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "strong": {
+          "$type": "color",
+          "$value": "{color.vann.300}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "stronger": {
+          "$type": "color",
+          "$value": "{color.vann.150}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "strongest": {
+          "$type": "color",
+          "$value": "{color.vann.75}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        }
+      },
+      "subtle": {
+        "subtlest": {
+          "$type": "color",
+          "$value": "{color.sand.900}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "subtler": {
+          "$type": "color",
+          "$value": "{color.sand.800}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "subtle": {
+          "$type": "color",
+          "$value": "{color.sand.700}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "default": {
+          "$type": "color",
+          "$value": "{color.sand.600}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "medium": {
+          "$type": "color",
+          "$value": "{color.sand.500}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "strong": {
+          "$type": "color",
+          "$value": "{color.sand.400}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "stronger": {
+          "$type": "color",
+          "$value": "{color.sand.300}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "strongest": {
+          "$type": "color",
+          "$value": "{color.sand.200}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        }
+      }
     },
-    "accent": {
-        "brand": {
-            "primary": {
-                "subtlest": {
-                    "$type": "color",
-                    "$value": "{color.natt.700}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "subtler": {
-                    "$type": "color",
-                    "$value": "{color.natt.600}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "subtle": {
-                    "$type": "color",
-                    "$value": "{color.natt.500}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "default": {
-                    "$type": "color",
-                    "$value": "{color.natt.400}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "medium": {
-                    "$type": "color",
-                    "$value": "{color.natt.300}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "strong": {
-                    "$type": "color",
-                    "$value": "{color.natt.200}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "stronger": {
-                    "$type": "color",
-                    "$value": "{color.natt.100}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "strongest": {
-                    "$type": "color",
-                    "$value": "{color.natt.50}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                }
-            },
-            "secondary": {
-                "subtlest": {
-                    "$type": "color",
-                    "$value": "{color.frost.800}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "subtler": {
-                    "$type": "color",
-                    "$value": "{color.frost.700}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "subtle": {
-                    "$type": "color",
-                    "$value": "{color.frost.600}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "default": {
-                    "$type": "color",
-                    "$value": "{color.frost.500}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "medium": {
-                    "$type": "color",
-                    "$value": "{color.frost.400}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "strong": {
-                    "$type": "color",
-                    "$value": "{color.frost.300}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "stronger": {
-                    "$type": "color",
-                    "$value": "{color.frost.200}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "strongest": {
-                    "$type": "color",
-                    "$value": "{color.frost.100}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                }
-            },
-            "tertiary": {
-                "subtlest": {
-                    "$type": "color",
-                    "$value": "{color.syrin.750}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "subtler": {
-                    "$type": "color",
-                    "$value": "{color.syrin.650}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "subtle": {
-                    "$type": "color",
-                    "$value": "{color.syrin.550}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "default": {
-                    "$type": "color",
-                    "$value": "{color.syrin.450}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "medium": {
-                    "$type": "color",
-                    "$value": "{color.syrin.350}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "strong": {
-                    "$type": "color",
-                    "$value": "{color.syrin.250}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "stronger": {
-                    "$type": "color",
-                    "$value": "{color.syrin.100}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "strongest": {
-                    "$type": "color",
-                    "$value": "{color.syrin.50}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                }
-            },
-            "emphasis": {
-                "sublest": {
-                    "$type": "color",
-                    "$value": "{color.vann.800}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "subtler": {
-                    "$type": "color",
-                    "$value": "{color.vann.700}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "subtle": {
-                    "$type": "color",
-                    "$value": "{color.vann.650}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "default": {
-                    "$type": "color",
-                    "$value": "{color.vann.550}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "medium": {
-                    "$type": "color",
-                    "$value": "{color.vann.450}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "strong": {
-                    "$type": "color",
-                    "$value": "{color.vann.300}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "stronger": {
-                    "$type": "color",
-                    "$value": "{color.vann.150}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "strongest": {
-                    "$type": "color",
-                    "$value": "{color.vann.75}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                }
-            },
-            "subtle": {
-                "subtlest": {
-                    "$type": "color",
-                    "$value": "{color.sand.850}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "subtler": {
-                    "$type": "color",
-                    "$value": "{color.sand.750}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "subtle": {
-                    "$type": "color",
-                    "$value": "{color.sand.650}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "default": {
-                    "$type": "color",
-                    "$value": "{color.sand.550}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "medium": {
-                    "$type": "color",
-                    "$value": "{color.sand.450}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "strong": {
-                    "$type": "color",
-                    "$value": "{color.sand.350}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "stronger": {
-                    "$type": "color",
-                    "$value": "{color.sand.250}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "strongest": {
-                    "$type": "color",
-                    "$value": "{color.sand.150}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                }
+    "feedback": {
+      "info": {
+        "subtlest": {
+          "$type": "color",
+          "$value": "{color.frost.800}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
             }
+          }
         },
-        "feedback": {
-            "info": {
-                "subtlest": {
-                    "$type": "color",
-                    "$value": "{color.frost.800}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "subtler": {
-                    "$type": "color",
-                    "$value": "{color.frost.700}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "subtle": {
-                    "$type": "color",
-                    "$value": "{color.frost.600}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "default": {
-                    "$type": "color",
-                    "$value": "{color.frost.500}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "medium": {
-                    "$type": "color",
-                    "$value": "{color.frost.400}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "strong": {
-                    "$type": "color",
-                    "$value": "{color.frost.300}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "stronger": {
-                    "$type": "color",
-                    "$value": "{color.frost.200}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "strongest": {
-                    "$type": "color",
-                    "$value": "{color.frost.100}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                }
-            },
-            "success": {
-                "subtlest": {
-                    "$type": "color",
-                    "$value": "{color.skog.800}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "subtler": {
-                    "$type": "color",
-                    "$value": "{color.skog.700}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "subtle": {
-                    "$type": "color",
-                    "$value": "{color.skog.600}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "default": {
-                    "$type": "color",
-                    "$value": "{color.skog.500}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "medium": {
-                    "$type": "color",
-                    "$value": "{color.skog.400}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "strong": {
-                    "$type": "color",
-                    "$value": "{color.skog.300}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "stronger": {
-                    "$type": "color",
-                    "$value": "{color.skog.200}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "strongest": {
-                    "$type": "color",
-                    "$value": "{color.skog.100}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                }
-            },
-            "critical": {
-                "subtlest": {
-                    "$type": "color",
-                    "$value": "{color.bær.800}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "subtler": {
-                    "$type": "color",
-                    "$value": "{color.bær.700}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "subtle": {
-                    "$type": "color",
-                    "$value": "{color.bær.600}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "default": {
-                    "$type": "color",
-                    "$value": "{color.bær.500}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "medium": {
-                    "$type": "color",
-                    "$value": "{color.bær.400}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "strong": {
-                    "$type": "color",
-                    "$value": "{color.bær.300}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "stronger": {
-                    "$type": "color",
-                    "$value": "{color.bær.200}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "strongest": {
-                    "$type": "color",
-                    "$value": "{color.bær.100}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                }
-            },
-            "warning": {
-                "subtlest": {
-                    "$type": "color",
-                    "$value": "{color.sol.750}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "subtler": {
-                    "$type": "color",
-                    "$value": "{color.sol.650}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "subtle": {
-                    "$type": "color",
-                    "$value": "{color.sol.550}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "default": {
-                    "$type": "color",
-                    "$value": "{color.sol.450}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "medium": {
-                    "$type": "color",
-                    "$value": "{color.sol.350}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "strong": {
-                    "$type": "color",
-                    "$value": "{color.sol.250}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "stronger": {
-                    "$type": "color",
-                    "$value": "{color.sol.150}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "strongest": {
-                    "$type": "color",
-                    "$value": "{color.sol.100}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                }
-            },
-            "tip": {
-                "sublest": {
-                    "$type": "color",
-                    "$value": "{color.syrin.800}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "subtler": {
-                    "$type": "color",
-                    "$value": "{color.syrin.700}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "subtle": {
-                    "$type": "color",
-                    "$value": "{color.syrin.600}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "default": {
-                    "$type": "color",
-                    "$value": "{color.syrin.500}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "medium": {
-                    "$type": "color",
-                    "$value": "{color.syrin.400}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "strong": {
-                    "$type": "color",
-                    "$value": "{color.syrin.300}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "stronger": {
-                    "$type": "color",
-                    "$value": "{color.syrin.200}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "strongest": {
-                    "$type": "color",
-                    "$value": "{color.syrin.100}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                }
+        "subtler": {
+          "$type": "color",
+          "$value": "{color.frost.700}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
             }
+          }
         },
-        "neutral": {
-            "subtlest": {
-                "$type": "color",
-                "$value": "{color.gray.900}",
-                "$description": "",
-                "$extensions": {
-                    "com.figma": {
-                        "hiddenFromPublishing": false,
-                        "scopes": [],
-                        "codeSyntax": {}
-                    }
-                }
-            },
-            "subtler": {
-                "$type": "color",
-                "$value": "{color.gray.750}",
-                "$description": "",
-                "$extensions": {
-                    "com.figma": {
-                        "hiddenFromPublishing": false,
-                        "scopes": [],
-                        "codeSyntax": {}
-                    }
-                }
-            },
-            "subtle": {
-                "$type": "color",
-                "$value": "{color.gray.650}",
-                "$description": "",
-                "$extensions": {
-                    "com.figma": {
-                        "hiddenFromPublishing": false,
-                        "scopes": [],
-                        "codeSyntax": {}
-                    }
-                }
-            },
-            "default": {
-                "$type": "color",
-                "$value": "{color.gray.450}",
-                "$description": "",
-                "$extensions": {
-                    "com.figma": {
-                        "hiddenFromPublishing": false,
-                        "scopes": [],
-                        "codeSyntax": {}
-                    }
-                }
-            },
-            "medium": {
-                "$type": "color",
-                "$value": "{color.gray.350}",
-                "$description": "",
-                "$extensions": {
-                    "com.figma": {
-                        "hiddenFromPublishing": false,
-                        "scopes": [],
-                        "codeSyntax": {}
-                    }
-                }
-            },
-            "strong": {
-                "$type": "color",
-                "$value": "{color.gray.250}",
-                "$description": "",
-                "$extensions": {
-                    "com.figma": {
-                        "hiddenFromPublishing": false,
-                        "scopes": [],
-                        "codeSyntax": {}
-                    }
-                }
-            },
-            "stronger": {
-                "$type": "color",
-                "$value": "{color.gray.150}",
-                "$description": "",
-                "$extensions": {
-                    "com.figma": {
-                        "hiddenFromPublishing": false,
-                        "scopes": [],
-                        "codeSyntax": {}
-                    }
-                }
-            },
-            "strongest": {
-                "$type": "color",
-                "$value": "{color.alpha.white.100}",
-                "$description": "",
-                "$extensions": {
-                    "com.figma": {
-                        "hiddenFromPublishing": false,
-                        "scopes": [],
-                        "codeSyntax": {}
-                    }
-                }
-            },
-            "inverted": {
-                "$type": "color",
-                "$value": "{color.gray.1000}",
-                "$description": "",
-                "$extensions": {
-                    "com.figma": {
-                        "hiddenFromPublishing": false,
-                        "scopes": [],
-                        "codeSyntax": {}
-                    }
-                }
+        "subtle": {
+          "$type": "color",
+          "$value": "{color.frost.600}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
             }
+          }
         },
-        "interactive": {
-            "default": {
-                "$type": "color",
-                "$value": "{color.vann.300}",
-                "$description": "",
-                "$extensions": {
-                    "com.figma": {
-                        "hiddenFromPublishing": false,
-                        "scopes": [],
-                        "codeSyntax": {}
-                    }
-                }
-            },
-            "hover": {
-                "$type": "color",
-                "$value": "{color.vann.400}",
-                "$description": "",
-                "$extensions": {
-                    "com.figma": {
-                        "hiddenFromPublishing": false,
-                        "scopes": [],
-                        "codeSyntax": {}
-                    }
-                }
-            },
-            "pressed": {
-                "$type": "color",
-                "$value": "{color.vann.450}",
-                "$description": "",
-                "$extensions": {
-                    "com.figma": {
-                        "hiddenFromPublishing": false,
-                        "scopes": [],
-                        "codeSyntax": {}
-                    }
-                }
-            },
-            "focus": {
-                "$type": "color",
-                "$value": "{color.alpha.white.100}",
-                "$description": "",
-                "$extensions": {
-                    "com.figma": {
-                        "hiddenFromPublishing": false,
-                        "scopes": [],
-                        "codeSyntax": {}
-                    }
-                }
+        "default": {
+          "$type": "color",
+          "$value": "{color.frost.500}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
             }
+          }
+        },
+        "medium": {
+          "$type": "color",
+          "$value": "{color.frost.400}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "strong": {
+          "$type": "color",
+          "$value": "{color.frost.300}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "stronger": {
+          "$type": "color",
+          "$value": "{color.frost.200}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "strongest": {
+          "$type": "color",
+          "$value": "{color.frost.100}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
         }
+      },
+      "success": {
+        "subtlest": {
+          "$type": "color",
+          "$value": "{color.skog.800}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "subtler": {
+          "$type": "color",
+          "$value": "{color.skog.700}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "subtle": {
+          "$type": "color",
+          "$value": "{color.skog.600}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "default": {
+          "$type": "color",
+          "$value": "{color.skog.500}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "medium": {
+          "$type": "color",
+          "$value": "{color.skog.400}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "strong": {
+          "$type": "color",
+          "$value": "{color.skog.300}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "stronger": {
+          "$type": "color",
+          "$value": "{color.skog.200}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "strongest": {
+          "$type": "color",
+          "$value": "{color.skog.100}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        }
+      },
+      "warning": {
+        "subtlest": {
+          "$type": "color",
+          "$value": "{color.sol.750}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "subtler": {
+          "$type": "color",
+          "$value": "{color.sol.650}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "subtle": {
+          "$type": "color",
+          "$value": "{color.sol.550}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "default": {
+          "$type": "color",
+          "$value": "{color.sol.450}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "medium": {
+          "$type": "color",
+          "$value": "{color.sol.350}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "strong": {
+          "$type": "color",
+          "$value": "{color.sol.250}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "stronger": {
+          "$type": "color",
+          "$value": "{color.sol.150}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "strongest": {
+          "$type": "color",
+          "$value": "{color.sol.100}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        }
+      },
+      "critical": {
+        "subtlest": {
+          "$type": "color",
+          "$value": "{color.bær.800}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "subtler": {
+          "$type": "color",
+          "$value": "{color.bær.700}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "subtle": {
+          "$type": "color",
+          "$value": "{color.bær.600}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "default": {
+          "$type": "color",
+          "$value": "{color.bær.500}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "medium": {
+          "$type": "color",
+          "$value": "{color.bær.400}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "strong": {
+          "$type": "color",
+          "$value": "{color.bær.300}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "stronger": {
+          "$type": "color",
+          "$value": "{color.bær.200}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "strongest": {
+          "$type": "color",
+          "$value": "{color.bær.100}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        }
+      },
+      "tip": {
+        "sublest": {
+          "$type": "color",
+          "$value": "{color.syrin.800}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "subtler": {
+          "$type": "color",
+          "$value": "{color.syrin.700}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "subtle": {
+          "$type": "color",
+          "$value": "{color.syrin.600}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "default": {
+          "$type": "color",
+          "$value": "{color.syrin.500}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "medium": {
+          "$type": "color",
+          "$value": "{color.syrin.400}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "strong": {
+          "$type": "color",
+          "$value": "{color.syrin.300}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "strongest": {
+          "$type": "color",
+          "$value": "{color.syrin.100}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "stronger": {
+          "$type": "color",
+          "$value": "{color.syrin.200}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        }
+      }
     },
-    "speciality": {
-        "logo": {
-            "name": {
-                "$type": "color",
-                "$value": "{color.alpha.white.100}",
-                "$description": "",
-                "$extensions": {
-                    "com.figma": {
-                        "hiddenFromPublishing": false,
-                        "scopes": [],
-                        "codeSyntax": {}
-                    }
-                }
-            }
-        },
-        "background": {
-            "default": {
-                "$type": "color",
-                "$value": "{color.alpha.black.100}",
-                "$description": "",
-                "$extensions": {
-                    "com.figma": {
-                        "hiddenFromPublishing": false,
-                        "scopes": [],
-                        "codeSyntax": {}
-                    }
-                }
-            },
-            "subtle": {
-                "$type": "color",
-                "$value": "{color.gray.950}",
-                "$description": "",
-                "$extensions": {
-                    "com.figma": {
-                        "hiddenFromPublishing": false,
-                        "scopes": [],
-                        "codeSyntax": {}
-                    }
-                }
-            },
-            "accent": {
-                "$type": "color",
-                "$value": "{color.natt.950}",
-                "$description": "",
-                "$extensions": {
-                    "com.figma": {
-                        "hiddenFromPublishing": false,
-                        "scopes": [],
-                        "codeSyntax": {}
-                    }
-                }
-            },
-            "accent-subtle": {
-                "$type": "color",
-                "$value": "{color.vann.1000}",
-                "$description": "",
-                "$extensions": {
-                    "com.figma": {
-                        "hiddenFromPublishing": false,
-                        "scopes": [],
-                        "codeSyntax": {}
-                    }
-                }
-            },
-            "surface": {
-                "default": {
-                    "$type": "color",
-                    "$value": "{color.gray.850}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "default-hover": {
-                    "$type": "color",
-                    "$value": "{color.gray.750}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "default-pressed": {
-                    "$type": "color",
-                    "$value": "{color.gray.700}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                }
-            },
-            "transparent": {
-                "$type": "color",
-                "$value": "{color.alpha.white.0}",
-                "$description": "",
-                "$extensions": {
-                    "com.figma": {
-                        "hiddenFromPublishing": false,
-                        "scopes": [],
-                        "codeSyntax": {}
-                    }
-                }
-            }
-        },
-        "static": {
-            "neutral": {
-                "white": {
-                    "$type": "color",
-                    "$value": "{color.alpha.white.100}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "light-gray": {
-                    "$type": "color",
-                    "$value": "{color.gray.50}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "gray": {
-                    "$type": "color",
-                    "$value": "{color.gray.350}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "dark-gray": {
-                    "$type": "color",
-                    "$value": "{color.gray.700}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "strongest": {
-                    "$type": "color",
-                    "$value": "{color.alpha.black.100}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                }
-            },
-            "accent": {
-                "subtle": {
-                    "$type": "color",
-                    "$value": "{color.vann.150}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "subtler": {
-                    "$type": "color",
-                    "$value": "{color.vann.75}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "subtlest": {
-                    "$type": "color",
-                    "$value": "{color.vann.25}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "default": {
-                    "$type": "color",
-                    "$value": "{color.alpha.white.100}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "medium": {
-                    "$type": "color",
-                    "$value": "{color.vann.500}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "strong": {
-                    "$type": "color",
-                    "$value": "{color.vann.600}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "stronger": {
-                    "$type": "color",
-                    "$value": "{color.vann.700}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "strongest": {
-                    "$type": "color",
-                    "$value": "{color.vann.800}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                }
-            }
+    "neutral": {
+      "subtlest": {
+        "$type": "color",
+        "$value": "{color.gray.900}",
+        "$description": "",
+        "$extensions": {
+          "com.figma": {
+            "hiddenFromPublishing": false,
+            "scopes": [],
+            "codeSyntax": {}
+          }
         }
+      },
+      "subtler": {
+        "$type": "color",
+        "$value": "{color.gray.750}",
+        "$description": "",
+        "$extensions": {
+          "com.figma": {
+            "hiddenFromPublishing": false,
+            "scopes": [],
+            "codeSyntax": {}
+          }
+        }
+      },
+      "subtle": {
+        "$type": "color",
+        "$value": "{color.gray.650}",
+        "$description": "",
+        "$extensions": {
+          "com.figma": {
+            "hiddenFromPublishing": false,
+            "scopes": [],
+            "codeSyntax": {}
+          }
+        }
+      },
+      "default": {
+        "$type": "color",
+        "$value": "{color.gray.500}",
+        "$description": "",
+        "$extensions": {
+          "com.figma": {
+            "hiddenFromPublishing": false,
+            "scopes": [],
+            "codeSyntax": {}
+          }
+        }
+      },
+      "medium": {
+        "$type": "color",
+        "$value": "{color.gray.400}",
+        "$description": "",
+        "$extensions": {
+          "com.figma": {
+            "hiddenFromPublishing": false,
+            "scopes": [],
+            "codeSyntax": {}
+          }
+        }
+      },
+      "strong": {
+        "$type": "color",
+        "$value": "{color.gray.250}",
+        "$description": "",
+        "$extensions": {
+          "com.figma": {
+            "hiddenFromPublishing": false,
+            "scopes": [],
+            "codeSyntax": {}
+          }
+        }
+      },
+      "stronger": {
+        "$type": "color",
+        "$value": "{color.gray.150}",
+        "$description": "",
+        "$extensions": {
+          "com.figma": {
+            "hiddenFromPublishing": false,
+            "scopes": [],
+            "codeSyntax": {}
+          }
+        }
+      },
+      "strongest": {
+        "$type": "color",
+        "$value": "{color.alpha.white.1000}",
+        "$description": "",
+        "$extensions": {
+          "com.figma": {
+            "hiddenFromPublishing": false,
+            "scopes": [],
+            "codeSyntax": {}
+          }
+        }
+      },
+      "inverted": {
+        "$type": "color",
+        "$value": "{color.gray.1000}",
+        "$description": "",
+        "$extensions": {
+          "com.figma": {
+            "hiddenFromPublishing": false,
+            "scopes": [],
+            "codeSyntax": {}
+          }
+        }
+      },
+      "alpha": {
+        "subtlest": {
+          "$type": "color",
+          "$value": "{color.alpha.white.25}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "subtler": {
+          "$type": "color",
+          "$value": "{color.alpha.white.50}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "subtle": {
+          "$type": "color",
+          "$value": "{color.alpha.white.75}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "default": {
+          "$type": "color",
+          "$value": "{color.alpha.white.100}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "medium": {
+          "$type": "color",
+          "$value": "{color.alpha.white.200}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "strong": {
+          "$type": "color",
+          "$value": "{color.alpha.white.300}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "stronger": {
+          "$type": "color",
+          "$value": "{color.alpha.white.400}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "strongest": {
+          "$type": "color",
+          "$value": "{color.alpha.white.500}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        }
+      }
+    },
+    "interactive": {
+      "default": {
+        "$type": "color",
+        "$value": "{color.vann.400}",
+        "$description": "",
+        "$extensions": {
+          "com.figma": {
+            "hiddenFromPublishing": false,
+            "scopes": [],
+            "codeSyntax": {}
+          }
+        }
+      },
+      "hover": {
+        "$type": "color",
+        "$value": "{color.vann.300}",
+        "$description": "",
+        "$extensions": {
+          "com.figma": {
+            "hiddenFromPublishing": false,
+            "scopes": [],
+            "codeSyntax": {}
+          }
+        }
+      },
+      "pressed": {
+        "$type": "color",
+        "$value": "{color.vann.200}",
+        "$description": "",
+        "$extensions": {
+          "com.figma": {
+            "hiddenFromPublishing": false,
+            "scopes": [],
+            "codeSyntax": {}
+          }
+        }
+      },
+      "focus": {
+        "$type": "color",
+        "$value": "{color.alpha.white.1000}",
+        "$description": "",
+        "$extensions": {
+          "com.figma": {
+            "hiddenFromPublishing": false,
+            "scopes": [],
+            "codeSyntax": {}
+          }
+        }
+      },
+      "selected": {
+        "default": {
+          "$type": "color",
+          "$value": "{color.alpha.white.1000}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "hover": {
+          "$type": "color",
+          "$value": "{color.vann.50}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "pressed": {
+          "$type": "color",
+          "$value": "{color.vann.100}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        }
+      }
     }
+  },
+  "accent": {
+    "brand": {
+      "primary": {
+        "subtlest": {
+          "$type": "color",
+          "$value": "{color.vann.800}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "subtler": {
+          "$type": "color",
+          "$value": "{color.vann.700}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "subtle": {
+          "$type": "color",
+          "$value": "{color.vann.600}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "default": {
+          "$type": "color",
+          "$value": "{color.vann.500}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "medium": {
+          "$type": "color",
+          "$value": "{color.vann.400}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "strong": {
+          "$type": "color",
+          "$value": "{color.vann.300}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "stronger": {
+          "$type": "color",
+          "$value": "{color.vann.200}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "strongest": {
+          "$type": "color",
+          "$value": "{color.vann.100}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        }
+      },
+      "secondary": {
+        "subtlest": {
+          "$type": "color",
+          "$value": "{color.frost.900}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "subtler": {
+          "$type": "color",
+          "$value": "{color.frost.800}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "subtle": {
+          "$type": "color",
+          "$value": "{color.frost.700}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "default": {
+          "$type": "color",
+          "$value": "{color.frost.600}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "medium": {
+          "$type": "color",
+          "$value": "{color.frost.500}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "strong": {
+          "$type": "color",
+          "$value": "{color.frost.300}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "stronger": {
+          "$type": "color",
+          "$value": "{color.frost.200}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "strongest": {
+          "$type": "color",
+          "$value": "{color.frost.100}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        }
+      },
+      "tertiary": {
+        "subtlest": {
+          "$type": "color",
+          "$value": "{color.syrin.950}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "subtler": {
+          "$type": "color",
+          "$value": "{color.syrin.850}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "subtle": {
+          "$type": "color",
+          "$value": "{color.syrin.750}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "default": {
+          "$type": "color",
+          "$value": "{color.syrin.650}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "medium": {
+          "$type": "color",
+          "$value": "{color.syrin.550}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "strong": {
+          "$type": "color",
+          "$value": "{color.syrin.300}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "stronger": {
+          "$type": "color",
+          "$value": "{color.syrin.200}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "strongest": {
+          "$type": "color",
+          "$value": "{color.syrin.100}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        }
+      },
+      "emphasis": {
+        "sublest": {
+          "$type": "color",
+          "$value": "{color.vann.800}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "subtler": {
+          "$type": "color",
+          "$value": "{color.vann.700}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "subtle": {
+          "$type": "color",
+          "$value": "{color.vann.650}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "default": {
+          "$type": "color",
+          "$value": "{color.vann.550}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "medium": {
+          "$type": "color",
+          "$value": "{color.vann.450}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "strong": {
+          "$type": "color",
+          "$value": "{color.vann.300}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "stronger": {
+          "$type": "color",
+          "$value": "{color.vann.150}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "strongest": {
+          "$type": "color",
+          "$value": "{color.vann.75}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        }
+      },
+      "subtle": {
+        "subtlest": {
+          "$type": "color",
+          "$value": "{color.sand.850}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "subtler": {
+          "$type": "color",
+          "$value": "{color.sand.750}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "subtle": {
+          "$type": "color",
+          "$value": "{color.sand.650}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "default": {
+          "$type": "color",
+          "$value": "{color.sand.550}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "medium": {
+          "$type": "color",
+          "$value": "{color.sand.450}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "strong": {
+          "$type": "color",
+          "$value": "{color.sand.350}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "stronger": {
+          "$type": "color",
+          "$value": "{color.sand.250}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "strongest": {
+          "$type": "color",
+          "$value": "{color.sand.150}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        }
+      }
+    },
+    "feedback": {
+      "info": {
+        "subtlest": {
+          "$type": "color",
+          "$value": "{color.frost.800}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "subtler": {
+          "$type": "color",
+          "$value": "{color.frost.700}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "subtle": {
+          "$type": "color",
+          "$value": "{color.frost.600}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "default": {
+          "$type": "color",
+          "$value": "{color.frost.500}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "medium": {
+          "$type": "color",
+          "$value": "{color.frost.400}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "strong": {
+          "$type": "color",
+          "$value": "{color.frost.300}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "stronger": {
+          "$type": "color",
+          "$value": "{color.frost.200}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "strongest": {
+          "$type": "color",
+          "$value": "{color.frost.100}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        }
+      },
+      "success": {
+        "subtlest": {
+          "$type": "color",
+          "$value": "{color.skog.800}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "subtler": {
+          "$type": "color",
+          "$value": "{color.skog.700}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "subtle": {
+          "$type": "color",
+          "$value": "{color.skog.550}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "default": {
+          "$type": "color",
+          "$value": "{color.skog.500}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "medium": {
+          "$type": "color",
+          "$value": "{color.skog.400}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "strong": {
+          "$type": "color",
+          "$value": "{color.skog.300}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "stronger": {
+          "$type": "color",
+          "$value": "{color.skog.200}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "strongest": {
+          "$type": "color",
+          "$value": "{color.skog.100}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        }
+      },
+      "critical": {
+        "subtlest": {
+          "$type": "color",
+          "$value": "{color.bær.800}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "subtler": {
+          "$type": "color",
+          "$value": "{color.bær.700}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "subtle": {
+          "$type": "color",
+          "$value": "{color.bær.600}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "default": {
+          "$type": "color",
+          "$value": "{color.bær.500}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "medium": {
+          "$type": "color",
+          "$value": "{color.bær.400}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "strong": {
+          "$type": "color",
+          "$value": "{color.bær.300}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "stronger": {
+          "$type": "color",
+          "$value": "{color.bær.200}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "strongest": {
+          "$type": "color",
+          "$value": "{color.bær.100}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        }
+      },
+      "warning": {
+        "subtlest": {
+          "$type": "color",
+          "$value": "{color.sol.750}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "subtler": {
+          "$type": "color",
+          "$value": "{color.sol.650}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "subtle": {
+          "$type": "color",
+          "$value": "{color.sol.550}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "default": {
+          "$type": "color",
+          "$value": "{color.sol.450}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "medium": {
+          "$type": "color",
+          "$value": "{color.sol.350}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "strong": {
+          "$type": "color",
+          "$value": "{color.sol.250}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "stronger": {
+          "$type": "color",
+          "$value": "{color.sol.150}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "strongest": {
+          "$type": "color",
+          "$value": "{color.sol.100}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        }
+      },
+      "tip": {
+        "sublest": {
+          "$type": "color",
+          "$value": "{color.syrin.800}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "subtler": {
+          "$type": "color",
+          "$value": "{color.syrin.700}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "subtle": {
+          "$type": "color",
+          "$value": "{color.syrin.600}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "default": {
+          "$type": "color",
+          "$value": "{color.syrin.500}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "medium": {
+          "$type": "color",
+          "$value": "{color.syrin.400}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "strong": {
+          "$type": "color",
+          "$value": "{color.syrin.300}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "stronger": {
+          "$type": "color",
+          "$value": "{color.syrin.200}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "strongest": {
+          "$type": "color",
+          "$value": "{color.syrin.100}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        }
+      }
+    },
+    "neutral": {
+      "subtlest": {
+        "$type": "color",
+        "$value": "{color.gray.900}",
+        "$description": "",
+        "$extensions": {
+          "com.figma": {
+            "hiddenFromPublishing": false,
+            "scopes": [],
+            "codeSyntax": {}
+          }
+        }
+      },
+      "alpha": {
+        "subtlest": {
+          "$type": "color",
+          "$value": "{color.alpha.white.25}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "subtler": {
+          "$type": "color",
+          "$value": "{color.alpha.white.50}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "subtle": {
+          "$type": "color",
+          "$value": "{color.alpha.white.75}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "default": {
+          "$type": "color",
+          "$value": "{color.alpha.white.100}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "medium": {
+          "$type": "color",
+          "$value": "{color.alpha.white.200}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "strong": {
+          "$type": "color",
+          "$value": "{color.alpha.white.300}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "stronger": {
+          "$type": "color",
+          "$value": "{color.alpha.white.400}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "strongest": {
+          "$type": "color",
+          "$value": "{color.alpha.white.500}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        }
+      },
+      "subtler": {
+        "$type": "color",
+        "$value": "{color.gray.750}",
+        "$description": "",
+        "$extensions": {
+          "com.figma": {
+            "hiddenFromPublishing": false,
+            "scopes": [],
+            "codeSyntax": {}
+          }
+        }
+      },
+      "subtle": {
+        "$type": "color",
+        "$value": "{color.gray.650}",
+        "$description": "",
+        "$extensions": {
+          "com.figma": {
+            "hiddenFromPublishing": false,
+            "scopes": [],
+            "codeSyntax": {}
+          }
+        }
+      },
+      "default": {
+        "$type": "color",
+        "$value": "{color.gray.500}",
+        "$description": "",
+        "$extensions": {
+          "com.figma": {
+            "hiddenFromPublishing": false,
+            "scopes": [],
+            "codeSyntax": {}
+          }
+        }
+      },
+      "medium": {
+        "$type": "color",
+        "$value": "{color.gray.400}",
+        "$description": "",
+        "$extensions": {
+          "com.figma": {
+            "hiddenFromPublishing": false,
+            "scopes": [],
+            "codeSyntax": {}
+          }
+        }
+      },
+      "strong": {
+        "$type": "color",
+        "$value": "{color.gray.250}",
+        "$description": "",
+        "$extensions": {
+          "com.figma": {
+            "hiddenFromPublishing": false,
+            "scopes": [],
+            "codeSyntax": {}
+          }
+        }
+      },
+      "stronger": {
+        "$type": "color",
+        "$value": "{color.gray.150}",
+        "$description": "",
+        "$extensions": {
+          "com.figma": {
+            "hiddenFromPublishing": false,
+            "scopes": [],
+            "codeSyntax": {}
+          }
+        }
+      },
+      "strongest": {
+        "$type": "color",
+        "$value": "{color.alpha.white.1000}",
+        "$description": "",
+        "$extensions": {
+          "com.figma": {
+            "hiddenFromPublishing": false,
+            "scopes": [],
+            "codeSyntax": {}
+          }
+        }
+      },
+      "inverted": {
+        "$type": "color",
+        "$value": "{color.gray.1000}",
+        "$description": "",
+        "$extensions": {
+          "com.figma": {
+            "hiddenFromPublishing": false,
+            "scopes": [],
+            "codeSyntax": {}
+          }
+        }
+      }
+    },
+    "interactive": {
+      "default": {
+        "$type": "color",
+        "$value": "{color.vann.300}",
+        "$description": "",
+        "$extensions": {
+          "com.figma": {
+            "hiddenFromPublishing": false,
+            "scopes": [],
+            "codeSyntax": {}
+          }
+        }
+      },
+      "hover": {
+        "$type": "color",
+        "$value": "{color.vann.400}",
+        "$description": "",
+        "$extensions": {
+          "com.figma": {
+            "hiddenFromPublishing": false,
+            "scopes": [],
+            "codeSyntax": {}
+          }
+        }
+      },
+      "pressed": {
+        "$type": "color",
+        "$value": "{color.vann.500}",
+        "$description": "",
+        "$extensions": {
+          "com.figma": {
+            "hiddenFromPublishing": false,
+            "scopes": [],
+            "codeSyntax": {}
+          }
+        }
+      },
+      "focus": {
+        "$type": "color",
+        "$value": "{color.alpha.white.1000}",
+        "$description": "",
+        "$extensions": {
+          "com.figma": {
+            "hiddenFromPublishing": false,
+            "scopes": [],
+            "codeSyntax": {}
+          }
+        }
+      },
+      "selected": {
+        "default": {
+          "$type": "color",
+          "$value": "{color.alpha.white.1000}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "hover": {
+          "$type": "color",
+          "$value": "{color.vann.50}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "pressed": {
+          "$type": "color",
+          "$value": "{color.vann.100}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        }
+      }
+    }
+  },
+  "speciality": {
+    "logo": {
+      "name": {
+        "$type": "color",
+        "$value": "{color.alpha.white.1000}",
+        "$description": "",
+        "$extensions": {
+          "com.figma": {
+            "hiddenFromPublishing": false,
+            "scopes": [],
+            "codeSyntax": {}
+          }
+        }
+      }
+    },
+    "background": {
+      "default": {
+        "$type": "color",
+        "$value": "{color.alpha.black.1000}",
+        "$description": "",
+        "$extensions": {
+          "com.figma": {
+            "hiddenFromPublishing": false,
+            "scopes": [],
+            "codeSyntax": {}
+          }
+        }
+      },
+      "subtle": {
+        "$type": "color",
+        "$value": "{color.gray.950}",
+        "$description": "",
+        "$extensions": {
+          "com.figma": {
+            "hiddenFromPublishing": false,
+            "scopes": [],
+            "codeSyntax": {}
+          }
+        }
+      },
+      "accent": {
+        "$type": "color",
+        "$value": "{color.gray.1000}",
+        "$description": "",
+        "$extensions": {
+          "com.figma": {
+            "hiddenFromPublishing": false,
+            "scopes": [],
+            "codeSyntax": {}
+          }
+        }
+      },
+      "accent-subtle": {
+        "$type": "color",
+        "$value": "{color.gray.950}",
+        "$description": "",
+        "$extensions": {
+          "com.figma": {
+            "hiddenFromPublishing": false,
+            "scopes": [],
+            "codeSyntax": {}
+          }
+        }
+      },
+      "transparent": {
+        "$type": "color",
+        "$value": "{color.alpha.white.0}",
+        "$description": "",
+        "$extensions": {
+          "com.figma": {
+            "hiddenFromPublishing": false,
+            "scopes": [],
+            "codeSyntax": {}
+          }
+        }
+      },
+      "surface": {
+        "primary": {
+          "default": {
+            "$type": "color",
+            "$value": "{color.gray.900}",
+            "$description": "",
+            "$extensions": {
+              "com.figma": {
+                "hiddenFromPublishing": false,
+                "scopes": [],
+                "codeSyntax": {}
+              }
+            }
+          },
+          "default-hover": {
+            "$type": "color",
+            "$value": "{color.gray.800}",
+            "$description": "",
+            "$extensions": {
+              "com.figma": {
+                "hiddenFromPublishing": false,
+                "scopes": [],
+                "codeSyntax": {}
+              }
+            }
+          },
+          "default-pressed": {
+            "$type": "color",
+            "$value": "{color.gray.700}",
+            "$description": "",
+            "$extensions": {
+              "com.figma": {
+                "hiddenFromPublishing": false,
+                "scopes": [],
+                "codeSyntax": {}
+              }
+            }
+          }
+        },
+        "secondary": {
+          "default": {
+            "$type": "color",
+            "$value": "{color.gray.900}",
+            "$description": "",
+            "$extensions": {
+              "com.figma": {
+                "hiddenFromPublishing": false,
+                "scopes": [],
+                "codeSyntax": {}
+              }
+            }
+          },
+          "default-hover": {
+            "$type": "color",
+            "$value": "{color.gray.800}",
+            "$description": "",
+            "$extensions": {
+              "com.figma": {
+                "hiddenFromPublishing": false,
+                "scopes": [],
+                "codeSyntax": {}
+              }
+            }
+          },
+          "default-pressed": {
+            "$type": "color",
+            "$value": "{color.gray.700}",
+            "$description": "",
+            "$extensions": {
+              "com.figma": {
+                "hiddenFromPublishing": false,
+                "scopes": [],
+                "codeSyntax": {}
+              }
+            }
+          }
+        },
+        "tertiary": {
+          "default": {
+            "$type": "color",
+            "$value": "{color.gray.900}",
+            "$description": "",
+            "$extensions": {
+              "com.figma": {
+                "hiddenFromPublishing": false,
+                "scopes": [],
+                "codeSyntax": {}
+              }
+            }
+          },
+          "default-hover": {
+            "$type": "color",
+            "$value": "{color.gray.800}",
+            "$description": "",
+            "$extensions": {
+              "com.figma": {
+                "hiddenFromPublishing": false,
+                "scopes": [],
+                "codeSyntax": {}
+              }
+            }
+          },
+          "default-pressed": {
+            "$type": "color",
+            "$value": "{color.gray.700}",
+            "$description": "",
+            "$extensions": {
+              "com.figma": {
+                "hiddenFromPublishing": false,
+                "scopes": [],
+                "codeSyntax": {}
+              }
+            }
+          }
+        },
+        "accent": {
+          "accent": {
+            "$type": "color",
+            "$value": "{color.gray.900}",
+            "$description": "",
+            "$extensions": {
+              "com.figma": {
+                "hiddenFromPublishing": false,
+                "scopes": [],
+                "codeSyntax": {}
+              }
+            }
+          },
+          "accent-hover": {
+            "$type": "color",
+            "$value": "{color.gray.800}",
+            "$description": "",
+            "$extensions": {
+              "com.figma": {
+                "hiddenFromPublishing": false,
+                "scopes": [],
+                "codeSyntax": {}
+              }
+            }
+          },
+          "accent-pressed": {
+            "$type": "color",
+            "$value": "{color.gray.700}",
+            "$description": "",
+            "$extensions": {
+              "com.figma": {
+                "hiddenFromPublishing": false,
+                "scopes": [],
+                "codeSyntax": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "buttons": {
+      "primary": {
+        "default": {
+          "fill": {
+            "default": {
+              "$type": "color",
+              "$value": "{color.vann.550}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": [],
+                  "codeSyntax": {}
+                }
+              }
+            },
+            "hover": {
+              "$type": "color",
+              "$value": "{color.vann.500}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": [],
+                  "codeSyntax": {}
+                }
+              }
+            },
+            "pressed": {
+              "$type": "color",
+              "$value": "{color.vann.400}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": [],
+                  "codeSyntax": {}
+                }
+              }
+            }
+          }
+        },
+        "accent": {
+          "fill": {
+            "default": {
+              "$type": "color",
+              "$value": "{color.vann.550}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": [],
+                  "codeSyntax": {}
+                }
+              }
+            },
+            "hover": {
+              "$type": "color",
+              "$value": "{color.vann.500}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": [],
+                  "codeSyntax": {}
+                }
+              }
+            },
+            "pressed": {
+              "$type": "color",
+              "$value": "{color.vann.400}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": [],
+                  "codeSyntax": {}
+                }
+              }
+            }
+          },
+          "foreground": {
+            "default": {
+              "$type": "color",
+              "$value": "{color.alpha.white.1000}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": [],
+                  "codeSyntax": {}
+                }
+              }
+            }
+          }
+        }
+      },
+      "secondary": {
+        "default": {
+          "border": {
+            "default": {
+              "$type": "color",
+              "$value": "{color.vann.300}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": [],
+                  "codeSyntax": {}
+                }
+              }
+            }
+          },
+          "fill": {
+            "default": {
+              "$type": "color",
+              "$value": "{color.alpha.white.0}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": [],
+                  "codeSyntax": {}
+                }
+              }
+            },
+            "hover": {
+              "$type": "color",
+              "$value": "{color.alpha.white.100}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": [],
+                  "codeSyntax": {}
+                }
+              }
+            },
+            "pressed": {
+              "$type": "color",
+              "$value": "{color.alpha.white.200}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": [],
+                  "codeSyntax": {}
+                }
+              }
+            }
+          },
+          "foreground": {
+            "default": {
+              "$type": "color",
+              "$value": "{color.vann.100}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": [],
+                  "codeSyntax": {}
+                }
+              }
+            }
+          }
+        },
+        "accent": {
+          "border": {
+            "default": {
+              "$type": "color",
+              "$value": "{color.vann.300}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": [],
+                  "codeSyntax": {}
+                }
+              }
+            }
+          },
+          "fill": {
+            "default": {
+              "$type": "color",
+              "$value": "{color.alpha.white.0}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": [],
+                  "codeSyntax": {}
+                }
+              }
+            },
+            "hover": {
+              "$type": "color",
+              "$value": "{color.alpha.white.100}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": [],
+                  "codeSyntax": {}
+                }
+              }
+            },
+            "pressed": {
+              "$type": "color",
+              "$value": "{color.alpha.white.200}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": [],
+                  "codeSyntax": {}
+                }
+              }
+            }
+          },
+          "foreground": {
+            "default": {
+              "$type": "color",
+              "$value": "{color.vann.100}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": [],
+                  "codeSyntax": {}
+                }
+              }
+            }
+          }
+        }
+      },
+      "tertiary": {
+        "default": {
+          "fill": {
+            "default": {
+              "$type": "color",
+              "$value": "{color.alpha.white.0}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": [],
+                  "codeSyntax": {}
+                }
+              }
+            },
+            "hover": {
+              "$type": "color",
+              "$value": "{color.alpha.white.100}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": [],
+                  "codeSyntax": {}
+                }
+              }
+            },
+            "pressed": {
+              "$type": "color",
+              "$value": "{color.alpha.white.200}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": [],
+                  "codeSyntax": {}
+                }
+              }
+            }
+          },
+          "foreground": {
+            "default": {
+              "$type": "color",
+              "$value": "{color.vann.100}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": [],
+                  "codeSyntax": {}
+                }
+              }
+            }
+          }
+        },
+        "accent": {
+          "fill": {
+            "default": {
+              "$type": "color",
+              "$value": "{color.alpha.white.0}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": [],
+                  "codeSyntax": {}
+                }
+              }
+            },
+            "hover": {
+              "$type": "color",
+              "$value": "{color.alpha.white.100}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": [],
+                  "codeSyntax": {}
+                }
+              }
+            },
+            "pressed": {
+              "$type": "color",
+              "$value": "{color.alpha.white.200}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": [],
+                  "codeSyntax": {}
+                }
+              }
+            }
+          },
+          "foreground": {
+            "default": {
+              "$type": "color",
+              "$value": "{color.vann.100}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": [],
+                  "codeSyntax": {}
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "static": {
+      "alpha": {
+        "white": {
+          "subtlest": {
+            "$type": "color",
+            "$value": "{color.alpha.white.50}",
+            "$description": "",
+            "$extensions": {
+              "com.figma": {
+                "hiddenFromPublishing": false,
+                "scopes": [],
+                "codeSyntax": {}
+              }
+            }
+          },
+          "subtler": {
+            "$type": "color",
+            "$value": "{color.alpha.white.100}",
+            "$description": "",
+            "$extensions": {
+              "com.figma": {
+                "hiddenFromPublishing": false,
+                "scopes": [],
+                "codeSyntax": {}
+              }
+            }
+          },
+          "subtle": {
+            "$type": "color",
+            "$value": "{color.alpha.white.150}",
+            "$description": "",
+            "$extensions": {
+              "com.figma": {
+                "hiddenFromPublishing": false,
+                "scopes": [],
+                "codeSyntax": {}
+              }
+            }
+          },
+          "default": {
+            "$type": "color",
+            "$value": "{color.alpha.white.200}",
+            "$description": "",
+            "$extensions": {
+              "com.figma": {
+                "hiddenFromPublishing": false,
+                "scopes": [],
+                "codeSyntax": {}
+              }
+            }
+          },
+          "medium": {
+            "$type": "color",
+            "$value": "{color.alpha.white.400}",
+            "$description": "",
+            "$extensions": {
+              "com.figma": {
+                "hiddenFromPublishing": false,
+                "scopes": [],
+                "codeSyntax": {}
+              }
+            }
+          },
+          "strong": {
+            "$type": "color",
+            "$value": "{color.alpha.white.600}",
+            "$description": "",
+            "$extensions": {
+              "com.figma": {
+                "hiddenFromPublishing": false,
+                "scopes": [],
+                "codeSyntax": {}
+              }
+            }
+          },
+          "stronger": {
+            "$type": "color",
+            "$value": "{color.alpha.white.700}",
+            "$description": "",
+            "$extensions": {
+              "com.figma": {
+                "hiddenFromPublishing": false,
+                "scopes": [],
+                "codeSyntax": {}
+              }
+            }
+          },
+          "strongest": {
+            "$type": "color",
+            "$value": "{color.alpha.white.800}",
+            "$description": "",
+            "$extensions": {
+              "com.figma": {
+                "hiddenFromPublishing": false,
+                "scopes": [],
+                "codeSyntax": {}
+              }
+            }
+          }
+        },
+        "black": {
+          "subtlest": {
+            "$type": "color",
+            "$value": "{color.alpha.black.50}",
+            "$description": "",
+            "$extensions": {
+              "com.figma": {
+                "hiddenFromPublishing": false,
+                "scopes": [],
+                "codeSyntax": {}
+              }
+            }
+          },
+          "subtler": {
+            "$type": "color",
+            "$value": "{color.alpha.black.100}",
+            "$description": "",
+            "$extensions": {
+              "com.figma": {
+                "hiddenFromPublishing": false,
+                "scopes": [],
+                "codeSyntax": {}
+              }
+            }
+          },
+          "subtle": {
+            "$type": "color",
+            "$value": "{color.alpha.black.150}",
+            "$description": "",
+            "$extensions": {
+              "com.figma": {
+                "hiddenFromPublishing": false,
+                "scopes": [],
+                "codeSyntax": {}
+              }
+            }
+          },
+          "default": {
+            "$type": "color",
+            "$value": "{color.alpha.black.200}",
+            "$description": "",
+            "$extensions": {
+              "com.figma": {
+                "hiddenFromPublishing": false,
+                "scopes": [],
+                "codeSyntax": {}
+              }
+            }
+          },
+          "medium": {
+            "$type": "color",
+            "$value": "{color.alpha.black.400}",
+            "$description": "",
+            "$extensions": {
+              "com.figma": {
+                "hiddenFromPublishing": false,
+                "scopes": [],
+                "codeSyntax": {}
+              }
+            }
+          },
+          "strong": {
+            "$type": "color",
+            "$value": "{color.alpha.black.600}",
+            "$description": "",
+            "$extensions": {
+              "com.figma": {
+                "hiddenFromPublishing": false,
+                "scopes": [],
+                "codeSyntax": {}
+              }
+            }
+          },
+          "stronger": {
+            "$type": "color",
+            "$value": "{color.alpha.black.700}",
+            "$description": "",
+            "$extensions": {
+              "com.figma": {
+                "hiddenFromPublishing": false,
+                "scopes": [],
+                "codeSyntax": {}
+              }
+            }
+          },
+          "strongest": {
+            "$type": "color",
+            "$value": "{color.alpha.black.800}",
+            "$description": "",
+            "$extensions": {
+              "com.figma": {
+                "hiddenFromPublishing": false,
+                "scopes": [],
+                "codeSyntax": {}
+              }
+            }
+          }
+        }
+      },
+      "accent": {
+        "subtlest": {
+          "$type": "color",
+          "$value": "{color.vann.25}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "subtler": {
+          "$type": "color",
+          "$value": "{color.vann.75}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "subtle": {
+          "$type": "color",
+          "$value": "{color.vann.150}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "default": {
+          "$type": "color",
+          "$value": "{color.vann.350}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "medium": {
+          "$type": "color",
+          "$value": "{color.vann.500}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "strong": {
+          "$type": "color",
+          "$value": "{color.vann.600}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "stronger": {
+          "$type": "color",
+          "$value": "{color.vann.700}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "strongest": {
+          "$type": "color",
+          "$value": "{color.vann.800}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        }
+      },
+      "neutral": {
+        "white": {
+          "$type": "color",
+          "$value": "{color.alpha.white.1000}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "subtlest": {
+          "$type": "color",
+          "$value": "{color.gray.50}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "subtler": {
+          "$type": "color",
+          "$value": "{color.gray.100}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "subtle": {
+          "$type": "color",
+          "$value": "{color.gray.150}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "default": {
+          "$type": "color",
+          "$value": "{color.gray.300}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "medium": {
+          "$type": "color",
+          "$value": "{color.gray.400}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "strong": {
+          "$type": "color",
+          "$value": "{color.gray.700}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "stronger": {
+          "$type": "color",
+          "$value": "{color.gray.800}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "strongest": {
+          "$type": "color",
+          "$value": "{color.alpha.black.1000}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        }
+      }
+    }
+  }
 }

--- a/packages/ffe-core/tokens/02 Semantic.Light.json
+++ b/packages/ffe-core/tokens/02 Semantic.Light.json
@@ -1,2572 +1,3552 @@
 {
-    "default": {
-        "brand": {
-            "primary": {
-                "subtlest": {
-                    "$type": "color",
-                    "$value": "{color.vann.50}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "subtler": {
-                    "$type": "color",
-                    "$value": "{color.vann.150}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "subtle": {
-                    "$type": "color",
-                    "$value": "{color.vann.250}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "default": {
-                    "$type": "color",
-                    "$value": "{color.vann.350}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "medium": {
-                    "$type": "color",
-                    "$value": "{color.vann.500}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "strong": {
-                    "$type": "color",
-                    "$value": "{color.vann.600}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "stronger": {
-                    "$type": "color",
-                    "$value": "{color.vann.700}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "strongest": {
-                    "$type": "color",
-                    "$value": "{color.vann.800}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                }
-            },
-            "secondary": {
-                "subtlest": {
-                    "$type": "color",
-                    "$value": "{color.frost.25}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "subtler": {
-                    "$type": "color",
-                    "$value": "{color.frost.50}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "subtle": {
-                    "$type": "color",
-                    "$value": "{color.frost.75}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "default": {
-                    "$type": "color",
-                    "$value": "{color.frost.150}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "medium": {
-                    "$type": "color",
-                    "$value": "{color.frost.250}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "strong": {
-                    "$type": "color",
-                    "$value": "{color.frost.350}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "stronger": {
-                    "$type": "color",
-                    "$value": "{color.frost.450}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "strongest": {
-                    "$type": "color",
-                    "$value": "{color.frost.550}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                }
-            },
-            "tertiary": {
-                "subtlest": {
-                    "$type": "color",
-                    "$value": "{color.syrin.25}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "subtler": {
-                    "$type": "color",
-                    "$value": "{color.syrin.50}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "subtle": {
-                    "$type": "color",
-                    "$value": "{color.syrin.75}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "default": {
-                    "$type": "color",
-                    "$value": "{color.syrin.150}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "medium": {
-                    "$type": "color",
-                    "$value": "{color.syrin.350}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "strong": {
-                    "$type": "color",
-                    "$value": "{color.syrin.450}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "stronger": {
-                    "$type": "color",
-                    "$value": "{color.syrin.550}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "strongest": {
-                    "$type": "color",
-                    "$value": "{color.syrin.700}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                }
-            },
-            "emphasis": {
-                "sublest": {
-                    "$type": "color",
-                    "$value": "{color.vann.50}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "subtler": {
-                    "$type": "color",
-                    "$value": "{color.vann.100}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "subtle": {
-                    "$type": "color",
-                    "$value": "{color.vann.200}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "default": {
-                    "$type": "color",
-                    "$value": "{color.vann.300}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "medium": {
-                    "$type": "color",
-                    "$value": "{color.vann.400}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "strong": {
-                    "$type": "color",
-                    "$value": "{color.vann.550}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "stronger": {
-                    "$type": "color",
-                    "$value": "{color.vann.650}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "strongest": {
-                    "$type": "color",
-                    "$value": "{color.vann.700}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                }
-            },
-            "subtle": {
-                "subtlest": {
-                    "$type": "color",
-                    "$value": "{color.sand.0}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "subtler": {
-                    "$type": "color",
-                    "$value": "{color.sand.25}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "subtle": {
-                    "$type": "color",
-                    "$value": "{color.sand.75}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "default": {
-                    "$type": "color",
-                    "$value": "{color.sand.150}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "medium": {
-                    "$type": "color",
-                    "$value": "{color.sand.300}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "strong": {
-                    "$type": "color",
-                    "$value": "{color.sand.450}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "stronger": {
-                    "$type": "color",
-                    "$value": "{color.sand.550}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "strongest": {
-                    "$type": "color",
-                    "$value": "{color.sand.650}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                }
+  "default": {
+    "brand": {
+      "primary": {
+        "subtlest": {
+          "$type": "color",
+          "$value": "{color.vann.50}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
             }
+          }
         },
-        "feedback": {
-            "info": {
-                "subtlest": {
-                    "$type": "color",
-                    "$value": "{color.frost.50}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "subtler": {
-                    "$type": "color",
-                    "$value": "{color.frost.100}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "subtle": {
-                    "$type": "color",
-                    "$value": "{color.frost.200}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "default": {
-                    "$type": "color",
-                    "$value": "{color.frost.300}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "medium": {
-                    "$type": "color",
-                    "$value": "{color.frost.400}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "strong": {
-                    "$type": "color",
-                    "$value": "{color.frost.500}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "stronger": {
-                    "$type": "color",
-                    "$value": "{color.frost.600}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "strongest": {
-                    "$type": "color",
-                    "$value": "{color.frost.700}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                }
-            },
-            "success": {
-                "subtlest": {
-                    "$type": "color",
-                    "$value": "{color.skog.50}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "subtler": {
-                    "$type": "color",
-                    "$value": "{color.skog.100}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "subtle": {
-                    "$type": "color",
-                    "$value": "{color.skog.200}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "default": {
-                    "$type": "color",
-                    "$value": "{color.skog.300}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "medium": {
-                    "$type": "color",
-                    "$value": "{color.skog.400}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "strong": {
-                    "$type": "color",
-                    "$value": "{color.skog.550}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "stronger": {
-                    "$type": "color",
-                    "$value": "{color.skog.650}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "strongest": {
-                    "$type": "color",
-                    "$value": "{color.skog.750}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                }
-            },
-            "warning": {
-                "subtlest": {
-                    "$type": "color",
-                    "$value": "{color.sol.50}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "subtler": {
-                    "$type": "color",
-                    "$value": "{color.sol.100}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "subtle": {
-                    "$type": "color",
-                    "$value": "{color.sol.200}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "default": {
-                    "$type": "color",
-                    "$value": "{color.sol.300}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "medium": {
-                    "$type": "color",
-                    "$value": "{color.sol.400}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "strong": {
-                    "$type": "color",
-                    "$value": "{color.sol.500}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "stronger": {
-                    "$type": "color",
-                    "$value": "{color.sol.600}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "strongest": {
-                    "$type": "color",
-                    "$value": "{color.sol.700}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                }
-            },
-            "critical": {
-                "subtlest": {
-                    "$type": "color",
-                    "$value": "{color.bær.50}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "subtler": {
-                    "$type": "color",
-                    "$value": "{color.bær.100}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "subtle": {
-                    "$type": "color",
-                    "$value": "{color.bær.200}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "default": {
-                    "$type": "color",
-                    "$value": "{color.bær.300}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "medium": {
-                    "$type": "color",
-                    "$value": "{color.bær.400}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "strong": {
-                    "$type": "color",
-                    "$value": "{color.bær.500}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "stronger": {
-                    "$type": "color",
-                    "$value": "{color.bær.600}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "strongest": {
-                    "$type": "color",
-                    "$value": "{color.bær.700}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                }
-            },
-            "tip": {
-                "sublest": {
-                    "$type": "color",
-                    "$value": "{color.syrin.50}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "subtler": {
-                    "$type": "color",
-                    "$value": "{color.syrin.100}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "subtle": {
-                    "$type": "color",
-                    "$value": "{color.syrin.200}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "default": {
-                    "$type": "color",
-                    "$value": "{color.syrin.300}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "medium": {
-                    "$type": "color",
-                    "$value": "{color.syrin.400}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "strong": {
-                    "$type": "color",
-                    "$value": "{color.syrin.500}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "stronger": {
-                    "$type": "color",
-                    "$value": "{color.syrin.600}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "strongest": {
-                    "$type": "color",
-                    "$value": "{color.syrin.700}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                }
+        "subtler": {
+          "$type": "color",
+          "$value": "{color.vann.150}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
             }
+          }
         },
-        "neutral": {
-            "sublest": {
-                "$type": "color",
-                "$value": "{color.alpha.white.100}",
-                "$description": "",
-                "$extensions": {
-                    "com.figma": {
-                        "hiddenFromPublishing": false,
-                        "scopes": [],
-                        "codeSyntax": {}
-                    }
-                }
-            },
-            "subtler": {
-                "$type": "color",
-                "$value": "{color.gray.50}",
-                "$description": "",
-                "$extensions": {
-                    "com.figma": {
-                        "hiddenFromPublishing": false,
-                        "scopes": [],
-                        "codeSyntax": {}
-                    }
-                }
-            },
-            "subtle": {
-                "$type": "color",
-                "$value": "{color.gray.100}",
-                "$description": "",
-                "$extensions": {
-                    "com.figma": {
-                        "hiddenFromPublishing": false,
-                        "scopes": [],
-                        "codeSyntax": {}
-                    }
-                }
-            },
-            "default": {
-                "$type": "color",
-                "$value": "{color.gray.200}",
-                "$description": "",
-                "$extensions": {
-                    "com.figma": {
-                        "hiddenFromPublishing": false,
-                        "scopes": [],
-                        "codeSyntax": {}
-                    }
-                }
-            },
-            "medium": {
-                "$type": "color",
-                "$value": "{color.gray.400}",
-                "$description": "",
-                "$extensions": {
-                    "com.figma": {
-                        "hiddenFromPublishing": false,
-                        "scopes": [],
-                        "codeSyntax": {}
-                    }
-                }
-            },
-            "strong": {
-                "$type": "color",
-                "$value": "{color.gray.600}",
-                "$description": "",
-                "$extensions": {
-                    "com.figma": {
-                        "hiddenFromPublishing": false,
-                        "scopes": [],
-                        "codeSyntax": {}
-                    }
-                }
-            },
-            "stronger": {
-                "$type": "color",
-                "$value": "{color.gray.750}",
-                "$description": "",
-                "$extensions": {
-                    "com.figma": {
-                        "hiddenFromPublishing": false,
-                        "scopes": [],
-                        "codeSyntax": {}
-                    }
-                }
-            },
-            "strongest": {
-                "$type": "color",
-                "$value": "{color.gray.950}",
-                "$description": "",
-                "$extensions": {
-                    "com.figma": {
-                        "hiddenFromPublishing": false,
-                        "scopes": [],
-                        "codeSyntax": {}
-                    }
-                }
-            },
-            "inverted": {
-                "$type": "color",
-                "$value": "{color.alpha.white.100}",
-                "$description": "",
-                "$extensions": {
-                    "com.figma": {
-                        "hiddenFromPublishing": false,
-                        "scopes": [],
-                        "codeSyntax": {}
-                    }
-                }
+        "subtle": {
+          "$type": "color",
+          "$value": "{color.vann.250}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
             }
+          }
         },
-        "interactive": {
-            "default": {
-                "$type": "color",
-                "$value": "{color.vann.600}",
-                "$description": "",
-                "$extensions": {
-                    "com.figma": {
-                        "hiddenFromPublishing": false,
-                        "scopes": [],
-                        "codeSyntax": {}
-                    }
-                }
-            },
-            "hover": {
-                "$type": "color",
-                "$value": "{color.vann.700}",
-                "$description": "",
-                "$extensions": {
-                    "com.figma": {
-                        "hiddenFromPublishing": false,
-                        "scopes": [],
-                        "codeSyntax": {}
-                    }
-                }
-            },
-            "pressed": {
-                "$type": "color",
-                "$value": "{color.vann.800}",
-                "$description": "",
-                "$extensions": {
-                    "com.figma": {
-                        "hiddenFromPublishing": false,
-                        "scopes": [],
-                        "codeSyntax": {}
-                    }
-                }
-            },
-            "focus": {
-                "$type": "color",
-                "$value": "{color.vann.800}",
-                "$description": "",
-                "$extensions": {
-                    "com.figma": {
-                        "hiddenFromPublishing": false,
-                        "scopes": [],
-                        "codeSyntax": {}
-                    }
-                }
+        "default": {
+          "$type": "color",
+          "$value": "{color.vann.350}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
             }
+          }
+        },
+        "medium": {
+          "$type": "color",
+          "$value": "{color.vann.500}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "strong": {
+          "$type": "color",
+          "$value": "{color.vann.600}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "stronger": {
+          "$type": "color",
+          "$value": "{color.vann.700}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "strongest": {
+          "$type": "color",
+          "$value": "{color.vann.800}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
         }
+      },
+      "secondary": {
+        "subtlest": {
+          "$type": "color",
+          "$value": "{color.frost.25}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "subtler": {
+          "$type": "color",
+          "$value": "{color.frost.50}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "subtle": {
+          "$type": "color",
+          "$value": "{color.frost.75}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "default": {
+          "$type": "color",
+          "$value": "{color.frost.150}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "medium": {
+          "$type": "color",
+          "$value": "{color.frost.250}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "strong": {
+          "$type": "color",
+          "$value": "{color.frost.350}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "stronger": {
+          "$type": "color",
+          "$value": "{color.frost.450}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "strongest": {
+          "$type": "color",
+          "$value": "{color.frost.550}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        }
+      },
+      "tertiary": {
+        "subtlest": {
+          "$type": "color",
+          "$value": "{color.syrin.25}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "subtler": {
+          "$type": "color",
+          "$value": "{color.syrin.50}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "subtle": {
+          "$type": "color",
+          "$value": "{color.syrin.75}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "default": {
+          "$type": "color",
+          "$value": "{color.syrin.150}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "medium": {
+          "$type": "color",
+          "$value": "{color.syrin.250}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "strong": {
+          "$type": "color",
+          "$value": "{color.syrin.450}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "stronger": {
+          "$type": "color",
+          "$value": "{color.syrin.550}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "strongest": {
+          "$type": "color",
+          "$value": "{color.syrin.650}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        }
+      },
+      "emphasis": {
+        "sublest": {
+          "$type": "color",
+          "$value": "{color.vann.50}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "subtler": {
+          "$type": "color",
+          "$value": "{color.vann.100}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "subtle": {
+          "$type": "color",
+          "$value": "{color.vann.200}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "default": {
+          "$type": "color",
+          "$value": "{color.vann.300}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "medium": {
+          "$type": "color",
+          "$value": "{color.vann.400}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "strong": {
+          "$type": "color",
+          "$value": "{color.vann.550}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "stronger": {
+          "$type": "color",
+          "$value": "{color.vann.650}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "strongest": {
+          "$type": "color",
+          "$value": "{color.vann.700}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        }
+      },
+      "subtle": {
+        "subtlest": {
+          "$type": "color",
+          "$value": "{color.sand.0}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "subtler": {
+          "$type": "color",
+          "$value": "{color.sand.25}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "subtle": {
+          "$type": "color",
+          "$value": "{color.sand.75}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "default": {
+          "$type": "color",
+          "$value": "{color.sand.150}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "medium": {
+          "$type": "color",
+          "$value": "{color.sand.300}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "strong": {
+          "$type": "color",
+          "$value": "{color.sand.450}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "stronger": {
+          "$type": "color",
+          "$value": "{color.sand.550}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "strongest": {
+          "$type": "color",
+          "$value": "{color.sand.650}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        }
+      }
     },
-    "accent": {
-        "brand": {
-            "primary": {
-                "subtlest": {
-                    "$type": "color",
-                    "$value": "{color.vann.600}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "subtler": {
-                    "$type": "color",
-                    "$value": "{color.vann.500}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "subtle": {
-                    "$type": "color",
-                    "$value": "{color.vann.400}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "default": {
-                    "$type": "color",
-                    "$value": "{color.vann.350}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "medium": {
-                    "$type": "color",
-                    "$value": "{color.vann.250}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "strong": {
-                    "$type": "color",
-                    "$value": "{color.vann.150}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "stronger": {
-                    "$type": "color",
-                    "$value": "{color.vann.75}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "strongest": {
-                    "$type": "color",
-                    "$value": "{color.vann.25}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                }
-            },
-            "secondary": {
-                "subtlest": {
-                    "$type": "color",
-                    "$value": "{color.frost.600}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "subtler": {
-                    "$type": "color",
-                    "$value": "{color.frost.500}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "subtle": {
-                    "$type": "color",
-                    "$value": "{color.frost.400}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "default": {
-                    "$type": "color",
-                    "$value": "{color.frost.300}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "medium": {
-                    "$type": "color",
-                    "$value": "{color.frost.200}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "strong": {
-                    "$type": "color",
-                    "$value": "{color.frost.100}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "stronger": {
-                    "$type": "color",
-                    "$value": "{color.frost.50}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "strongest": {
-                    "$type": "color",
-                    "$value": "{color.frost.25}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                }
-            },
-            "tertiary": {
-                "subtlest": {
-                    "$type": "color",
-                    "$value": "{color.syrin.600}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "subtler": {
-                    "$type": "color",
-                    "$value": "{color.syrin.500}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "subtle": {
-                    "$type": "color",
-                    "$value": "{color.syrin.400}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "default": {
-                    "$type": "color",
-                    "$value": "{color.syrin.300}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "medium": {
-                    "$type": "color",
-                    "$value": "{color.syrin.200}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "strong": {
-                    "$type": "color",
-                    "$value": "{color.syrin.100}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "stronger": {
-                    "$type": "color",
-                    "$value": "{color.syrin.50}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "strongest": {
-                    "$type": "color",
-                    "$value": "{color.syrin.25}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                }
-            },
-            "emphasis": {
-                "sublest": {
-                    "$type": "color",
-                    "$value": "{color.vann.500}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "subtler": {
-                    "$type": "color",
-                    "$value": "{color.vann.450}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "subtle": {
-                    "$type": "color",
-                    "$value": "{color.vann.350}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "default": {
-                    "$type": "color",
-                    "$value": "{color.vann.250}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "medium": {
-                    "$type": "color",
-                    "$value": "{color.vann.200}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "strong": {
-                    "$type": "color",
-                    "$value": "{color.vann.100}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "stronger": {
-                    "$type": "color",
-                    "$value": "{color.vann.75}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "strongest": {
-                    "$type": "color",
-                    "$value": "{color.vann.25}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                }
-            },
-            "subtle": {
-                "subtlest": {
-                    "$type": "color",
-                    "$value": "{color.sand.650}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "subtler": {
-                    "$type": "color",
-                    "$value": "{color.sand.550}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "subtle": {
-                    "$type": "color",
-                    "$value": "{color.sand.450}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "default": {
-                    "$type": "color",
-                    "$value": "{color.sand.350}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "medium": {
-                    "$type": "color",
-                    "$value": "{color.sand.250}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "strong": {
-                    "$type": "color",
-                    "$value": "{color.sand.150}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "stronger": {
-                    "$type": "color",
-                    "$value": "{color.sand.75}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "strongest": {
-                    "$type": "color",
-                    "$value": "{color.sand.25}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                }
+    "feedback": {
+      "info": {
+        "subtlest": {
+          "$type": "color",
+          "$value": "{color.frost.50}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
             }
+          }
         },
-        "feedback": {
-            "info": {
-                "subtlest": {
-                    "$type": "color",
-                    "$value": "{color.frost.600}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "subtler": {
-                    "$type": "color",
-                    "$value": "{color.frost.500}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "subtle": {
-                    "$type": "color",
-                    "$value": "{color.frost.400}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "default": {
-                    "$type": "color",
-                    "$value": "{color.frost.300}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "medium": {
-                    "$type": "color",
-                    "$value": "{color.frost.200}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "strong": {
-                    "$type": "color",
-                    "$value": "{color.frost.150}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "stronger": {
-                    "$type": "color",
-                    "$value": "{color.frost.50}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "strongest": {
-                    "$type": "color",
-                    "$value": "{color.frost.25}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                }
-            },
-            "success": {
-                "subtlest": {
-                    "$type": "color",
-                    "$value": "{color.skog.700}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "subtler": {
-                    "$type": "color",
-                    "$value": "{color.skog.600}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "subtle": {
-                    "$type": "color",
-                    "$value": "{color.skog.500}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "default": {
-                    "$type": "color",
-                    "$value": "{color.skog.450}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "medium": {
-                    "$type": "color",
-                    "$value": "{color.skog.400}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "strong": {
-                    "$type": "color",
-                    "$value": "{color.skog.200}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "stronger": {
-                    "$type": "color",
-                    "$value": "{color.skog.100}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "strongest": {
-                    "$type": "color",
-                    "$value": "{color.skog.50}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                }
-            },
-            "critical": {
-                "subtlest": {
-                    "$type": "color",
-                    "$value": "{color.bær.700}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "subtler": {
-                    "$type": "color",
-                    "$value": "{color.bær.600}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "subtle": {
-                    "$type": "color",
-                    "$value": "{color.bær.500}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "default": {
-                    "$type": "color",
-                    "$value": "{color.bær.400}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "medium": {
-                    "$type": "color",
-                    "$value": "{color.bær.300}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "strong": {
-                    "$type": "color",
-                    "$value": "{color.bær.200}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "stronger": {
-                    "$type": "color",
-                    "$value": "{color.bær.100}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "strongest": {
-                    "$type": "color",
-                    "$value": "{color.bær.50}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                }
-            },
-            "warning": {
-                "subtlest": {
-                    "$type": "color",
-                    "$value": "{color.sol.700}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "subtler": {
-                    "$type": "color",
-                    "$value": "{color.sol.600}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "subtle": {
-                    "$type": "color",
-                    "$value": "{color.sol.500}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "default": {
-                    "$type": "color",
-                    "$value": "{color.sol.400}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "medium": {
-                    "$type": "color",
-                    "$value": "{color.sol.300}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "strong": {
-                    "$type": "color",
-                    "$value": "{color.sol.200}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "stronger": {
-                    "$type": "color",
-                    "$value": "{color.sol.100}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "strongest": {
-                    "$type": "color",
-                    "$value": "{color.sol.50}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                }
-            },
-            "tip": {
-                "sublest": {
-                    "$type": "color",
-                    "$value": "{color.syrin.600}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "subtler": {
-                    "$type": "color",
-                    "$value": "{color.syrin.550}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "subtle": {
-                    "$type": "color",
-                    "$value": "{color.syrin.400}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "default": {
-                    "$type": "color",
-                    "$value": "{color.syrin.300}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "medium": {
-                    "$type": "color",
-                    "$value": "{color.syrin.200}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "strong": {
-                    "$type": "color",
-                    "$value": "{color.syrin.150}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "stronger": {
-                    "$type": "color",
-                    "$value": "{color.syrin.50}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "strongest": {
-                    "$type": "color",
-                    "$value": "{color.syrin.25}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                }
+        "subtler": {
+          "$type": "color",
+          "$value": "{color.frost.100}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
             }
+          }
         },
-        "neutral": {
-            "subtlest": {
-                "$type": "color",
-                "$value": "{color.vann.600}",
-                "$description": "",
-                "$extensions": {
-                    "com.figma": {
-                        "hiddenFromPublishing": false,
-                        "scopes": [],
-                        "codeSyntax": {}
-                    }
-                }
-            },
-            "subtler": {
-                "$type": "color",
-                "$value": "{color.vann.550}",
-                "$description": "",
-                "$extensions": {
-                    "com.figma": {
-                        "hiddenFromPublishing": false,
-                        "scopes": [],
-                        "codeSyntax": {}
-                    }
-                }
-            },
-            "subtle": {
-                "$type": "color",
-                "$value": "{color.vann.350}",
-                "$description": "",
-                "$extensions": {
-                    "com.figma": {
-                        "hiddenFromPublishing": false,
-                        "scopes": [],
-                        "codeSyntax": {}
-                    }
-                }
-            },
-            "default": {
-                "$type": "color",
-                "$value": "{color.vann.250}",
-                "$description": "",
-                "$extensions": {
-                    "com.figma": {
-                        "hiddenFromPublishing": false,
-                        "scopes": [],
-                        "codeSyntax": {}
-                    }
-                }
-            },
-            "medium": {
-                "$type": "color",
-                "$value": "{color.vann.150}",
-                "$description": "",
-                "$extensions": {
-                    "com.figma": {
-                        "hiddenFromPublishing": false,
-                        "scopes": [],
-                        "codeSyntax": {}
-                    }
-                }
-            },
-            "strong": {
-                "$type": "color",
-                "$value": "{color.vann.75}",
-                "$description": "",
-                "$extensions": {
-                    "com.figma": {
-                        "hiddenFromPublishing": false,
-                        "scopes": [],
-                        "codeSyntax": {}
-                    }
-                }
-            },
-            "stronger": {
-                "$type": "color",
-                "$value": "{color.vann.50}",
-                "$description": "",
-                "$extensions": {
-                    "com.figma": {
-                        "hiddenFromPublishing": false,
-                        "scopes": [],
-                        "codeSyntax": {}
-                    }
-                }
-            },
-            "strongest": {
-                "$type": "color",
-                "$value": "{color.alpha.white.100}",
-                "$description": "",
-                "$extensions": {
-                    "com.figma": {
-                        "hiddenFromPublishing": false,
-                        "scopes": [],
-                        "codeSyntax": {}
-                    }
-                }
-            },
-            "inverted": {
-                "$type": "color",
-                "$value": "{color.vann.1000}",
-                "$description": "",
-                "$extensions": {
-                    "com.figma": {
-                        "hiddenFromPublishing": false,
-                        "scopes": [],
-                        "codeSyntax": {}
-                    }
-                }
+        "subtle": {
+          "$type": "color",
+          "$value": "{color.frost.200}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
             }
+          }
         },
-        "interactive": {
-            "default": {
-                "$type": "color",
-                "$value": "{color.vann.450}",
-                "$description": "",
-                "$extensions": {
-                    "com.figma": {
-                        "hiddenFromPublishing": false,
-                        "scopes": [],
-                        "codeSyntax": {}
-                    }
-                }
-            },
-            "hover": {
-                "$type": "color",
-                "$value": "{color.vann.350}",
-                "$description": "",
-                "$extensions": {
-                    "com.figma": {
-                        "hiddenFromPublishing": false,
-                        "scopes": [],
-                        "codeSyntax": {}
-                    }
-                }
-            },
-            "pressed": {
-                "$type": "color",
-                "$value": "{color.vann.250}",
-                "$description": "",
-                "$extensions": {
-                    "com.figma": {
-                        "hiddenFromPublishing": false,
-                        "scopes": [],
-                        "codeSyntax": {}
-                    }
-                }
-            },
-            "focus": {
-                "$type": "color",
-                "$value": "{color.alpha.white.100}",
-                "$description": "",
-                "$extensions": {
-                    "com.figma": {
-                        "hiddenFromPublishing": false,
-                        "scopes": [],
-                        "codeSyntax": {}
-                    }
-                }
+        "default": {
+          "$type": "color",
+          "$value": "{color.frost.300}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
             }
+          }
+        },
+        "medium": {
+          "$type": "color",
+          "$value": "{color.frost.400}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "strong": {
+          "$type": "color",
+          "$value": "{color.frost.500}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "stronger": {
+          "$type": "color",
+          "$value": "{color.frost.600}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "strongest": {
+          "$type": "color",
+          "$value": "{color.frost.700}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
         }
+      },
+      "success": {
+        "subtlest": {
+          "$type": "color",
+          "$value": "{color.skog.50}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "subtler": {
+          "$type": "color",
+          "$value": "{color.skog.100}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "subtle": {
+          "$type": "color",
+          "$value": "{color.skog.200}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "default": {
+          "$type": "color",
+          "$value": "{color.skog.300}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "medium": {
+          "$type": "color",
+          "$value": "{color.skog.400}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "strong": {
+          "$type": "color",
+          "$value": "{color.skog.550}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "stronger": {
+          "$type": "color",
+          "$value": "{color.skog.650}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "strongest": {
+          "$type": "color",
+          "$value": "{color.skog.750}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        }
+      },
+      "warning": {
+        "subtlest": {
+          "$type": "color",
+          "$value": "{color.sol.50}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "subtler": {
+          "$type": "color",
+          "$value": "{color.sol.100}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "subtle": {
+          "$type": "color",
+          "$value": "{color.sol.200}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "default": {
+          "$type": "color",
+          "$value": "{color.sol.300}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "medium": {
+          "$type": "color",
+          "$value": "{color.sol.400}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "strong": {
+          "$type": "color",
+          "$value": "{color.sol.500}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "stronger": {
+          "$type": "color",
+          "$value": "{color.sol.600}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "strongest": {
+          "$type": "color",
+          "$value": "{color.sol.700}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        }
+      },
+      "critical": {
+        "subtlest": {
+          "$type": "color",
+          "$value": "{color.bær.50}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "subtler": {
+          "$type": "color",
+          "$value": "{color.bær.100}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "subtle": {
+          "$type": "color",
+          "$value": "{color.bær.200}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "default": {
+          "$type": "color",
+          "$value": "{color.bær.300}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "medium": {
+          "$type": "color",
+          "$value": "{color.bær.400}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "strong": {
+          "$type": "color",
+          "$value": "{color.bær.500}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "stronger": {
+          "$type": "color",
+          "$value": "{color.bær.600}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "strongest": {
+          "$type": "color",
+          "$value": "{color.bær.700}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        }
+      },
+      "tip": {
+        "sublest": {
+          "$type": "color",
+          "$value": "{color.syrin.50}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "subtler": {
+          "$type": "color",
+          "$value": "{color.syrin.100}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "subtle": {
+          "$type": "color",
+          "$value": "{color.syrin.200}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "default": {
+          "$type": "color",
+          "$value": "{color.syrin.300}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "medium": {
+          "$type": "color",
+          "$value": "{color.syrin.400}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "strong": {
+          "$type": "color",
+          "$value": "{color.syrin.500}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "strongest": {
+          "$type": "color",
+          "$value": "{color.syrin.700}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "stronger": {
+          "$type": "color",
+          "$value": "{color.syrin.600}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        }
+      }
     },
-    "speciality": {
-        "logo": {
-            "name": {
-                "$type": "color",
-                "$value": "{color.vann.800}",
-                "$description": "",
-                "$extensions": {
-                    "com.figma": {
-                        "hiddenFromPublishing": false,
-                        "scopes": [],
-                        "codeSyntax": {}
-                    }
-                }
-            }
-        },
-        "background": {
-            "default": {
-                "$type": "color",
-                "$value": "{color.alpha.white.100}",
-                "$description": "",
-                "$extensions": {
-                    "com.figma": {
-                        "hiddenFromPublishing": false,
-                        "scopes": [],
-                        "codeSyntax": {}
-                    }
-                }
-            },
-            "subtle": {
-                "$type": "color",
-                "$value": "{color.sand.0}",
-                "$description": "",
-                "$extensions": {
-                    "com.figma": {
-                        "hiddenFromPublishing": false,
-                        "scopes": [],
-                        "codeSyntax": {}
-                    }
-                }
-            },
-            "accent": {
-                "$type": "color",
-                "$value": "{color.vann.650}",
-                "$description": "",
-                "$extensions": {
-                    "com.figma": {
-                        "hiddenFromPublishing": false,
-                        "scopes": [],
-                        "codeSyntax": {}
-                    }
-                }
-            },
-            "accent-subtle": {
-                "$type": "color",
-                "$value": "{color.vann.850}",
-                "$description": "",
-                "$extensions": {
-                    "com.figma": {
-                        "hiddenFromPublishing": false,
-                        "scopes": [],
-                        "codeSyntax": {}
-                    }
-                }
-            },
-            "surface": {
-                "default": {
-                    "$type": "color",
-                    "$value": "{color.alpha.white.100}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "default-hover": {
-                    "$type": "color",
-                    "$value": "{color.vann.25}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "default-pressed": {
-                    "$type": "color",
-                    "$value": "{color.vann.50}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                }
-            },
-            "transparent": {
-                "$type": "color",
-                "$value": "{color.alpha.white.0}",
-                "$description": "",
-                "$extensions": {
-                    "com.figma": {
-                        "hiddenFromPublishing": false,
-                        "scopes": [],
-                        "codeSyntax": {}
-                    }
-                }
-            }
-        },
-        "static": {
-            "neutral": {
-                "white": {
-                    "$type": "color",
-                    "$value": "{color.alpha.white.100}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "light-gray": {
-                    "$type": "color",
-                    "$value": "{color.gray.50}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "gray": {
-                    "$type": "color",
-                    "$value": "{color.gray.350}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "dark-gray": {
-                    "$type": "color",
-                    "$value": "{color.gray.700}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "strongest": {
-                    "$type": "color",
-                    "$value": "{color.alpha.black.100}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                }
-            },
-            "accent": {
-                "subtle": {
-                    "$type": "color",
-                    "$value": "{color.vann.150}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "subtler": {
-                    "$type": "color",
-                    "$value": "{color.vann.75}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "subtlest": {
-                    "$type": "color",
-                    "$value": "{color.vann.25}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "default": {
-                    "$type": "color",
-                    "$value": "{color.alpha.white.100}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "medium": {
-                    "$type": "color",
-                    "$value": "{color.vann.500}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "strong": {
-                    "$type": "color",
-                    "$value": "{color.vann.600}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "stronger": {
-                    "$type": "color",
-                    "$value": "{color.vann.700}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "strongest": {
-                    "$type": "color",
-                    "$value": "{color.vann.800}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                }
-            }
+    "neutral": {
+      "subtlest": {
+        "$type": "color",
+        "$value": "{color.gray.25}",
+        "$description": "",
+        "$extensions": {
+          "com.figma": {
+            "hiddenFromPublishing": false,
+            "scopes": [],
+            "codeSyntax": {}
+          }
         }
+      },
+      "subtler": {
+        "$type": "color",
+        "$value": "{color.gray.50}",
+        "$description": "",
+        "$extensions": {
+          "com.figma": {
+            "hiddenFromPublishing": false,
+            "scopes": [],
+            "codeSyntax": {}
+          }
+        }
+      },
+      "subtle": {
+        "$type": "color",
+        "$value": "{color.gray.100}",
+        "$description": "",
+        "$extensions": {
+          "com.figma": {
+            "hiddenFromPublishing": false,
+            "scopes": [],
+            "codeSyntax": {}
+          }
+        }
+      },
+      "default": {
+        "$type": "color",
+        "$value": "{color.gray.150}",
+        "$description": "",
+        "$extensions": {
+          "com.figma": {
+            "hiddenFromPublishing": false,
+            "scopes": [],
+            "codeSyntax": {}
+          }
+        }
+      },
+      "medium": {
+        "$type": "color",
+        "$value": "{color.gray.300}",
+        "$description": "",
+        "$extensions": {
+          "com.figma": {
+            "hiddenFromPublishing": false,
+            "scopes": [],
+            "codeSyntax": {}
+          }
+        }
+      },
+      "strong": {
+        "$type": "color",
+        "$value": "{color.gray.400}",
+        "$description": "",
+        "$extensions": {
+          "com.figma": {
+            "hiddenFromPublishing": false,
+            "scopes": [],
+            "codeSyntax": {}
+          }
+        }
+      },
+      "stronger": {
+        "$type": "color",
+        "$value": "{color.gray.750}",
+        "$description": "",
+        "$extensions": {
+          "com.figma": {
+            "hiddenFromPublishing": false,
+            "scopes": [],
+            "codeSyntax": {}
+          }
+        }
+      },
+      "strongest": {
+        "$type": "color",
+        "$value": "{color.gray.950}",
+        "$description": "",
+        "$extensions": {
+          "com.figma": {
+            "hiddenFromPublishing": false,
+            "scopes": [],
+            "codeSyntax": {}
+          }
+        }
+      },
+      "inverted": {
+        "$type": "color",
+        "$value": "{color.alpha.white.1000}",
+        "$description": "",
+        "$extensions": {
+          "com.figma": {
+            "hiddenFromPublishing": false,
+            "scopes": [],
+            "codeSyntax": {}
+          }
+        }
+      },
+      "alpha": {
+        "subtlest": {
+          "$type": "color",
+          "$value": "{color.alpha.black.25}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "subtler": {
+          "$type": "color",
+          "$value": "{color.alpha.black.50}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "subtle": {
+          "$type": "color",
+          "$value": "{color.alpha.black.75}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "default": {
+          "$type": "color",
+          "$value": "{color.alpha.black.100}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "medium": {
+          "$type": "color",
+          "$value": "{color.alpha.black.200}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "strong": {
+          "$type": "color",
+          "$value": "{color.alpha.black.300}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "stronger": {
+          "$type": "color",
+          "$value": "{color.alpha.black.400}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "strongest": {
+          "$type": "color",
+          "$value": "{color.alpha.black.500}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        }
+      }
+    },
+    "interactive": {
+      "default": {
+        "$type": "color",
+        "$value": "{color.vann.600}",
+        "$description": "",
+        "$extensions": {
+          "com.figma": {
+            "hiddenFromPublishing": false,
+            "scopes": [],
+            "codeSyntax": {}
+          }
+        }
+      },
+      "hover": {
+        "$type": "color",
+        "$value": "{color.vann.700}",
+        "$description": "",
+        "$extensions": {
+          "com.figma": {
+            "hiddenFromPublishing": false,
+            "scopes": [],
+            "codeSyntax": {}
+          }
+        }
+      },
+      "pressed": {
+        "$type": "color",
+        "$value": "{color.vann.800}",
+        "$description": "",
+        "$extensions": {
+          "com.figma": {
+            "hiddenFromPublishing": false,
+            "scopes": [],
+            "codeSyntax": {}
+          }
+        }
+      },
+      "focus": {
+        "$type": "color",
+        "$value": "{color.vann.800}",
+        "$description": "",
+        "$extensions": {
+          "com.figma": {
+            "hiddenFromPublishing": false,
+            "scopes": [],
+            "codeSyntax": {}
+          }
+        }
+      },
+      "selected": {
+        "default": {
+          "$type": "color",
+          "$value": "{color.vann.600}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "hover": {
+          "$type": "color",
+          "$value": "{color.vann.700}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "pressed": {
+          "$type": "color",
+          "$value": "{color.vann.800}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        }
+      }
     }
+  },
+  "accent": {
+    "brand": {
+      "primary": {
+        "subtlest": {
+          "$type": "color",
+          "$value": "{color.vann.700}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "subtler": {
+          "$type": "color",
+          "$value": "{color.vann.600}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "subtle": {
+          "$type": "color",
+          "$value": "{color.vann.500}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "default": {
+          "$type": "color",
+          "$value": "{color.vann.400}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "medium": {
+          "$type": "color",
+          "$value": "{color.vann.300}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "strong": {
+          "$type": "color",
+          "$value": "{color.vann.200}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "stronger": {
+          "$type": "color",
+          "$value": "{color.vann.100}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "strongest": {
+          "$type": "color",
+          "$value": "{color.vann.50}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        }
+      },
+      "secondary": {
+        "subtlest": {
+          "$type": "color",
+          "$value": "{color.frost.700}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "subtler": {
+          "$type": "color",
+          "$value": "{color.frost.650}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "subtle": {
+          "$type": "color",
+          "$value": "{color.frost.600}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "default": {
+          "$type": "color",
+          "$value": "{color.frost.550}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "medium": {
+          "$type": "color",
+          "$value": "{color.frost.500}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "strong": {
+          "$type": "color",
+          "$value": "{color.frost.100}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "stronger": {
+          "$type": "color",
+          "$value": "{color.frost.50}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "strongest": {
+          "$type": "color",
+          "$value": "{color.frost.25}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        }
+      },
+      "tertiary": {
+        "subtlest": {
+          "$type": "color",
+          "$value": "{color.syrin.750}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "subtler": {
+          "$type": "color",
+          "$value": "{color.syrin.700}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "subtle": {
+          "$type": "color",
+          "$value": "{color.syrin.650}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "default": {
+          "$type": "color",
+          "$value": "{color.syrin.600}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "medium": {
+          "$type": "color",
+          "$value": "{color.syrin.550}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "strong": {
+          "$type": "color",
+          "$value": "{color.syrin.150}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "stronger": {
+          "$type": "color",
+          "$value": "{color.syrin.50}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "strongest": {
+          "$type": "color",
+          "$value": "{color.syrin.25}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        }
+      },
+      "emphasis": {
+        "sublest": {
+          "$type": "color",
+          "$value": "{color.vann.500}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "subtler": {
+          "$type": "color",
+          "$value": "{color.vann.450}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "subtle": {
+          "$type": "color",
+          "$value": "{color.vann.350}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "default": {
+          "$type": "color",
+          "$value": "{color.vann.250}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "medium": {
+          "$type": "color",
+          "$value": "{color.vann.200}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "strong": {
+          "$type": "color",
+          "$value": "{color.vann.100}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "stronger": {
+          "$type": "color",
+          "$value": "{color.vann.75}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "strongest": {
+          "$type": "color",
+          "$value": "{color.vann.25}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        }
+      },
+      "subtle": {
+        "subtlest": {
+          "$type": "color",
+          "$value": "{color.sand.650}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "subtler": {
+          "$type": "color",
+          "$value": "{color.sand.550}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "subtle": {
+          "$type": "color",
+          "$value": "{color.sand.450}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "default": {
+          "$type": "color",
+          "$value": "{color.sand.350}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "medium": {
+          "$type": "color",
+          "$value": "{color.sand.250}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "strong": {
+          "$type": "color",
+          "$value": "{color.sand.150}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "stronger": {
+          "$type": "color",
+          "$value": "{color.sand.75}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "strongest": {
+          "$type": "color",
+          "$value": "{color.sand.25}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        }
+      }
+    },
+    "feedback": {
+      "info": {
+        "subtlest": {
+          "$type": "color",
+          "$value": "{color.frost.600}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "subtler": {
+          "$type": "color",
+          "$value": "{color.frost.500}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "subtle": {
+          "$type": "color",
+          "$value": "{color.frost.400}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "default": {
+          "$type": "color",
+          "$value": "{color.frost.300}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "medium": {
+          "$type": "color",
+          "$value": "{color.frost.200}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "strong": {
+          "$type": "color",
+          "$value": "{color.frost.150}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "stronger": {
+          "$type": "color",
+          "$value": "{color.frost.50}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "strongest": {
+          "$type": "color",
+          "$value": "{color.frost.25}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        }
+      },
+      "success": {
+        "subtlest": {
+          "$type": "color",
+          "$value": "{color.skog.700}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "subtler": {
+          "$type": "color",
+          "$value": "{color.skog.600}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "subtle": {
+          "$type": "color",
+          "$value": "{color.skog.550}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "default": {
+          "$type": "color",
+          "$value": "{color.skog.450}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "medium": {
+          "$type": "color",
+          "$value": "{color.skog.400}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "strong": {
+          "$type": "color",
+          "$value": "{color.skog.200}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "stronger": {
+          "$type": "color",
+          "$value": "{color.skog.100}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "strongest": {
+          "$type": "color",
+          "$value": "{color.skog.50}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        }
+      },
+      "critical": {
+        "subtlest": {
+          "$type": "color",
+          "$value": "{color.bær.700}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "subtler": {
+          "$type": "color",
+          "$value": "{color.bær.600}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "subtle": {
+          "$type": "color",
+          "$value": "{color.bær.500}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "default": {
+          "$type": "color",
+          "$value": "{color.bær.400}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "medium": {
+          "$type": "color",
+          "$value": "{color.bær.300}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "strong": {
+          "$type": "color",
+          "$value": "{color.bær.200}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "stronger": {
+          "$type": "color",
+          "$value": "{color.bær.100}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "strongest": {
+          "$type": "color",
+          "$value": "{color.bær.50}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        }
+      },
+      "warning": {
+        "subtlest": {
+          "$type": "color",
+          "$value": "{color.sol.700}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "subtler": {
+          "$type": "color",
+          "$value": "{color.sol.600}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "subtle": {
+          "$type": "color",
+          "$value": "{color.sol.500}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "default": {
+          "$type": "color",
+          "$value": "{color.sol.400}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "medium": {
+          "$type": "color",
+          "$value": "{color.sol.300}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "strong": {
+          "$type": "color",
+          "$value": "{color.sol.200}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "stronger": {
+          "$type": "color",
+          "$value": "{color.sol.100}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "strongest": {
+          "$type": "color",
+          "$value": "{color.sol.50}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        }
+      },
+      "tip": {
+        "sublest": {
+          "$type": "color",
+          "$value": "{color.syrin.600}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "subtler": {
+          "$type": "color",
+          "$value": "{color.syrin.550}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "subtle": {
+          "$type": "color",
+          "$value": "{color.syrin.400}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "default": {
+          "$type": "color",
+          "$value": "{color.syrin.300}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "medium": {
+          "$type": "color",
+          "$value": "{color.syrin.200}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "strong": {
+          "$type": "color",
+          "$value": "{color.syrin.150}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "stronger": {
+          "$type": "color",
+          "$value": "{color.syrin.50}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "strongest": {
+          "$type": "color",
+          "$value": "{color.syrin.25}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        }
+      }
+    },
+    "neutral": {
+      "subtlest": {
+        "$type": "color",
+        "$value": "{color.alpha.white.50}",
+        "$description": "",
+        "$extensions": {
+          "com.figma": {
+            "hiddenFromPublishing": false,
+            "scopes": [],
+            "codeSyntax": {}
+          }
+        }
+      },
+      "alpha": {
+        "subtlest": {
+          "$type": "color",
+          "$value": "{color.alpha.white.25}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "subtler": {
+          "$type": "color",
+          "$value": "{color.alpha.white.50}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "subtle": {
+          "$type": "color",
+          "$value": "{color.alpha.white.75}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "default": {
+          "$type": "color",
+          "$value": "{color.alpha.white.100}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "medium": {
+          "$type": "color",
+          "$value": "{color.alpha.white.200}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "strong": {
+          "$type": "color",
+          "$value": "{color.alpha.white.300}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "stronger": {
+          "$type": "color",
+          "$value": "{color.alpha.white.400}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "strongest": {
+          "$type": "color",
+          "$value": "{color.alpha.white.500}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        }
+      },
+      "subtler": {
+        "$type": "color",
+        "$value": "{color.alpha.white.100}",
+        "$description": "",
+        "$extensions": {
+          "com.figma": {
+            "hiddenFromPublishing": false,
+            "scopes": [],
+            "codeSyntax": {}
+          }
+        }
+      },
+      "subtle": {
+        "$type": "color",
+        "$value": "{color.alpha.white.200}",
+        "$description": "",
+        "$extensions": {
+          "com.figma": {
+            "hiddenFromPublishing": false,
+            "scopes": [],
+            "codeSyntax": {}
+          }
+        }
+      },
+      "default": {
+        "$type": "color",
+        "$value": "{color.alpha.white.300}",
+        "$description": "",
+        "$extensions": {
+          "com.figma": {
+            "hiddenFromPublishing": false,
+            "scopes": [],
+            "codeSyntax": {}
+          }
+        }
+      },
+      "medium": {
+        "$type": "color",
+        "$value": "{color.alpha.white.400}",
+        "$description": "",
+        "$extensions": {
+          "com.figma": {
+            "hiddenFromPublishing": false,
+            "scopes": [],
+            "codeSyntax": {}
+          }
+        }
+      },
+      "strong": {
+        "$type": "color",
+        "$value": "{color.alpha.white.500}",
+        "$description": "",
+        "$extensions": {
+          "com.figma": {
+            "hiddenFromPublishing": false,
+            "scopes": [],
+            "codeSyntax": {}
+          }
+        }
+      },
+      "stronger": {
+        "$type": "color",
+        "$value": "{color.alpha.white.800}",
+        "$description": "",
+        "$extensions": {
+          "com.figma": {
+            "hiddenFromPublishing": false,
+            "scopes": [],
+            "codeSyntax": {}
+          }
+        }
+      },
+      "strongest": {
+        "$type": "color",
+        "$value": "{color.alpha.white.1000}",
+        "$description": "",
+        "$extensions": {
+          "com.figma": {
+            "hiddenFromPublishing": false,
+            "scopes": [],
+            "codeSyntax": {}
+          }
+        }
+      },
+      "inverted": {
+        "$type": "color",
+        "$value": "{color.vann.1000}",
+        "$description": "",
+        "$extensions": {
+          "com.figma": {
+            "hiddenFromPublishing": false,
+            "scopes": [],
+            "codeSyntax": {}
+          }
+        }
+      }
+    },
+    "interactive": {
+      "default": {
+        "$type": "color",
+        "$value": "{color.vann.0}",
+        "$description": "",
+        "$extensions": {
+          "com.figma": {
+            "hiddenFromPublishing": false,
+            "scopes": [],
+            "codeSyntax": {}
+          }
+        }
+      },
+      "hover": {
+        "$type": "color",
+        "$value": "{color.vann.25}",
+        "$description": "",
+        "$extensions": {
+          "com.figma": {
+            "hiddenFromPublishing": false,
+            "scopes": [],
+            "codeSyntax": {}
+          }
+        }
+      },
+      "pressed": {
+        "$type": "color",
+        "$value": "{color.vann.50}",
+        "$description": "",
+        "$extensions": {
+          "com.figma": {
+            "hiddenFromPublishing": false,
+            "scopes": [],
+            "codeSyntax": {}
+          }
+        }
+      },
+      "focus": {
+        "$type": "color",
+        "$value": "{color.alpha.white.1000}",
+        "$description": "",
+        "$extensions": {
+          "com.figma": {
+            "hiddenFromPublishing": false,
+            "scopes": [],
+            "codeSyntax": {}
+          }
+        }
+      },
+      "selected": {
+        "default": {
+          "$type": "color",
+          "$value": "{color.alpha.white.1000}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "hover": {
+          "$type": "color",
+          "$value": "{color.vann.50}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "pressed": {
+          "$type": "color",
+          "$value": "{color.vann.100}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        }
+      }
+    }
+  },
+  "speciality": {
+    "logo": {
+      "name": {
+        "$type": "color",
+        "$value": "{color.vann.800}",
+        "$description": "",
+        "$extensions": {
+          "com.figma": {
+            "hiddenFromPublishing": false,
+            "scopes": [],
+            "codeSyntax": {}
+          }
+        }
+      }
+    },
+    "background": {
+      "default": {
+        "$type": "color",
+        "$value": "{color.alpha.white.1000}",
+        "$description": "",
+        "$extensions": {
+          "com.figma": {
+            "hiddenFromPublishing": false,
+            "scopes": [],
+            "codeSyntax": {}
+          }
+        }
+      },
+      "subtle": {
+        "$type": "color",
+        "$value": "{color.sand.25}",
+        "$description": "",
+        "$extensions": {
+          "com.figma": {
+            "hiddenFromPublishing": false,
+            "scopes": [],
+            "codeSyntax": {}
+          }
+        }
+      },
+      "accent": {
+        "$type": "color",
+        "$value": "{color.vann.650}",
+        "$description": "",
+        "$extensions": {
+          "com.figma": {
+            "hiddenFromPublishing": false,
+            "scopes": [],
+            "codeSyntax": {}
+          }
+        }
+      },
+      "accent-subtle": {
+        "$type": "color",
+        "$value": "{color.vann.700}",
+        "$description": "",
+        "$extensions": {
+          "com.figma": {
+            "hiddenFromPublishing": false,
+            "scopes": [],
+            "codeSyntax": {}
+          }
+        }
+      },
+      "transparent": {
+        "$type": "color",
+        "$value": "{color.alpha.white.0}",
+        "$description": "",
+        "$extensions": {
+          "com.figma": {
+            "hiddenFromPublishing": false,
+            "scopes": [],
+            "codeSyntax": {}
+          }
+        }
+      },
+      "surface": {
+        "primary": {
+          "default": {
+            "$type": "color",
+            "$value": "{color.alpha.white.1000}",
+            "$description": "",
+            "$extensions": {
+              "com.figma": {
+                "hiddenFromPublishing": false,
+                "scopes": [],
+                "codeSyntax": {}
+              }
+            }
+          },
+          "default-hover": {
+            "$type": "color",
+            "$value": "{color.gray.25}",
+            "$description": "",
+            "$extensions": {
+              "com.figma": {
+                "hiddenFromPublishing": false,
+                "scopes": [],
+                "codeSyntax": {}
+              }
+            }
+          },
+          "default-pressed": {
+            "$type": "color",
+            "$value": "{color.gray.50}",
+            "$description": "",
+            "$extensions": {
+              "com.figma": {
+                "hiddenFromPublishing": false,
+                "scopes": [],
+                "codeSyntax": {}
+              }
+            }
+          }
+        },
+        "secondary": {
+          "default": {
+            "$type": "color",
+            "$value": "{color.frost.25}",
+            "$description": "",
+            "$extensions": {
+              "com.figma": {
+                "hiddenFromPublishing": false,
+                "scopes": [],
+                "codeSyntax": {}
+              }
+            }
+          },
+          "default-hover": {
+            "$type": "color",
+            "$value": "{color.frost.50}",
+            "$description": "",
+            "$extensions": {
+              "com.figma": {
+                "hiddenFromPublishing": false,
+                "scopes": [],
+                "codeSyntax": {}
+              }
+            }
+          },
+          "default-pressed": {
+            "$type": "color",
+            "$value": "{color.frost.75}",
+            "$description": "",
+            "$extensions": {
+              "com.figma": {
+                "hiddenFromPublishing": false,
+                "scopes": [],
+                "codeSyntax": {}
+              }
+            }
+          }
+        },
+        "tertiary": {
+          "default": {
+            "$type": "color",
+            "$value": "{color.syrin.25}",
+            "$description": "",
+            "$extensions": {
+              "com.figma": {
+                "hiddenFromPublishing": false,
+                "scopes": [],
+                "codeSyntax": {}
+              }
+            }
+          },
+          "default-hover": {
+            "$type": "color",
+            "$value": "{color.syrin.50}",
+            "$description": "",
+            "$extensions": {
+              "com.figma": {
+                "hiddenFromPublishing": false,
+                "scopes": [],
+                "codeSyntax": {}
+              }
+            }
+          },
+          "default-pressed": {
+            "$type": "color",
+            "$value": "{color.syrin.75}",
+            "$description": "",
+            "$extensions": {
+              "com.figma": {
+                "hiddenFromPublishing": false,
+                "scopes": [],
+                "codeSyntax": {}
+              }
+            }
+          }
+        },
+        "accent": {
+          "accent": {
+            "$type": "color",
+            "$value": "{color.vann.600}",
+            "$description": "",
+            "$extensions": {
+              "com.figma": {
+                "hiddenFromPublishing": false,
+                "scopes": [],
+                "codeSyntax": {}
+              }
+            }
+          },
+          "accent-hover": {
+            "$type": "color",
+            "$value": "{color.vann.500}",
+            "$description": "",
+            "$extensions": {
+              "com.figma": {
+                "hiddenFromPublishing": false,
+                "scopes": [],
+                "codeSyntax": {}
+              }
+            }
+          },
+          "accent-pressed": {
+            "$type": "color",
+            "$value": "{color.vann.400}",
+            "$description": "",
+            "$extensions": {
+              "com.figma": {
+                "hiddenFromPublishing": false,
+                "scopes": [],
+                "codeSyntax": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "buttons": {
+      "primary": {
+        "default": {
+          "fill": {
+            "default": {
+              "$type": "color",
+              "$value": "{color.vann.600}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": [],
+                  "codeSyntax": {}
+                }
+              }
+            },
+            "hover": {
+              "$type": "color",
+              "$value": "{color.vann.700}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": [],
+                  "codeSyntax": {}
+                }
+              }
+            },
+            "pressed": {
+              "$type": "color",
+              "$value": "{color.vann.800}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": [],
+                  "codeSyntax": {}
+                }
+              }
+            }
+          }
+        },
+        "accent": {
+          "fill": {
+            "default": {
+              "$type": "color",
+              "$value": "{color.vann.25}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": [],
+                  "codeSyntax": {}
+                }
+              }
+            },
+            "hover": {
+              "$type": "color",
+              "$value": "{color.vann.75}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": [],
+                  "codeSyntax": {}
+                }
+              }
+            },
+            "pressed": {
+              "$type": "color",
+              "$value": "{color.vann.100}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": [],
+                  "codeSyntax": {}
+                }
+              }
+            }
+          },
+          "foreground": {
+            "default": {
+              "$type": "color",
+              "$value": "{color.vann.850}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": [],
+                  "codeSyntax": {}
+                }
+              }
+            }
+          }
+        }
+      },
+      "secondary": {
+        "default": {
+          "border": {
+            "default": {
+              "$type": "color",
+              "$value": "{color.vann.600}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": [],
+                  "codeSyntax": {}
+                }
+              }
+            }
+          },
+          "fill": {
+            "default": {
+              "$type": "color",
+              "$value": "{color.alpha.white.0}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": [],
+                  "codeSyntax": {}
+                }
+              }
+            },
+            "hover": {
+              "$type": "color",
+              "$value": "{color.alpha.water.100}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": [],
+                  "codeSyntax": {}
+                }
+              }
+            },
+            "pressed": {
+              "$type": "color",
+              "$value": "{color.alpha.water.200}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": [],
+                  "codeSyntax": {}
+                }
+              }
+            }
+          },
+          "foreground": {
+            "default": {
+              "$type": "color",
+              "$value": "{color.vann.700}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": [],
+                  "codeSyntax": {}
+                }
+              }
+            }
+          }
+        },
+        "accent": {
+          "border": {
+            "default": {
+              "$type": "color",
+              "$value": "{color.alpha.white.1000}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": [],
+                  "codeSyntax": {}
+                }
+              }
+            }
+          },
+          "fill": {
+            "default": {
+              "$type": "color",
+              "$value": "{color.alpha.white.0}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": [],
+                  "codeSyntax": {}
+                }
+              }
+            },
+            "hover": {
+              "$type": "color",
+              "$value": "{color.alpha.white.100}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": [],
+                  "codeSyntax": {}
+                }
+              }
+            },
+            "pressed": {
+              "$type": "color",
+              "$value": "{color.alpha.white.200}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": [],
+                  "codeSyntax": {}
+                }
+              }
+            }
+          },
+          "foreground": {
+            "default": {
+              "$type": "color",
+              "$value": "{color.alpha.white.1000}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": [],
+                  "codeSyntax": {}
+                }
+              }
+            }
+          }
+        }
+      },
+      "tertiary": {
+        "default": {
+          "fill": {
+            "default": {
+              "$type": "color",
+              "$value": "{color.alpha.white.0}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": [],
+                  "codeSyntax": {}
+                }
+              }
+            },
+            "hover": {
+              "$type": "color",
+              "$value": "{color.alpha.water.100}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": [],
+                  "codeSyntax": {}
+                }
+              }
+            },
+            "pressed": {
+              "$type": "color",
+              "$value": "{color.alpha.water.200}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": [],
+                  "codeSyntax": {}
+                }
+              }
+            }
+          },
+          "foreground": {
+            "default": {
+              "$type": "color",
+              "$value": "{color.vann.700}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": [],
+                  "codeSyntax": {}
+                }
+              }
+            }
+          }
+        },
+        "accent": {
+          "fill": {
+            "default": {
+              "$type": "color",
+              "$value": "{color.alpha.white.0}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": [],
+                  "codeSyntax": {}
+                }
+              }
+            },
+            "hover": {
+              "$type": "color",
+              "$value": "{color.alpha.white.100}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": [],
+                  "codeSyntax": {}
+                }
+              }
+            },
+            "pressed": {
+              "$type": "color",
+              "$value": "{color.alpha.white.200}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": [],
+                  "codeSyntax": {}
+                }
+              }
+            }
+          },
+          "foreground": {
+            "default": {
+              "$type": "color",
+              "$value": "{color.alpha.white.1000}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": [],
+                  "codeSyntax": {}
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "static": {
+      "alpha": {
+        "white": {
+          "subtlest": {
+            "$type": "color",
+            "$value": "{color.alpha.white.50}",
+            "$description": "",
+            "$extensions": {
+              "com.figma": {
+                "hiddenFromPublishing": false,
+                "scopes": [],
+                "codeSyntax": {}
+              }
+            }
+          },
+          "subtler": {
+            "$type": "color",
+            "$value": "{color.alpha.white.100}",
+            "$description": "",
+            "$extensions": {
+              "com.figma": {
+                "hiddenFromPublishing": false,
+                "scopes": [],
+                "codeSyntax": {}
+              }
+            }
+          },
+          "subtle": {
+            "$type": "color",
+            "$value": "{color.alpha.white.150}",
+            "$description": "",
+            "$extensions": {
+              "com.figma": {
+                "hiddenFromPublishing": false,
+                "scopes": [],
+                "codeSyntax": {}
+              }
+            }
+          },
+          "default": {
+            "$type": "color",
+            "$value": "{color.alpha.white.200}",
+            "$description": "",
+            "$extensions": {
+              "com.figma": {
+                "hiddenFromPublishing": false,
+                "scopes": [],
+                "codeSyntax": {}
+              }
+            }
+          },
+          "medium": {
+            "$type": "color",
+            "$value": "{color.alpha.white.400}",
+            "$description": "",
+            "$extensions": {
+              "com.figma": {
+                "hiddenFromPublishing": false,
+                "scopes": [],
+                "codeSyntax": {}
+              }
+            }
+          },
+          "strong": {
+            "$type": "color",
+            "$value": "{color.alpha.white.600}",
+            "$description": "",
+            "$extensions": {
+              "com.figma": {
+                "hiddenFromPublishing": false,
+                "scopes": [],
+                "codeSyntax": {}
+              }
+            }
+          },
+          "stronger": {
+            "$type": "color",
+            "$value": "{color.alpha.white.700}",
+            "$description": "",
+            "$extensions": {
+              "com.figma": {
+                "hiddenFromPublishing": false,
+                "scopes": [],
+                "codeSyntax": {}
+              }
+            }
+          },
+          "strongest": {
+            "$type": "color",
+            "$value": "{color.alpha.white.800}",
+            "$description": "",
+            "$extensions": {
+              "com.figma": {
+                "hiddenFromPublishing": false,
+                "scopes": [],
+                "codeSyntax": {}
+              }
+            }
+          }
+        },
+        "black": {
+          "subtlest": {
+            "$type": "color",
+            "$value": "{color.alpha.black.50}",
+            "$description": "",
+            "$extensions": {
+              "com.figma": {
+                "hiddenFromPublishing": false,
+                "scopes": [],
+                "codeSyntax": {}
+              }
+            }
+          },
+          "subtler": {
+            "$type": "color",
+            "$value": "{color.alpha.black.100}",
+            "$description": "",
+            "$extensions": {
+              "com.figma": {
+                "hiddenFromPublishing": false,
+                "scopes": [],
+                "codeSyntax": {}
+              }
+            }
+          },
+          "subtle": {
+            "$type": "color",
+            "$value": "{color.alpha.black.150}",
+            "$description": "",
+            "$extensions": {
+              "com.figma": {
+                "hiddenFromPublishing": false,
+                "scopes": [],
+                "codeSyntax": {}
+              }
+            }
+          },
+          "default": {
+            "$type": "color",
+            "$value": "{color.alpha.black.200}",
+            "$description": "",
+            "$extensions": {
+              "com.figma": {
+                "hiddenFromPublishing": false,
+                "scopes": [],
+                "codeSyntax": {}
+              }
+            }
+          },
+          "medium": {
+            "$type": "color",
+            "$value": "{color.alpha.black.400}",
+            "$description": "",
+            "$extensions": {
+              "com.figma": {
+                "hiddenFromPublishing": false,
+                "scopes": [],
+                "codeSyntax": {}
+              }
+            }
+          },
+          "strong": {
+            "$type": "color",
+            "$value": "{color.alpha.black.600}",
+            "$description": "",
+            "$extensions": {
+              "com.figma": {
+                "hiddenFromPublishing": false,
+                "scopes": [],
+                "codeSyntax": {}
+              }
+            }
+          },
+          "stronger": {
+            "$type": "color",
+            "$value": "{color.alpha.black.700}",
+            "$description": "",
+            "$extensions": {
+              "com.figma": {
+                "hiddenFromPublishing": false,
+                "scopes": [],
+                "codeSyntax": {}
+              }
+            }
+          },
+          "strongest": {
+            "$type": "color",
+            "$value": "{color.alpha.black.800}",
+            "$description": "",
+            "$extensions": {
+              "com.figma": {
+                "hiddenFromPublishing": false,
+                "scopes": [],
+                "codeSyntax": {}
+              }
+            }
+          }
+        }
+      },
+      "accent": {
+        "subtlest": {
+          "$type": "color",
+          "$value": "{color.vann.25}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "subtler": {
+          "$type": "color",
+          "$value": "{color.vann.75}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "subtle": {
+          "$type": "color",
+          "$value": "{color.vann.150}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "default": {
+          "$type": "color",
+          "$value": "{color.vann.350}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "medium": {
+          "$type": "color",
+          "$value": "{color.vann.500}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "strong": {
+          "$type": "color",
+          "$value": "{color.vann.600}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "stronger": {
+          "$type": "color",
+          "$value": "{color.vann.700}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "strongest": {
+          "$type": "color",
+          "$value": "{color.vann.800}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        }
+      },
+      "neutral": {
+        "white": {
+          "$type": "color",
+          "$value": "{color.alpha.white.1000}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "subtlest": {
+          "$type": "color",
+          "$value": "{color.gray.50}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "subtler": {
+          "$type": "color",
+          "$value": "{color.gray.100}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "subtle": {
+          "$type": "color",
+          "$value": "{color.gray.150}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "default": {
+          "$type": "color",
+          "$value": "{color.gray.300}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "medium": {
+          "$type": "color",
+          "$value": "{color.gray.400}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "strong": {
+          "$type": "color",
+          "$value": "{color.gray.700}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "stronger": {
+          "$type": "color",
+          "$value": "{color.gray.800}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "strongest": {
+          "$type": "color",
+          "$value": "{color.alpha.black.1000}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        }
+      }
+    }
+  }
 }

--- a/packages/ffe-core/tokens/03 Context.Accent.json
+++ b/packages/ffe-core/tokens/03 Context.Accent.json
@@ -1,1578 +1,1995 @@
 {
-    "color": {
-        "background": {
-            "default": {
-                "$type": "color",
-                "$value": "{speciality.background.accent}",
-                "$description": "",
-                "$extensions": {
-                    "com.figma": {
-                        "hiddenFromPublishing": false,
-                        "scopes": ["FRAME_FILL", "SHAPE_FILL"],
-                        "codeSyntax": {}
-                    }
-                }
-            },
-            "subtle": {
-                "$type": "color",
-                "$value": "{speciality.background.accent-subtle}",
-                "$description": "",
-                "$extensions": {
-                    "com.figma": {
-                        "hiddenFromPublishing": false,
-                        "scopes": ["FRAME_FILL", "SHAPE_FILL"],
-                        "codeSyntax": {}
-                    }
-                }
+  "color": {
+    "background": {
+      "default": {
+        "$type": "color",
+        "$value": "{speciality.background.accent}",
+        "$description": "",
+        "$extensions": {
+          "com.figma": {
+            "hiddenFromPublishing": false,
+            "scopes": [
+              "FRAME_FILL",
+              "SHAPE_FILL"
+            ],
+            "codeSyntax": {
+              "WEB": "--ffe-color-background-default"
             }
+          }
+        }
+      },
+      "subtle": {
+        "$type": "color",
+        "$value": "{speciality.background.accent-subtle}",
+        "$description": "",
+        "$extensions": {
+          "com.figma": {
+            "hiddenFromPublishing": false,
+            "scopes": [
+              "FRAME_FILL",
+              "SHAPE_FILL"
+            ],
+            "codeSyntax": {
+              "WEB": "--ffe-color-background-subtle"
+            }
+          }
+        }
+      }
+    },
+    "surface": {
+      "primary": {
+        "default": {
+          "$type": "color",
+          "$value": "{speciality.background.surface.accent.accent}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "FRAME_FILL",
+                "SHAPE_FILL"
+              ],
+              "codeSyntax": {}
+            }
+          }
         },
-        "surface": {
-            "primary": {
-                "default": {
-                    "$type": "color",
-                    "$value": "{accent.neutral.subtlest}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["FRAME_FILL", "SHAPE_FILL"],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "default-hover": {
-                    "$type": "color",
-                    "$value": "{accent.neutral.subtler}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["FRAME_FILL", "SHAPE_FILL"],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "default-pressed": {
-                    "$type": "color",
-                    "$value": "{accent.neutral.subtle}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["FRAME_FILL", "SHAPE_FILL"],
-                            "codeSyntax": {}
-                        }
-                    }
-                }
-            },
-            "secondary": {
-                "default": {
-                    "$type": "color",
-                    "$value": "{accent.brand.secondary.subtlest}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["FRAME_FILL", "SHAPE_FILL"],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "hover": {
-                    "$type": "color",
-                    "$value": "{accent.brand.secondary.subtler}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["FRAME_FILL", "SHAPE_FILL"],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "pressed": {
-                    "$type": "color",
-                    "$value": "{accent.brand.secondary.subtle}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["FRAME_FILL", "SHAPE_FILL"],
-                            "codeSyntax": {}
-                        }
-                    }
-                }
-            },
-            "tertiary": {
-                "default": {
-                    "$type": "color",
-                    "$value": "{accent.brand.tertiary.subtlest}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["FRAME_FILL", "SHAPE_FILL"],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "hover": {
-                    "$type": "color",
-                    "$value": "{accent.brand.tertiary.subtler}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["FRAME_FILL", "SHAPE_FILL"],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "pressed": {
-                    "$type": "color",
-                    "$value": "{accent.brand.tertiary.subtle}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["FRAME_FILL", "SHAPE_FILL"],
-                            "codeSyntax": {}
-                        }
-                    }
-                }
-            },
-            "feedback": {
-                "info": {
-                    "$type": "color",
-                    "$value": "{accent.feedback.info.subtlest}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["FRAME_FILL", "SHAPE_FILL"],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "success": {
-                    "$type": "color",
-                    "$value": "{accent.feedback.success.subtlest}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["FRAME_FILL", "SHAPE_FILL"],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "warning": {
-                    "$type": "color",
-                    "$value": "{accent.feedback.warning.subtlest}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["FRAME_FILL", "SHAPE_FILL"],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "critical": {
-                    "$type": "color",
-                    "$value": "{accent.feedback.critical.subtlest}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["FRAME_FILL", "SHAPE_FILL"],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "tip": {
-                    "$type": "color",
-                    "$value": "{accent.feedback.tip.sublest}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["FRAME_FILL", "SHAPE_FILL"],
-                            "codeSyntax": {}
-                        }
-                    }
-                }
+        "default-hover": {
+          "$type": "color",
+          "$value": "{speciality.background.surface.accent.accent-hover}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "FRAME_FILL",
+                "SHAPE_FILL"
+              ],
+              "codeSyntax": {}
             }
+          }
+        },
+        "default-pressed": {
+          "$type": "color",
+          "$value": "{speciality.background.surface.accent.accent-pressed}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "FRAME_FILL",
+                "SHAPE_FILL"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        }
+      },
+      "secondary": {
+        "default": {
+          "$type": "color",
+          "$value": "#005aa4",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "FRAME_FILL",
+                "SHAPE_FILL"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "hover": {
+          "$type": "color",
+          "$value": "{speciality.background.surface.accent.accent-hover}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "FRAME_FILL",
+                "SHAPE_FILL"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "pressed": {
+          "$type": "color",
+          "$value": "{speciality.background.surface.accent.accent-pressed}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "FRAME_FILL",
+                "SHAPE_FILL"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        }
+      },
+      "tertiary": {
+        "default": {
+          "$type": "color",
+          "$value": "{speciality.background.surface.accent.accent}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "FRAME_FILL",
+                "SHAPE_FILL"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "hover": {
+          "$type": "color",
+          "$value": "{speciality.background.surface.accent.accent-hover}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "FRAME_FILL",
+                "SHAPE_FILL"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "pressed": {
+          "$type": "color",
+          "$value": "{speciality.background.surface.accent.accent-pressed}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "FRAME_FILL",
+                "SHAPE_FILL"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        }
+      },
+      "feedback": {
+        "info": {
+          "$type": "color",
+          "$value": "{accent.feedback.info.subtlest}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "FRAME_FILL",
+                "SHAPE_FILL"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "success": {
+          "$type": "color",
+          "$value": "{accent.feedback.success.subtlest}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "FRAME_FILL",
+                "SHAPE_FILL"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "warning": {
+          "$type": "color",
+          "$value": "{accent.feedback.warning.subtlest}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "FRAME_FILL",
+                "SHAPE_FILL"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "critical": {
+          "$type": "color",
+          "$value": "{accent.feedback.critical.subtlest}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "FRAME_FILL",
+                "SHAPE_FILL"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "tip": {
+          "$type": "color",
+          "$value": "{accent.feedback.tip.sublest}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "FRAME_FILL",
+                "SHAPE_FILL"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        }
+      }
+    },
+    "fill": {
+      "primary": {
+        "default": {
+          "$type": "color",
+          "$value": "{accent.brand.primary.strong}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "FRAME_FILL",
+                "SHAPE_FILL"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "hover": {
+          "$type": "color",
+          "$value": "{accent.brand.primary.stronger}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "FRAME_FILL",
+                "SHAPE_FILL"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "pressed": {
+          "$type": "color",
+          "$value": "{accent.brand.primary.strongest}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "FRAME_FILL",
+                "SHAPE_FILL"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "selected": {
+          "default": {
+            "$type": "color",
+            "$value": "{accent.interactive.selected.default}",
+            "$description": "",
+            "$extensions": {
+              "com.figma": {
+                "hiddenFromPublishing": false,
+                "scopes": [
+                  "FRAME_FILL",
+                  "SHAPE_FILL"
+                ],
+                "codeSyntax": {}
+              }
+            }
+          },
+          "hover": {
+            "$type": "color",
+            "$value": "{accent.interactive.selected.hover}",
+            "$description": "",
+            "$extensions": {
+              "com.figma": {
+                "hiddenFromPublishing": false,
+                "scopes": [
+                  "FRAME_FILL",
+                  "SHAPE_FILL"
+                ],
+                "codeSyntax": {}
+              }
+            }
+          },
+          "pressed": {
+            "$type": "color",
+            "$value": "{accent.interactive.selected.pressed}",
+            "$description": "",
+            "$extensions": {
+              "com.figma": {
+                "hiddenFromPublishing": false,
+                "scopes": [
+                  "FRAME_FILL",
+                  "SHAPE_FILL"
+                ],
+                "codeSyntax": {}
+              }
+            }
+          }
+        },
+        "subtle": {
+          "$type": "color",
+          "$value": "{accent.brand.primary.subtler}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "FRAME_FILL",
+                "SHAPE_FILL"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "subtle-hover": {
+          "$type": "color",
+          "$value": "{accent.brand.primary.subtle}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "FRAME_FILL",
+                "SHAPE_FILL"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "subtle-pressed": {
+          "$type": "color",
+          "$value": "{accent.brand.primary.default}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "FRAME_FILL",
+                "SHAPE_FILL"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "invisible": {
+          "$type": "color",
+          "$value": "{speciality.background.transparent}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "FRAME_FILL",
+                "SHAPE_FILL"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        }
+      },
+      "secondary": {
+        "default": {
+          "$type": "color",
+          "$value": "{accent.brand.secondary.medium}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "FRAME_FILL",
+                "SHAPE_FILL"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "default-hover": {
+          "$type": "color",
+          "$value": "{accent.brand.secondary.strong}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "FRAME_FILL",
+                "SHAPE_FILL"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "default-pressed": {
+          "$type": "color",
+          "$value": "{accent.brand.secondary.stronger}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "FRAME_FILL",
+                "SHAPE_FILL"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "subtle": {
+          "$type": "color",
+          "$value": "{accent.brand.secondary.subtler}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "FRAME_FILL",
+                "SHAPE_FILL"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "subtle-hover": {
+          "$type": "color",
+          "$value": "{accent.brand.secondary.subtle}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "FRAME_FILL",
+                "SHAPE_FILL"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "subtle-pressed": {
+          "$type": "color",
+          "$value": "{accent.brand.secondary.default}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "FRAME_FILL",
+                "SHAPE_FILL"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        }
+      },
+      "tertiary": {
+        "default": {
+          "$type": "color",
+          "$value": "{accent.brand.tertiary.medium}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "FRAME_FILL",
+                "SHAPE_FILL"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "default-hover": {
+          "$type": "color",
+          "$value": "{accent.brand.tertiary.strong}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "FRAME_FILL",
+                "SHAPE_FILL"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "default-pressed": {
+          "$type": "color",
+          "$value": "{accent.brand.tertiary.stronger}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "FRAME_FILL",
+                "SHAPE_FILL"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "subtle": {
+          "$type": "color",
+          "$value": "{accent.brand.tertiary.subtle}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "FRAME_FILL",
+                "SHAPE_FILL"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "subtle-hover": {
+          "$type": "color",
+          "$value": "{accent.brand.tertiary.default}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "FRAME_FILL",
+                "SHAPE_FILL"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "subtle-pressed": {
+          "$type": "color",
+          "$value": "{accent.brand.tertiary.medium}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "FRAME_FILL",
+                "SHAPE_FILL"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        }
+      },
+      "neutral": {
+        "default": {
+          "$type": "color",
+          "$value": "{accent.neutral.alpha.strong}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "FRAME_FILL",
+                "SHAPE_FILL"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "default-hover": {
+          "$type": "color",
+          "$value": "{accent.neutral.alpha.stronger}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "FRAME_FILL",
+                "SHAPE_FILL"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "default-pressed": {
+          "$type": "color",
+          "$value": "{accent.neutral.alpha.strongest}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "FRAME_FILL",
+                "SHAPE_FILL"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "subtle": {
+          "$type": "color",
+          "$value": "{accent.neutral.alpha.default}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "FRAME_FILL",
+                "SHAPE_FILL"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "subtle-hover": {
+          "$type": "color",
+          "$value": "{accent.neutral.alpha.medium}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "FRAME_FILL",
+                "SHAPE_FILL"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "subtle-pressed": {
+          "$type": "color",
+          "$value": "{accent.neutral.alpha.strong}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "FRAME_FILL",
+                "SHAPE_FILL"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "extra-subtle": {
+          "$type": "color",
+          "$value": "{accent.neutral.alpha.subtlest}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "FRAME_FILL",
+                "SHAPE_FILL"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "extra-subtle-hover": {
+          "$type": "color",
+          "$value": "{accent.neutral.alpha.subtler}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "FRAME_FILL",
+                "SHAPE_FILL"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "extra-subtle-pressed": {
+          "$type": "color",
+          "$value": "{accent.neutral.alpha.subtle}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "FRAME_FILL",
+                "SHAPE_FILL"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        }
+      },
+      "feedback": {
+        "info": {
+          "$type": "color",
+          "$value": "{accent.feedback.info.strong}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "FRAME_FILL",
+                "SHAPE_FILL"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "info-subtle": {
+          "$type": "color",
+          "$value": "{accent.feedback.info.subtler}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "FRAME_FILL",
+                "SHAPE_FILL"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "success": {
+          "$type": "color",
+          "$value": "{accent.feedback.success.strong}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "FRAME_FILL",
+                "SHAPE_FILL"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "success-subtle": {
+          "$type": "color",
+          "$value": "{accent.feedback.success.subtler}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "FRAME_FILL",
+                "SHAPE_FILL"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "warning": {
+          "$type": "color",
+          "$value": "{accent.feedback.warning.strong}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "FRAME_FILL",
+                "SHAPE_FILL"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "warning-subtle": {
+          "$type": "color",
+          "$value": "{accent.feedback.warning.subtler}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "FRAME_FILL",
+                "SHAPE_FILL"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "critical": {
+          "$type": "color",
+          "$value": "{accent.feedback.critical.strong}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "FRAME_FILL",
+                "SHAPE_FILL"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "critical-subtle": {
+          "$type": "color",
+          "$value": "{accent.feedback.critical.subtler}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "FRAME_FILL",
+                "SHAPE_FILL"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "tip": {
+          "$type": "color",
+          "$value": "{accent.feedback.tip.stronger}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "FRAME_FILL",
+                "SHAPE_FILL"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "tip-subtle": {
+          "$type": "color",
+          "$value": "{accent.feedback.tip.subtler}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "FRAME_FILL",
+                "SHAPE_FILL"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        }
+      }
+    },
+    "foreground": {
+      "default": {
+        "$type": "color",
+        "$value": "{accent.neutral.strongest}",
+        "$description": "",
+        "$extensions": {
+          "com.figma": {
+            "hiddenFromPublishing": false,
+            "scopes": [
+              "TEXT_FILL"
+            ],
+            "codeSyntax": {}
+          }
+        }
+      },
+      "subtle": {
+        "$type": "color",
+        "$value": "{accent.neutral.strong}",
+        "$description": "",
+        "$extensions": {
+          "com.figma": {
+            "hiddenFromPublishing": false,
+            "scopes": [
+              "TEXT_FILL"
+            ],
+            "codeSyntax": {}
+          }
+        }
+      },
+      "emphasis": {
+        "$type": "color",
+        "$value": "{accent.brand.emphasis.stronger}",
+        "$description": "",
+        "$extensions": {
+          "com.figma": {
+            "hiddenFromPublishing": false,
+            "scopes": [
+              "TEXT_FILL"
+            ],
+            "codeSyntax": {}
+          }
+        }
+      },
+      "inverse": {
+        "$type": "color",
+        "$value": "{accent.neutral.inverted}",
+        "$description": "",
+        "$extensions": {
+          "com.figma": {
+            "hiddenFromPublishing": false,
+            "scopes": [
+              "TEXT_FILL"
+            ],
+            "codeSyntax": {}
+          }
+        }
+      },
+      "on-fill": {
+        "default": {
+          "$type": "color",
+          "$value": "{accent.neutral.inverted}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "TEXT_FILL"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "inverse": {
+          "$type": "color",
+          "$value": "{accent.neutral.strongest}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "TEXT_FILL"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        }
+      },
+      "interactive": {
+        "link": {
+          "$type": "color",
+          "$value": "{accent.interactive.default}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "TEXT_FILL"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "link-hover": {
+          "$type": "color",
+          "$value": "{accent.interactive.hover}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "TEXT_FILL"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "link-pressed": {
+          "$type": "color",
+          "$value": "{accent.interactive.pressed}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "TEXT_FILL"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "link-active": {
+          "$type": "color",
+          "$value": "{accent.interactive.selected.default}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "TEXT_FILL"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        }
+      },
+      "feedback": {
+        "info": {
+          "$type": "color",
+          "$value": "{accent.feedback.info.strongest}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "TEXT_FILL"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "success": {
+          "$type": "color",
+          "$value": "{accent.feedback.success.strongest}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "TEXT_FILL"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "warning": {
+          "$type": "color",
+          "$value": "{accent.feedback.warning.strongest}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "TEXT_FILL"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "critical": {
+          "$type": "color",
+          "$value": "{accent.feedback.critical.strongest}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "TEXT_FILL"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "tip": {
+          "$type": "color",
+          "$value": "{accent.feedback.tip.strongest}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "TEXT_FILL"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        }
+      }
+    },
+    "border": {
+      "primary": {
+        "default": {
+          "$type": "color",
+          "$value": "{speciality.static.alpha.white.stronger}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "STROKE_COLOR"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "default-hover": {
+          "$type": "color",
+          "$value": "{speciality.static.alpha.white.strong}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "STROKE_COLOR"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "default-pressed": {
+          "$type": "color",
+          "$value": "{speciality.static.alpha.white.medium}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "STROKE_COLOR"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "subtle": {
+          "$type": "color",
+          "$value": "{speciality.static.alpha.white.default}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "STROKE_COLOR"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "subtle-hover": {
+          "$type": "color",
+          "$value": "{speciality.static.alpha.white.medium}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "STROKE_COLOR"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "subtle-pressed": {
+          "$type": "color",
+          "$value": "{speciality.static.alpha.white.strong}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "STROKE_COLOR"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "emphasis": {
+          "$type": "color",
+          "$value": "{accent.brand.primary.strongest}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "STROKE_COLOR"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        }
+      },
+      "secondary": {
+        "default": {
+          "$type": "color",
+          "$value": "{accent.brand.secondary.medium}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "STROKE_COLOR"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "hover": {
+          "$type": "color",
+          "$value": "{accent.brand.secondary.strong}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "STROKE_COLOR"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "pressed": {
+          "$type": "color",
+          "$value": "{accent.brand.secondary.stronger}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "STROKE_COLOR"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        }
+      },
+      "tertiary": {
+        "default": {
+          "$type": "color",
+          "$value": "{accent.brand.tertiary.medium}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "STROKE_COLOR"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "hover": {
+          "$type": "color",
+          "$value": "{accent.brand.tertiary.strong}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "STROKE_COLOR"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "pressed": {
+          "$type": "color",
+          "$value": "{accent.brand.tertiary.stronger}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "STROKE_COLOR"
+              ],
+              "codeSyntax": {
+                "WEB": "color--ffe-border-tertiary-pressed"
+              }
+            }
+          }
+        }
+      },
+      "interactive": {
+        "focus": {
+          "$type": "color",
+          "$value": "{accent.interactive.focus}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "STROKE_COLOR"
+              ],
+              "codeSyntax": {
+                "WEB": "--ffe-color-border-interactive-focus"
+              }
+            }
+          }
+        },
+        "selected": {
+          "$type": "color",
+          "$value": "{accent.brand.primary.stronger}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "STROKE_COLOR"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        }
+      },
+      "feedback": {
+        "info": {
+          "$type": "color",
+          "$value": "{accent.feedback.info.strong}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "STROKE_COLOR"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "success": {
+          "$type": "color",
+          "$value": "{accent.feedback.success.strong}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "STROKE_COLOR"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "warning": {
+          "$type": "color",
+          "$value": "{accent.feedback.warning.strong}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "STROKE_COLOR"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "critical": {
+          "$type": "color",
+          "$value": "{accent.feedback.critical.strong}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "STROKE_COLOR"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "tip": {
+          "$type": "color",
+          "$value": "{accent.feedback.tip.strong}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "STROKE_COLOR"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        }
+      }
+    },
+    "component": {
+      "button": {
+        "action": {
+          "border": {
+            "default": {
+              "$type": "color",
+              "$value": "{default.feedback.success.medium}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": [
+                    "STROKE_COLOR"
+                  ],
+                  "codeSyntax": {}
+                }
+              }
+            },
+            "hover": {
+              "$type": "color",
+              "$value": "{default.feedback.success.strong}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": [
+                    "STROKE_COLOR"
+                  ],
+                  "codeSyntax": {}
+                }
+              }
+            },
+            "pressed": {
+              "$type": "color",
+              "$value": "{default.feedback.success.stronger}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": [
+                    "STROKE_COLOR"
+                  ],
+                  "codeSyntax": {}
+                }
+              }
+            }
+          },
+          "fill": {
+            "default": {
+              "$type": "color",
+              "$value": "{accent.feedback.success.subtle}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": [
+                    "FRAME_FILL"
+                  ],
+                  "codeSyntax": {}
+                }
+              }
+            },
+            "hover": {
+              "$type": "color",
+              "$value": "{accent.feedback.success.subtler}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": [
+                    "FRAME_FILL"
+                  ],
+                  "codeSyntax": {}
+                }
+              }
+            },
+            "pressed": {
+              "$type": "color",
+              "$value": "{accent.feedback.success.subtle}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": [
+                    "FRAME_FILL"
+                  ],
+                  "codeSyntax": {}
+                }
+              }
+            }
+          },
+          "foreground": {
+            "default": {
+              "$type": "color",
+              "$value": "{speciality.static.neutral.white}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": [
+                    "TEXT_FILL"
+                  ],
+                  "codeSyntax": {}
+                }
+              }
+            },
+            "hover": {
+              "$type": "color",
+              "$value": "{speciality.static.neutral.white}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": [
+                    "TEXT_FILL"
+                  ],
+                  "codeSyntax": {}
+                }
+              }
+            }
+          }
+        },
+        "primary": {
+          "border": {
+            "default": {
+              "$type": "color",
+              "$value": "{accent.brand.emphasis.strong}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": [
+                    "STROKE_COLOR"
+                  ],
+                  "codeSyntax": {}
+                }
+              }
+            },
+            "hover": {
+              "$type": "color",
+              "$value": "{accent.brand.emphasis.stronger}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": [
+                    "STROKE_COLOR"
+                  ],
+                  "codeSyntax": {}
+                }
+              }
+            },
+            "pressed": {
+              "$type": "color",
+              "$value": "{accent.brand.emphasis.strongest}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": [
+                    "STROKE_COLOR"
+                  ],
+                  "codeSyntax": {}
+                }
+              }
+            }
+          },
+          "fill": {
+            "default": {
+              "$type": "color",
+              "$value": "{speciality.buttons.primary.accent.fill.default}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": [
+                    "FRAME_FILL"
+                  ],
+                  "codeSyntax": {}
+                }
+              }
+            },
+            "hover": {
+              "$type": "color",
+              "$value": "{speciality.buttons.primary.accent.fill.hover}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": [
+                    "FRAME_FILL"
+                  ],
+                  "codeSyntax": {}
+                }
+              }
+            },
+            "pressed": {
+              "$type": "color",
+              "$value": "{speciality.buttons.primary.accent.fill.pressed}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": [
+                    "FRAME_FILL"
+                  ],
+                  "codeSyntax": {}
+                }
+              }
+            }
+          },
+          "foreground": {
+            "default": {
+              "$type": "color",
+              "$value": "{speciality.buttons.primary.accent.foreground.default}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": [
+                    "TEXT_FILL"
+                  ],
+                  "codeSyntax": {}
+                }
+              }
+            },
+            "hover": {
+              "$type": "color",
+              "$value": "{speciality.buttons.primary.accent.foreground.default}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": [
+                    "TEXT_FILL"
+                  ],
+                  "codeSyntax": {}
+                }
+              }
+            }
+          }
+        },
+        "secondary": {
+          "border": {
+            "default": {
+              "$type": "color",
+              "$value": "{speciality.buttons.secondary.accent.border.default}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": [
+                    "STROKE_COLOR"
+                  ],
+                  "codeSyntax": {}
+                }
+              }
+            },
+            "hover": {
+              "$type": "color",
+              "$value": "{speciality.buttons.secondary.accent.border.default}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": [
+                    "STROKE_COLOR"
+                  ],
+                  "codeSyntax": {}
+                }
+              }
+            },
+            "pressed": {
+              "$type": "color",
+              "$value": "{speciality.buttons.secondary.accent.border.default}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": [
+                    "STROKE_COLOR"
+                  ],
+                  "codeSyntax": {}
+                }
+              }
+            }
+          },
+          "fill": {
+            "default": {
+              "$type": "color",
+              "$value": "{speciality.buttons.secondary.accent.fill.default}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": [
+                    "FRAME_FILL"
+                  ],
+                  "codeSyntax": {}
+                }
+              }
+            },
+            "hover": {
+              "$type": "color",
+              "$value": "{speciality.buttons.secondary.accent.fill.hover}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": [
+                    "FRAME_FILL"
+                  ],
+                  "codeSyntax": {}
+                }
+              }
+            },
+            "pressed": {
+              "$type": "color",
+              "$value": "{speciality.buttons.secondary.accent.fill.pressed}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": [
+                    "FRAME_FILL"
+                  ],
+                  "codeSyntax": {}
+                }
+              }
+            }
+          },
+          "foreground": {
+            "default": {
+              "$type": "color",
+              "$value": "{speciality.buttons.secondary.accent.foreground.default}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": [
+                    "TEXT_FILL"
+                  ],
+                  "codeSyntax": {}
+                }
+              }
+            },
+            "hover": {
+              "$type": "color",
+              "$value": "{speciality.buttons.secondary.accent.foreground.default}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": [
+                    "TEXT_FILL"
+                  ],
+                  "codeSyntax": {}
+                }
+              }
+            }
+          }
+        },
+        "tertiary": {
+          "fill": {
+            "default": {
+              "$type": "color",
+              "$value": "{speciality.buttons.tertiary.accent.fill.default}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": [
+                    "FRAME_FILL"
+                  ],
+                  "codeSyntax": {}
+                }
+              }
+            },
+            "hover": {
+              "$type": "color",
+              "$value": "{speciality.buttons.tertiary.accent.fill.hover}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": [
+                    "FRAME_FILL"
+                  ],
+                  "codeSyntax": {}
+                }
+              }
+            },
+            "pressed": {
+              "$type": "color",
+              "$value": "{speciality.buttons.tertiary.accent.fill.pressed}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": [
+                    "FRAME_FILL"
+                  ],
+                  "codeSyntax": {}
+                }
+              }
+            }
+          },
+          "foreground": {
+            "default": {
+              "$type": "color",
+              "$value": "{speciality.buttons.tertiary.accent.foreground.default}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": [
+                    "TEXT_FILL"
+                  ],
+                  "codeSyntax": {}
+                }
+              }
+            },
+            "hover": {
+              "$type": "color",
+              "$value": "{speciality.buttons.tertiary.accent.foreground.default}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": [
+                    "TEXT_FILL"
+                  ],
+                  "codeSyntax": {}
+                }
+              }
+            }
+          }
+        }
+      },
+      "toggleSwitch": {
+        "handle": {
+          "default": {
+            "$type": "color",
+            "$value": "{speciality.static.neutral.white}",
+            "$description": "",
+            "$extensions": {
+              "com.figma": {
+                "hiddenFromPublishing": false,
+                "scopes": [],
+                "codeSyntax": {}
+              }
+            }
+          }
         },
         "fill": {
-            "primary": {
-                "default": {
-                    "$type": "color",
-                    "$value": "{accent.brand.primary.medium}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["FRAME_FILL", "SHAPE_FILL"],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "hover": {
-                    "$type": "color",
-                    "$value": "{accent.brand.primary.strong}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["FRAME_FILL", "SHAPE_FILL"],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "pressed": {
-                    "$type": "color",
-                    "$value": "{accent.brand.primary.stronger}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["FRAME_FILL", "SHAPE_FILL"],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "selected": {
-                    "$type": "color",
-                    "$value": "{accent.brand.primary.strong}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["FRAME_FILL", "SHAPE_FILL"],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "selected-hover": {
-                    "$type": "color",
-                    "$value": "{accent.brand.primary.stronger}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["FRAME_FILL", "SHAPE_FILL"],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "selected-pressed": {
-                    "$type": "color",
-                    "$value": "{accent.brand.primary.strongest}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["FRAME_FILL", "SHAPE_FILL"],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "subtle": {
-                    "$type": "color",
-                    "$value": "{accent.brand.primary.subtlest}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["FRAME_FILL", "SHAPE_FILL"],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "subtle-hover": {
-                    "$type": "color",
-                    "$value": "{accent.brand.primary.subtler}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["FRAME_FILL", "SHAPE_FILL"],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "subtle-pressed": {
-                    "$type": "color",
-                    "$value": "{accent.brand.primary.subtle}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["FRAME_FILL", "SHAPE_FILL"],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "invisible": {
-                    "$type": "color",
-                    "$value": "{speciality.background.transparent}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["FRAME_FILL", "SHAPE_FILL"],
-                            "codeSyntax": {}
-                        }
-                    }
-                }
-            },
-            "secondary": {
-                "default": {
-                    "$type": "color",
-                    "$value": "{accent.brand.secondary.strong}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["FRAME_FILL", "SHAPE_FILL"],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "default-hover": {
-                    "$type": "color",
-                    "$value": "{accent.brand.secondary.stronger}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["FRAME_FILL", "SHAPE_FILL"],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "default-pressed": {
-                    "$type": "color",
-                    "$value": "{accent.brand.secondary.strongest}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["FRAME_FILL", "SHAPE_FILL"],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "subtle": {
-                    "$type": "color",
-                    "$value": "{accent.brand.secondary.subtlest}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["FRAME_FILL", "SHAPE_FILL"],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "subtle-hover": {
-                    "$type": "color",
-                    "$value": "{accent.brand.secondary.subtler}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["FRAME_FILL", "SHAPE_FILL"],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "subtle-pressed": {
-                    "$type": "color",
-                    "$value": "{accent.brand.secondary.subtle}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["FRAME_FILL", "SHAPE_FILL"],
-                            "codeSyntax": {}
-                        }
-                    }
-                }
-            },
-            "tertiary": {
-                "default": {
-                    "$type": "color",
-                    "$value": "{accent.brand.tertiary.strong}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["FRAME_FILL", "SHAPE_FILL"],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "default-hover": {
-                    "$type": "color",
-                    "$value": "{accent.brand.tertiary.stronger}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["FRAME_FILL", "SHAPE_FILL"],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "default-pressed": {
-                    "$type": "color",
-                    "$value": "{accent.brand.tertiary.strongest}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["FRAME_FILL", "SHAPE_FILL"],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "subtle": {
-                    "$type": "color",
-                    "$value": "{accent.brand.tertiary.subtlest}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["FRAME_FILL", "SHAPE_FILL"],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "subtle-hover": {
-                    "$type": "color",
-                    "$value": "{accent.brand.tertiary.subtler}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["FRAME_FILL", "SHAPE_FILL"],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "subtle-pressed": {
-                    "$type": "color",
-                    "$value": "{accent.brand.tertiary.subtle}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["FRAME_FILL", "SHAPE_FILL"],
-                            "codeSyntax": {}
-                        }
-                    }
-                }
-            },
-            "feedback": {
-                "info": {
-                    "$type": "color",
-                    "$value": "{accent.feedback.info.strong}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["FRAME_FILL", "SHAPE_FILL"],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "info-subtle": {
-                    "$type": "color",
-                    "$value": "{accent.feedback.info.subtler}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["FRAME_FILL", "SHAPE_FILL"],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "success": {
-                    "$type": "color",
-                    "$value": "{accent.feedback.success.strong}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["FRAME_FILL", "SHAPE_FILL"],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "success-subtle": {
-                    "$type": "color",
-                    "$value": "{accent.feedback.success.subtler}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["FRAME_FILL", "SHAPE_FILL"],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "warning": {
-                    "$type": "color",
-                    "$value": "{accent.feedback.warning.strong}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["FRAME_FILL", "SHAPE_FILL"],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "warning-subtle": {
-                    "$type": "color",
-                    "$value": "{accent.feedback.warning.subtler}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["FRAME_FILL", "SHAPE_FILL"],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "critical": {
-                    "$type": "color",
-                    "$value": "{accent.feedback.critical.strong}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["FRAME_FILL", "SHAPE_FILL"],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "critical-subtle": {
-                    "$type": "color",
-                    "$value": "{accent.feedback.critical.subtler}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["FRAME_FILL", "SHAPE_FILL"],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "tip": {
-                    "$type": "color",
-                    "$value": "{accent.feedback.tip.stronger}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["FRAME_FILL", "SHAPE_FILL"],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "tip-subtle": {
-                    "$type": "color",
-                    "$value": "{accent.feedback.tip.subtler}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["FRAME_FILL", "SHAPE_FILL"],
-                            "codeSyntax": {}
-                        }
-                    }
-                }
+          "default": {
+            "$type": "color",
+            "$value": "{default.neutral.medium}",
+            "$description": "",
+            "$extensions": {
+              "com.figma": {
+                "hiddenFromPublishing": false,
+                "scopes": [],
+                "codeSyntax": {}
+              }
             }
-        },
-        "foreground": {
-            "default": {
-                "$type": "color",
-                "$value": "{accent.neutral.strongest}",
-                "$description": "",
-                "$extensions": {
-                    "com.figma": {
-                        "hiddenFromPublishing": false,
-                        "scopes": ["TEXT_FILL"],
-                        "codeSyntax": {}
-                    }
-                }
-            },
-            "subtle": {
-                "$type": "color",
-                "$value": "{accent.neutral.strong}",
-                "$description": "",
-                "$extensions": {
-                    "com.figma": {
-                        "hiddenFromPublishing": false,
-                        "scopes": ["TEXT_FILL"],
-                        "codeSyntax": {}
-                    }
-                }
-            },
-            "emphasis": {
-                "$type": "color",
-                "$value": "{accent.brand.emphasis.strongest}",
-                "$description": "",
-                "$extensions": {
-                    "com.figma": {
-                        "hiddenFromPublishing": false,
-                        "scopes": ["TEXT_FILL"],
-                        "codeSyntax": {}
-                    }
-                }
-            },
-            "inverse": {
-                "$type": "color",
-                "$value": "{accent.neutral.inverted}",
-                "$description": "",
-                "$extensions": {
-                    "com.figma": {
-                        "hiddenFromPublishing": false,
-                        "scopes": ["TEXT_FILL"],
-                        "codeSyntax": {}
-                    }
-                }
-            },
-            "on-fill": {
-                "default": {
-                    "$type": "color",
-                    "$value": "{accent.neutral.inverted}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["TEXT_FILL"],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "inverse": {
-                    "$type": "color",
-                    "$value": "{accent.neutral.strongest}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["TEXT_FILL"],
-                            "codeSyntax": {}
-                        }
-                    }
-                }
-            },
-            "interactive": {
-                "link": {
-                    "$type": "color",
-                    "$value": "{speciality.static.accent.subtler}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["TEXT_FILL"],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "link-hover": {
-                    "$type": "color",
-                    "$value": "{speciality.static.accent.subtle}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["TEXT_FILL"],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "link-pressed": {
-                    "$type": "color",
-                    "$value": "{speciality.static.accent.default}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["TEXT_FILL"],
-                            "codeSyntax": {}
-                        }
-                    }
-                }
-            },
-            "feedback": {
-                "info": {
-                    "$type": "color",
-                    "$value": "{accent.feedback.info.strongest}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["TEXT_FILL"],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "success": {
-                    "$type": "color",
-                    "$value": "{accent.feedback.success.strongest}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["TEXT_FILL"],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "warning": {
-                    "$type": "color",
-                    "$value": "{accent.feedback.warning.strongest}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["TEXT_FILL"],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "critical": {
-                    "$type": "color",
-                    "$value": "{accent.feedback.critical.strongest}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["TEXT_FILL"],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "tip": {
-                    "$type": "color",
-                    "$value": "{accent.feedback.tip.strongest}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["TEXT_FILL"],
-                            "codeSyntax": {}
-                        }
-                    }
-                }
+          },
+          "default-hover": {
+            "$type": "color",
+            "$value": "{default.neutral.strong}",
+            "$description": "",
+            "$extensions": {
+              "com.figma": {
+                "hiddenFromPublishing": false,
+                "scopes": [],
+                "codeSyntax": {}
+              }
             }
-        },
-        "border": {
-            "primary": {
-                "default": {
-                    "$type": "color",
-                    "$value": "{accent.neutral.medium}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["STROKE_COLOR"],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "hover": {
-                    "$type": "color",
-                    "$value": "{accent.neutral.strong}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["STROKE_COLOR"],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "pressed": {
-                    "$type": "color",
-                    "$value": "{accent.neutral.strongest}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["STROKE_COLOR"],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "subtle": {
-                    "$type": "color",
-                    "$value": "{accent.neutral.subtler}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["STROKE_COLOR"],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "emphasis": {
-                    "$type": "color",
-                    "$value": "{accent.brand.primary.strongest}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["STROKE_COLOR"],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "selected": {
-                    "$type": "color",
-                    "$value": "{accent.brand.primary.stronger}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["STROKE_COLOR"],
-                            "codeSyntax": {}
-                        }
-                    }
-                }
-            },
-            "secondary": {
-                "default": {
-                    "$type": "color",
-                    "$value": "{color.natt.400}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["STROKE_COLOR"],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "hover": {
-                    "$type": "color",
-                    "$value": "{color.natt.500}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["STROKE_COLOR"],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "pressed": {
-                    "$type": "color",
-                    "$value": "{color.natt.600}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["STROKE_COLOR"],
-                            "codeSyntax": {}
-                        }
-                    }
-                }
-            },
-            "tertiary": {
-                "default": {
-                    "$type": "color",
-                    "$value": "{accent.brand.tertiary.default}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["STROKE_COLOR"],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "hover": {
-                    "$type": "color",
-                    "$value": "{accent.brand.tertiary.medium}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["STROKE_COLOR"],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "pressed": {
-                    "$type": "color",
-                    "$value": "{accent.brand.tertiary.strong}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["STROKE_COLOR"],
-                            "codeSyntax": {}
-                        }
-                    }
-                }
-            },
-            "interactive": {
-                "focus": {
-                    "$type": "color",
-                    "$value": "{accent.interactive.focus}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["STROKE_COLOR"],
-                            "codeSyntax": {}
-                        }
-                    }
-                }
-            },
-            "feedback": {
-                "info": {
-                    "$type": "color",
-                    "$value": "{accent.feedback.info.strong}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["STROKE_COLOR"],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "success": {
-                    "$type": "color",
-                    "$value": "{accent.feedback.success.strong}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["STROKE_COLOR"],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "warning": {
-                    "$type": "color",
-                    "$value": "{accent.feedback.warning.strong}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["STROKE_COLOR"],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "critical": {
-                    "$type": "color",
-                    "$value": "{accent.feedback.critical.strong}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["STROKE_COLOR"],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "tip": {
-                    "$type": "color",
-                    "$value": "{accent.feedback.tip.strong}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["STROKE_COLOR"],
-                            "codeSyntax": {}
-                        }
-                    }
-                }
+          },
+          "default-pressed": {
+            "$type": "color",
+            "$value": "{default.neutral.medium}",
+            "$description": "",
+            "$extensions": {
+              "com.figma": {
+                "hiddenFromPublishing": false,
+                "scopes": [],
+                "codeSyntax": {}
+              }
             }
-        },
-        "component": {
-            "button": {
-                "action": {
-                    "border": {
-                        "default": {
-                            "$type": "color",
-                            "$value": "{default.feedback.success.subtle}",
-                            "$description": "",
-                            "$extensions": {
-                                "com.figma": {
-                                    "hiddenFromPublishing": false,
-                                    "scopes": ["STROKE_COLOR"],
-                                    "codeSyntax": {}
-                                }
-                            }
-                        },
-                        "hover": {
-                            "$type": "color",
-                            "$value": "{default.feedback.success.default}",
-                            "$description": "",
-                            "$extensions": {
-                                "com.figma": {
-                                    "hiddenFromPublishing": false,
-                                    "scopes": ["STROKE_COLOR"],
-                                    "codeSyntax": {}
-                                }
-                            }
-                        },
-                        "pressed": {
-                            "$type": "color",
-                            "$value": "{default.feedback.success.medium}",
-                            "$description": "",
-                            "$extensions": {
-                                "com.figma": {
-                                    "hiddenFromPublishing": false,
-                                    "scopes": ["STROKE_COLOR"],
-                                    "codeSyntax": {}
-                                }
-                            }
-                        }
-                    },
-                    "fill": {
-                        "default": {
-                            "$type": "color",
-                            "$value": "{accent.feedback.success.strong}",
-                            "$description": "",
-                            "$extensions": {
-                                "com.figma": {
-                                    "hiddenFromPublishing": false,
-                                    "scopes": ["FRAME_FILL"],
-                                    "codeSyntax": {}
-                                }
-                            }
-                        },
-                        "hover": {
-                            "$type": "color",
-                            "$value": "{accent.feedback.success.stronger}",
-                            "$description": "",
-                            "$extensions": {
-                                "com.figma": {
-                                    "hiddenFromPublishing": false,
-                                    "scopes": ["FRAME_FILL"],
-                                    "codeSyntax": {}
-                                }
-                            }
-                        },
-                        "pressed": {
-                            "$type": "color",
-                            "$value": "{accent.feedback.success.strongest}",
-                            "$description": "",
-                            "$extensions": {
-                                "com.figma": {
-                                    "hiddenFromPublishing": false,
-                                    "scopes": ["FRAME_FILL"],
-                                    "codeSyntax": {}
-                                }
-                            }
-                        }
-                    },
-                    "foreground": {
-                        "default": {
-                            "$type": "color",
-                            "$value": "{accent.neutral.inverted}",
-                            "$description": "",
-                            "$extensions": {
-                                "com.figma": {
-                                    "hiddenFromPublishing": false,
-                                    "scopes": ["TEXT_FILL"],
-                                    "codeSyntax": {}
-                                }
-                            }
-                        },
-                        "hover": {
-                            "$type": "color",
-                            "$value": "{accent.neutral.inverted}",
-                            "$description": "",
-                            "$extensions": {
-                                "com.figma": {
-                                    "hiddenFromPublishing": false,
-                                    "scopes": ["TEXT_FILL"],
-                                    "codeSyntax": {}
-                                }
-                            }
-                        }
-                    }
-                },
-                "primary": {
-                    "border": {
-                        "default": {
-                            "$type": "color",
-                            "$value": "{accent.brand.primary.medium}",
-                            "$description": "",
-                            "$extensions": {
-                                "com.figma": {
-                                    "hiddenFromPublishing": false,
-                                    "scopes": ["STROKE_COLOR"],
-                                    "codeSyntax": {}
-                                }
-                            }
-                        },
-                        "hover": {
-                            "$type": "color",
-                            "$value": "{default.brand.primary.default}",
-                            "$description": "",
-                            "$extensions": {
-                                "com.figma": {
-                                    "hiddenFromPublishing": false,
-                                    "scopes": ["STROKE_COLOR"],
-                                    "codeSyntax": {}
-                                }
-                            }
-                        },
-                        "pressed": {
-                            "$type": "color",
-                            "$value": "{default.brand.primary.stronger}",
-                            "$description": "",
-                            "$extensions": {
-                                "com.figma": {
-                                    "hiddenFromPublishing": false,
-                                    "scopes": ["STROKE_COLOR"],
-                                    "codeSyntax": {}
-                                }
-                            }
-                        }
-                    },
-                    "fill": {
-                        "default": {
-                            "$type": "color",
-                            "$value": "{accent.brand.primary.strong}",
-                            "$description": "",
-                            "$extensions": {
-                                "com.figma": {
-                                    "hiddenFromPublishing": false,
-                                    "scopes": ["FRAME_FILL"],
-                                    "codeSyntax": {}
-                                }
-                            }
-                        },
-                        "hover": {
-                            "$type": "color",
-                            "$value": "{accent.brand.primary.stronger}",
-                            "$description": "",
-                            "$extensions": {
-                                "com.figma": {
-                                    "hiddenFromPublishing": false,
-                                    "scopes": ["FRAME_FILL"],
-                                    "codeSyntax": {}
-                                }
-                            }
-                        },
-                        "pressed": {
-                            "$type": "color",
-                            "$value": "{accent.brand.primary.strongest}",
-                            "$description": "",
-                            "$extensions": {
-                                "com.figma": {
-                                    "hiddenFromPublishing": false,
-                                    "scopes": ["FRAME_FILL"],
-                                    "codeSyntax": {}
-                                }
-                            }
-                        }
-                    },
-                    "foreground": {
-                        "default": {
-                            "$type": "color",
-                            "$value": "{accent.neutral.inverted}",
-                            "$description": "",
-                            "$extensions": {
-                                "com.figma": {
-                                    "hiddenFromPublishing": false,
-                                    "scopes": ["TEXT_FILL"],
-                                    "codeSyntax": {}
-                                }
-                            }
-                        },
-                        "hover": {
-                            "$type": "color",
-                            "$value": "{accent.neutral.inverted}",
-                            "$description": "",
-                            "$extensions": {
-                                "com.figma": {
-                                    "hiddenFromPublishing": false,
-                                    "scopes": ["TEXT_FILL"],
-                                    "codeSyntax": {}
-                                }
-                            }
-                        }
-                    }
-                },
-                "secondary": {
-                    "border": {
-                        "default": {
-                            "$type": "color",
-                            "$value": "{accent.brand.primary.strong}",
-                            "$description": "",
-                            "$extensions": {
-                                "com.figma": {
-                                    "hiddenFromPublishing": false,
-                                    "scopes": ["STROKE_COLOR"],
-                                    "codeSyntax": {}
-                                }
-                            }
-                        },
-                        "hover": {
-                            "$type": "color",
-                            "$value": "{accent.brand.primary.stronger}",
-                            "$description": "",
-                            "$extensions": {
-                                "com.figma": {
-                                    "hiddenFromPublishing": false,
-                                    "scopes": ["STROKE_COLOR"],
-                                    "codeSyntax": {}
-                                }
-                            }
-                        },
-                        "pressed": {
-                            "$type": "color",
-                            "$value": "{accent.brand.primary.strongest}",
-                            "$description": "",
-                            "$extensions": {
-                                "com.figma": {
-                                    "hiddenFromPublishing": false,
-                                    "scopes": ["STROKE_COLOR"],
-                                    "codeSyntax": {}
-                                }
-                            }
-                        }
-                    },
-                    "fill": {
-                        "default": {
-                            "$type": "color",
-                            "$value": "{color.fill.primary.invisible}",
-                            "$description": "",
-                            "$extensions": {
-                                "com.figma": {
-                                    "hiddenFromPublishing": false,
-                                    "scopes": ["FRAME_FILL"],
-                                    "codeSyntax": {}
-                                }
-                            }
-                        },
-                        "hover": {
-                            "$type": "color",
-                            "$value": "{accent.brand.primary.subtlest}",
-                            "$description": "",
-                            "$extensions": {
-                                "com.figma": {
-                                    "hiddenFromPublishing": false,
-                                    "scopes": ["FRAME_FILL"],
-                                    "codeSyntax": {}
-                                }
-                            }
-                        },
-                        "pressed": {
-                            "$type": "color",
-                            "$value": "{accent.brand.primary.subtler}",
-                            "$description": "",
-                            "$extensions": {
-                                "com.figma": {
-                                    "hiddenFromPublishing": false,
-                                    "scopes": ["FRAME_FILL"],
-                                    "codeSyntax": {}
-                                }
-                            }
-                        }
-                    },
-                    "foreground": {
-                        "default": {
-                            "$type": "color",
-                            "$value": "{speciality.static.neutral.white}",
-                            "$description": "",
-                            "$extensions": {
-                                "com.figma": {
-                                    "hiddenFromPublishing": false,
-                                    "scopes": ["TEXT_FILL"],
-                                    "codeSyntax": {}
-                                }
-                            }
-                        },
-                        "hover": {
-                            "$type": "color",
-                            "$value": "{speciality.static.neutral.white}",
-                            "$description": "",
-                            "$extensions": {
-                                "com.figma": {
-                                    "hiddenFromPublishing": false,
-                                    "scopes": ["TEXT_FILL"],
-                                    "codeSyntax": {}
-                                }
-                            }
-                        }
-                    }
-                },
-                "tertiary": {
-                    "border": {
-                        "default": {
-                            "$type": "color",
-                            "$value": "{speciality.background.accent}",
-                            "$description": "",
-                            "$extensions": {
-                                "com.figma": {
-                                    "hiddenFromPublishing": false,
-                                    "scopes": ["STROKE_COLOR"],
-                                    "codeSyntax": {}
-                                }
-                            }
-                        },
-                        "hover": {
-                            "$type": "color",
-                            "$value": "{default.brand.primary.stronger}",
-                            "$description": "",
-                            "$extensions": {
-                                "com.figma": {
-                                    "hiddenFromPublishing": false,
-                                    "scopes": ["STROKE_COLOR"],
-                                    "codeSyntax": {}
-                                }
-                            }
-                        },
-                        "pressed": {
-                            "$type": "color",
-                            "$value": "{default.brand.primary.strongest}",
-                            "$description": "",
-                            "$extensions": {
-                                "com.figma": {
-                                    "hiddenFromPublishing": false,
-                                    "scopes": ["STROKE_COLOR"],
-                                    "codeSyntax": {}
-                                }
-                            }
-                        }
-                    },
-                    "fill": {
-                        "default": {
-                            "$type": "color",
-                            "$value": "{color.fill.primary.invisible}",
-                            "$description": "",
-                            "$extensions": {
-                                "com.figma": {
-                                    "hiddenFromPublishing": false,
-                                    "scopes": ["FRAME_FILL"],
-                                    "codeSyntax": {}
-                                }
-                            }
-                        },
-                        "hover": {
-                            "$type": "color",
-                            "$value": "{accent.brand.primary.subtlest}",
-                            "$description": "",
-                            "$extensions": {
-                                "com.figma": {
-                                    "hiddenFromPublishing": false,
-                                    "scopes": ["FRAME_FILL"],
-                                    "codeSyntax": {}
-                                }
-                            }
-                        },
-                        "pressed": {
-                            "$type": "color",
-                            "$value": "{accent.brand.primary.subtler}",
-                            "$description": "",
-                            "$extensions": {
-                                "com.figma": {
-                                    "hiddenFromPublishing": false,
-                                    "scopes": ["FRAME_FILL"],
-                                    "codeSyntax": {}
-                                }
-                            }
-                        }
-                    },
-                    "foreground": {
-                        "default": {
-                            "$type": "color",
-                            "$value": "{speciality.static.neutral.white}",
-                            "$description": "",
-                            "$extensions": {
-                                "com.figma": {
-                                    "hiddenFromPublishing": false,
-                                    "scopes": ["TEXT_FILL"],
-                                    "codeSyntax": {}
-                                }
-                            }
-                        },
-                        "hover": {
-                            "$type": "color",
-                            "$value": "{speciality.static.neutral.white}",
-                            "$description": "",
-                            "$extensions": {
-                                "com.figma": {
-                                    "hiddenFromPublishing": false,
-                                    "scopes": ["TEXT_FILL"],
-                                    "codeSyntax": {}
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "toggleSwitch": {
-                "handle": {
-                    "default": {
-                        "$type": "color",
-                        "$value": "{speciality.static.neutral.white}",
-                        "$description": "",
-                        "$extensions": {
-                            "com.figma": {
-                                "hiddenFromPublishing": false,
-                                "scopes": [],
-                                "codeSyntax": {}
-                            }
-                        }
-                    }
-                },
-                "fill": {
-                    "default": {
-                        "$type": "color",
-                        "$value": "{default.neutral.medium}",
-                        "$description": "",
-                        "$extensions": {
-                            "com.figma": {
-                                "hiddenFromPublishing": false,
-                                "scopes": [],
-                                "codeSyntax": {}
-                            }
-                        }
-                    },
-                    "default-hover": {
-                        "$type": "color",
-                        "$value": "{default.neutral.strong}",
-                        "$description": "",
-                        "$extensions": {
-                            "com.figma": {
-                                "hiddenFromPublishing": false,
-                                "scopes": [],
-                                "codeSyntax": {}
-                            }
-                        }
-                    },
-                    "default-pressed": {
-                        "$type": "color",
-                        "$value": "{default.neutral.medium}",
-                        "$description": "",
-                        "$extensions": {
-                            "com.figma": {
-                                "hiddenFromPublishing": false,
-                                "scopes": [],
-                                "codeSyntax": {}
-                            }
-                        }
-                    },
-                    "selected": {
-                        "$type": "color",
-                        "$value": "{accent.feedback.success.default}",
-                        "$description": "",
-                        "$extensions": {
-                            "com.figma": {
-                                "hiddenFromPublishing": false,
-                                "scopes": [],
-                                "codeSyntax": {}
-                            }
-                        }
-                    },
-                    "selected-hover": {
-                        "$type": "color",
-                        "$value": "{accent.feedback.success.subtle}",
-                        "$description": "",
-                        "$extensions": {
-                            "com.figma": {
-                                "hiddenFromPublishing": false,
-                                "scopes": [],
-                                "codeSyntax": {}
-                            }
-                        }
-                    },
-                    "selected-pressed": {
-                        "$type": "color",
-                        "$value": "{accent.feedback.success.default}",
-                        "$description": "",
-                        "$extensions": {
-                            "com.figma": {
-                                "hiddenFromPublishing": false,
-                                "scopes": [],
-                                "codeSyntax": {}
-                            }
-                        }
-                    },
-                    "critical": {
-                        "$type": "color",
-                        "$value": "{accent.feedback.critical.default}",
-                        "$description": "",
-                        "$extensions": {
-                            "com.figma": {
-                                "hiddenFromPublishing": false,
-                                "scopes": [],
-                                "codeSyntax": {}
-                            }
-                        }
-                    }
-                }
-            },
-            "logo": {
-                "name": {
-                    "$type": "color",
-                    "$value": "{color.alpha.white.100}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "number1": {
-                    "$type": "color",
-                    "$value": "{color.alpha.white.100}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "circle-dark-red": {
-                    "$type": "color",
-                    "$value": "#af0000",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "circle-light-red": {
-                    "$type": "color",
-                    "$value": "#e60000",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                }
+          },
+          "selected": {
+            "$type": "color",
+            "$value": "{accent.feedback.success.default}",
+            "$description": "",
+            "$extensions": {
+              "com.figma": {
+                "hiddenFromPublishing": false,
+                "scopes": [],
+                "codeSyntax": {}
+              }
             }
+          },
+          "selected-hover": {
+            "$type": "color",
+            "$value": "{accent.feedback.success.subtle}",
+            "$description": "",
+            "$extensions": {
+              "com.figma": {
+                "hiddenFromPublishing": false,
+                "scopes": [],
+                "codeSyntax": {}
+              }
+            }
+          },
+          "selected-pressed": {
+            "$type": "color",
+            "$value": "{accent.feedback.success.default}",
+            "$description": "",
+            "$extensions": {
+              "com.figma": {
+                "hiddenFromPublishing": false,
+                "scopes": [],
+                "codeSyntax": {}
+              }
+            }
+          },
+          "critical": {
+            "$type": "color",
+            "$value": "{accent.feedback.critical.default}",
+            "$description": "",
+            "$extensions": {
+              "com.figma": {
+                "hiddenFromPublishing": false,
+                "scopes": [],
+                "codeSyntax": {}
+              }
+            }
+          }
         }
+      },
+      "logo": {
+        "name": {
+          "$type": "color",
+          "$value": "{color.alpha.white.1000}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "number1": {
+          "$type": "color",
+          "$value": "{color.alpha.white.1000}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "circle-dark-red": {
+          "$type": "color",
+          "$value": "#af0000",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "circle-light-red": {
+          "$type": "color",
+          "$value": "#e60000",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        }
+      }
     }
+  }
 }

--- a/packages/ffe-core/tokens/03 Context.Default.json
+++ b/packages/ffe-core/tokens/03 Context.Default.json
@@ -1,1578 +1,1995 @@
 {
-    "color": {
-        "background": {
-            "default": {
-                "$type": "color",
-                "$value": "{speciality.background.default}",
-                "$description": "",
-                "$extensions": {
-                    "com.figma": {
-                        "hiddenFromPublishing": false,
-                        "scopes": ["FRAME_FILL", "SHAPE_FILL"],
-                        "codeSyntax": {}
-                    }
-                }
-            },
-            "subtle": {
-                "$type": "color",
-                "$value": "{speciality.background.subtle}",
-                "$description": "",
-                "$extensions": {
-                    "com.figma": {
-                        "hiddenFromPublishing": false,
-                        "scopes": ["FRAME_FILL", "SHAPE_FILL"],
-                        "codeSyntax": {}
-                    }
-                }
+  "color": {
+    "background": {
+      "default": {
+        "$type": "color",
+        "$value": "{speciality.background.default}",
+        "$description": "",
+        "$extensions": {
+          "com.figma": {
+            "hiddenFromPublishing": false,
+            "scopes": [
+              "FRAME_FILL",
+              "SHAPE_FILL"
+            ],
+            "codeSyntax": {
+              "WEB": "--ffe-color-background-default"
             }
+          }
+        }
+      },
+      "subtle": {
+        "$type": "color",
+        "$value": "{speciality.background.subtle}",
+        "$description": "",
+        "$extensions": {
+          "com.figma": {
+            "hiddenFromPublishing": false,
+            "scopes": [
+              "FRAME_FILL",
+              "SHAPE_FILL"
+            ],
+            "codeSyntax": {
+              "WEB": "--ffe-color-background-subtle"
+            }
+          }
+        }
+      }
+    },
+    "surface": {
+      "primary": {
+        "default": {
+          "$type": "color",
+          "$value": "{speciality.background.surface.primary.default}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "FRAME_FILL",
+                "SHAPE_FILL"
+              ],
+              "codeSyntax": {}
+            }
+          }
         },
-        "surface": {
-            "primary": {
-                "default": {
-                    "$type": "color",
-                    "$value": "{speciality.background.surface.default}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["FRAME_FILL", "SHAPE_FILL"],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "default-hover": {
-                    "$type": "color",
-                    "$value": "{speciality.background.surface.default-hover}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["FRAME_FILL", "SHAPE_FILL"],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "default-pressed": {
-                    "$type": "color",
-                    "$value": "{speciality.background.surface.default-pressed}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["FRAME_FILL", "SHAPE_FILL"],
-                            "codeSyntax": {}
-                        }
-                    }
-                }
-            },
-            "secondary": {
-                "default": {
-                    "$type": "color",
-                    "$value": "{default.brand.secondary.subtlest}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["FRAME_FILL", "SHAPE_FILL"],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "hover": {
-                    "$type": "color",
-                    "$value": "{default.brand.secondary.subtler}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["FRAME_FILL", "SHAPE_FILL"],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "pressed": {
-                    "$type": "color",
-                    "$value": "{default.brand.secondary.subtle}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["FRAME_FILL", "SHAPE_FILL"],
-                            "codeSyntax": {}
-                        }
-                    }
-                }
-            },
-            "tertiary": {
-                "default": {
-                    "$type": "color",
-                    "$value": "{default.brand.tertiary.subtlest}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["FRAME_FILL", "SHAPE_FILL"],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "hover": {
-                    "$type": "color",
-                    "$value": "{default.brand.tertiary.subtler}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["FRAME_FILL", "SHAPE_FILL"],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "pressed": {
-                    "$type": "color",
-                    "$value": "{default.brand.tertiary.subtle}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["FRAME_FILL", "SHAPE_FILL"],
-                            "codeSyntax": {}
-                        }
-                    }
-                }
-            },
-            "feedback": {
-                "info": {
-                    "$type": "color",
-                    "$value": "{default.feedback.info.subtlest}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["FRAME_FILL", "SHAPE_FILL"],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "success": {
-                    "$type": "color",
-                    "$value": "{default.feedback.success.subtlest}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["FRAME_FILL", "SHAPE_FILL"],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "warning": {
-                    "$type": "color",
-                    "$value": "{default.feedback.warning.subtlest}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["FRAME_FILL", "SHAPE_FILL"],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "critical": {
-                    "$type": "color",
-                    "$value": "{default.feedback.critical.subtlest}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["FRAME_FILL", "SHAPE_FILL"],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "tip": {
-                    "$type": "color",
-                    "$value": "{default.feedback.tip.sublest}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["FRAME_FILL", "SHAPE_FILL"],
-                            "codeSyntax": {}
-                        }
-                    }
-                }
+        "default-hover": {
+          "$type": "color",
+          "$value": "{speciality.background.surface.primary.default-hover}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "FRAME_FILL",
+                "SHAPE_FILL"
+              ],
+              "codeSyntax": {}
             }
+          }
+        },
+        "default-pressed": {
+          "$type": "color",
+          "$value": "{speciality.background.surface.primary.default-pressed}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "FRAME_FILL",
+                "SHAPE_FILL"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        }
+      },
+      "secondary": {
+        "default": {
+          "$type": "color",
+          "$value": "{speciality.background.surface.secondary.default}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "FRAME_FILL",
+                "SHAPE_FILL"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "hover": {
+          "$type": "color",
+          "$value": "{speciality.background.surface.secondary.default-hover}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "FRAME_FILL",
+                "SHAPE_FILL"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "pressed": {
+          "$type": "color",
+          "$value": "{speciality.background.surface.secondary.default-pressed}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "FRAME_FILL",
+                "SHAPE_FILL"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        }
+      },
+      "tertiary": {
+        "default": {
+          "$type": "color",
+          "$value": "{speciality.background.surface.tertiary.default}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "FRAME_FILL",
+                "SHAPE_FILL"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "hover": {
+          "$type": "color",
+          "$value": "{speciality.background.surface.tertiary.default-hover}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "FRAME_FILL",
+                "SHAPE_FILL"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "pressed": {
+          "$type": "color",
+          "$value": "{speciality.background.surface.tertiary.default-pressed}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "FRAME_FILL",
+                "SHAPE_FILL"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        }
+      },
+      "feedback": {
+        "info": {
+          "$type": "color",
+          "$value": "{default.feedback.info.subtlest}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "FRAME_FILL",
+                "SHAPE_FILL"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "success": {
+          "$type": "color",
+          "$value": "{default.feedback.success.subtlest}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "FRAME_FILL",
+                "SHAPE_FILL"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "warning": {
+          "$type": "color",
+          "$value": "{default.feedback.warning.subtlest}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "FRAME_FILL",
+                "SHAPE_FILL"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "critical": {
+          "$type": "color",
+          "$value": "{default.feedback.critical.subtlest}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "FRAME_FILL",
+                "SHAPE_FILL"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "tip": {
+          "$type": "color",
+          "$value": "{default.feedback.tip.sublest}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "FRAME_FILL",
+                "SHAPE_FILL"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        }
+      }
+    },
+    "fill": {
+      "primary": {
+        "default": {
+          "$type": "color",
+          "$value": "{default.brand.primary.strong}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "FRAME_FILL",
+                "SHAPE_FILL"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "hover": {
+          "$type": "color",
+          "$value": "{default.brand.primary.stronger}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "FRAME_FILL",
+                "SHAPE_FILL"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "pressed": {
+          "$type": "color",
+          "$value": "{default.brand.primary.strongest}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "FRAME_FILL",
+                "SHAPE_FILL"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "selected": {
+          "default": {
+            "$type": "color",
+            "$value": "{default.interactive.selected.default}",
+            "$description": "",
+            "$extensions": {
+              "com.figma": {
+                "hiddenFromPublishing": false,
+                "scopes": [
+                  "FRAME_FILL",
+                  "SHAPE_FILL"
+                ],
+                "codeSyntax": {}
+              }
+            }
+          },
+          "hover": {
+            "$type": "color",
+            "$value": "{default.interactive.selected.hover}",
+            "$description": "",
+            "$extensions": {
+              "com.figma": {
+                "hiddenFromPublishing": false,
+                "scopes": [
+                  "FRAME_FILL",
+                  "SHAPE_FILL"
+                ],
+                "codeSyntax": {}
+              }
+            }
+          },
+          "pressed": {
+            "$type": "color",
+            "$value": "{default.interactive.selected.pressed}",
+            "$description": "",
+            "$extensions": {
+              "com.figma": {
+                "hiddenFromPublishing": false,
+                "scopes": [
+                  "FRAME_FILL",
+                  "SHAPE_FILL"
+                ],
+                "codeSyntax": {}
+              }
+            }
+          }
+        },
+        "subtle": {
+          "$type": "color",
+          "$value": "{default.brand.primary.subtlest}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "FRAME_FILL",
+                "SHAPE_FILL"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "subtle-hover": {
+          "$type": "color",
+          "$value": "{default.brand.primary.subtler}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "FRAME_FILL",
+                "SHAPE_FILL"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "subtle-pressed": {
+          "$type": "color",
+          "$value": "{default.brand.primary.subtle}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "FRAME_FILL",
+                "SHAPE_FILL"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "invisible": {
+          "$type": "color",
+          "$value": "{speciality.background.transparent}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "FRAME_FILL",
+                "SHAPE_FILL"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        }
+      },
+      "secondary": {
+        "default": {
+          "$type": "color",
+          "$value": "{default.brand.secondary.medium}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "FRAME_FILL",
+                "SHAPE_FILL"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "default-hover": {
+          "$type": "color",
+          "$value": "{default.brand.secondary.strong}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "FRAME_FILL",
+                "SHAPE_FILL"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "default-pressed": {
+          "$type": "color",
+          "$value": "{default.brand.secondary.stronger}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "FRAME_FILL",
+                "SHAPE_FILL"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "subtle": {
+          "$type": "color",
+          "$value": "{default.brand.secondary.subtler}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "FRAME_FILL",
+                "SHAPE_FILL"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "subtle-hover": {
+          "$type": "color",
+          "$value": "{default.brand.secondary.subtle}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "FRAME_FILL",
+                "SHAPE_FILL"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "subtle-pressed": {
+          "$type": "color",
+          "$value": "{default.brand.secondary.default}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "FRAME_FILL",
+                "SHAPE_FILL"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        }
+      },
+      "tertiary": {
+        "default": {
+          "$type": "color",
+          "$value": "{default.brand.tertiary.medium}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "FRAME_FILL",
+                "SHAPE_FILL"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "default-hover": {
+          "$type": "color",
+          "$value": "{default.brand.tertiary.strong}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "FRAME_FILL",
+                "SHAPE_FILL"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "default-pressed": {
+          "$type": "color",
+          "$value": "{default.brand.tertiary.stronger}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "FRAME_FILL",
+                "SHAPE_FILL"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "subtle": {
+          "$type": "color",
+          "$value": "{default.brand.tertiary.subtle}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "FRAME_FILL",
+                "SHAPE_FILL"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "subtle-hover": {
+          "$type": "color",
+          "$value": "{default.brand.tertiary.default}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "FRAME_FILL",
+                "SHAPE_FILL"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "subtle-pressed": {
+          "$type": "color",
+          "$value": "{default.brand.tertiary.medium}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "FRAME_FILL",
+                "SHAPE_FILL"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        }
+      },
+      "neutral": {
+        "default": {
+          "$type": "color",
+          "$value": "{default.neutral.alpha.strong}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "FRAME_FILL",
+                "SHAPE_FILL"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "default-hover": {
+          "$type": "color",
+          "$value": "{default.neutral.alpha.stronger}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "FRAME_FILL",
+                "SHAPE_FILL"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "default-pressed": {
+          "$type": "color",
+          "$value": "{default.neutral.alpha.strongest}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "FRAME_FILL",
+                "SHAPE_FILL"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "subtle": {
+          "$type": "color",
+          "$value": "{default.neutral.alpha.default}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "FRAME_FILL",
+                "SHAPE_FILL"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "subtle-hover": {
+          "$type": "color",
+          "$value": "{default.neutral.alpha.medium}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "FRAME_FILL",
+                "SHAPE_FILL"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "subtle-pressed": {
+          "$type": "color",
+          "$value": "{default.neutral.alpha.strong}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "FRAME_FILL",
+                "SHAPE_FILL"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "extra-subtle": {
+          "$type": "color",
+          "$value": "{default.neutral.alpha.subtlest}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "FRAME_FILL",
+                "SHAPE_FILL"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "extra-subtle-hover": {
+          "$type": "color",
+          "$value": "{default.neutral.alpha.subtler}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "FRAME_FILL",
+                "SHAPE_FILL"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "extra-subtle-pressed": {
+          "$type": "color",
+          "$value": "{default.neutral.alpha.subtle}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "FRAME_FILL",
+                "SHAPE_FILL"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        }
+      },
+      "feedback": {
+        "info": {
+          "$type": "color",
+          "$value": "{default.feedback.info.strong}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "FRAME_FILL",
+                "SHAPE_FILL"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "info-subtle": {
+          "$type": "color",
+          "$value": "{default.feedback.info.subtler}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "FRAME_FILL",
+                "SHAPE_FILL"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "success": {
+          "$type": "color",
+          "$value": "{default.feedback.success.strong}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "FRAME_FILL",
+                "SHAPE_FILL"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "success-subtle": {
+          "$type": "color",
+          "$value": "{default.feedback.success.subtler}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "FRAME_FILL",
+                "SHAPE_FILL"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "warning": {
+          "$type": "color",
+          "$value": "{default.feedback.warning.strong}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "FRAME_FILL",
+                "SHAPE_FILL"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "warning-subtle": {
+          "$type": "color",
+          "$value": "{default.feedback.warning.subtler}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "FRAME_FILL",
+                "SHAPE_FILL"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "critical": {
+          "$type": "color",
+          "$value": "{default.feedback.critical.strong}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "FRAME_FILL",
+                "SHAPE_FILL"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "critical-subtle": {
+          "$type": "color",
+          "$value": "{default.feedback.critical.subtler}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "FRAME_FILL",
+                "SHAPE_FILL"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "tip": {
+          "$type": "color",
+          "$value": "{default.feedback.tip.stronger}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "FRAME_FILL",
+                "SHAPE_FILL"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "tip-subtle": {
+          "$type": "color",
+          "$value": "{default.feedback.tip.subtler}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "FRAME_FILL",
+                "SHAPE_FILL"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        }
+      }
+    },
+    "foreground": {
+      "default": {
+        "$type": "color",
+        "$value": "{default.neutral.strongest}",
+        "$description": "",
+        "$extensions": {
+          "com.figma": {
+            "hiddenFromPublishing": false,
+            "scopes": [
+              "TEXT_FILL"
+            ],
+            "codeSyntax": {}
+          }
+        }
+      },
+      "subtle": {
+        "$type": "color",
+        "$value": "{default.neutral.strong}",
+        "$description": "",
+        "$extensions": {
+          "com.figma": {
+            "hiddenFromPublishing": false,
+            "scopes": [
+              "TEXT_FILL"
+            ],
+            "codeSyntax": {}
+          }
+        }
+      },
+      "emphasis": {
+        "$type": "color",
+        "$value": "{default.brand.emphasis.stronger}",
+        "$description": "",
+        "$extensions": {
+          "com.figma": {
+            "hiddenFromPublishing": false,
+            "scopes": [
+              "TEXT_FILL"
+            ],
+            "codeSyntax": {}
+          }
+        }
+      },
+      "inverse": {
+        "$type": "color",
+        "$value": "{default.neutral.subtlest}",
+        "$description": "",
+        "$extensions": {
+          "com.figma": {
+            "hiddenFromPublishing": false,
+            "scopes": [
+              "TEXT_FILL"
+            ],
+            "codeSyntax": {}
+          }
+        }
+      },
+      "on-fill": {
+        "default": {
+          "$type": "color",
+          "$value": "{default.neutral.inverted}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "TEXT_FILL"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "inverse": {
+          "$type": "color",
+          "$value": "{default.neutral.strongest}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "TEXT_FILL"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        }
+      },
+      "interactive": {
+        "link": {
+          "$type": "color",
+          "$value": "{default.interactive.default}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "TEXT_FILL"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "link-hover": {
+          "$type": "color",
+          "$value": "{default.interactive.hover}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "TEXT_FILL"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "link-pressed": {
+          "$type": "color",
+          "$value": "{default.interactive.pressed}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "TEXT_FILL"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "link-active": {
+          "$type": "color",
+          "$value": "{default.interactive.selected.default}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "TEXT_FILL"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        }
+      },
+      "feedback": {
+        "info": {
+          "$type": "color",
+          "$value": "{default.feedback.info.strongest}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "TEXT_FILL"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "success": {
+          "$type": "color",
+          "$value": "{default.feedback.success.strongest}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "TEXT_FILL"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "warning": {
+          "$type": "color",
+          "$value": "{default.feedback.warning.strongest}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "TEXT_FILL"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "critical": {
+          "$type": "color",
+          "$value": "{default.feedback.critical.strongest}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "TEXT_FILL"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "tip": {
+          "$type": "color",
+          "$value": "{default.feedback.tip.strongest}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "TEXT_FILL"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        }
+      }
+    },
+    "border": {
+      "primary": {
+        "default": {
+          "$type": "color",
+          "$value": "{default.neutral.default}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "STROKE_COLOR"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "default-hover": {
+          "$type": "color",
+          "$value": "{default.neutral.medium}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "STROKE_COLOR"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "default-pressed": {
+          "$type": "color",
+          "$value": "{default.neutral.strong}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "STROKE_COLOR"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "subtle": {
+          "$type": "color",
+          "$value": "{default.neutral.subtler}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "STROKE_COLOR"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "subtle-hover": {
+          "$type": "color",
+          "$value": "{default.neutral.subtle}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "STROKE_COLOR"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "subtle-pressed": {
+          "$type": "color",
+          "$value": "{default.neutral.default}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "STROKE_COLOR"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "emphasis": {
+          "$type": "color",
+          "$value": "{default.brand.emphasis.strongest}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "STROKE_COLOR"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        }
+      },
+      "secondary": {
+        "default": {
+          "$type": "color",
+          "$value": "{default.brand.secondary.medium}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "STROKE_COLOR"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "hover": {
+          "$type": "color",
+          "$value": "{default.brand.secondary.strong}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "STROKE_COLOR"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "pressed": {
+          "$type": "color",
+          "$value": "{default.brand.secondary.stronger}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "STROKE_COLOR"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        }
+      },
+      "tertiary": {
+        "default": {
+          "$type": "color",
+          "$value": "{default.brand.tertiary.medium}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "STROKE_COLOR"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "hover": {
+          "$type": "color",
+          "$value": "{default.brand.tertiary.strong}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "STROKE_COLOR"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "pressed": {
+          "$type": "color",
+          "$value": "{default.brand.tertiary.stronger}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "STROKE_COLOR"
+              ],
+              "codeSyntax": {
+                "WEB": "color--ffe-border-tertiary-pressed"
+              }
+            }
+          }
+        }
+      },
+      "interactive": {
+        "focus": {
+          "$type": "color",
+          "$value": "{default.interactive.focus}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "STROKE_COLOR"
+              ],
+              "codeSyntax": {
+                "WEB": "--ffe-color-border-interactive-focus"
+              }
+            }
+          }
+        },
+        "selected": {
+          "$type": "color",
+          "$value": "{default.brand.primary.stronger}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "STROKE_COLOR"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        }
+      },
+      "feedback": {
+        "info": {
+          "$type": "color",
+          "$value": "{default.feedback.info.strong}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "STROKE_COLOR"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "success": {
+          "$type": "color",
+          "$value": "{default.feedback.success.strong}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "STROKE_COLOR"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "warning": {
+          "$type": "color",
+          "$value": "{default.feedback.warning.strong}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "STROKE_COLOR"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "critical": {
+          "$type": "color",
+          "$value": "{default.feedback.critical.strong}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "STROKE_COLOR"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "tip": {
+          "$type": "color",
+          "$value": "{default.feedback.tip.strong}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [
+                "STROKE_COLOR"
+              ],
+              "codeSyntax": {}
+            }
+          }
+        }
+      }
+    },
+    "component": {
+      "button": {
+        "action": {
+          "border": {
+            "default": {
+              "$type": "color",
+              "$value": "{default.feedback.success.medium}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": [
+                    "STROKE_COLOR"
+                  ],
+                  "codeSyntax": {}
+                }
+              }
+            },
+            "hover": {
+              "$type": "color",
+              "$value": "{default.feedback.success.strong}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": [
+                    "STROKE_COLOR"
+                  ],
+                  "codeSyntax": {}
+                }
+              }
+            },
+            "pressed": {
+              "$type": "color",
+              "$value": "{default.feedback.success.stronger}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": [
+                    "STROKE_COLOR"
+                  ],
+                  "codeSyntax": {}
+                }
+              }
+            }
+          },
+          "fill": {
+            "default": {
+              "$type": "color",
+              "$value": "{accent.feedback.success.subtle}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": [
+                    "FRAME_FILL"
+                  ],
+                  "codeSyntax": {}
+                }
+              }
+            },
+            "hover": {
+              "$type": "color",
+              "$value": "{accent.feedback.success.subtler}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": [
+                    "FRAME_FILL"
+                  ],
+                  "codeSyntax": {}
+                }
+              }
+            },
+            "pressed": {
+              "$type": "color",
+              "$value": "{accent.feedback.success.subtle}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": [
+                    "FRAME_FILL"
+                  ],
+                  "codeSyntax": {}
+                }
+              }
+            }
+          },
+          "foreground": {
+            "default": {
+              "$type": "color",
+              "$value": "{speciality.static.neutral.white}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": [
+                    "TEXT_FILL"
+                  ],
+                  "codeSyntax": {}
+                }
+              }
+            },
+            "hover": {
+              "$type": "color",
+              "$value": "{speciality.static.neutral.white}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": [
+                    "TEXT_FILL"
+                  ],
+                  "codeSyntax": {}
+                }
+              }
+            }
+          }
+        },
+        "primary": {
+          "border": {
+            "default": {
+              "$type": "color",
+              "$value": "{default.brand.emphasis.strong}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": [
+                    "STROKE_COLOR"
+                  ],
+                  "codeSyntax": {}
+                }
+              }
+            },
+            "hover": {
+              "$type": "color",
+              "$value": "{default.brand.emphasis.stronger}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": [
+                    "STROKE_COLOR"
+                  ],
+                  "codeSyntax": {}
+                }
+              }
+            },
+            "pressed": {
+              "$type": "color",
+              "$value": "{default.brand.emphasis.strongest}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": [
+                    "STROKE_COLOR"
+                  ],
+                  "codeSyntax": {}
+                }
+              }
+            }
+          },
+          "fill": {
+            "default": {
+              "$type": "color",
+              "$value": "{speciality.buttons.primary.default.fill.default}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": [
+                    "FRAME_FILL"
+                  ],
+                  "codeSyntax": {}
+                }
+              }
+            },
+            "hover": {
+              "$type": "color",
+              "$value": "{speciality.buttons.primary.default.fill.hover}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": [
+                    "FRAME_FILL"
+                  ],
+                  "codeSyntax": {}
+                }
+              }
+            },
+            "pressed": {
+              "$type": "color",
+              "$value": "{speciality.buttons.primary.default.fill.pressed}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": [
+                    "FRAME_FILL"
+                  ],
+                  "codeSyntax": {}
+                }
+              }
+            }
+          },
+          "foreground": {
+            "default": {
+              "$type": "color",
+              "$value": "{speciality.static.neutral.white}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": [
+                    "TEXT_FILL"
+                  ],
+                  "codeSyntax": {}
+                }
+              }
+            },
+            "hover": {
+              "$type": "color",
+              "$value": "{speciality.static.neutral.white}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": [
+                    "TEXT_FILL"
+                  ],
+                  "codeSyntax": {}
+                }
+              }
+            }
+          }
+        },
+        "secondary": {
+          "border": {
+            "default": {
+              "$type": "color",
+              "$value": "{speciality.buttons.secondary.default.border.default}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": [
+                    "STROKE_COLOR"
+                  ],
+                  "codeSyntax": {}
+                }
+              }
+            },
+            "hover": {
+              "$type": "color",
+              "$value": "{speciality.buttons.secondary.default.border.default}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": [
+                    "STROKE_COLOR"
+                  ],
+                  "codeSyntax": {}
+                }
+              }
+            },
+            "pressed": {
+              "$type": "color",
+              "$value": "{speciality.buttons.secondary.default.border.default}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": [
+                    "STROKE_COLOR"
+                  ],
+                  "codeSyntax": {}
+                }
+              }
+            }
+          },
+          "fill": {
+            "default": {
+              "$type": "color",
+              "$value": "{speciality.buttons.secondary.default.fill.default}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": [
+                    "FRAME_FILL"
+                  ],
+                  "codeSyntax": {}
+                }
+              }
+            },
+            "hover": {
+              "$type": "color",
+              "$value": "{speciality.buttons.secondary.default.fill.hover}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": [
+                    "FRAME_FILL"
+                  ],
+                  "codeSyntax": {}
+                }
+              }
+            },
+            "pressed": {
+              "$type": "color",
+              "$value": "{speciality.buttons.secondary.default.fill.pressed}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": [
+                    "FRAME_FILL"
+                  ],
+                  "codeSyntax": {}
+                }
+              }
+            }
+          },
+          "foreground": {
+            "default": {
+              "$type": "color",
+              "$value": "{speciality.buttons.secondary.default.foreground.default}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": [
+                    "TEXT_FILL"
+                  ],
+                  "codeSyntax": {}
+                }
+              }
+            },
+            "hover": {
+              "$type": "color",
+              "$value": "{speciality.buttons.secondary.default.foreground.default}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": [
+                    "TEXT_FILL"
+                  ],
+                  "codeSyntax": {}
+                }
+              }
+            }
+          }
+        },
+        "tertiary": {
+          "fill": {
+            "default": {
+              "$type": "color",
+              "$value": "{speciality.buttons.tertiary.default.fill.default}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": [
+                    "FRAME_FILL"
+                  ],
+                  "codeSyntax": {}
+                }
+              }
+            },
+            "hover": {
+              "$type": "color",
+              "$value": "{speciality.buttons.tertiary.default.fill.hover}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": [
+                    "FRAME_FILL"
+                  ],
+                  "codeSyntax": {}
+                }
+              }
+            },
+            "pressed": {
+              "$type": "color",
+              "$value": "{speciality.buttons.tertiary.default.fill.pressed}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": [
+                    "FRAME_FILL"
+                  ],
+                  "codeSyntax": {}
+                }
+              }
+            }
+          },
+          "foreground": {
+            "default": {
+              "$type": "color",
+              "$value": "{speciality.buttons.tertiary.default.foreground.default}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": [
+                    "TEXT_FILL"
+                  ],
+                  "codeSyntax": {}
+                }
+              }
+            },
+            "hover": {
+              "$type": "color",
+              "$value": "{speciality.buttons.tertiary.default.foreground.default}",
+              "$description": "",
+              "$extensions": {
+                "com.figma": {
+                  "hiddenFromPublishing": false,
+                  "scopes": [
+                    "TEXT_FILL"
+                  ],
+                  "codeSyntax": {}
+                }
+              }
+            }
+          }
+        }
+      },
+      "toggleSwitch": {
+        "handle": {
+          "default": {
+            "$type": "color",
+            "$value": "{speciality.static.neutral.white}",
+            "$description": "",
+            "$extensions": {
+              "com.figma": {
+                "hiddenFromPublishing": false,
+                "scopes": [],
+                "codeSyntax": {}
+              }
+            }
+          }
         },
         "fill": {
-            "primary": {
-                "default": {
-                    "$type": "color",
-                    "$value": "{default.brand.primary.medium}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["FRAME_FILL", "SHAPE_FILL"],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "hover": {
-                    "$type": "color",
-                    "$value": "{default.brand.primary.strong}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["FRAME_FILL", "SHAPE_FILL"],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "pressed": {
-                    "$type": "color",
-                    "$value": "{default.brand.primary.stronger}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["FRAME_FILL", "SHAPE_FILL"],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "selected": {
-                    "$type": "color",
-                    "$value": "{default.brand.primary.strong}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["FRAME_FILL", "SHAPE_FILL"],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "selected-hover": {
-                    "$type": "color",
-                    "$value": "{default.brand.primary.stronger}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["FRAME_FILL", "SHAPE_FILL"],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "selected-pressed": {
-                    "$type": "color",
-                    "$value": "{default.brand.primary.strongest}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["FRAME_FILL", "SHAPE_FILL"],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "subtle": {
-                    "$type": "color",
-                    "$value": "{default.brand.primary.subtlest}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["FRAME_FILL", "SHAPE_FILL"],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "subtle-hover": {
-                    "$type": "color",
-                    "$value": "{default.brand.primary.subtler}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["FRAME_FILL", "SHAPE_FILL"],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "subtle-pressed": {
-                    "$type": "color",
-                    "$value": "{default.brand.primary.subtle}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["FRAME_FILL", "SHAPE_FILL"],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "invisible": {
-                    "$type": "color",
-                    "$value": "{speciality.background.transparent}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["FRAME_FILL", "SHAPE_FILL"],
-                            "codeSyntax": {}
-                        }
-                    }
-                }
-            },
-            "secondary": {
-                "default": {
-                    "$type": "color",
-                    "$value": "{default.brand.secondary.strong}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["FRAME_FILL", "SHAPE_FILL"],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "default-hover": {
-                    "$type": "color",
-                    "$value": "{default.brand.secondary.stronger}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["FRAME_FILL", "SHAPE_FILL"],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "default-pressed": {
-                    "$type": "color",
-                    "$value": "{default.brand.secondary.strongest}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["FRAME_FILL", "SHAPE_FILL"],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "subtle": {
-                    "$type": "color",
-                    "$value": "{default.brand.secondary.subtlest}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["FRAME_FILL", "SHAPE_FILL"],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "subtle-hover": {
-                    "$type": "color",
-                    "$value": "{default.brand.secondary.subtler}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["FRAME_FILL", "SHAPE_FILL"],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "subtle-pressed": {
-                    "$type": "color",
-                    "$value": "{default.brand.secondary.subtle}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["FRAME_FILL", "SHAPE_FILL"],
-                            "codeSyntax": {}
-                        }
-                    }
-                }
-            },
-            "tertiary": {
-                "default": {
-                    "$type": "color",
-                    "$value": "{default.brand.tertiary.strong}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["FRAME_FILL", "SHAPE_FILL"],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "default-hover": {
-                    "$type": "color",
-                    "$value": "{default.brand.tertiary.stronger}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["FRAME_FILL", "SHAPE_FILL"],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "default-pressed": {
-                    "$type": "color",
-                    "$value": "{default.brand.tertiary.strongest}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["FRAME_FILL", "SHAPE_FILL"],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "subtle": {
-                    "$type": "color",
-                    "$value": "{default.brand.tertiary.subtlest}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["FRAME_FILL", "SHAPE_FILL"],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "subtle-hover": {
-                    "$type": "color",
-                    "$value": "{default.brand.tertiary.subtler}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["FRAME_FILL", "SHAPE_FILL"],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "subtle-pressed": {
-                    "$type": "color",
-                    "$value": "{default.brand.tertiary.subtle}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["FRAME_FILL", "SHAPE_FILL"],
-                            "codeSyntax": {}
-                        }
-                    }
-                }
-            },
-            "feedback": {
-                "info": {
-                    "$type": "color",
-                    "$value": "{default.feedback.info.strong}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["FRAME_FILL", "SHAPE_FILL"],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "info-subtle": {
-                    "$type": "color",
-                    "$value": "{default.feedback.info.subtler}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["FRAME_FILL", "SHAPE_FILL"],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "success": {
-                    "$type": "color",
-                    "$value": "{default.feedback.success.strong}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["FRAME_FILL", "SHAPE_FILL"],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "success-subtle": {
-                    "$type": "color",
-                    "$value": "{default.feedback.success.subtler}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["FRAME_FILL", "SHAPE_FILL"],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "warning": {
-                    "$type": "color",
-                    "$value": "{default.feedback.warning.strong}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["FRAME_FILL", "SHAPE_FILL"],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "warning-subtle": {
-                    "$type": "color",
-                    "$value": "{default.feedback.warning.subtler}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["FRAME_FILL", "SHAPE_FILL"],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "critical": {
-                    "$type": "color",
-                    "$value": "{default.feedback.critical.strong}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["FRAME_FILL", "SHAPE_FILL"],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "critical-subtle": {
-                    "$type": "color",
-                    "$value": "{default.feedback.critical.subtler}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["FRAME_FILL", "SHAPE_FILL"],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "tip": {
-                    "$type": "color",
-                    "$value": "{default.feedback.tip.stronger}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["FRAME_FILL", "SHAPE_FILL"],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "tip-subtle": {
-                    "$type": "color",
-                    "$value": "{default.feedback.tip.subtler}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["FRAME_FILL", "SHAPE_FILL"],
-                            "codeSyntax": {}
-                        }
-                    }
-                }
+          "default": {
+            "$type": "color",
+            "$value": "{default.neutral.medium}",
+            "$description": "",
+            "$extensions": {
+              "com.figma": {
+                "hiddenFromPublishing": false,
+                "scopes": [],
+                "codeSyntax": {}
+              }
             }
-        },
-        "foreground": {
-            "default": {
-                "$type": "color",
-                "$value": "{default.neutral.strongest}",
-                "$description": "",
-                "$extensions": {
-                    "com.figma": {
-                        "hiddenFromPublishing": false,
-                        "scopes": ["TEXT_FILL"],
-                        "codeSyntax": {}
-                    }
-                }
-            },
-            "subtle": {
-                "$type": "color",
-                "$value": "{default.neutral.strong}",
-                "$description": "",
-                "$extensions": {
-                    "com.figma": {
-                        "hiddenFromPublishing": false,
-                        "scopes": ["TEXT_FILL"],
-                        "codeSyntax": {}
-                    }
-                }
-            },
-            "emphasis": {
-                "$type": "color",
-                "$value": "{default.brand.emphasis.strongest}",
-                "$description": "",
-                "$extensions": {
-                    "com.figma": {
-                        "hiddenFromPublishing": false,
-                        "scopes": ["TEXT_FILL"],
-                        "codeSyntax": {}
-                    }
-                }
-            },
-            "inverse": {
-                "$type": "color",
-                "$value": "{default.neutral.sublest}",
-                "$description": "",
-                "$extensions": {
-                    "com.figma": {
-                        "hiddenFromPublishing": false,
-                        "scopes": ["TEXT_FILL"],
-                        "codeSyntax": {}
-                    }
-                }
-            },
-            "on-fill": {
-                "default": {
-                    "$type": "color",
-                    "$value": "{default.neutral.inverted}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["TEXT_FILL"],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "inverse": {
-                    "$type": "color",
-                    "$value": "{default.neutral.strongest}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["TEXT_FILL"],
-                            "codeSyntax": {}
-                        }
-                    }
-                }
-            },
-            "interactive": {
-                "link": {
-                    "$type": "color",
-                    "$value": "{default.interactive.default}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["TEXT_FILL"],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "link-hover": {
-                    "$type": "color",
-                    "$value": "{default.interactive.hover}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["TEXT_FILL"],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "link-pressed": {
-                    "$type": "color",
-                    "$value": "{default.interactive.pressed}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["TEXT_FILL"],
-                            "codeSyntax": {}
-                        }
-                    }
-                }
-            },
-            "feedback": {
-                "info": {
-                    "$type": "color",
-                    "$value": "{default.feedback.info.strongest}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["TEXT_FILL"],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "success": {
-                    "$type": "color",
-                    "$value": "{default.feedback.success.strongest}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["TEXT_FILL"],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "warning": {
-                    "$type": "color",
-                    "$value": "{default.feedback.warning.strongest}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["TEXT_FILL"],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "critical": {
-                    "$type": "color",
-                    "$value": "{default.feedback.critical.strongest}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["TEXT_FILL"],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "tip": {
-                    "$type": "color",
-                    "$value": "{default.feedback.tip.strongest}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["TEXT_FILL"],
-                            "codeSyntax": {}
-                        }
-                    }
-                }
+          },
+          "default-hover": {
+            "$type": "color",
+            "$value": "{default.neutral.strong}",
+            "$description": "",
+            "$extensions": {
+              "com.figma": {
+                "hiddenFromPublishing": false,
+                "scopes": [],
+                "codeSyntax": {}
+              }
             }
-        },
-        "border": {
-            "primary": {
-                "default": {
-                    "$type": "color",
-                    "$value": "{default.neutral.medium}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["STROKE_COLOR"],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "hover": {
-                    "$type": "color",
-                    "$value": "{default.neutral.strong}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["STROKE_COLOR"],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "pressed": {
-                    "$type": "color",
-                    "$value": "{default.neutral.strongest}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["STROKE_COLOR"],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "subtle": {
-                    "$type": "color",
-                    "$value": "{default.neutral.subtler}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["STROKE_COLOR"],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "emphasis": {
-                    "$type": "color",
-                    "$value": "{default.brand.emphasis.strongest}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["STROKE_COLOR"],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "selected": {
-                    "$type": "color",
-                    "$value": "{default.brand.primary.stronger}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["STROKE_COLOR"],
-                            "codeSyntax": {}
-                        }
-                    }
-                }
-            },
-            "secondary": {
-                "default": {
-                    "$type": "color",
-                    "$value": "{accent.brand.secondary.medium}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["STROKE_COLOR"],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "hover": {
-                    "$type": "color",
-                    "$value": "{default.brand.secondary.strong}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["STROKE_COLOR"],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "pressed": {
-                    "$type": "color",
-                    "$value": "{default.brand.secondary.stronger}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["STROKE_COLOR"],
-                            "codeSyntax": {}
-                        }
-                    }
-                }
-            },
-            "tertiary": {
-                "default": {
-                    "$type": "color",
-                    "$value": "{default.brand.tertiary.strong}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["STROKE_COLOR"],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "hover": {
-                    "$type": "color",
-                    "$value": "{default.brand.tertiary.stronger}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["STROKE_COLOR"],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "pressed": {
-                    "$type": "color",
-                    "$value": "{default.brand.tertiary.strongest}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["STROKE_COLOR"],
-                            "codeSyntax": {}
-                        }
-                    }
-                }
-            },
-            "interactive": {
-                "focus": {
-                    "$type": "color",
-                    "$value": "{default.interactive.focus}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["STROKE_COLOR"],
-                            "codeSyntax": {}
-                        }
-                    }
-                }
-            },
-            "feedback": {
-                "info": {
-                    "$type": "color",
-                    "$value": "{default.feedback.info.strong}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["STROKE_COLOR"],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "success": {
-                    "$type": "color",
-                    "$value": "{default.feedback.success.strong}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["STROKE_COLOR"],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "warning": {
-                    "$type": "color",
-                    "$value": "{default.feedback.warning.strong}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["STROKE_COLOR"],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "critical": {
-                    "$type": "color",
-                    "$value": "{default.feedback.critical.strong}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["STROKE_COLOR"],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "tip": {
-                    "$type": "color",
-                    "$value": "{default.feedback.tip.strong}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": ["STROKE_COLOR"],
-                            "codeSyntax": {}
-                        }
-                    }
-                }
+          },
+          "default-pressed": {
+            "$type": "color",
+            "$value": "{default.neutral.medium}",
+            "$description": "",
+            "$extensions": {
+              "com.figma": {
+                "hiddenFromPublishing": false,
+                "scopes": [],
+                "codeSyntax": {}
+              }
             }
-        },
-        "component": {
-            "button": {
-                "action": {
-                    "border": {
-                        "default": {
-                            "$type": "color",
-                            "$value": "{default.feedback.success.strong}",
-                            "$description": "",
-                            "$extensions": {
-                                "com.figma": {
-                                    "hiddenFromPublishing": false,
-                                    "scopes": ["STROKE_COLOR"],
-                                    "codeSyntax": {}
-                                }
-                            }
-                        },
-                        "hover": {
-                            "$type": "color",
-                            "$value": "{default.feedback.success.stronger}",
-                            "$description": "",
-                            "$extensions": {
-                                "com.figma": {
-                                    "hiddenFromPublishing": false,
-                                    "scopes": ["STROKE_COLOR"],
-                                    "codeSyntax": {}
-                                }
-                            }
-                        },
-                        "pressed": {
-                            "$type": "color",
-                            "$value": "{default.feedback.success.strongest}",
-                            "$description": "",
-                            "$extensions": {
-                                "com.figma": {
-                                    "hiddenFromPublishing": false,
-                                    "scopes": ["STROKE_COLOR"],
-                                    "codeSyntax": {}
-                                }
-                            }
-                        }
-                    },
-                    "fill": {
-                        "default": {
-                            "$type": "color",
-                            "$value": "{default.feedback.success.strong}",
-                            "$description": "",
-                            "$extensions": {
-                                "com.figma": {
-                                    "hiddenFromPublishing": false,
-                                    "scopes": ["FRAME_FILL"],
-                                    "codeSyntax": {}
-                                }
-                            }
-                        },
-                        "hover": {
-                            "$type": "color",
-                            "$value": "{default.feedback.success.stronger}",
-                            "$description": "",
-                            "$extensions": {
-                                "com.figma": {
-                                    "hiddenFromPublishing": false,
-                                    "scopes": ["FRAME_FILL"],
-                                    "codeSyntax": {}
-                                }
-                            }
-                        },
-                        "pressed": {
-                            "$type": "color",
-                            "$value": "{default.feedback.success.strongest}",
-                            "$description": "",
-                            "$extensions": {
-                                "com.figma": {
-                                    "hiddenFromPublishing": false,
-                                    "scopes": ["FRAME_FILL"],
-                                    "codeSyntax": {}
-                                }
-                            }
-                        }
-                    },
-                    "foreground": {
-                        "default": {
-                            "$type": "color",
-                            "$value": "{default.neutral.inverted}",
-                            "$description": "",
-                            "$extensions": {
-                                "com.figma": {
-                                    "hiddenFromPublishing": false,
-                                    "scopes": ["TEXT_FILL"],
-                                    "codeSyntax": {}
-                                }
-                            }
-                        },
-                        "hover": {
-                            "$type": "color",
-                            "$value": "{default.neutral.sublest}",
-                            "$description": "",
-                            "$extensions": {
-                                "com.figma": {
-                                    "hiddenFromPublishing": false,
-                                    "scopes": ["TEXT_FILL"],
-                                    "codeSyntax": {}
-                                }
-                            }
-                        }
-                    }
-                },
-                "primary": {
-                    "border": {
-                        "default": {
-                            "$type": "color",
-                            "$value": "{default.brand.primary.strong}",
-                            "$description": "",
-                            "$extensions": {
-                                "com.figma": {
-                                    "hiddenFromPublishing": false,
-                                    "scopes": ["STROKE_COLOR"],
-                                    "codeSyntax": {}
-                                }
-                            }
-                        },
-                        "hover": {
-                            "$type": "color",
-                            "$value": "{default.brand.primary.stronger}",
-                            "$description": "",
-                            "$extensions": {
-                                "com.figma": {
-                                    "hiddenFromPublishing": false,
-                                    "scopes": ["STROKE_COLOR"],
-                                    "codeSyntax": {}
-                                }
-                            }
-                        },
-                        "pressed": {
-                            "$type": "color",
-                            "$value": "{default.brand.primary.strongest}",
-                            "$description": "",
-                            "$extensions": {
-                                "com.figma": {
-                                    "hiddenFromPublishing": false,
-                                    "scopes": ["STROKE_COLOR"],
-                                    "codeSyntax": {}
-                                }
-                            }
-                        }
-                    },
-                    "fill": {
-                        "default": {
-                            "$type": "color",
-                            "$value": "{default.brand.primary.strong}",
-                            "$description": "",
-                            "$extensions": {
-                                "com.figma": {
-                                    "hiddenFromPublishing": false,
-                                    "scopes": ["FRAME_FILL"],
-                                    "codeSyntax": {}
-                                }
-                            }
-                        },
-                        "hover": {
-                            "$type": "color",
-                            "$value": "{default.brand.primary.stronger}",
-                            "$description": "",
-                            "$extensions": {
-                                "com.figma": {
-                                    "hiddenFromPublishing": false,
-                                    "scopes": ["FRAME_FILL"],
-                                    "codeSyntax": {}
-                                }
-                            }
-                        },
-                        "pressed": {
-                            "$type": "color",
-                            "$value": "{default.brand.primary.strongest}",
-                            "$description": "",
-                            "$extensions": {
-                                "com.figma": {
-                                    "hiddenFromPublishing": false,
-                                    "scopes": ["FRAME_FILL"],
-                                    "codeSyntax": {}
-                                }
-                            }
-                        }
-                    },
-                    "foreground": {
-                        "default": {
-                            "$type": "color",
-                            "$value": "{default.neutral.inverted}",
-                            "$description": "",
-                            "$extensions": {
-                                "com.figma": {
-                                    "hiddenFromPublishing": false,
-                                    "scopes": ["TEXT_FILL"],
-                                    "codeSyntax": {}
-                                }
-                            }
-                        },
-                        "hover": {
-                            "$type": "color",
-                            "$value": "{default.neutral.sublest}",
-                            "$description": "",
-                            "$extensions": {
-                                "com.figma": {
-                                    "hiddenFromPublishing": false,
-                                    "scopes": ["TEXT_FILL"],
-                                    "codeSyntax": {}
-                                }
-                            }
-                        }
-                    }
-                },
-                "secondary": {
-                    "border": {
-                        "default": {
-                            "$type": "color",
-                            "$value": "{default.brand.primary.strong}",
-                            "$description": "",
-                            "$extensions": {
-                                "com.figma": {
-                                    "hiddenFromPublishing": false,
-                                    "scopes": ["STROKE_COLOR"],
-                                    "codeSyntax": {}
-                                }
-                            }
-                        },
-                        "hover": {
-                            "$type": "color",
-                            "$value": "{default.brand.primary.stronger}",
-                            "$description": "",
-                            "$extensions": {
-                                "com.figma": {
-                                    "hiddenFromPublishing": false,
-                                    "scopes": ["STROKE_COLOR"],
-                                    "codeSyntax": {}
-                                }
-                            }
-                        },
-                        "pressed": {
-                            "$type": "color",
-                            "$value": "{default.brand.primary.strongest}",
-                            "$description": "",
-                            "$extensions": {
-                                "com.figma": {
-                                    "hiddenFromPublishing": false,
-                                    "scopes": ["STROKE_COLOR"],
-                                    "codeSyntax": {}
-                                }
-                            }
-                        }
-                    },
-                    "fill": {
-                        "default": {
-                            "$type": "color",
-                            "$value": "{color.fill.primary.invisible}",
-                            "$description": "",
-                            "$extensions": {
-                                "com.figma": {
-                                    "hiddenFromPublishing": false,
-                                    "scopes": ["FRAME_FILL"],
-                                    "codeSyntax": {}
-                                }
-                            }
-                        },
-                        "hover": {
-                            "$type": "color",
-                            "$value": "{default.brand.primary.subtlest}",
-                            "$description": "",
-                            "$extensions": {
-                                "com.figma": {
-                                    "hiddenFromPublishing": false,
-                                    "scopes": ["FRAME_FILL"],
-                                    "codeSyntax": {}
-                                }
-                            }
-                        },
-                        "pressed": {
-                            "$type": "color",
-                            "$value": "{default.brand.primary.subtler}",
-                            "$description": "",
-                            "$extensions": {
-                                "com.figma": {
-                                    "hiddenFromPublishing": false,
-                                    "scopes": ["FRAME_FILL"],
-                                    "codeSyntax": {}
-                                }
-                            }
-                        }
-                    },
-                    "foreground": {
-                        "default": {
-                            "$type": "color",
-                            "$value": "{default.brand.emphasis.strongest}",
-                            "$description": "",
-                            "$extensions": {
-                                "com.figma": {
-                                    "hiddenFromPublishing": false,
-                                    "scopes": ["TEXT_FILL"],
-                                    "codeSyntax": {}
-                                }
-                            }
-                        },
-                        "hover": {
-                            "$type": "color",
-                            "$value": "{default.brand.emphasis.strongest}",
-                            "$description": "",
-                            "$extensions": {
-                                "com.figma": {
-                                    "hiddenFromPublishing": false,
-                                    "scopes": ["TEXT_FILL"],
-                                    "codeSyntax": {}
-                                }
-                            }
-                        }
-                    }
-                },
-                "tertiary": {
-                    "border": {
-                        "default": {
-                            "$type": "color",
-                            "$value": "{default.brand.primary.default}",
-                            "$description": "",
-                            "$extensions": {
-                                "com.figma": {
-                                    "hiddenFromPublishing": false,
-                                    "scopes": ["STROKE_COLOR"],
-                                    "codeSyntax": {}
-                                }
-                            }
-                        },
-                        "hover": {
-                            "$type": "color",
-                            "$value": "{default.brand.primary.stronger}",
-                            "$description": "",
-                            "$extensions": {
-                                "com.figma": {
-                                    "hiddenFromPublishing": false,
-                                    "scopes": ["STROKE_COLOR"],
-                                    "codeSyntax": {}
-                                }
-                            }
-                        },
-                        "pressed": {
-                            "$type": "color",
-                            "$value": "{default.brand.primary.strongest}",
-                            "$description": "",
-                            "$extensions": {
-                                "com.figma": {
-                                    "hiddenFromPublishing": false,
-                                    "scopes": ["STROKE_COLOR"],
-                                    "codeSyntax": {}
-                                }
-                            }
-                        }
-                    },
-                    "fill": {
-                        "default": {
-                            "$type": "color",
-                            "$value": "{color.background.default}",
-                            "$description": "",
-                            "$extensions": {
-                                "com.figma": {
-                                    "hiddenFromPublishing": false,
-                                    "scopes": ["FRAME_FILL"],
-                                    "codeSyntax": {}
-                                }
-                            }
-                        },
-                        "hover": {
-                            "$type": "color",
-                            "$value": "{default.brand.primary.subtlest}",
-                            "$description": "",
-                            "$extensions": {
-                                "com.figma": {
-                                    "hiddenFromPublishing": false,
-                                    "scopes": ["FRAME_FILL"],
-                                    "codeSyntax": {}
-                                }
-                            }
-                        },
-                        "pressed": {
-                            "$type": "color",
-                            "$value": "{default.brand.primary.subtler}",
-                            "$description": "",
-                            "$extensions": {
-                                "com.figma": {
-                                    "hiddenFromPublishing": false,
-                                    "scopes": ["FRAME_FILL"],
-                                    "codeSyntax": {}
-                                }
-                            }
-                        }
-                    },
-                    "foreground": {
-                        "default": {
-                            "$type": "color",
-                            "$value": "{default.brand.emphasis.strongest}",
-                            "$description": "",
-                            "$extensions": {
-                                "com.figma": {
-                                    "hiddenFromPublishing": false,
-                                    "scopes": ["TEXT_FILL"],
-                                    "codeSyntax": {}
-                                }
-                            }
-                        },
-                        "hover": {
-                            "$type": "color",
-                            "$value": "{default.brand.emphasis.strongest}",
-                            "$description": "",
-                            "$extensions": {
-                                "com.figma": {
-                                    "hiddenFromPublishing": false,
-                                    "scopes": ["TEXT_FILL"],
-                                    "codeSyntax": {}
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "toggleSwitch": {
-                "handle": {
-                    "default": {
-                        "$type": "color",
-                        "$value": "{speciality.static.neutral.white}",
-                        "$description": "",
-                        "$extensions": {
-                            "com.figma": {
-                                "hiddenFromPublishing": false,
-                                "scopes": [],
-                                "codeSyntax": {}
-                            }
-                        }
-                    }
-                },
-                "fill": {
-                    "default": {
-                        "$type": "color",
-                        "$value": "{default.neutral.medium}",
-                        "$description": "",
-                        "$extensions": {
-                            "com.figma": {
-                                "hiddenFromPublishing": false,
-                                "scopes": [],
-                                "codeSyntax": {}
-                            }
-                        }
-                    },
-                    "default-hover": {
-                        "$type": "color",
-                        "$value": "{default.neutral.strong}",
-                        "$description": "",
-                        "$extensions": {
-                            "com.figma": {
-                                "hiddenFromPublishing": false,
-                                "scopes": [],
-                                "codeSyntax": {}
-                            }
-                        }
-                    },
-                    "default-pressed": {
-                        "$type": "color",
-                        "$value": "{default.neutral.medium}",
-                        "$description": "",
-                        "$extensions": {
-                            "com.figma": {
-                                "hiddenFromPublishing": false,
-                                "scopes": [],
-                                "codeSyntax": {}
-                            }
-                        }
-                    },
-                    "selected": {
-                        "$type": "color",
-                        "$value": "{accent.feedback.success.default}",
-                        "$description": "",
-                        "$extensions": {
-                            "com.figma": {
-                                "hiddenFromPublishing": false,
-                                "scopes": [],
-                                "codeSyntax": {}
-                            }
-                        }
-                    },
-                    "selected-hover": {
-                        "$type": "color",
-                        "$value": "{accent.feedback.success.subtle}",
-                        "$description": "",
-                        "$extensions": {
-                            "com.figma": {
-                                "hiddenFromPublishing": false,
-                                "scopes": [],
-                                "codeSyntax": {}
-                            }
-                        }
-                    },
-                    "selected-pressed": {
-                        "$type": "color",
-                        "$value": "{accent.feedback.success.default}",
-                        "$description": "",
-                        "$extensions": {
-                            "com.figma": {
-                                "hiddenFromPublishing": false,
-                                "scopes": [],
-                                "codeSyntax": {}
-                            }
-                        }
-                    },
-                    "critical": {
-                        "$type": "color",
-                        "$value": "{default.feedback.critical.medium}",
-                        "$description": "",
-                        "$extensions": {
-                            "com.figma": {
-                                "hiddenFromPublishing": false,
-                                "scopes": [],
-                                "codeSyntax": {}
-                            }
-                        }
-                    }
-                }
-            },
-            "logo": {
-                "name": {
-                    "$type": "color",
-                    "$value": "{speciality.logo.name}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "number1": {
-                    "$type": "color",
-                    "$value": "{color.alpha.white.100}",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "circle-dark-red": {
-                    "$type": "color",
-                    "$value": "#af0000",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                },
-                "circle-light-red": {
-                    "$type": "color",
-                    "$value": "#e60000",
-                    "$description": "",
-                    "$extensions": {
-                        "com.figma": {
-                            "hiddenFromPublishing": false,
-                            "scopes": [],
-                            "codeSyntax": {}
-                        }
-                    }
-                }
+          },
+          "selected": {
+            "$type": "color",
+            "$value": "{accent.feedback.success.default}",
+            "$description": "",
+            "$extensions": {
+              "com.figma": {
+                "hiddenFromPublishing": false,
+                "scopes": [],
+                "codeSyntax": {}
+              }
             }
+          },
+          "selected-hover": {
+            "$type": "color",
+            "$value": "{accent.feedback.success.subtle}",
+            "$description": "",
+            "$extensions": {
+              "com.figma": {
+                "hiddenFromPublishing": false,
+                "scopes": [],
+                "codeSyntax": {}
+              }
+            }
+          },
+          "selected-pressed": {
+            "$type": "color",
+            "$value": "{accent.feedback.success.default}",
+            "$description": "",
+            "$extensions": {
+              "com.figma": {
+                "hiddenFromPublishing": false,
+                "scopes": [],
+                "codeSyntax": {}
+              }
+            }
+          },
+          "critical": {
+            "$type": "color",
+            "$value": "{default.feedback.critical.medium}",
+            "$description": "",
+            "$extensions": {
+              "com.figma": {
+                "hiddenFromPublishing": false,
+                "scopes": [],
+                "codeSyntax": {}
+              }
+            }
+          }
         }
+      },
+      "logo": {
+        "name": {
+          "$type": "color",
+          "$value": "{speciality.logo.name}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "number1": {
+          "$type": "color",
+          "$value": "{color.alpha.white.1000}",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "circle-dark-red": {
+          "$type": "color",
+          "$value": "#af0000",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        },
+        "circle-light-red": {
+          "$type": "color",
+          "$value": "#e60000",
+          "$description": "",
+          "$extensions": {
+            "com.figma": {
+              "hiddenFromPublishing": false,
+              "scopes": [],
+              "codeSyntax": {}
+            }
+          }
+        }
+      }
     }
+  }
 }

--- a/packages/ffe-datepicker-react/src/calendar/Calendar.tsx
+++ b/packages/ffe-datepicker-react/src/calendar/Calendar.tsx
@@ -265,6 +265,7 @@ export class Calendar extends Component<CalendarProps, State> {
                 role="dialog"
                 aria-modal={true}
                 aria-labelledby={`${this.datepickerId}-title`}
+                className="ffe-default-mode"
             >
                 <div
                     className={this.props.calendarClassName || 'ffe-calendar'}

--- a/packages/ffe-datepicker-react/src/datepicker/DatepickerComp.tsx
+++ b/packages/ffe-datepicker-react/src/datepicker/DatepickerComp.tsx
@@ -272,7 +272,7 @@ export const DatepickerComp: React.FC<DatepickerCompProps> = ({
     return (
         // eslint-disable-next-line jsx-a11y/no-static-element-interactions,jsx-a11y/no-noninteractive-element-interactions
         <div
-            className={classNames('ffe-datepicker', {
+            className={classNames('ffe-datepicker', 'ffe-default-mode', {
                 'ffe-datepicker--full-width': fullWidth,
                 'ffe-input-group--message': hasMessage,
                 'ffe-datepicker--invalid': ariaInvalid(),

--- a/packages/ffe-datepicker/less/calendar.less
+++ b/packages/ffe-datepicker/less/calendar.less
@@ -129,7 +129,7 @@
         aspect-ratio: 1;
         color: var(--ffe-color-foreground-default);
         border: var(--ffe-g-border-width) solid transparent;
-        border-radius: var(--ffe-g-border-radius);
+        border-radius: var(--ffe-g-border-radius-sm);
         display: inline-block;
         line-height: 2.1875;
         cursor: pointer;
@@ -141,25 +141,25 @@
 
         @media (hover: hover) and (pointer: fine) {
             &:hover {
-                background: var(--ffe-color-fill-primary-subtle-hover);
+                background: var(--ffe-color-fill-neutral-subtle-hover);
                 color: var(--ffe-color-foreground-default);
             }
         }
 
         &:active {
-            background: var(--ffe-color-fill-primary-subtle-pressed);
+            background: var(--ffe-color-fill-neutral-subtle-pressed);
             color: var(--ffe-color-foreground-default);
         }
 
         &:focus-visible,
         &--focus {
             border: var(--ffe-g-border-width) solid
-                var(--ffe-color-border-primary-default);
+                var(--ffe-color-border-interactive-focus);
             outline: none;
         }
 
         &--selected {
-            background: var(--ffe-color-fill-primary-selected);
+            background: var(--ffe-color-fill-primary-selected-default);
             color: var(--ffe-color-foreground-inverse);
 
             &.ffe-calendar__date--focus {

--- a/packages/ffe-datepicker/less/dateinput.less
+++ b/packages/ffe-datepicker/less/dateinput.less
@@ -19,9 +19,9 @@
 
     @media (hover: hover) and (pointer: fine) {
         &:hover {
-            border-color: var(--ffe-color-border-primary-hover);
+            border-color: var(--ffe-color-border-primary-default-hover);
             box-shadow: var(--ffe-g-border-focus-box-shadow)
-                var(--ffe-color-border-primary-hover);
+                var(--ffe-color-border-primary-default-hover);
         }
     }
 

--- a/packages/ffe-dropdown-react/src/Dropdown.tsx
+++ b/packages/ffe-dropdown-react/src/Dropdown.tsx
@@ -12,6 +12,7 @@ export const Dropdown = React.forwardRef<HTMLSelectElement, DropdownProps>(
             <select
                 className={classNames(
                     'ffe-dropdown',
+                    'ffe-default-mode',
                     { 'ffe-dropdown--inline': inline },
                     className,
                 )}

--- a/packages/ffe-form-react/src/Input.tsx
+++ b/packages/ffe-form-react/src/Input.tsx
@@ -14,6 +14,7 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
             <input
                 className={classNames(
                     'ffe-input-field',
+                    'ffe-default-mode',
                     { 'ffe-input-field--inline': inline },
                     { 'ffe-input-field--text-right-align': textRightAlign },
                     className,

--- a/packages/ffe-form-react/src/InputGroup.mdx
+++ b/packages/ffe-form-react/src/InputGroup.mdx
@@ -13,14 +13,18 @@ skjemaelementet, og en feilmelding for valideringsfeil som vil bli vist om det e
 <Canvas of={InputGroupStories.Standard} />
 <Controls of={InputGroupStories.Standard} />
 
+### Uten plass til feilmelding
 Default oppførsel er at det holdes av plass under inputfeltene for å vise en feilmelding uten at innholdet lengre ned endres.
 Dersom man ikke ønsker dette kan det skrus av med å sette extraMargin prop til false.
 
 <Canvas of={InputGroupStories.ExtraMarginFalse} />
 
+### Med description
 Dersom man skal vise en hjelpetekst som alltid er synlig brukes description i stedet for tooltip.
 
 <Canvas of={InputGroupStories.Description} />
+
+### Med flere elementer
 
 Utviklere bør merke seg at man er nødt til å bruke det såkalte function-as-a-child-patternet med mindre man bare
 har ett child-element til InputGroup. Dette er fordi InputGroup setter properties som ID og liknende på rot-elementet,
@@ -28,6 +32,7 @@ og det forventes at det er et skjemaelement.
 
 <Canvas of={InputGroupStories.ManyChildren} />
 
+### Feilmelding
 Sender man inn en string eller et `<ErrorFieldMessage>`-element til fieldMessage vil dette rendres som en feilmelding.
 
 <Canvas of={InputGroupStories.FieldMessageString} />

--- a/packages/ffe-form-react/src/InputGroup.stories.tsx
+++ b/packages/ffe-form-react/src/InputGroup.stories.tsx
@@ -54,7 +54,7 @@ export const ManyChildren: Story = {
             {props => (
                 <>
                     <Input {...props} />
-                    <div>Annet innehold</div>
+                    <div>Annet innhold</div>
                 </>
             )}
         </InputGroup>

--- a/packages/ffe-form-react/src/PhoneNumber.tsx
+++ b/packages/ffe-form-react/src/PhoneNumber.tsx
@@ -120,7 +120,14 @@ export const PhoneNumber = React.forwardRef<
                             {text.COUNTRY_CODE}
                         </label>
                         <div className="ffe-phone-number__input-group">
-                            <span className="ffe-phone-number__plus">+</span>
+                            <span
+                                className={classNames(
+                                    'ffe-phone-number__plus',
+                                    'ffe-default-mode',
+                                )}
+                            >
+                                +
+                            </span>
                             <input
                                 ref={countryRef}
                                 id={countryCodeId}
@@ -128,6 +135,7 @@ export const PhoneNumber = React.forwardRef<
                                 className={classNames(
                                     'ffe-input-field',
                                     'ffe-phone-number__country-code-input',
+                                    'ffe-default-mode',
                                 )}
                                 type="tel"
                                 aria-invalid={
@@ -161,6 +169,7 @@ export const PhoneNumber = React.forwardRef<
                             className={classNames(
                                 'ffe-input-field',
                                 'ffe-phone-number__phone-input',
+                                'ffe-default-mode',
                             )}
                             aria-invalid={
                                 !!(

--- a/packages/ffe-form-react/src/TextArea.tsx
+++ b/packages/ffe-form-react/src/TextArea.tsx
@@ -8,7 +8,11 @@ export const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(
     ({ className, ...rest }, ref) => {
         return (
             <textarea
-                className={classNames('ffe-textarea', className)}
+                className={classNames(
+                    'ffe-textarea',
+                    'ffe-default-mode',
+                    className,
+                )}
                 ref={ref}
                 {...rest}
             />

--- a/packages/ffe-form/less/checkbox.less
+++ b/packages/ffe-form/less/checkbox.less
@@ -93,7 +93,7 @@
     @media (hover: hover) and (pointer: fine) {
         &:hover + .ffe-checkbox {
             &::before {
-                border-color: var(--ffe-color-border-primary-hover);
+                border-color: var(--ffe-color-border-primary-default-hover);
                 background: var(--ffe-color-surface-primary-default-hover);
             }
         }
@@ -102,9 +102,9 @@
     &:focus + .ffe-checkbox::before,
     &:focus-visible + .ffe-checkbox::before {
         border: var(--ffe-g-border-width) solid
-            var(--ffe-color-border-primary-selected);
+            var(--ffe-color-border-interactive-selected);
         box-shadow: var(--ffe-g-border-focus-box-shadow)
-            var(--ffe-color-border-primary-selected);
+            var(--ffe-color-border-interactive-selected);
     }
 
     &:active + .ffe-checkbox {
@@ -116,14 +116,14 @@
 
     &:active:checked + .ffe-checkbox {
         &::before {
-            border-color: var(--ffe-color-border-primary-selected);
+            border-color: var(--ffe-color-border-interactive-selected);
             background: var(--ffe-color-fill-primary-pressed);
         }
     }
 
     &:checked + .ffe-checkbox {
         &::before {
-            border-color: var(--ffe-color-border-primary-selected);
+            border-color: var(--ffe-color-border-interactive-selected);
             background: var(--ffe-color-fill-primary-selected, #002776);
         }
         &::after {

--- a/packages/ffe-form/less/dropdown.less
+++ b/packages/ffe-form/less/dropdown.less
@@ -40,6 +40,10 @@
     font-size: var(--ffe-fontsize-form-dropdown);
     .chevron(@ffe-color-chevron-light-default);
 
+    &.ffe-default-mode {
+        .chevron(@ffe-color-chevron-light-default);
+    }
+
     @media (prefers-color-scheme: dark) {
         :where(.regard-color-scheme-preference) & {
             .chevron(@ffe-color-chevron-dark-default);
@@ -48,9 +52,9 @@
 
     @media (hover: hover) and (pointer: fine) {
         &:hover {
-            border-color: var(--ffe-color-border-primary-hover);
+            border-color: var(--ffe-color-border-primary-default-hover);
             box-shadow: var(--ffe-g-border-focus-box-shadow)
-                var(--ffe-color-border-primary-hover);
+                var(--ffe-color-border-primary-default-hover);
         }
     }
 

--- a/packages/ffe-form/less/input-field.less
+++ b/packages/ffe-form/less/input-field.less
@@ -24,9 +24,9 @@
 
     @media (hover: hover) and (pointer: fine) {
         &:hover {
-            border-color: var(--ffe-color-border-primary-hover);
+            border-color: var(--ffe-color-border-primary-default-hover);
             box-shadow: var(--ffe-g-border-focus-box-shadow)
-                var(--ffe-color-border-primary-hover);
+                var(--ffe-color-border-primary-default-hover);
         }
     }
 
@@ -66,7 +66,7 @@
 
         @media (hover: hover) and (pointer: fine) {
             &:hover {
-                border-color: var(--ffe-color-border-primary-hover);
+                border-color: var(--ffe-color-border-primary-default-hover);
                 background-color: var(
                     --ffe-color-component-form-input-fill-default-hover
                 );

--- a/packages/ffe-form/less/radio-block.less
+++ b/packages/ffe-form/less/radio-block.less
@@ -77,7 +77,7 @@
 
     @media (hover: hover) and (pointer: fine) {
         &:hover {
-            --outer-circle-color: var(--ffe-color-border-primary-hover);
+            --outer-circle-color: var(--ffe-color-border-primary-default-hover);
 
             .ffe-radio-block__header {
                 background-color: var(
@@ -97,23 +97,23 @@
     }
 
     &:active .ffe-radio-block__content {
-        --outer-circle-color: var(--ffe-color-border-primary-pressed);
+        --outer-circle-color: var(--ffe-color-border-primary-default-pressed);
     }
 }
 
 .ffe-radio-input {
     &:checked + .ffe-radio-block__content {
-        --outer-circle-color: var(--ffe-color-border-primary-selected);
+        --outer-circle-color: var(--ffe-color-border-interactive-selected);
 
         &::before {
-            background-color: var(--ffe-color-fill-primary-selected);
+            background-color: var(--ffe-color-fill-primary-selected-default);
             border: 4px solid var(--block-background);
             box-shadow: var(--ffe-g-border-focus-box-shadow)
-                var(--ffe-color-border-primary-selected);
+                var(--ffe-color-border-interactive-selected);
         }
 
         .ffe-radio-block__header {
-            background-color: var(--ffe-color-fill-primary-selected);
+            background-color: var(--ffe-color-fill-primary-selected-default);
             color: var(--ffe-color-foreground-on-fill-default);
         }
 

--- a/packages/ffe-form/less/radio-button.less
+++ b/packages/ffe-form/less/radio-button.less
@@ -100,7 +100,7 @@
     }
 
     &:checked + .ffe-radio-button {
-        --outer-circle-color: var(--ffe-color-fill-primary-selected);
+        --outer-circle-color: var(--ffe-color-fill-primary-selected-default);
         --inner-circle-color: var(--ffe-color-fill-primary-pressed);
 
         &::before {

--- a/packages/ffe-form/less/radio-switch.less
+++ b/packages/ffe-form/less/radio-switch.less
@@ -23,6 +23,7 @@
     margin-top: var(--ffe-spacing-sm);
     line-height: 1.5;
     overflow-wrap: anywhere;
+    background-color: var(--circle-background);
 
     &::before {
         content: '';
@@ -40,7 +41,7 @@
     @media (hover: hover) and (pointer: fine) {
         &:hover {
             background-color: var(--ffe-color-surface-primary-default-hover);
-            border-color: var(--ffe-color-border-primary-hover);
+            border-color: var(--ffe-color-border-primary-default-hover);
 
             &::before {
                 background-color: var(--ffe-color-surface-primary-default);
@@ -78,11 +79,11 @@
     }
 
     &:checked + .ffe-radio-switch {
-        --outer-circle-color: var(--ffe-color-fill-primary-selected);
+        --outer-circle-color: var(--ffe-color-fill-primary-selected-default);
         --inner-circle-color: var(--ffe-color-fill-primary-pressed);
+        --circle-background: var(--ffe-color-fill-primary-selected-default);
 
-        background-color: var(--ffe-color-fill-primary-selected);
-        color: var(--ffe-color-foreground-on-fill-default);
+        color: var(--ffe-color-foreground-inverse);
         border-color: var(--ffe-color-border-primary-emphasis);
         box-shadow: var(--ffe-g-border-focus-box-shadow)
             var(--ffe-color-border-primary-emphasis);
@@ -90,7 +91,7 @@
         &::before {
             border: 5px solid var(--ffe-color-surface-primary-default);
             outline: 2px solid var(--ffe-color-border-primary-emphasis);
-            background-color: var(--ffe-color-fill-primary-selected);
+            background-color: var(--ffe-color-fill-primary-selected-default);
         }
 
         @media (hover: hover) and (pointer: fine) {

--- a/packages/ffe-form/less/textarea.less
+++ b/packages/ffe-form/less/textarea.less
@@ -14,9 +14,9 @@
 
     @media (hover: hover) and (pointer: fine) {
         &:hover {
-            border-color: var(--ffe-color-border-primary-hover);
+            border-color: var(--ffe-color-border-primary-default-hover);
             box-shadow: var(--ffe-g-border-focus-box-shadow)
-                var(--ffe-color-border-primary-hover);
+                var(--ffe-color-border-primary-default-hover);
         }
     }
 

--- a/packages/ffe-lists-react/src/DetailListCard.tsx
+++ b/packages/ffe-lists-react/src/DetailListCard.tsx
@@ -5,6 +5,8 @@ export type BackgroundColor = 'primary' | 'secondary' | 'tertiary';
 
 export interface DetailListCardProps
     extends React.ComponentPropsWithoutRef<'dl'> {
+    /** Avgjør utseende i kontekst accent. Hvis man ønsker et blått utseende i kontekst accent, velg appearance: 'accent' */
+    appearance?: 'default' | 'accent';
     /**
      * Property has new values that work with dark and accent mode as part of the Semantic Color update
      * Possible values: `primary` `secondary` `tertiary`
@@ -20,6 +22,7 @@ export interface DetailListCardProps
 
 export const DetailListCard: React.FC<DetailListCardProps> = ({
     className,
+    appearance = 'default',
     bgColor,
     children,
     ...rest
@@ -28,6 +31,7 @@ export const DetailListCard: React.FC<DetailListCardProps> = ({
         <dl
             className={classNames('ffe-detail-list-card', className, {
                 [`ffe-detail-list-card--bg-${bgColor}`]: bgColor,
+                'ffe-default-mode': appearance === 'default',
             })}
             {...rest}
         >

--- a/packages/ffe-searchable-dropdown-react/less/searchable-dropdown.less
+++ b/packages/ffe-searchable-dropdown-react/less/searchable-dropdown.less
@@ -5,7 +5,7 @@
     --detail-text-color: var(
         --ffe-color-component-form-input-foreground-on-fill-subtle
     );
-    --selected-icon-color: var(--ffe-color-fill-primary-selected);
+    --selected-icon-color: var(--ffe-color-fill-primary-selected-default);
     --text-color: var(var(--ffe-color-foreground-default));
 
     min-height: 2.8125rem;
@@ -25,14 +25,14 @@
     }
     @media (hover: hover) and (pointer: fine) {
         &:hover {
-            --border-color: var(--ffe-color-border-primary-hover);
-            box-shadow: 0 0 0 1px var(--ffe-color-border-primary-hover);
+            --border-color: var(--ffe-color-border-primary-default-hover);
+            box-shadow: 0 0 0 1px var(--ffe-color-border-primary-default-hover);
         }
     }
 
     &:focus-within {
-        --border-color: var(--ffe-color-border-primary-selected);
-        box-shadow: 0 0 0 1px var(--ffe-color-border-primary-selected);
+        --border-color: var(--ffe-color-border-interactive-selected);
+        box-shadow: 0 0 0 1px var(--ffe-color-border-interactive-selected);
     }
 
     &__input {
@@ -42,7 +42,7 @@
         border-right: none;
         @media (hover: hover) and (pointer: fine) {
             &:hover + .ffe-searchable-dropdown__button {
-                --border-color: var(--ffe-color-border-primary-hover);
+                --border-color: var(--ffe-color-border-primary-default-hover);
             }
         }
     }

--- a/packages/ffe-searchable-dropdown-react/src/multi/SearchableDropdownMultiSelect.tsx
+++ b/packages/ffe-searchable-dropdown-react/src/multi/SearchableDropdownMultiSelect.tsx
@@ -357,6 +357,7 @@ function SearchableDropdownMultiSelectWithForwardRef<
                 className,
                 'ffe-searchable-dropdown',
                 'ffe-searchable-dropdown--multi',
+                'ffe-default-mode',
             )}
         >
             {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions */}

--- a/packages/ffe-searchable-dropdown-react/src/single/SearchableDropdown.tsx
+++ b/packages/ffe-searchable-dropdown-react/src/single/SearchableDropdown.tsx
@@ -300,7 +300,11 @@ function SearchableDropdownWithForwardRef<Item extends Record<string, any>>(
         // eslint-disable-next-line jsx-a11y/no-static-element-interactions
         <div
             onKeyDown={handleKeyDown}
-            className={classNames(className, 'ffe-searchable-dropdown')}
+            className={classNames(
+                className,
+                'ffe-searchable-dropdown',
+                'ffe-default-mode',
+            )}
             ref={containerRef}
             onMouseDown={addFlagOnEventHandler(id)}
             onFocus={addFlagOnEventHandler(id)}

--- a/packages/ffe-tables/less/tables.less
+++ b/packages/ffe-tables/less/tables.less
@@ -126,7 +126,7 @@
 
         &-ascending,
         &-descending {
-            background: var(--ffe-color-fill-primary-selected);
+            background: var(--ffe-color-fill-primary-selected-default);
             color: var(--ffe-color-foreground-inverse);
 
             @media (hover: hover) and (pointer: fine) {

--- a/packages/ffe-tabs/less/tab.less
+++ b/packages/ffe-tabs/less/tab.less
@@ -43,7 +43,7 @@
     }
 
     &--selected {
-        background-color: var(--ffe-color-fill-primary-selected);
+        background-color: var(--ffe-color-fill-primary-selected-default);
         color: var(--ffe-color-foreground-on-fill-default);
         z-index: 2;
 


### PR DESCRIPTION
## Nye darkmode farger, etterjustering. 

Nye variabler og mange av komponentene har nå default context inni accent context. 

### BREAKING VARIABEL ENDRINGER 
`--ffe-color-border-primary-hover` erstattes av `--ffe-color-border-primary-default-hover`
`--ffe-color-border-primary-pressed` erstattes av `--ffe-color-border-primary-default-pressed`
`--ffe-color-fill-primary-selected` erstattes av `--ffe-color-fill-primary-selected-default` 
`--ffe-color-border-primary-selected` erstattes av `--ffe-color-border-interactive-selected`

I tillegg er det mange nye variabler. Alpha-variantene i det semantiske laget har fått 0-1000 verdier i stedet for 0-100. 
nye variabler i context-laget (det brukerne skal bruke) er:
`--ffe-color-foreground-interactive-link-active` 
`--ffe-color-border-primary-subtle-hover`
`--ffe-color-border-primary-subtle-pressed`

### Default context inni Accent context 
For å redusere det blå er nå mange av komponentene gjort om i accent context. Dette gjelder: 
- Accordion 
- Cards, men med en prop `appearance: 'default' | 'accent` hvis man vil overskrive 
- Datepicker
- Dropdown
- Feedback, textinput 
- De fleste form-elementer
- DetailListCard, men med en prop `appearance: 'default' | 'accent` hvis man vil overskrive 
- Pagination (dropdown)
- SearchableDropdown

![image](https://github.com/user-attachments/assets/0414a9dc-458a-483b-9ad0-28e7899819a9)

Accountselector må komme i en separat commit. 

Trenger flere øyne på å se at alle commit-meldingene ble riktige!

fixes #2779 