### PR TITLE
fix(ffe-form): riktig bakgrunnsfarge på checkbox

### DIFF
--- a/packages/ffe-form/less/checkbox.less
+++ b/packages/ffe-form/less/checkbox.less
@@ -124,7 +124,7 @@
     &:checked + .ffe-checkbox {
         &::before {
             border-color: var(--ffe-color-border-interactive-selected);
-            background: var(--ffe-color-fill-primary-selected, #002776);
+            background: var(--ffe-color-fill-primary-selected-default, #002776);
         }
         &::after {
             border-color: var(--ffe-color-foreground-inverse);


### PR DESCRIPTION
Retter en bug i ffe-form, der checkbox hadde feil bakgrunnsfarge som følge av at fargevariabelen har blitt endret i ffe-core, men ikke oppdatert i ffe-form.

Fixes #2833 