### PR TITLE
Feilretting og forbedringer av Modal-komponenten

### DIFF
--- a/packages/ffe-modals-react/src/Modal.tsx
+++ b/packages/ffe-modals-react/src/Modal.tsx
@@ -18,6 +18,7 @@ export interface ModalProps extends React.ComponentPropsWithoutRef<'dialog'> {
 export type ModalHandle = {
     readonly open: () => void;
     readonly close: () => void;
+    readonly isOpen: boolean;
 };
 
 export const Modal = React.forwardRef<ModalHandle, ModalProps>(
@@ -44,11 +45,21 @@ export const Modal = React.forwardRef<ModalHandle, ModalProps>(
 
         useImperativeHandle(ref, () => ({
             open: () => {
-                setIsOpen(true);
-                dialogRef.current?.showModal();
+                // Prevent opening an already open modal
+                if (!isOpen && dialogRef.current) {
+                    setIsOpen(true);
+                    dialogRef.current.showModal();
+                }
             },
             close: () => {
-                dialogRef.current?.close();
+                // Prevent closing an already closed modal
+                if (isOpen && dialogRef.current) {
+                    dialogRef.current.close();
+                }
+            },
+            // Expose isOpen state
+            get isOpen() {
+                return isOpen;
             },
         }));
 

--- a/packages/ffe-modals-react/src/Modal.tsx
+++ b/packages/ffe-modals-react/src/Modal.tsx
@@ -19,6 +19,7 @@ export type ModalHandle = {
     readonly open: () => void;
     readonly close: () => void;
     readonly isOpen: boolean;
+    readonly dialogRef: React.RefObject<HTMLDialogElement>;
 };
 
 export const Modal = React.forwardRef<ModalHandle, ModalProps>(
@@ -61,6 +62,8 @@ export const Modal = React.forwardRef<ModalHandle, ModalProps>(
             get isOpen() {
                 return isOpen;
             },
+            // Expose dialogRef directly
+            dialogRef,
         }));
 
         useEffect(() => {

--- a/packages/ffe-modals/less/modal.less
+++ b/packages/ffe-modals/less/modal.less
@@ -61,13 +61,13 @@
         }
     }
 
-    /* Add a more specific selector to target only the close button in modals */
+    /* Add a more specific selector to target only the close button in modals 
     /* This ensures the styling works regardless of CSS import order */
     &[open] &__close {
         width: auto;
         display: block;
 
-        @media (min-width: 480px) {
+        @media (width >= 480px) {
             width: auto;
             display: block;
         }

--- a/packages/ffe-modals/less/modal.less
+++ b/packages/ffe-modals/less/modal.less
@@ -60,4 +60,16 @@
             clear: both;
         }
     }
+
+    /* Add a more specific selector to target only the close button in modals */
+    /* This ensures the styling works regardless of CSS import order */
+    &[open] &__close {
+        width: auto;
+        display: block;
+
+        @media (min-width: 480px) {
+            width: auto;
+            display: block;
+        }
+    }
 }


### PR DESCRIPTION
Denne PR-en fikser to bugs og legger til ny funksjonalitet i Modal-komponenten:

Eksponert isOpen-tilstand og dialogRef: Modal-komponenten eksponerer nå både isOpen-tilstanden og det underliggende dialogRef-objektet. Dette gir brukere mulighet til å sjekke om modalen er åpen og få direkte tilgang til HTMLDialogElement.
Forebygger duplikate kall: Lagt til sjekker som forhindrer at showModal() og close() kan kalles flere ganger, noe som tidligere førte til InvalidStateError exceptions.
Fikset stylingproblemer ved 480px breakpoint: Modalen hadde stylingproblemer når CSS ble importert i feil rekkefølge. Dette er nå løst med mer spesifikke CSS-selektorer som fungerer uavhengig av importrekkefølge.
Bakgrunn for dialogRef-eksponering
Vi har mottatt tilbakemeldinger fra kundefront-pm-betaling som opplever feilsituasjoner grunnet manglende tilgang til modalens åpen/lukket-tilstand. Teamet har måttet lage workarounds med lokale state-håndteringer.

Vurderinger
Vi vurderte flere alternativer:

Kun eksponere isOpen: Dette ville løst det umiddelbare behovet for tilstandssjekk
Eksponere hele dialogRef: Gir full tilgang til det underliggende DOM-elementet
Selv om det å eksponere interne implementasjonsdetaljer potensielt kan gjøre det vanskeligere å endre implementasjonen senere, valgte vi å eksponere hele dialogRef fordi:

Det gir brukere større fleksibilitet
Det fjerner behovet for workarounds
Flere teams har etterspurt denne funksjonaliteten
Det muliggjør mer avanserte brukstilfeller som ikke dekkes av det begrensede API-et
Alternativet med kun isOpen ville vært mer i tråd med abstraksjonstenkning, men ville sannsynligvis ført til flere feature requests i fremtiden.
