### PR TITLE
chore: Fix bug in color table

### DIFF
--- a/packages/ffe-core/documentation/Colors.mdx
+++ b/packages/ffe-core/documentation/Colors.mdx
@@ -61,7 +61,7 @@ Da blir fargene tilgjengelige i kebab-case uten `--ffe-color`. Feks `--ffe-color
                     style={{ backgroundColor: `var(${color})` }}
                 ></td>
                 <td
-                    class="dark-mode ffe-accent-color"
+                    class="dark-mode ffe-accent-mode"
                     style={{ backgroundColor: `var(${color})` }}
                 ></td>
             </tr>


### PR DESCRIPTION
Fikser color table til å liste dark accent riktig


Med buggen
![image](https://github.com/user-attachments/assets/8a49da25-4820-4cbd-b529-1dd2e7d68c5e)


Etter fiksen
![image](https://github.com/user-attachments/assets/472a869f-34b0-4ca2-8ee3-66d7adc21ec0)
