### PR TITLE
fix(ffe-datepicker-react): fix infinite loop and wrong onChange values

### DIFF
--- a/packages/ffe-datepicker-react/src/datepicker/Datepicker.mdx
+++ b/packages/ffe-datepicker-react/src/datepicker/Datepicker.mdx
@@ -48,8 +48,8 @@ async function getDatepickerByLabelText(
     /** The datepicker element */
     element: Element;
     /** Function to get the value of the datepicker
-     * @returns string in the format 'dd.mm.yyyy' or null if the datepicker is empty */
-    getValue: () => string | null;
+     * @returns string in the format 'dd.mm.yyyy' or <empty string> if the datepicker is empty */
+    getValue: () => string ;
     /**Function to set the value of the datepicker
      * @param value string in the format 'dd.mm.yyyy'
      * @returns void

--- a/packages/ffe-datepicker-react/src/datepicker/Datepicker.spec.tsx
+++ b/packages/ffe-datepicker-react/src/datepicker/Datepicker.spec.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { Datepicker, DatepickerProps } from './Datepicker';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 const defaultProps = {
@@ -69,7 +69,7 @@ describe('<Datepicker />', () => {
             renderDatePicker({ onChange });
             const [dayInput] = screen.getAllByRole('spinbutton');
             await userEvent.type(dayInput, '{arrowup}');
-            expect(onChange).toHaveBeenCalledWith('');
+            () => expect(onChange).toHaveBeenCalledTimes(0);
         });
 
         it('reponds to arrow left and right', async () => {
@@ -106,7 +106,7 @@ describe('<Datepicker />', () => {
                 renderDatePicker({ onChange });
                 const [dayInput] = screen.getAllByRole('spinbutton');
                 await user.type(dayInput, '4');
-                expect(onChange).toHaveBeenCalledWith('');
+                expect(onChange).toHaveBeenCalledTimes(0);
             });
         });
 
@@ -136,6 +136,17 @@ describe('<Datepicker />', () => {
                     expect(date.getAttribute('aria-invalid')).toBe('true');
                     expect(month.getAttribute('aria-invalid')).toBe('true');
                     expect(year.getAttribute('aria-invalid')).toBe('true');
+                });
+
+                describe('when input field is emptied', () => {
+                    const user = userEvent.setup();
+                    it('calls onChange method', async () => {
+                        const onChange = jest.fn();
+                        renderDatePicker({ onChange, value: '01.01.2021' });
+                        const [dayInput] = screen.getAllByRole('spinbutton');
+                        await user.type(dayInput, '00');
+                        await waitFor(() => expect(onChange).toHaveBeenCalledWith(''));
+                    });
                 });
 
                 it('has correct aria-describedby if aria-describedby given as input prop', () => {

--- a/packages/ffe-datepicker-react/src/datepicker/Datepicker.stories.tsx
+++ b/packages/ffe-datepicker-react/src/datepicker/Datepicker.stories.tsx
@@ -28,6 +28,7 @@ export const Standard: Story = {
                     value={value ?? date}
                     onChange={date => {
                         setDate(date);
+                        console.log('Datepicker value:', date);
                     }}
                     {...args}
                 />

--- a/packages/ffe-datepicker-react/src/datepicker/DatepickerComp.tsx
+++ b/packages/ffe-datepicker-react/src/datepicker/DatepickerComp.tsx
@@ -71,29 +71,31 @@ export const DatepickerComp: React.FC<DatepickerCompProps> = ({
         setLastChangedValue,
     } = useContext(DatepickerContext);
 
+    const formatDate = useCallback(() => {
+        return getPaddedDateString(day, month, year);
+    }, [day, month, year]);
+
     const [displayDatePicker, setDisplayDatePicker] = useState(false);
     const [minDate, setMinDate] = useState(minDateProp);
     const [maxDate, setMaxDate] = useState(maxDateProp);
-    const [lastValidDate, setLastValidDate] = useState('');
+    const [lastValidDate, setLastValidDate] = useState(formatDate());
     const datepickerId = useId();
     const buttonRef = useRef<HTMLButtonElement>(null);
     const dayRef = useRef<HTMLSpanElement>(null);
     const monthRef = useRef<HTMLSpanElement>(null);
     const yearRef = useRef<HTMLSpanElement>(null);
 
-    const formatDate = useCallback(() => {
-        return getPaddedDateString(day, month, year);
-    }, [day, month, year]);
+  
 
     const getFieldMessageId = () => {
         return fieldMessage ? `${datepickerId}-fieldmessage` : undefined;
     };
 
-    const _onChange = useCallback(
+    const _onChange = useCallback(debounce(
         (date: string) => {
             setLastChangedValue(date);
             onChange(date);
-        },
+        },250),
         [onChange, setLastChangedValue],
     );
 
@@ -278,7 +280,7 @@ export const DatepickerComp: React.FC<DatepickerCompProps> = ({
             return;
         }
         _onChange('');
-    }, [day, month, year, _onChange]);
+    }, [lastValidDate]);
 
     return (
         // eslint-disable-next-line jsx-a11y/no-static-element-interactions,jsx-a11y/no-noninteractive-element-interactions

--- a/packages/ffe-datepicker-react/src/datepicker/DatepickerInContext.spec.tsx
+++ b/packages/ffe-datepicker-react/src/datepicker/DatepickerInContext.spec.tsx
@@ -20,14 +20,14 @@ const renderDatePicker = (props?: Partial<DatepickerProps>) =>
     );
 
 describe('<InputGroup><Datepicker /></InputGroup>', () => {
-    it('empty datepicker returns null from testing functions', async () => {
+    it('empty datepicker returns <empty string> from testing functions', async () => {
         renderDatePicker();
 
         const datepicker = await getDatepickerByLabelText('Datovelger');
         expect(
             datepicker.element.classList.contains('ffe-datepicker'),
         ).toBeTruthy();
-        expect(datepicker.getValue()).toBe(null);
+        expect(datepicker.getValue()).toBe('');
     });
 
     it('datepicker returns value from testing functions', async () => {
@@ -53,7 +53,7 @@ describe('<InputGroup><Datepicker /></InputGroup>', () => {
         const datepicker = await getDatepickerByLabelText('Datovelger');
         await datepicker.setValue('');
 
-        expect(datepicker.getValue()).toBeNull();
+        expect(datepicker.getValue()).toBe('');
     });
 
     it('2 number year date is updated to correct 4 number year', async () => {

--- a/packages/ffe-datepicker-react/src/datepicker/testHelper.ts
+++ b/packages/ffe-datepicker-react/src/datepicker/testHelper.ts
@@ -49,9 +49,9 @@ export type DatepickerTestHelper = {
     /**
      * Function to get the value of the datepicker
      *
-     * @returns string in the format 'dd.mm.yyyy' or null if the datepicker is empty
+     * @returns string in the format 'dd.mm.yyyy' or empty string if the datepicker is empty
      */
-    getValue: () => string | null;
+    getValue: () => string;
     /**
      * Function to set the value of the datepicker
      *
@@ -84,7 +84,7 @@ export async function getDatepickerByLabelText(
             element => element !== null && element !== undefined,
         ) as HTMLElement[];
 
-    function getValue(element: Element): string | null {
+    function getValue(element: Element): string {
         const [dayElement, monthElement, yearElement] = Array.from(
             element.querySelectorAll('[role="spinbutton"]'),
         );
@@ -99,7 +99,7 @@ export async function getDatepickerByLabelText(
             day !== '' &&
             day !== '0'
             ? `${leftPad(day)}.${leftPad(month)}.${year}`
-            : null;
+            : '';
     }
 
     async function setValue(element: HTMLElement, value: string) {


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse
Fixes #2864 

- fiker infinite loop. Testet med npm link mot prosjekt som hadde uendelig loop i tester
- fjerner tom string fra omChange ved oppstart
- fikser at calenderen gir feil verdi når den endrer datoen
- oppdaterer test helper til å retunere tom string.
