### PR TITLE
fix(ffe-datepicker-react): add RTL dependency for test helper

### DIFF
--- a/packages/ffe-datepicker-react/package.json
+++ b/packages/ffe-datepicker-react/package.json
@@ -28,6 +28,7 @@
         "@sb1/ffe-form": "^32.1.8",
         "@sb1/ffe-icons-react": "^12.0.3",
         "@types/lodash.debounce": "^4.0.9",
+        "@testing-library/react": "^16.0.0",
         "classnames": "^2.3.1",
         "lodash.debounce": "^4.0.8",
         "uuid": "^9.0.0"


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse

Legger til avhengighet til avhengighet til react testing library slik at prosjekter som ikke har det innstallert ikke får feil.
Ikke optimalt, men har ikke klart å løse det på andre måter.
