### PR TITLE
fix(ffe-datepicker-react): add missing dep to ffe-form-react

### DIFF
--- a/packages/ffe-datepicker-react/package.json
+++ b/packages/ffe-datepicker-react/package.json
@@ -26,6 +26,7 @@
     "dependencies": {
         "@sb1/ffe-datepicker": "^14.1.8",
         "@sb1/ffe-form": "^32.1.8",
+        "@sb1/ffe-form-react": "^23.3.11",
         "@sb1/ffe-icons-react": "^12.0.4",
         "@types/lodash.debounce": "^4.0.9",
         "@testing-library/react": "^16.0.0",


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse
Form-reacter dratt inn for å vise error field i datepicker. 

fixes #2777 
