### PR TITLE
fix(ffe-form): fikser chevron farge i dark mode på dropdown

### DIFF
--- a/packages/ffe-form/less/dropdown.less
+++ b/packages/ffe-form/less/dropdown.less
@@ -10,16 +10,6 @@
     }
 }
 
-@media (prefers-color-scheme: dark) {
-    :where(.regard-color-scheme-preference) {
-        &.ffe-accent-mode, .ffe-accent-mode {
-            .ffe-dropdown {
-                .chevron(@ffe-color-chevron-dark-accent);
-            }
-        }
-    }
-}
-
 .ffe-dropdown {
     appearance: none;
     background-color: var(--ffe-color-surface-primary-default);
@@ -87,5 +77,19 @@
     &::placeholder {
         color: var(--ffe-color-foreground-subtle);
         opacity: 1;
+    }
+}
+
+@media (prefers-color-scheme: dark) {
+    .regard-color-scheme-preference {
+        .ffe-dropdown {
+            .chevron(@ffe-color-chevron-dark-default);
+        }
+
+        .ffe-accent-mode:not(.ffe-default-mode) {
+            .ffe-dropdown {
+                .chevron(@ffe-color-chevron-dark-accent);
+            }
+        }
     }
 }


### PR DESCRIPTION
Kom inn i kanalen. 
Fixes #2902 

Virker som feilen bare var i rekkefølgen, darkmode ble overskrevet. Grunnen til at det fungerte i storybook var fordi det er en egen fargesetting for storybook, med `dark-mode`, som er i en annen fil. Så overskrivingen ble riktig i storybook. 

Har testet med npm link i skjera-prosjektet. 
Før fiksen: 
![image](https://github.com/user-attachments/assets/d2c4a5ee-a8bf-4934-b3b6-e7bd754e5f0f)
![image](https://github.com/user-attachments/assets/f0ea6af6-58a5-4f28-b65c-5c019a8fc56f)


Nå: 
![image](https://github.com/user-attachments/assets/1c80df79-0e2e-4874-9bbc-593a3e99f0fb)
![image](https://github.com/user-attachments/assets/e999f533-c6c0-49d0-a626-f78c69565254)
