### PR TITLE
fix(ffe-icons-react): add missing dep classnames

### DIFF
--- a/packages/ffe-icons-react/package.json
+++ b/packages/ffe-icons-react/package.json
@@ -26,7 +26,8 @@
         "test": "ffe-buildtool jest"
     },
     "dependencies": {
-        "@sb1/ffe-icons": "^17.0.4"
+        "@sb1/ffe-icons": "^17.0.4",
+        "classnames": "^2.5.1"
     },
     "devDependencies": {
         "@sb1/ffe-buildtool": "^0.10.1",


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse
Legger til manglende dep classnames.

Brukt her: https://github.com/SpareBank1/designsystem/blob/develop/packages/ffe-icons-react/src/Icon.tsx#L2
