### PR TITLE
fix(ffe-form): holder av plass til tooltip i label

### DIFF
--- a/packages/ffe-form/less/input-group.less
+++ b/packages/ffe-form/less/input-group.less
@@ -10,6 +10,7 @@
 
     .ffe-form-label {
         margin-bottom: 0;
+        padding-top: var(--ffe-spacing-2xs);
     }
 
     .ffe-field-message--error {


### PR DESCRIPTION
Fikser en bug der to input groups ved siden av hverandre får forskjellig høyde dersom den ene har tooltip og den andre ikke. Dermed alignes de litt ujevnt mot hverandre. Bugen skyldes at tooltip-knappen er noen få px høyere enn label og fiksen består derfor av å legge inn noe padding i toppen av label slik at total høyde blir konsistent.

Før:
<img width="494" alt="image" src="https://github.com/user-attachments/assets/ea33541d-db81-4b0e-ade7-2eed40f88a18" />

Etter:
<img width="494" alt="image" src="https://github.com/user-attachments/assets/5fde8c12-3b1a-40cc-8ba4-3b4f699ed272" />