### PR TITLE
feat(ffe-buttons-react): ariaLabel er ikke lenger en påkrevd prop

### DIFF
--- a/packages/ffe-buttons-react/src/ButtonGroup.mdx
+++ b/packages/ffe-buttons-react/src/ButtonGroup.mdx
@@ -12,3 +12,16 @@ ButtonGroup hjelper deg med å samle alle knappene og få de på en rad. På min
 
 <Canvas of={ButtonGroupStories.Standard} />
 <Controls of={ButtonGroupStories.Standard} />
+
+### Mindre margin
+`thin` fjerner marginen rundt knappegruppen.
+<Canvas of={ButtonGroupStories.Condensed} />
+<Controls of={ButtonGroupStories.Condensed} />
+
+### Med Aria-label
+`ariaLabel` (eller `aria-label`) er ikke påkrevd, men det anbefales å ha med der det gir mening. For eksempel kan det være nyttig å inkludere
+"Skjemakontroller" eller "Skjemaknapper" der knappene er en del av et skjema, så det blir lettere å finne for en bruker med skjermleser. Noen ganger er det nok
+at det ligger i en gruppe, og man trenger ikke `aria-label`.
+
+<Canvas of={ButtonGroupStories.WithAriaLabel} />
+<Controls of={ButtonGroupStories.WithAriaLabel} />

--- a/packages/ffe-buttons-react/src/ButtonGroup.spec.tsx
+++ b/packages/ffe-buttons-react/src/ButtonGroup.spec.tsx
@@ -4,7 +4,6 @@ import { render, screen } from '@testing-library/react';
 
 const defaultProps = {
     thin: false,
-    ariaLabel: 'A group of buttons',
 };
 
 const renderButtonGroup = (props?: Partial<ButtonGroupProps>) =>
@@ -53,13 +52,19 @@ describe('<ButtonGroup />', () => {
         expect(buttonGroup.classList.contains('my-class')).toBe(true);
     });
 
-    it('should use aria-label', () => {
+    it('should set aria-label when included as prop', () => {
         renderButtonGroup({
-            ariaLabel: 'My amazing buttons',
+            ariaLabel: 'Skjemakontroller',
         });
         const buttonGroup = screen.getByRole('group');
         expect(buttonGroup.getAttribute('aria-label')).toBe(
-            'My amazing buttons',
+            'Skjemakontroller',
         );
+    });
+
+    it('should not set aria-label when not included as prop', () => {
+        renderButtonGroup();
+        const buttonGroup = screen.getByRole('group');
+        expect(buttonGroup.getAttribute('aria-label')).toBeNull();
     });
 });

--- a/packages/ffe-buttons-react/src/ButtonGroup.stories.tsx
+++ b/packages/ffe-buttons-react/src/ButtonGroup.stories.tsx
@@ -14,8 +14,33 @@ export default meta;
 type Story = StoryObj<typeof ButtonGroup>;
 
 export const Standard: Story = {
+    args: {},
+    render: args => (
+        <ButtonGroup {...args}>
+            <SecondaryButton>Forrige</SecondaryButton>
+            <PrimaryButton>Neste</PrimaryButton>
+            <TertiaryButton>Avbryt</TertiaryButton>
+        </ButtonGroup>
+    ),
+};
+
+export const WithAriaLabel: Story = {
     args: {
         ariaLabel: 'Knappegruppe',
+    },
+    render: args => (
+        <ButtonGroup {...args}>
+            <SecondaryButton>Forrige</SecondaryButton>
+            <PrimaryButton>Neste</PrimaryButton>
+            <TertiaryButton>Avbryt</TertiaryButton>
+        </ButtonGroup>
+    ),
+};
+
+export const Condensed: Story = {
+    args: {
+        thin: true,
+        ariaLabel: 'Eksempel knappegruppe',
     },
     render: args => (
         <ButtonGroup {...args}>

--- a/packages/ffe-buttons-react/src/ButtonGroup.tsx
+++ b/packages/ffe-buttons-react/src/ButtonGroup.tsx
@@ -6,8 +6,8 @@ export interface ButtonGroupProps extends React.ComponentProps<'div'> {
     thin?: boolean;
     /** Applies the inline modifier to make all child buttons inline */
     inline?: boolean;
-    /** Label for the group of buttons */
-    ariaLabel: string;
+    /** Label for the group of buttons for users with screen reader*/
+    ariaLabel?: string;
 }
 
 export const ButtonGroup: React.FC<ButtonGroupProps> = ({
@@ -26,6 +26,6 @@ export const ButtonGroup: React.FC<ButtonGroupProps> = ({
         )}
         {...rest}
         role="group"
-        aria-label={ariaLabel}
+        aria-label={ariaLabel === "" ? undefined : ariaLabel}
     />
 );


### PR DESCRIPTION
Fixes #2935 

## Beskrivelse

`ariaLabel` er ikke lenger en påkrevd prop. Den beholdes som en egen prop (selv om man egentlig bare kunne brukt `aria-label` som kommer inn som en del av ...rest) for å skape oppmerksomhet for brukerne av `ButtonGroup` at det er en mulighet, og forhåpentligvis trigge en nysgjerrighet for om det trengs eller ikke. 

## Motivasjon og kontekst
Det kom inn i kanalen et spørsmål om det var nødvendig. 
Det er tatt en runde med UU-speisalist @SindreSafvenbom om det er nødvendig eller ikke, og svaret er kanskje. Det er en UX for UU-vurdering som er vanskelig å ta på generelt grunnlag. 

Fordeler med å ha den påkrevd: 
Den ble nok gjort påkrevd i utgangspunktet fordi det kan være en veldig nyttig greie for brukere med skjermlesere, og det var trodd at så lenge den ikke er påkrevd så er det få utviklere som kom til å enten vite at den eksisterer og at det er behov, eller gidde å ta den i bruk. 
Å ha `aria-label` på en gruppe med `role="group` kan være nyttig for brukere som benytter seg av skjermleser, fordi "gruppe" ikke sier seg selv. For eksempel i et skjema kan det være nyttig for brukere som benytter seg av skjermleser å kunne hoppe rett til "Skjemaknapper", i stedet for å måtte flytte seg inn på hver gruppe for å vite hvor knappene er.

Hvorfor vi har valgt å gjøre den valgfri nå: 
Selv om det ofte kan være nyttig for brukere med skjermleser å ha et gruppenavn, finnes det også tilfeller hvor det ikke er nødvendig og heller bare støyete for brukeren. På fagdagen om UU i januar ble det klart at det er mulig å over-bruke "aria-label" og at ikke absolutt alt trenger å få et navn. Så, vi fjerner at det er påkrevd i håp om at teamene selv kan ta en vurdering på når det er viktig og ikke. 
