### PR TITLE
fix(ffe-searchable-downdown-react): remove double var

### DIFF
--- a/packages/ffe-searchable-dropdown-react/less/searchable-dropdown.less
+++ b/packages/ffe-searchable-dropdown-react/less/searchable-dropdown.less
@@ -6,7 +6,7 @@
         --ffe-color-component-form-input-foreground-on-fill-subtle
     );
     --selected-icon-color: var(--ffe-color-fill-primary-selected-default);
-    --text-color: var(var(--ffe-color-foreground-default));
+    --text-color: var(--ffe-color-foreground-default);
 
     min-height: 2.8125rem;
     min-width: fit-content;


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse

Fjerner dobbel `var` i CSS. Virker som en skrivefeil.
