### PR TITLE
fix(ffe-cards): var(inherit) is invalid css

### DIFF
--- a/packages/ffe-cards/less/common-card-styling.less
+++ b/packages/ffe-cards/less/common-card-styling.less
@@ -83,6 +83,6 @@
     }
 
     .ffe-card__action--raw:visited {
-        color: var(inherit);
+        color: inherit;
     }
 }


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse

var(inherit) er ugyldig css. Fikser til inherit

## Motivasjon og kontekst

Utviklere får ikke bygget. Se [slack-melding](https://sb1-utvikling.slack.com/archives/CNS68BM1B/p1748946526816019) der utvikler varslet om dette.
## Testing

Har ikke testet dette.
