### PR TITLE
fix(ffe-cards): spesifiserer text-align på card action

### DIFF
--- a/packages/ffe-cards/less/common-card-styling.less
+++ b/packages/ffe-cards/less/common-card-styling.less
@@ -50,7 +50,7 @@
     }
     &:focus,
     &:active,
-    &:focus-within{
+    &:focus-within {
         border-color: var(--ffe-color-border-interactive-focus);
         box-shadow: var(--ffe-g-border-focus-box-shadow)
             var(--ffe-color-border-interactive-focus);
@@ -74,6 +74,7 @@
         font: inherit;
         cursor: pointer;
         outline: inherit;
+        text-align: left;
     }
 
     a.ffe-card__action--raw {


### PR DESCRIPTION
Fikser en bug der klikkbare kort (`CardAction`) får midtstilt tittel på små skjermer når kortet er en `button`. Dette skjer ikke når kortet er en link, og skyldes at user agent stylesheet defaulter til midtstilt tekst på `button`-elementet når ingen verdi er satt.

Før:
<img width="221" alt="image" src="https://github.com/user-attachments/assets/5ca33889-ead4-4bb2-965a-b52b21e07381" />

Etter:
<img width="221" alt="image" src="https://github.com/user-attachments/assets/f8d3033c-b973-49ec-8c5b-86639b4ce00f" />
