### PR TITLE
Manglende avhengigheter

### DIFF
--- a/packages/ffe-badge-react/package.json
+++ b/packages/ffe-badge-react/package.json
@@ -33,7 +33,8 @@
     },
     "dependencies": {
         "@sb1/ffe-badge": "^1.1.5",
-        "@sb1/ffe-core": "^32.0.5"
+        "@sb1/ffe-core": "^32.0.5",
+        "classnames": "^2.5.1"
     },
     "peerDependencies": {
         "react": ">=18.2.0"

--- a/packages/ffe-chips-react/package.json
+++ b/packages/ffe-chips-react/package.json
@@ -30,7 +30,8 @@
     "dependencies": {
         "@sb1/ffe-chips": "^2.0.28",
         "@sb1/ffe-core": "^32.0.5",
-        "@sb1/ffe-icons-react": "^12.0.5"
+        "@sb1/ffe-icons-react": "^12.0.5",
+        "classnames": "^2.5.1"
     },
     "devDependencies": {
         "@sb1/ffe-buildtool": "^0.10.1",

--- a/packages/ffe-datepicker-react/package.json
+++ b/packages/ffe-datepicker-react/package.json
@@ -25,6 +25,7 @@
     },
     "dependencies": {
         "@sb1/ffe-datepicker": "^14.2.0",
+        "@sb1/ffe-dropdown-react": "^8.1.11",
         "@sb1/ffe-form": "^32.1.10",
         "@sb1/ffe-form-react": "^23.3.14",
         "@sb1/ffe-icons-react": "^12.0.5",

--- a/packages/ffe-feedback-react/package.json
+++ b/packages/ffe-feedback-react/package.json
@@ -29,6 +29,7 @@
         "@sb1/ffe-core-react": "^10.1.8",
         "@sb1/ffe-feedback": "^4.1.7",
         "@sb1/ffe-form-react": "^23.3.14",
+        "@sb1/ffe-icons-react": "^12.0.5",
         "classnames": "^2.3.1"
     },
     "devDependencies": {

--- a/packages/ffe-modals-react/package.json
+++ b/packages/ffe-modals-react/package.json
@@ -26,6 +26,7 @@
     "dependencies": {
         "@sb1/ffe-icons-react": "^12.0.5",
         "@sb1/ffe-modals": "^2.1.4",
+        "classnames": "^2.5.1",
         "dialog-polyfill": "^0.5.6"
     },
     "devDependencies": {

--- a/packages/ffe-pagination-react/package.json
+++ b/packages/ffe-pagination-react/package.json
@@ -25,10 +25,12 @@
     },
     "dependencies": {
         "@sb1/ffe-buttons-react": "^24.4.0",
+        "@sb1/ffe-core": "^32.0.5",
         "@sb1/ffe-core-react": "^10.1.8",
         "@sb1/ffe-dropdown-react": "^8.1.11",
         "@sb1/ffe-icons-react": "^12.0.5",
-        "@sb1/ffe-pagination": "^3.0.26"
+        "@sb1/ffe-pagination": "^3.0.26",
+        "classnames": "^2.5.1"
     },
     "devDependencies": {
         "@sb1/ffe-buildtool": "^0.10.1",

--- a/packages/ffe-spinner-react/package.json
+++ b/packages/ffe-spinner-react/package.json
@@ -24,7 +24,8 @@
         "test:watch": "ffe-buildtool jest --watch"
     },
     "dependencies": {
-        "@sb1/ffe-spinner": "^6.0.25"
+        "@sb1/ffe-spinner": "^6.0.25",
+        "classnames": "^2.5.1"
     },
     "devDependencies": {
         "@sb1/ffe-buildtool": "^0.10.1",

--- a/packages/ffe-tables-react/package.json
+++ b/packages/ffe-tables-react/package.json
@@ -26,6 +26,7 @@
     },
     "dependencies": {
         "@sb1/ffe-collapse-react": "^5.1.33",
+        "@sb1/ffe-core-react": "^10.1.8",
         "@sb1/ffe-icons-react": "^12.0.5",
         "@sb1/ffe-tables": "^18.0.26",
         "classnames": "^2.3.1"

--- a/packages/ffe-tags-react/package.json
+++ b/packages/ffe-tags-react/package.json
@@ -34,7 +34,8 @@
     "dependencies": {
         "@sb1/ffe-core": "^32.0.5",
         "@sb1/ffe-icons-react": "^12.0.1",
-        "@sb1/ffe-tags": "^1.1.5"
+        "@sb1/ffe-tags": "^1.1.5",
+        "classnames": "^2.5.1"
     },
     "peerDependencies": {
         "react": ">=18.2.0"


### PR DESCRIPTION
Legger til manglende avhengigheter der det trengtes
Brukte `depcheck` til å sjekke alle avhengigheter som manglet i alle react-pakkene. Ignorerte avhengigheter som kun var introdusert i test eller storybook-filer. 

fixes #2957 