### PR TITLE
fix(ffe-cards): fjerner z-index fra group card

### DIFF
--- a/packages/ffe-cards/less/group-card.less
+++ b/packages/ffe-cards/less/group-card.less
@@ -10,7 +10,6 @@
         var(--ffe-color-border-primary-default);
 
     color: var(--ffe-color-foreground-default);
-    position: relative;
     border: 1px solid var(--ffe-color-border-primary-default);
 
     &--no-margin {
@@ -61,8 +60,6 @@
         border: 1px solid transparent;
         margin: 0;
         transition: all var(--ffe-transition-duration) var(--ffe-ease);
-        position: relative;
-        z-index: 0;
 
         &--no-padding {
             padding: 0;
@@ -70,10 +67,6 @@
 
         &--clickable {
             .clickable-card-styling();
-        }
-
-        &:focus-within {
-            z-index: 1;
         }
     }
 


### PR DESCRIPTION
fjerner z-index for å unngå position-bugs i listeelementer

group card har hatt position og z-index, tilsynelatende for å sikre at focus outline ikke forsvinner under andre listeelementer. Etter testing ser stylingen imidlertid ikke ut til å ha noen effekt, samtidig som den skaper utfordringer med innholdet i listeelementer.

Fixes #2983 