### PR TITLE
fix(ffe-tabs): fjerner z-index fra tabs

### DIFF
--- a/packages/ffe-tabs/less/tab.less
+++ b/packages/ffe-tabs/less/tab.less
@@ -2,7 +2,6 @@
 
 .ffe-tab {
     display: flex;
-
     background-color: var(--ffe-color-surface-primary-default);
     color: var(--ffe-color-foreground-default);
     padding: var(--ffe-spacing-xs) var(--ffe-spacing-md);
@@ -20,7 +19,6 @@
         background-color var(--ffe-transition-duration) var(--ffe-ease);
     cursor: pointer;
     width: auto;
-    position: relative;
     flex: none;
     order: 0;
     flex-grow: 1;
@@ -54,7 +52,6 @@
     &--selected {
         background-color: var(--ffe-color-fill-primary-selected-default);
         color: var(--ffe-color-foreground-inverse);
-        z-index: 2;
 
         @media (hover: hover) and (pointer: fine) {
             &:hover {


### PR DESCRIPTION
Verdens minste PR? 
Fjerner z-index fra --selected tab. Ser ingen grunn til at den skal være der nå. Tipper den var lagt inn tidligere pga. focus state, men nå bruker vi outline så det trengs ikke lengre

fixes #2845 