### PR TITLE
chore: legger til eksempel for bruk av description i samtlige skjemae…

### DIFF
--- a/packages/ffe-account-selector-react/src/account-selector-multi/AccountSelectorMulti.mdx
+++ b/packages/ffe-account-selector-react/src/account-selector-multi/AccountSelectorMulti.mdx
@@ -18,3 +18,9 @@ Kontovelger med støtte for å velge flere kontoer på én gang.
 
 <Canvas of={AccountSelectorMultiStories.Standard} />
 <Controls of={AccountSelectorMultiStories.Standard} />
+
+## Med beskrivelse
+
+Du kan bruke `description='tekst her'` på `InputGroup` for å legge til en beskrivelse mellom label og AccountSelectorMulti.
+
+<Canvas of={AccountSelectorMultiStories.WithDescription} />

--- a/packages/ffe-account-selector-react/src/account-selector-multi/AccountSelectorMulti.stories.tsx
+++ b/packages/ffe-account-selector-react/src/account-selector-multi/AccountSelectorMulti.stories.tsx
@@ -100,3 +100,18 @@ export const ControlledState: Story = {
         );
     },
 };
+
+export const WithDescription: Story = {
+    args: {
+        accounts,
+        locale: 'nb',
+        formatAccountNumber: true,
+    },
+    render: function Render(args) {
+        return (
+            <InputGroup label="Velg konto" description="Velg de kontoene du ønsker å bruke">
+                <AccountSelectorMulti {...args} />
+            </InputGroup>
+        );
+    },
+};

--- a/packages/ffe-account-selector-react/src/account-selector/AccountSelector.mdx
+++ b/packages/ffe-account-selector-react/src/account-selector/AccountSelector.mdx
@@ -21,44 +21,43 @@ I mobilbanken så er foretrukken løsning `openAccountPicker` i stedet for denne
 <Canvas of={AccountSelectorStories.Standard} />
 <Controls of={AccountSelectorStories.Standard} />
 
+## Saldo
 Kontovelger som også viser saldo/beløp
-
-## Forhåndsvisning
 
 <Canvas of={AccountSelectorStories.ShowBalance} />
 
+## Tillate å skrive eget
 Trenger du å tillate at brukere kan skrive inn sitt eget kontonummer kan du aktivere dette ved å sende med `allowCustomAccount={true}`.
-
-## Forhåndsvisning
 
 <Canvas of={AccountSelectorStories.AllowCustomAccount} />
 
+## Ingen formattering
 Hvis du ikke ønsker at kontonummeret en bruker skriver inn skal formatteres, kan du skru det av med `formatAccountNumber={false}`.
-
-## Forhåndsvisning
 
 <Canvas of={AccountSelectorStories.NoFormatAccount} />
 
+## Egendefinert listElement 
 Dersom du ønsker å gjøre endringer på selve listevisningen, kan du gjøre det med `listElementBody`.
-
-## Forhåndsvisning
 
 <Canvas of={AccountSelectorStories.ListElementBody} />
 
+## Skjule kontodetlajer
 Dersom du ønsker å skjule kontodetaljer, kan du bruke `hideAccountDetails`.
-
-## Forhåndsvisning
 
 <Canvas of={AccountSelectorStories.HideAccountDetails} />
 
+## Ekstra tekst nederst 
 Dersom du ønsker å ha ekstra tekst på bunnen av lista, kan du bruke `postListElement`.
-
-## Forhåndsvisning
 
 <Canvas of={AccountSelectorStories.PostListElement} />
 
+## Tilpass visningen av valgt konto
 Dersom du ønsker å vise en annen informasjon enn kontonavn i inputen, så kan du velge hvilken attribute som brukes med `displayAttribute`.
 
-## Forhåndsvisning
-
 <Canvas of={AccountSelectorStories.CustomDisplayAttribute} />
+
+## Med beskrivelse
+
+Du kan bruke `description='tekst her'` på `InputGroup` for å legge til en beskrivelse mellom label og AccountSelector.
+
+<Canvas of={AccountSelectorStories.WithDescription} />

--- a/packages/ffe-account-selector-react/src/account-selector/AccountSelector.stories.tsx
+++ b/packages/ffe-account-selector-react/src/account-selector/AccountSelector.stories.tsx
@@ -288,3 +288,26 @@ export const CustomDisplayAttribute: StoryObj<
         );
     },
 };
+
+export const WithDescription: Story = {
+    args: {
+        accounts,
+        locale: 'nb',
+        formatAccountNumber: true,
+        allowCustomAccount: false,
+    },
+    render: function Render(args) {
+        const [selectedAccount, setSelectedAccount] = useState<Account>();
+
+        return (
+            <InputGroup label="Velg konto" description="Velg den kontoen du har mest lyst på">
+                <AccountSelector
+                    {...args}
+                    selectedAccount={selectedAccount}
+                    onAccountSelected={setSelectedAccount}
+                    onReset={() => setSelectedAccount(undefined)}
+                />
+            </InputGroup>
+        );
+    },
+};

--- a/packages/ffe-datepicker-react/src/datepicker/Datepicker.mdx
+++ b/packages/ffe-datepicker-react/src/datepicker/Datepicker.mdx
@@ -23,6 +23,12 @@ Du kan aktivere nedtrekksmeny for måned og år ved å sette `dropdownCaption={t
 <Canvas of={DatepickerStories.WithDropdownCaption} />
 <Controls of={DatepickerStories.Standard} />
 
+## Med beskrivelse
+
+Du kan bruke `description='tekst her'` på `InputGroup` for å legge til en beskrivelse mellom label og Datepicker.
+
+<Canvas of={DatepickerStories.WithDescription} />
+
 ## Testing med React Testing Library
 
 Testing av `Datepicker` krever litt ekstra kode, så vi har gjort det enklere ved å tilby en funksjon som

--- a/packages/ffe-datepicker-react/src/datepicker/Datepicker.stories.tsx
+++ b/packages/ffe-datepicker-react/src/datepicker/Datepicker.stories.tsx
@@ -218,3 +218,27 @@ export const TwoWayControlledComponent: Story = {
         );
     },
 };
+
+export const WithDescription: Story = {
+    args: {
+        ...Standard.args,
+    },
+    render: function Render({ value, onChange, ...args }: DatepickerProps) {
+        const [date, setDate] = useState('01.12.2024');
+
+        return (
+            <InputGroup label="Dato"
+                labelId={Standard?.args?.labelId}
+                description="Dette er en beskrivelse av Datepicker-komponenten. Den gir ekstra informasjon om hvordan den skal brukes.">
+                <Datepicker
+                    value={value ?? date}
+                    onChange={date => {
+                        setDate(date);
+                        console.log('Datepicker value:', date);
+                    }}
+                    {...args}
+                />
+            </InputGroup>
+        );
+    },
+};

--- a/packages/ffe-dropdown-react/src/Dropdown.mdx
+++ b/packages/ffe-dropdown-react/src/Dropdown.mdx
@@ -7,7 +7,8 @@ import dependencies from '../ffe-dependencies';
 
 # Dropdown
 
-Dropdown er en vanlig nedtrekksliste som kan brukes man n책r man har 5-10 valg 책 velge mellom. Har du mindre enn 5 valg, bruk radio buttons istedenfor.
+Dropdown er en vanlig nedtrekksliste som kan brukes man n책r man har 5-10 valg 책 velge mellom. Har du mindre enn 5 valg, bruk `RadioButtons` istedenfor.
+Har du flere burde du bruke `SearchableDropdown`.
 
 <InstallImport
     packageName="@sb1/ffe-dropdown-react"
@@ -18,3 +19,9 @@ Dropdown er en vanlig nedtrekksliste som kan brukes man n책r man har 5-10 valg �
 
 <Canvas of={DropdownStories.Standard} />
 <Controls of={DropdownStories.Standard} />
+
+## Med beskrivelse
+
+Du kan bruke `description='tekst her'` p책 `InputGroup` for 책 legge til en beskrivelse mellom label og Dropdown.
+
+<Canvas of={DropdownStories.WithDescription} />

--- a/packages/ffe-dropdown-react/src/Dropdown.stories.tsx
+++ b/packages/ffe-dropdown-react/src/Dropdown.stories.tsx
@@ -55,3 +55,24 @@ export const AriaInvalid: Story = {
         );
     },
 };
+
+export const WithDescription: Story = {
+    args: {
+        inline: false,
+    },
+    render: args => {
+        return (
+            <InputGroup 
+                label="Måned"
+                description='Velg en måned for fakturering'>
+                <Dropdown {...args}>
+                    <option value="jan">Januar</option>
+                    <option value="feb">Februar</option>
+                    <option value="mar">Mars</option>
+                    <option value="apr">April</option>
+                    <option value="mai">Mai</option>
+                </Dropdown>
+            </InputGroup>
+        );
+    },
+};

--- a/packages/ffe-form-react/src/Checkbox.stories.tsx
+++ b/packages/ffe-form-react/src/Checkbox.stories.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Checkbox } from './Checkbox';
 import type { StoryObj, Meta } from '@storybook/react';
+import { InputGroup } from './InputGroup';
 
 const meta: Meta<typeof Checkbox> = {
     title: 'Komponenter/Form/Checkbox',
@@ -88,5 +89,29 @@ export const RenderProps: Story = {
                 </label>
             )}
         </Checkbox>
+    ),
+};
+
+export const Description: Story = {
+    args: {
+        ...Standard.args,
+        inline: false,
+    },
+    render: args => (
+        <InputGroup label="Hva pleier du å lese?" description="Velg en eller flere aviser">
+            {() => (
+                <>
+                    <Checkbox {...args} name="newspapers" value="vg">
+                        VG
+                    </Checkbox>
+                    <Checkbox {...args} name="newspapers" value="dagbladet">
+                        Dagbladet
+                    </Checkbox>
+                    <Checkbox {...args} name="newspapers" value="nrk">
+                        NRK
+                    </Checkbox>
+                </>
+            )}
+        </InputGroup>
     ),
 };

--- a/packages/ffe-form-react/src/RadioButton.mdx
+++ b/packages/ffe-form-react/src/RadioButton.mdx
@@ -57,3 +57,9 @@ Du kan merke at et felt er ugyldig ved å sette `aria-invalid="true"`.
 
 <Canvas of={RadioButtonStories.AriaInvalid} />
 <Controls of={RadioButtonStories.AriaInvalid} />
+
+## Med beskrivelse
+
+Du kan bruke `description='tekst her'` på `InputGroup` for å legge til en beskrivelse mellom label og Radio-knappene.
+
+<Canvas of={RadioButtonStories.WithDescription} />

--- a/packages/ffe-form-react/src/RadioButton.stories.tsx
+++ b/packages/ffe-form-react/src/RadioButton.stories.tsx
@@ -167,3 +167,40 @@ export const WithTooltip: Story = {
         return <RadioButtonWithGroupTooltip {...args} />;
     },
 };
+
+export const WithDescription: Story = {
+    args: {
+        selectedValue: 'bankkunde',
+    },
+    render: function Render(args) {
+        const [selected, setSelected] = useState(args.selectedValue);
+    const id = useId();
+
+    return (
+        <RadioButtonInputGroup
+            label="Velg faktureringstype"
+            name={`radio-button-description-demo-${id}`}
+            onChange={e => setSelected(e.target.value)}
+            selectedValue={selected}
+            description="Velg faktureringstype for abonnementet ditt. Dette påvirker hvor ofte du vil motta faktura."
+        >
+            {inputProps => (
+                <>
+                    <RadioButton
+                        value="monthly"
+                        {...inputProps}
+                    >
+                        Månedlig fakturering
+                    </RadioButton>
+                    <RadioButton
+                        value="quarterly"
+                        {...inputProps}
+                    >
+                        Kvartalsvis fakturering
+                    </RadioButton>
+                </>
+            )}
+        </RadioButtonInputGroup>
+    );
+    },
+};

--- a/packages/ffe-form-react/src/RadioSwitch.mdx
+++ b/packages/ffe-form-react/src/RadioSwitch.mdx
@@ -33,3 +33,9 @@ Du kan merke at et felt er ugyldig ved å sette `aria-invalid="true"`.
 
 <Canvas of={RadioSwitchStories.AriaInvalid} />
 <Controls of={RadioSwitchStories.AriaInvalid} />
+
+## Med beskrivelse
+
+Du kan bruke `description='tekst her'` på `InputGroup` for å legge til en beskrivelse mellom label og RadioSwitch.
+
+<Canvas of={RadioSwitchStories.WithDescription} />

--- a/packages/ffe-form-react/src/RadioSwitch.stories.tsx
+++ b/packages/ffe-form-react/src/RadioSwitch.stories.tsx
@@ -69,3 +69,27 @@ export const AriaInvalid: Story = {
         return <RadioSwitchAriaInvalid {...args} />;
     },
 };
+
+export const WithDescription: Story = {
+    args: {
+        ...Standard.args
+    },
+    render: function Render(args) {
+        const [selected, setSelected] = useState(args.selectedValue);
+        const id = useId();
+
+        return (
+            <RadioButtonInputGroup
+                label="Velg faktureringstype"
+                name={`radio-button-description-demo-${id}`}
+                onChange={e => setSelected(e.target.value)}
+                selectedValue={selected}
+                description="Velg faktureringstype for abonnementet ditt. Dette påvirker hvor ofte du vil motta faktura."
+            >
+
+                {inputProps => <RadioSwitch {...args} {...inputProps} />}
+            </RadioButtonInputGroup>
+        );
+    },
+};
+

--- a/packages/ffe-form-react/src/TextArea.mdx
+++ b/packages/ffe-form-react/src/TextArea.mdx
@@ -12,7 +12,14 @@ import * as TextAreaStories from './TextArea.stories.tsx';
 
 ## Med feilmelding
 
-Sender man inn en string eller et `<ErrorFieldMessage>`-element til `fieldMessage` på `<InputGroup>` vil TextArea-feltet rendres med `aria-invalid` og en feilmelding.
+Hvis du sender inn en tekststreng eller et `<ErrorFieldMessage>`-element til 
+`fieldMessage`-prop'en på `<InputGroup>`, vil TextArea-feltet rendres med `aria-invalid` og en feilmelding.
 
 <Canvas of={TextAreaStories.FieldMessage} />
 <Controls of={TextAreaStories.FieldMessage} />
+
+## Med beskrivelse
+
+Du kan bruke `InputGroup` til å legge til en beskrivelse for TextArea-feltet.
+
+<Canvas of={TextAreaStories.WithDescription} />

--- a/packages/ffe-form-react/src/TextArea.stories.tsx
+++ b/packages/ffe-form-react/src/TextArea.stories.tsx
@@ -35,3 +35,16 @@ export const FieldMessage: Story = {
         </InputGroup>
     ),
 };
+
+export const WithDescription: Story = {
+    args: {
+        ...Standard.args,
+    },
+    render: args => (
+        <InputGroup
+            label={'Beskriv skaden'}
+            description='Prøv å være så konkret som mulig'>
+            <TextArea {...args} />
+        </InputGroup>
+    ),
+};

--- a/packages/ffe-searchable-dropdown-react/src/multi/SearchableDropdownMultiSelect.mdx
+++ b/packages/ffe-searchable-dropdown-react/src/multi/SearchableDropdownMultiSelect.mdx
@@ -3,7 +3,7 @@ import * as SearchableDropdownMultiSelect from './SearchableDropdownMultiSelect.
 
 <Meta of={SearchableDropdownMultiSelect} />
 
-# SearchableDropdownMulti
+# SearchableDropdownMultiSelect
 
 For nedtrekkslister der du kan velge å vise flere resultater samtidig (som for eksempel sparekontoer eller aksjefond).
 
@@ -13,3 +13,9 @@ Dropdown multiselect skal kun brukes i situasjoner det gir mening å gi brukeren
 
 <Canvas of={SearchableDropdownMultiSelect.Standard} />
 <Controls of={SearchableDropdownMultiSelect.Standard} />
+
+## Med beskrivelse
+
+Du kan bruke `description='tekst her'` på `InputGroup` for å legge til en beskrivelse mellom label og SearchableDropdownMultiSelect.
+
+<Canvas of={SearchableDropdownMultiSelect.WithDescription} />

--- a/packages/ffe-searchable-dropdown-react/src/multi/SearchableDropdownMultiSelect.stories.tsx
+++ b/packages/ffe-searchable-dropdown-react/src/multi/SearchableDropdownMultiSelect.stories.tsx
@@ -358,3 +358,29 @@ export const AriaInvalid: Story = {
         );
     },
 };
+
+export const WithDescription: Story = {
+    args: {
+        ...Standard.args,
+    },
+    render: function Render({ id, labelledById, ...args }) {
+        return (
+            <>
+                <InputGroup
+                    label="Velg frukt"
+                    labelId={labelledById}
+                    inputId={id}
+                    description='Velg de du liker aller best'
+                >
+                    {inputProps => (
+                        <SearchableDropdownMultiSelect
+                            labelledById={labelledById}
+                            {...args}
+                            {...inputProps}
+                        />
+                    )}
+                </InputGroup>
+            </>
+        );
+    },
+};

--- a/packages/ffe-searchable-dropdown-react/src/single/SearchableDropdown.mdx
+++ b/packages/ffe-searchable-dropdown-react/src/single/SearchableDropdown.mdx
@@ -32,3 +32,9 @@ Vil du bestemme hvilket element som er valgt, kan du bruke `selectedItem`.
 Dersom du ønsker å ha ekstra tekst på bunnen av lista, kan du bruke `postListElement`.
 
 <Canvas of={SearchableDropdownStories.PostListElement} />
+
+## Med beskrivelse
+
+Du kan bruke `description='tekst her'` på `InputGroup` for å legge til en beskrivelse mellom label og SearchableDropdown.
+
+<Canvas of={SearchableDropdownStories.WithDescription} />

--- a/packages/ffe-searchable-dropdown-react/src/single/SearchableDropdown.stories.tsx
+++ b/packages/ffe-searchable-dropdown-react/src/single/SearchableDropdown.stories.tsx
@@ -282,3 +282,27 @@ export const AriaInvalid: Story = {
         );
     },
 };
+
+export const WithDescription: Story = {
+    args: {
+        ...Standard.args,
+    },
+    render: function Render({ id, labelledById, ...args }) {
+        return (
+            <InputGroup
+                label="Velg bedrift"
+                labelId={labelledById}
+                inputId={id}
+                description='Velg en bedrift for å fortsette'
+            >
+                {inputProps => (
+                    <SearchableDropdown
+                        labelledById={labelledById}
+                        {...args}
+                        {...inputProps}
+                    />
+                )}
+            </InputGroup>
+        );
+    },
+};


### PR DESCRIPTION
fixes #2812 

Legger til et eksempel for bruk av description i
- AccountSelector
- AccountselectorMulti
- Datepicker
- Dropdown
- Checkbox
- SearchableDropdown
- SearchableDropdownMulitSelect
- TextArea
- RadioButton
- RadioSwitch

Det var allerede mulig i alle komponentene via `InputGroup` og `RadioButtonInputGroup`