### PR TITLE
fix(ffe-datepicker-react): forhindrer scroll ved bruk av tastaturnavi…

### DIFF
--- a/packages/ffe-datepicker-react/src/calendar/Calendar.tsx
+++ b/packages/ffe-datepicker-react/src/calendar/Calendar.tsx
@@ -93,7 +93,7 @@ export class Calendar extends Component<CalendarProps, State> {
             'ArrowRight',
             'ArrowDown',
         ] as const;
-        if (!scrollableEvents.includes(event.key)) {
+        if (scrollableEvents.includes(event.key)) {
             event.preventDefault();
         }
 


### PR DESCRIPTION
fixes #2805 

Problem: Når man bruker tastaturet til å navigere i kalenderen, scrolles også siden den er på. 
Løsning: En veldig liten løsning, men det ser ut til å fungere. Får ikke testet pageUp og home osv selv (tror ikke det er mulig på mac?), men det ser ut som at det egentlig skulle vært sånn her, men at det er en glipp fra da det ble [oppdatert fra ts](https://github.com/SpareBank1/designsystem/commit/4ec8899fe421959c38b4f3697db11334269e907d#diff-869fec20cc18c1a81085765e2eb44c3d951789818f3fa77325caed25ba7d59f3R85). 

<img width="1159" height="367" alt="image" src="https://github.com/user-attachments/assets/34e0a4c9-5cbc-4a87-907c-2f8698460715" />