### PR TITLE
fix(ffe-buttons-react): tillater classname på slutten av inlinebasebu…

### DIFF
--- a/packages/ffe-buttons-react/src/InlineBaseButton.tsx
+++ b/packages/ffe-buttons-react/src/InlineBaseButton.tsx
@@ -44,10 +44,10 @@ function InlineBaseButtonWithForwardRef<As extends ElementType>(
         <Comp
             className={classNames(
                 'ffe-inline-button',
-                className,
                 `ffe-inline-button--${size}`,
                 `ffe-inline-button--${buttonType}`,
                 { 'ffe-inline-button--icon-only': iconOnly },
+                className,
             )}
             {...rest}
             ref={ref}


### PR DESCRIPTION
fixes #2994 

Veldig liten endring. Vi burde se nærmere på hvorfor dette var et behov, men liten fiks for de som trengte det nå 