### PR TITLE
Tag størrelser

### DIFF
--- a/examples/DSBanken/src/pages/AccountOverview.tsx
+++ b/examples/DSBanken/src/pages/AccountOverview.tsx
@@ -88,6 +88,11 @@ export const AccountOverview = () => {
                     <Heading2 noMargin={true}>Brukskonto</Heading2>
                     <SmallText>Bruk av Cards, Accordion og Table</SmallText>
                 </GridCol>
+                <div className='flex items-center gap-1'>
+                    <Tag type='subtle' size="lg" variant='warning'>Bruk</Tag>
+                    <Tag type='subtle' size="lg" variant='warning'>Kontoer</Tag>
+                    <Tag type='subtle' size="lg" variant='warning'>Tag</Tag>
+                </div>
             </GridRow>
 
             <GridRow>
@@ -378,7 +383,13 @@ export const AccountOverview = () => {
                                     <CardAction href="/felles-forsikringer">
                                         <Title>Hva skjer med felles forsikringer i samlivsbrudd?</Title>
                                     </CardAction>
-                                    <Subtext>En liten undertekst</Subtext>
+                                    <Subtext>
+                                        En liten undertekst
+                                    </Subtext>
+                                    <div className='flex items-center justify-center gap-1'>
+                                        <Tag variant="info" size="sm">Samlivsbrudd</Tag>
+                                        <Tag variant="success" size="sm">Flytting</Tag>
+                                    </div>
                                     <Text>
                                         Lorem ipsum dolor sit amet, consectetur adipiscing elit,
                                         sed do eiusmod tempor incididunt ut labore et dolore

--- a/packages/ffe-tags-react/src/Tag.mdx
+++ b/packages/ffe-tags-react/src/Tag.mdx
@@ -30,3 +30,8 @@ Du må installere pakken og importere stylingen og ikonet separat.
 
 <Canvas of={TagStories.WithIcon} />
 <Controls of={TagStories.WithIcon} />
+
+## Forskjellige størrelser
+`Tag` tilbyr `size` i `sm`, `md` og `lg`. Default er md. 
+
+<Canvas of={TagStories.DifferentSizes} />

--- a/packages/ffe-tags-react/src/Tag.spec.tsx
+++ b/packages/ffe-tags-react/src/Tag.spec.tsx
@@ -102,4 +102,18 @@ describe('<Tag/>', () => {
             expect(iconColor).toBe(tagColor);
         });
     });
+
+    describe('Sizes', () => {
+        it('should render a tag with size sm', () => {
+            render(<Tag size="sm">En tag</Tag>);
+            const tag = screen.getByText('En tag');
+            expect(tag.classList.contains('ffe-tag--sm')).toBeTruthy();
+        });
+
+        it('should render a tag with size lg', () => {
+            render(<Tag size="lg">En tag</Tag>);
+            const tag = screen.getByText('En tag');
+            expect(tag.classList.contains('ffe-tag--lg')).toBeTruthy();
+        });
+    });
 });

--- a/packages/ffe-tags-react/src/Tag.stories.tsx
+++ b/packages/ffe-tags-react/src/Tag.stories.tsx
@@ -96,3 +96,27 @@ export const Subtle: Story = {
         );
     },
 };
+
+
+export const DifferentSizes: Story = {
+    args: {
+        variant: 'info',
+    },
+    render: args => {
+        return (
+            <div>
+                <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap' }}>
+                    <Tag {...args} size='sm'>
+                        Tag Label
+                    </Tag>
+                    <Tag {...args}>
+                        Tag Label
+                    </Tag>
+                    <Tag {...args} size='lg'>
+                        Tag Label
+                    </Tag>
+                </div>
+            </div>
+        );
+    },
+};

--- a/packages/ffe-tags-react/src/Tag.tsx
+++ b/packages/ffe-tags-react/src/Tag.tsx
@@ -2,11 +2,13 @@ import classNames from 'classnames';
 import React from 'react';
 
 export type TagProps = {
-    /** Decides the emphasis of the tag, whether it has a strong or subtle look */
+    /** Bestemmer taggens uttrykk, om den skal være fremhevet eller subtil */
     type?: 'emphasis' | 'subtle';
     className?: string;
-    /** the color of the tag. Info, success, warning, critical, neutral or tip */
+    /** Fargen på taggen. Info, suksess, advarsel, kritisk, nøytral eller tips */
     variant?: 'info' | 'success' | 'warning' | 'critical' | 'neutral' | 'tip';
+    /** Størrelsen på taggen, standard er md */
+    size?: 'sm' | 'md' | 'lg';
     children: React.ReactNode;
 };
 
@@ -14,6 +16,7 @@ export function Tag({
     className,
     type = 'emphasis',
     variant = 'neutral',
+    size = 'md',
     children,
     ...rest
 }: TagProps) {
@@ -22,6 +25,7 @@ export function Tag({
             className={classNames(
                 'ffe-tag',
                 `ffe-tag--${variant}-${type}`,
+                { [`ffe-tag--${size}`]: size !== 'md' },
                 className,
             )}
             {...rest}

--- a/packages/ffe-tags/less/tag.less
+++ b/packages/ffe-tags/less/tag.less
@@ -9,11 +9,23 @@
     padding: var(--ffe-spacing-2xs) var(--ffe-spacing-xs);
     border-radius: var(--ffe-g-border-radius);
     min-width: fit-content;
+    height: fit-content;
     background-color: var(--background-color);
     color: var(--text-color);
+    font-size: var(--ffe-fontsize-small-text);
+    line-height: 1.4;
 
     .ffe-icons {
         color: var(--text-color);
+    }
+
+    &--sm {
+        padding: 2px var(--ffe-spacing-2xs);
+        border-radius: var(--ffe-g-border-radius-sm);
+    }
+
+    &--lg {
+        font-size: var(--ffe-fontsize-body-text);
     }
 
     &--info {
@@ -21,6 +33,7 @@
             --background-color: var(--ffe-color-fill-feedback-info);
             --text-color: var(--ffe-color-foreground-inverse);
         }
+
         &-subtle {
             --background-color: var(--ffe-color-fill-feedback-info-subtle);
             --text-color: var(--ffe-color-foreground-default);
@@ -32,6 +45,7 @@
             --background-color: var(--ffe-color-fill-feedback-success);
             --text-color: var(--ffe-color-foreground-inverse);
         }
+
         &-subtle {
             --background-color: var(--ffe-color-fill-feedback-success-subtle);
             --text-color: var(--ffe-color-foreground-default);
@@ -43,6 +57,7 @@
             --background-color: var(--ffe-color-fill-feedback-warning);
             --text-color: var(--ffe-color-foreground-inverse);
         }
+
         &-subtle {
             --background-color: var(--ffe-color-fill-feedback-warning-subtle);
             --text-color: var(--ffe-color-foreground-default);
@@ -54,6 +69,7 @@
             --background-color: var(--ffe-color-fill-feedback-critical);
             --text-color: var(--ffe-color-foreground-inverse);
         }
+
         &-subtle {
             --background-color: var(--ffe-color-fill-feedback-critical-subtle);
             --text-color: var(--ffe-color-foreground-default);
@@ -65,6 +81,7 @@
             --background-color: var(--ffe-color-fill-feedback-tip);
             --text-color: var(--ffe-color-foreground-inverse);
         }
+
         &-subtle {
             --background-color: var(--ffe-color-fill-feedback-tip-subtle);
             --text-color: var(--ffe-color-foreground-default);
@@ -76,6 +93,7 @@
             --background-color: var(--ffe-color-fill-neutral-default);
             --text-color: var(--ffe-color-foreground-default);
         }
+
         &-subtle {
             --background-color: var(--ffe-color-fill-neutral-subtle);
             --text-color: var(--ffe-color-foreground-default);


### PR DESCRIPTION
fixes #2974 
Legger til flere størrelser av Tag 
<img width="289" height="107" alt="image" src="https://github.com/user-attachments/assets/55b7a5f8-1582-458a-a014-fd9f4f80e194" />

Det er litt forskjell på Figma og kode selv om man putter inn akkurat samme verdier. Det er fordi Figma runder opp/ned på verdier, så `line-height: 1.4` tilsvarer 19,6px i kode men 20px i figma. Taggene blir pittelitt forskjellig størrelse, men det er snakk om 0.4px og vi har vurdert det til at det går fint. 