### PR TITLE
feat(ffe-lists-react)!: fjerner bruk av dårlig støttet dl og bruker d…

### DIFF
--- a/examples/DSBanken/src/components/ProfileView.tsx
+++ b/examples/DSBanken/src/components/ProfileView.tsx
@@ -1,4 +1,5 @@
 import { InputGroup } from '@sb1/ffe-form-react';
+import { DescriptionList, DescriptionListDescription, DescriptionListTerm } from '@sb1/ffe-lists-react';
 import { SearchableDropdown } from '@sb1/ffe-searchable-dropdown-react';
 import {
     Tag
@@ -16,6 +17,23 @@ const tags: { variant: 'success' | 'warning' | 'critical' | 'neutral' | 'tip' | 
 
 const ProfileView: React.FC = () => (
     <div>
+        <div>
+            <h3 className="ffe-h4">Personalia</h3>
+            <DescriptionList>
+                <DescriptionListTerm>Navn</DescriptionListTerm>
+                <DescriptionListDescription>
+                    Navn Navnesen
+                </DescriptionListDescription>
+                <DescriptionListTerm>Adresse</DescriptionListTerm>
+                <DescriptionListDescription>
+                    Husgata 14
+                </DescriptionListDescription>
+                <DescriptionListTerm>Postnummer og sted</DescriptionListTerm>
+                <DescriptionListDescription>
+                    1337 Sandvika
+                </DescriptionListDescription>
+            </DescriptionList>
+        </div>
         <div className='flex flex-wrap gap-1 mb-2'>
             {tags.map(({ variant, label }) => (
                 <Tag variant={variant}>{label}</Tag>

--- a/examples/DSBanken/src/pages/InvestmentDashboard.tsx
+++ b/examples/DSBanken/src/pages/InvestmentDashboard.tsx
@@ -67,7 +67,7 @@ export const InvestmentDashboard = () => {
 
             <GridRow>
                 <GridCol>
-                    <DetailListCard>
+                    <DetailListCard className='mb-4'>
                         <DetailListCardItem label="Kontonavn" value="Daglig konto" />
                         <DetailListCardItem label="Kontotype" value="Brukskonto" />
                         <DetailListCardItem label="Kontonummer" value="1234 45 34554" />

--- a/packages/ffe-lists-react/src/DescriptionList.tsx
+++ b/packages/ffe-lists-react/src/DescriptionList.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import classNames from 'classnames';
 
 export interface DescriptionListProps
-    extends React.ComponentPropsWithoutRef<'dl'> {
+    extends React.ComponentPropsWithoutRef<'div'> {
     size?: 'md' | 'lg';
     /** Displays dts and dds inline*/
     horizontal?: boolean;
@@ -14,7 +14,8 @@ export const DescriptionList: React.FC<DescriptionListProps> = ({
     horizontal,
     ...rest
 }) => (
-    <dl
+    <div
+        role='list'
         className={classNames(
             'ffe-description-list',
             { 'ffe-description-list--horizontal': horizontal },

--- a/packages/ffe-lists-react/src/DescriptionListDescription.tsx
+++ b/packages/ffe-lists-react/src/DescriptionListDescription.tsx
@@ -2,13 +2,14 @@ import React from 'react';
 import classNames from 'classnames';
 
 export interface DescriptionListDescriptionProps
-    extends React.ComponentPropsWithoutRef<'dt'> {}
+    extends React.ComponentPropsWithoutRef<'div'> {}
 
 export const DescriptionListDescription: React.FC<
     DescriptionListDescriptionProps
 > = ({ className, ...rest }) => {
     return (
-        <dd
+        <div
+            role="definition"
             className={classNames(
                 'ffe-description-list__description',
                 className,

--- a/packages/ffe-lists-react/src/DescriptionListMultiCol.tsx
+++ b/packages/ffe-lists-react/src/DescriptionListMultiCol.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import classNames from 'classnames';
 
 export interface DescriptionListMultiColProps
-    extends React.ComponentPropsWithoutRef<'dl'> {}
+    extends React.ComponentPropsWithoutRef<'div'> {}
 
 export const DescriptionListMultiCol: React.FC<
     DescriptionListMultiColProps
@@ -18,7 +18,8 @@ export const DescriptionListMultiCol: React.FC<
     });
 
     return (
-        <dl
+        <div
+            role="list"
             className={classNames('ffe-description-list-multicol', className)}
             {...rest}
         >
@@ -31,6 +32,6 @@ export const DescriptionListMultiCol: React.FC<
                     {pair[1]}
                 </div>
             ))}
-        </dl>
+        </div>
     );
 };

--- a/packages/ffe-lists-react/src/DescriptionListTerm.tsx
+++ b/packages/ffe-lists-react/src/DescriptionListTerm.tsx
@@ -2,14 +2,15 @@ import React from 'react';
 import classNames from 'classnames';
 
 export interface DescriptionListTermProps
-    extends React.ComponentPropsWithoutRef<'dt'> {}
+    extends React.ComponentPropsWithoutRef<'div'> {}
 
 export const DescriptionListTerm: React.FC<DescriptionListTermProps> = ({
     className,
     ...rest
 }) => {
     return (
-        <dt
+        <div 
+            role="term"
             className={classNames('ffe-description-list__term', className)}
             {...rest}
         />

--- a/packages/ffe-lists-react/src/DetailListCard.spec.tsx
+++ b/packages/ffe-lists-react/src/DetailListCard.spec.tsx
@@ -25,8 +25,8 @@ const renderDetailListCardItem = (props?: Partial<DetailListCardItemProps>) =>
 describe('<DetailListCard />', () => {
     it('add classNames correctly', () => {
         const { container } = renderDetailListCard({ className: 'test-class' });
-        expect(container.querySelector('dl')).toBeTruthy();
-        const dl = container.querySelector('dl');
+        expect(screen.getByRole('list')).toBeTruthy();
+        const dl = screen.getByRole('list');
 
         expect(dl?.classList.contains('ffe-detail-list-card')).toBe(true);
         expect(dl?.classList.contains('test-class')).toBe(true);
@@ -55,12 +55,13 @@ describe('<DetailListCard />', () => {
                 ?.getAttribute('id'),
         ).toEqual('test-id');
     });
+
     it('renders correct label content', () => {
         const { container } = renderDetailListCardItem({
             label: <span>Test Label</span>,
             value: 'value',
         });
-        const dt = container.querySelector('dt');
+        const dt = screen.getByRole('term');
         expect(
             dt?.classList.contains('ffe-detail-list-card__item-label'),
         ).toBeTruthy();

--- a/packages/ffe-lists-react/src/DetailListCard.tsx
+++ b/packages/ffe-lists-react/src/DetailListCard.tsx
@@ -4,7 +4,7 @@ import classNames from 'classnames';
 export type BackgroundColor = 'primary' | 'secondary' | 'tertiary';
 
 export interface DetailListCardProps
-    extends React.ComponentPropsWithoutRef<'dl'> {
+    extends React.ComponentPropsWithoutRef<'ul'> {
     /** Avgjør utseende i kontekst accent. Hvis man ønsker et blått utseende i kontekst accent, velg appearance: 'accent' */
     appearance?: 'default' | 'accent';
     /**
@@ -28,7 +28,7 @@ export const DetailListCard: React.FC<DetailListCardProps> = ({
     ...rest
 }) => {
     return (
-        <dl
+        <ul
             className={classNames('ffe-detail-list-card', className, {
                 [`ffe-detail-list-card--bg-${bgColor}`]: bgColor,
                 'ffe-default-mode': appearance === 'default',
@@ -36,6 +36,6 @@ export const DetailListCard: React.FC<DetailListCardProps> = ({
             {...rest}
         >
             {children}
-        </dl>
+        </ul>
     );
 };

--- a/packages/ffe-lists-react/src/DetailListCardItem.tsx
+++ b/packages/ffe-lists-react/src/DetailListCardItem.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import classNames from 'classnames';
 
 export interface DetailListCardItemProps
-    extends React.ComponentPropsWithoutRef<'div'> {
+    extends React.HTMLAttributes<HTMLLIElement> {
     /** Content of the label / left column */
     label: React.ReactNode;
     /** Content of the value / right column */
@@ -16,20 +16,24 @@ export const DetailListCardItem: React.FC<DetailListCardItemProps> = ({
     ...rest
 }) => {
     return (
-        <div
+        <li
             className={classNames('ffe-detail-list-card__item', className)}
             {...rest}
         >
-            <dt className="ffe-detail-list-card__item-label">
+            <div
+                role="term"
+                className="ffe-detail-list-card__item-label">
                 {React.isValidElement(label)
                     ? React.cloneElement(label, { ...label.props })
                     : label}
-            </dt>
-            <dd className="ffe-detail-list-card__item-value">
+            </div>
+            <div
+                role="definition"
+                className="ffe-detail-list-card__item-value">
                 {React.isValidElement(value)
                     ? React.cloneElement(value, { ...value.props })
                     : value}
-            </dd>
-        </div>
+            </div>
+        </li>
     );
 };

--- a/packages/ffe-lists/less/detail-list-card.less
+++ b/packages/ffe-lists/less/detail-list-card.less
@@ -8,6 +8,7 @@
     font-family: var(--ffe-g-font);
     font-variant-numeric: tabular-nums;
     container-type: inline-size;
+    padding: 0; //Overskriver padding på ul-elementet
 
     &__item:not(:last-child) {
         border-bottom: 1px solid var(--ffe-color-border-primary-subtle);


### PR DESCRIPTION
fixes #2499 

## Bakgrunn
`dl`, `dt` og `dd` er ikke godt støttet. https://a11ysupport.io/

## Endring 
Har gjort om fra dl, dt og dd i `DescriptionList` og `DetailList`. Har brukt `div` med role `list`, `listitem`, `term` og `definition` i stedet. 

## Testing 
Har testet på chrome og i safari. Safari har ikke like god støtte for role, men det ser ut til å fungere helt ok. Antar at ikke mange bruker skjermleser med safari uansett, siden det er litt halvveis støtte fra før av. 
F.eks: Denne lista blir lest opp som å ha 6 elementer: 
<img width="241" height="199" alt="image" src="https://github.com/user-attachments/assets/41e3ff5a-d415-4209-89f6-fa5d663deabe" />

Ideelt skal den si at det er 3 elementer (term og definition). 
Det fungerer fint med `DescriptionListCard` fordi det der er ett element for term og definition sammen som har fått `role="listitem"`. Det krever en større omskriving som jeg tenker vi heller kan ta senere

## Breaking change
I følge copiloten skal det ikke være store forskjeller på hvilke argumener `dl` aksepterer vs `div`, så det burde ikke brekke kode. **Men** dl kom med litt browser styling (i hovedsak margin-top og margin-bottom som jeg kunne se) som nå lenger ikke er en del av stylinga.
