### PR TITLE
fix(ffe-buttons): forhindrer tekstmarkering i inlinebuttons

### DIFF
--- a/packages/ffe-buttons/less/inline-base-button.less
+++ b/packages/ffe-buttons/less/inline-base-button.less
@@ -13,6 +13,7 @@
     text-decoration: none;
     font-size: var(--ffe-fontsize-body-text);
     align-items: center;
+    user-select: none; /* Forhindrer tekstmarkering */
 
     &:active {
         transform: scale(0.97);


### PR DESCRIPTION
fixes #2964 

Har testet på iphone i chome og safari og en random android telefon. Så ikke ut til å være et problem på android i utgangspunktet (testet chrome og edge) 
