### PR TITLE
Accordion no padding

### DIFF
--- a/packages/ffe-accordion-react/src/Accordion.mdx
+++ b/packages/ffe-accordion-react/src/Accordion.mdx
@@ -17,14 +17,15 @@ En accordion er bygget opp av to komponenter: `Accordion` og `AccordionItem`. Ac
     dependencies={dependencies}
 />
 
-## Med subtil bakgrunn
-
-<Canvas of={AccordionStories.WithSubtleBackground} />
-
-## Med ingen bakgrunn
+## Forhåndsvisning
 
 <Canvas of={AccordionStories.Standard} />
 <Controls of={AccordionStories.Standard} />
+
+## Med subtil bakgrunn
+Legg til `backgroundColor: 'var(--ffe-color-background-subtle)'` til elementet rundt accordion hvis du ønsker subtil bakgrunn.
+
+<Canvas of={AccordionStories.WithSubtleBackground} />
 
 ## AccordionItem
 

--- a/packages/ffe-accordion-react/src/Accordion.spec.tsx
+++ b/packages/ffe-accordion-react/src/Accordion.spec.tsx
@@ -82,4 +82,18 @@ describe('<Accordion />', () => {
         expect(screen.queryByTestId('content1')).toBeInTheDocument();
         expect(screen.queryByTestId('content2')).toBeInTheDocument();
     });
+
+    it('should set noPadding class when noPadding prop is true', () => {
+        render(
+            <Accordion headingLevel={3}>
+                <AccordionItem heading="heading1" isOpen noPadding>
+                    <span data-testid="content1">content1</span>
+                </AccordionItem>
+            </Accordion>,
+        );
+
+        const content = screen.getByTestId('content1');
+        const accordionBody = content.closest('.ffe-accordion-item__body');
+        expect(accordionBody).toHaveClass('ffe-accordion-item__body--no-padding');
+    });
 });

--- a/packages/ffe-accordion-react/src/Accordion.stories.tsx
+++ b/packages/ffe-accordion-react/src/Accordion.stories.tsx
@@ -64,3 +64,36 @@ export const Standard: Story = {
         </Accordion>
     ),
 };
+
+
+export const noBodyPadding: Story = {
+    args: {
+        headingLevel: 2,
+    },
+    render: args => (
+        <Accordion {...args}>
+            <AccordionItem heading="Mer informasjon" noPadding>
+                <div>
+                    <div style={{
+                        borderTop: '1px solid var(--ffe-color-border-primary-subtle)',
+                        padding: 'var(--ffe-spacing-xs) var(--ffe-spacing-sm)'
+                    }}>
+                        Her er en liste med noe greier
+                    </div>
+                    <div style={{
+                        borderTop: '1px solid var(--ffe-color-border-primary-subtle)',
+                        padding: 'var(--ffe-spacing-xs) var(--ffe-spacing-sm)'
+                    }}>
+                        Dette er elementer som skal visuelt skille seg fra hverandre
+                    </div>
+                    <div style={{
+                        borderTop: '1px solid var(--ffe-color-border-primary-subtle)',
+                        padding: 'var(--ffe-spacing-xs) var(--ffe-spacing-sm)'
+                    }}>
+                        Dette er et eksempel
+                    </div>
+                </div>
+            </AccordionItem>
+        </Accordion >
+    ),
+};

--- a/packages/ffe-accordion-react/src/AccordionItem.tsx
+++ b/packages/ffe-accordion-react/src/AccordionItem.tsx
@@ -18,6 +18,8 @@ export interface AccordionItemProps
     onToggleOpen?: (isOpen: boolean) => void;
     /** aria-label for the button */
     ariaLabel?: string;
+    /** Ingen padding i body-elementet hvis man ønsker egen styling */
+    noPadding?: boolean;
 }
 
 export const AccordionItem: React.FC<AccordionItemProps> = ({
@@ -28,6 +30,7 @@ export const AccordionItem: React.FC<AccordionItemProps> = ({
     className,
     onToggleOpen = Function.prototype,
     ariaLabel,
+    noPadding = false,
     ...rest
 }) => {
     const [isExpanded, setIsExpanded] = useState(defaultOpen);
@@ -105,7 +108,11 @@ export const AccordionItem: React.FC<AccordionItemProps> = ({
                 role="region"
             >
                 {!collapseHidden && (
-                    <div className="ffe-accordion-item__body">{children}</div>
+                    <div className={
+                        classNames("ffe-accordion-item__body", {
+                            "ffe-accordion-item__body--no-padding": noPadding,
+                        })
+                    }>{children}</div>
                 )}
             </Collapse>
         </div>

--- a/packages/ffe-accordion/less/ffe-accordion.less
+++ b/packages/ffe-accordion/less/ffe-accordion.less
@@ -102,6 +102,10 @@
             padding: var(--ffe-spacing-xs) var(--ffe-spacing-sm)
                 var(--ffe-spacing-md);
             color: var(--ffe-v-accordion-body-text-color);
+
+            &--no-padding {
+                padding: 0;
+            }
         }
 
         &--open {


### PR DESCRIPTION
fixes #2843 

Legger til noPadding, som legger seg på body til accordionItem. 

## Alternative løsninger
I stedet for dette kunne vi ha 
1. Tillat å sende inn klasse til body. Da blir det fort bare overskriving og kanskje ikke så ryddig, men det hadde dekket et større behov ifht. om andre ønsker å gjøre om på andre ting og ikke bare padding. Men hva skal man kalle det da? `bodyClassName`? Synes noPadding ble bedre siden det var det som var behovet her. 
2. Kunne evt kalt det `noBodyPadding` for å gjøre det 100% tydelig. Men, da blir det utenfor konvensjonen vi allerede har med noPadding på de andre elementene. Men kan være en ok løsning, men da burde vi kanskje hatt `noPadding` i tillegg? Synes det liksom bare baller på seg da. 