### PR TITLE
Input affix

### DIFF
--- a/packages/ffe-chips/less/chip.less
+++ b/packages/ffe-chips/less/chip.less
@@ -22,8 +22,8 @@
         background-color, transform, border-color, color, outline;
     transition-duration: var(--ffe-transition-duration);
     transition-timing-function: var(--ffe-ease);
-    outline: 2px solid transparent;
-    outline-offset: 3px;
+    outline: var(--ffe-g-outline-width) solid transparent;
+    outline-offset: var(--ffe-g-outline-offset);
     cursor: pointer;
 
     .ffe-icons,

--- a/packages/ffe-chips/less/chip.less
+++ b/packages/ffe-chips/less/chip.less
@@ -18,7 +18,8 @@
     background: var(--background-color);
     color: var(--text-color);
     border-radius: var(--border-radius);
-    transition-property: background-color, transform, border-color, color;
+    transition-property:
+        background-color, transform, border-color, color, outline;
     transition-duration: var(--ffe-transition-duration);
     transition-timing-function: var(--ffe-ease);
     cursor: pointer;

--- a/packages/ffe-chips/less/chip.less
+++ b/packages/ffe-chips/less/chip.less
@@ -22,6 +22,8 @@
         background-color, transform, border-color, color, outline;
     transition-duration: var(--ffe-transition-duration);
     transition-timing-function: var(--ffe-ease);
+    outline: 2px solid transparent;
+    outline-offset: 3px;
     cursor: pointer;
 
     .ffe-icons,
@@ -46,8 +48,7 @@
     }
 
     &:focus-visible {
-        outline: 2px solid var(--ffe-color-border-interactive-focus);
-        outline-offset: 3px;
+        outline-color: var(--ffe-color-border-interactive-focus);
     }
 
     &:active {

--- a/packages/ffe-datepicker-react/src/datepicker/DatepickerComp.tsx
+++ b/packages/ffe-datepicker-react/src/datepicker/DatepickerComp.tsx
@@ -311,134 +311,140 @@ export const DatepickerComp: React.FC<DatepickerCompProps> = ({
             role={'group'}
             id={id}
         >
-            {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions,jsx-a11y/no-noninteractive-element-interactions */}
-            <div
-                className={classNames('ffe-input-field', 'ffe-dateinput', {
-                    'ffe-input-field--invalid': ariaInvalid(),
-                })}
-                onBlur={evt => {
-                    const elementReceivingFocus = evt.relatedTarget;
+            <div className={classNames(
+                'ffe-input-field__wrapper',
+                'ffe-default-mode',
+            )}>
+                {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions,jsx-a11y/no-noninteractive-element-interactions */}
+                <div
+                    className={classNames('ffe-input-field', 'ffe-dateinput', {
+                        'ffe-input-field--invalid': ariaInvalid(),
+                    })}
+                    onBlur={evt => {
+                        const elementReceivingFocus = evt.relatedTarget;
 
-                    if (
-                        elementReceivingFocus !== yearRef.current &&
-                        elementReceivingFocus !== dayRef.current &&
-                        elementReceivingFocus !== monthRef.current
-                    ) {
-                        onBlur?.(evt);
-                        validateDateIntervals();
-                    }
-                }}
-            >
-                <SpinButton
-                    ref={dayRef}
-                    value={day ?? undefined}
-                    min={1}
-                    max={31}
-                    onPaste={handlePaste}
-                    onSpinButtonChange={(newValue, allowFocusNext = true) => {
-                        return allowFocusNext
-                            ? setDay(newValue, () =>
-                                  monthRef.current?.focus({
-                                      preventScroll: true,
-                                  }),
-                              )
-                            : setDay(newValue);
+                        if (
+                            elementReceivingFocus !== yearRef.current &&
+                            elementReceivingFocus !== dayRef.current &&
+                            elementReceivingFocus !== monthRef.current
+                        ) {
+                            onBlur?.(evt);
+                            validateDateIntervals();
+                        }
                     }}
-                    nextSpinButton={monthRef}
-                    maxLength={2}
-                    aria-invalid={ariaInvalid()}
-                    aria-valuenow={typeof day === 'number' ? day : undefined}
-                    aria-valuetext={`${day}`}
-                    aria-label={i18n[locale].DAY}
-                    aria-describedby={ariaDescribedby()}
-                    aria-labelledby={labelId}
                 >
-                    {day ? padZero(day) : 'dd'}
-                </SpinButton>
-                .
-                <SpinButton
-                    ref={monthRef}
-                    value={month ?? undefined}
-                    min={1}
-                    max={12}
-                    onPaste={handlePaste}
-                    onSpinButtonChange={(newValue, allowFocusNext = true) => {
-                        return allowFocusNext
-                            ? setMonth(newValue, () =>
-                                  yearRef.current?.focus({
-                                      preventScroll: true,
-                                  }),
-                              )
-                            : setMonth(newValue);
-                    }}
-                    nextSpinButton={yearRef}
-                    prevSpinButton={dayRef}
-                    maxLength={2}
-                    aria-invalid={ariaInvalid()}
-                    aria-valuenow={
-                        typeof month === 'number' ? month : undefined
-                    }
-                    aria-valuetext={
-                        isMonth(month)
-                            ? `${month} - ${i18n[locale][`MONTH_${month}`]}`
-                            : undefined
-                    }
-                    aria-label={i18n[locale].MONTH}
-                    aria-describedby={ariaDescribedby()}
-                    aria-labelledby={labelId}
-                >
-                    {month ? padZero(month) : 'mm'}
-                </SpinButton>
-                .
-                <SpinButton
-                    ref={yearRef}
-                    className={'ffe-dateinput__field-year'}
-                    value={year ?? undefined}
-                    min={1}
-                    max={9999}
-                    onPaste={handlePaste}
-                    onSpinButtonChange={newValue => {
-                        setYear(newValue);
-                    }}
-                    prevSpinButton={monthRef}
-                    maxLength={4}
-                    aria-invalid={ariaInvalid()}
-                    aria-valuetext={`${year}`}
-                    aria-valuenow={typeof year === 'number' ? year : undefined}
-                    aria-label={i18n[locale].YEAR}
-                    aria-describedby={ariaDescribedby()}
-                    aria-labelledby={labelId}
-                >
-                    {year ? year : 'yyyy'}
-                </SpinButton>
-            </div>
-            <Button
-                onClick={calendarButtonClickHandler}
-                locale={locale}
-                value={calendarActiveDate || ''}
-                ref={buttonRef}
-            />
-            {displayDatePicker && (
-                <Calendar
-                    calendarClassName={classNames(
-                        'ffe-calendar ffe-calendar--datepicker',
-                        { 'ffe-calendar--datepicker--above': calendarAbove },
-                    )}
+                    <SpinButton
+                        ref={dayRef}
+                        value={day ?? undefined}
+                        min={1}
+                        max={31}
+                        onPaste={handlePaste}
+                        onSpinButtonChange={(newValue, allowFocusNext = true) => {
+                            return allowFocusNext
+                                ? setDay(newValue, () =>
+                                    monthRef.current?.focus({
+                                        preventScroll: true,
+                                    }),
+                                )
+                                : setDay(newValue);
+                        }}
+                        nextSpinButton={monthRef}
+                        maxLength={2}
+                        aria-invalid={ariaInvalid()}
+                        aria-valuenow={typeof day === 'number' ? day : undefined}
+                        aria-valuetext={`${day}`}
+                        aria-label={i18n[locale].DAY}
+                        aria-describedby={ariaDescribedby()}
+                        aria-labelledby={labelId}
+                    >
+                        {day ? padZero(day) : 'dd'}
+                    </SpinButton>
+                    .
+                    <SpinButton
+                        ref={monthRef}
+                        value={month ?? undefined}
+                        min={1}
+                        max={12}
+                        onPaste={handlePaste}
+                        onSpinButtonChange={(newValue, allowFocusNext = true) => {
+                            return allowFocusNext
+                                ? setMonth(newValue, () =>
+                                    yearRef.current?.focus({
+                                        preventScroll: true,
+                                    }),
+                                )
+                                : setMonth(newValue);
+                        }}
+                        nextSpinButton={yearRef}
+                        prevSpinButton={dayRef}
+                        maxLength={2}
+                        aria-invalid={ariaInvalid()}
+                        aria-valuenow={
+                            typeof month === 'number' ? month : undefined
+                        }
+                        aria-valuetext={
+                            isMonth(month)
+                                ? `${month} - ${i18n[locale][`MONTH_${month}`]}`
+                                : undefined
+                        }
+                        aria-label={i18n[locale].MONTH}
+                        aria-describedby={ariaDescribedby()}
+                        aria-labelledby={labelId}
+                    >
+                        {month ? padZero(month) : 'mm'}
+                    </SpinButton>
+                    .
+                    <SpinButton
+                        ref={yearRef}
+                        className={'ffe-dateinput__field-year'}
+                        value={year ?? undefined}
+                        min={1}
+                        max={9999}
+                        onPaste={handlePaste}
+                        onSpinButtonChange={newValue => {
+                            setYear(newValue);
+                        }}
+                        prevSpinButton={monthRef}
+                        maxLength={4}
+                        aria-invalid={ariaInvalid()}
+                        aria-valuetext={`${year}`}
+                        aria-valuenow={typeof year === 'number' ? year : undefined}
+                        aria-label={i18n[locale].YEAR}
+                        aria-describedby={ariaDescribedby()}
+                        aria-labelledby={labelId}
+                    >
+                        {year ? year : 'yyyy'}
+                    </SpinButton>
+                </div>
+                <Button
+                    onClick={calendarButtonClickHandler}
                     locale={locale}
-                    onDatePicked={datePickedHandler}
-                    selectedDate={calendarActiveDate}
-                    focusOnMount={true}
-                    dropdownCaption={dropdownCaption}
-                    minDate={minDate}
-                    maxDate={maxDate}
+                    value={calendarActiveDate || ''}
+                    ref={buttonRef}
                 />
-            )}
+                {displayDatePicker && (
+                    <Calendar
+                        calendarClassName={classNames(
+                            'ffe-calendar ffe-calendar--datepicker',
+                            { 'ffe-calendar--datepicker--above': calendarAbove },
+                        )}
+                        locale={locale}
+                        onDatePicked={datePickedHandler}
+                        selectedDate={calendarActiveDate}
+                        focusOnMount={true}
+                        dropdownCaption={dropdownCaption}
+                        minDate={minDate}
+                        maxDate={maxDate}
+                    />
+                )}
 
-            {!!fieldMessage && (
-                <ErrorFieldMessage as="p" id={fieldMessageId}>
-                    {fieldMessage}
-                </ErrorFieldMessage>
-            )}
+                {!!fieldMessage && (
+                    <ErrorFieldMessage as="p" id={fieldMessageId}>
+                        {fieldMessage}
+                    </ErrorFieldMessage>
+                )}
+                <div className="ffe-input-field__backdrop" />
+            </div>
         </div>
     );
 };

--- a/packages/ffe-datepicker-react/src/input/DateInput.tsx
+++ b/packages/ffe-datepicker-react/src/input/DateInput.tsx
@@ -11,20 +11,26 @@ export interface DateInputProps extends React.ComponentPropsWithRef<'input'> {
 export const DateInput = React.forwardRef<HTMLInputElement, DateInputProps>(
     ({ ariaInvalid, value, className, locale = 'nb', ...rest }, ref) => {
         return (
-            <input
-                {...rest}
-                aria-invalid={
-                    ariaInvalid as unknown as React.ComponentPropsWithRef<'input'>['aria-invalid']
-                }
-                maxLength={10}
-                ref={ref}
-                aria-placeholder={i18n[locale].DATE_FORMAT}
-                value={value}
-                className={classNames(
-                    'ffe-input-field ffe-dateinput__field',
-                    className,
-                )}
-            />
+            <div className={classNames(
+                'ffe-input-field__wrapper',
+                'ffe-default-mode',
+            )}>
+                <input
+                    {...rest}
+                    aria-invalid={
+                        ariaInvalid as unknown as React.ComponentPropsWithRef<'input'>['aria-invalid']
+                    }
+                    maxLength={10}
+                    ref={ref}
+                    aria-placeholder={i18n[locale].DATE_FORMAT}
+                    value={value}
+                    className={classNames(
+                        'ffe-input-field ffe-dateinput__field',
+                        className,
+                    )}
+                />
+                <div className="ffe-input-field__backdrop" />
+            </div>
         );
     },
 );

--- a/packages/ffe-datepicker/less/dateinput.less
+++ b/packages/ffe-datepicker/less/dateinput.less
@@ -3,29 +3,21 @@
         color: var(--ffe-color-foreground-default) !important;
     }
 }
+
 .ffe-datepicker {
     position: relative;
     display: grid;
     grid-template-columns: 1fr auto;
     width: fit-content;
-    border: var(--ffe-g-border-width) solid
-        var(--ffe-color-border-primary-default);
     border-radius: var(--ffe-g-border-radius);
     transition:
         color var(--ffe-transition-duration) var(--ffe-ease),
         border var(--ffe-transition-duration) var(--ffe-ease),
-        box-shadow var(--ffe-transition-duration) var(--ffe-ease),
-        background-color var(--ffe-transition-duration) var(--ffe-ease);
+        background-color var(--ffe-transition-duration) var(--ffe-ease),
+        outline var(--ffe-transition-duration) var(--ffe-ease);
+
     &--full-width {
         width: 100%;
-    }
-
-    @media (hover: hover) and (pointer: fine) {
-        &:hover {
-            border-color: var(--ffe-color-border-primary-default-hover);
-            box-shadow: var(--ffe-g-border-focus-box-shadow)
-                var(--ffe-color-border-primary-default-hover);
-        }
     }
 
     &__button {
@@ -39,25 +31,35 @@
         width: 56px;
         cursor: pointer;
         isolation: isolate;
+        z-index: 2;
     }
 
-    .ffe-input-field:focus {
-        border: none;
-    }
-
-    &:focus-within,
-    &:has(&__button:focus) .ffe-input-field:hover {
-        outline: none;
-        box-shadow: var(--ffe-g-border-focus-box-shadow)
-            var(--ffe-color-component-form-input-border-active);
-        border-color: var(--ffe-color-component-form-input-border-active);
-    }
-
-    @media (pointer: fine) {
-        &:focus-within {
+    &:focus-within {
+        .ffe-input-field__backdrop {
+            border: var(--ffe-g-border-width) solid
+                var(--ffe-color-fill-primary-selected-default);
+            box-shadow: var(--ffe-g-border-focus-box-shadow)
+                var(--ffe-color-fill-primary-selected-default);
             outline: var(--ffe-g-outline-width) solid
                 var(--ffe-color-border-interactive-focus);
             outline-offset: var(--ffe-g-outline-offset);
+        }
+    }
+
+    &--invalid {
+        &:focus-within {
+            .ffe-input-field__backdrop {
+                border: var(--ffe-g-border-width) solid
+                    var(--ffe-color-border-feedback-critical);
+                box-shadow: var(--ffe-g-border-focus-box-shadow)
+                    var(--ffe-color-border-feedback-critical);
+                background-color: var(
+                    --ffe-color-component-form-input-fill-default
+                );
+                outline: var(--ffe-g-outline-width) solid
+                    var(--ffe-color-border-interactive-focus);
+                outline-offset: var(--ffe-g-outline-offset);
+            }
         }
     }
 
@@ -79,6 +81,7 @@
         grid-row: 1 e('/') -1;
         min-width: 210px;
         color: var(--ffe-color-foreground-default);
+        z-index: 1;
 
         &--full-width {
             display: block;
@@ -111,51 +114,6 @@
 
         &--message {
             padding-bottom: 0;
-        }
-    }
-
-    &--invalid {
-        border: var(--ffe-g-border-width) solid
-            var(--ffe-color-border-feedback-critical);
-        box-shadow: var(--ffe-g-border-focus-box-shadow)
-            var(--ffe-color-border-feedback-critical);
-        background-color: var(--ffe-color-surface-feedback-critical);
-
-        @media (hover: hover) and (pointer: fine) {
-            &:hover {
-                border: var(--ffe-g-border-width) solid
-                    var(--ffe-color-border-feedback-critical);
-                box-shadow: var(--ffe-g-border-focus-box-shadow)
-                    var(--ffe-color-border-feedback-critical);
-                background-color: var(--ffe-color-surface-primary-default);
-            }
-            &:focus-within:hover {
-                border-color: var(--ffe-color-border-feedback-critical);
-            }
-        }
-
-        &:focus-within {
-            outline: none;
-            box-shadow: var(--ffe-g-border-focus-box-shadow)
-                var(--ffe-color-border-feedback-critical);
-        }
-
-        .ffe-input-field {
-            &:focus-within {
-                border-color: var(--ffe-color-border-feedback-critical);
-                box-shadow: var(--ffe-g-border-focus-box-shadow)
-                    var(--ffe-color-border-feedback-critical);
-                background-color: var(--ffe-color-surface-primary-default);
-            }
-        }
-
-        .ffe-dateinput,
-        .ffe-dateinput__field {
-            color: var(--ffe-color-foreground-feedback-critical);
-        }
-
-        .ffe-input-field:has(~ .ffe-datepicker__button:hover) {
-            background-color: var(--ffe-color-surface-primary-default);
         }
     }
 }

--- a/packages/ffe-datepicker/less/dateinput.less
+++ b/packages/ffe-datepicker/less/dateinput.less
@@ -34,15 +34,18 @@
         z-index: 2;
     }
 
+    .ffe-input-field__backdrop {
+        outline: var(--ffe-g-outline-width) solid transparent;
+        outline-offset: var(--ffe-g-outline-offset);
+    }
+
     &:focus-within {
         .ffe-input-field__backdrop {
             border: var(--ffe-g-border-width) solid
                 var(--ffe-color-fill-primary-selected-default);
             box-shadow: var(--ffe-g-border-focus-box-shadow)
                 var(--ffe-color-fill-primary-selected-default);
-            outline: var(--ffe-g-outline-width) solid
-                var(--ffe-color-border-interactive-focus);
-            outline-offset: var(--ffe-g-outline-offset);
+            outline-color: var(--ffe-color-border-interactive-focus);
         }
     }
 
@@ -56,9 +59,6 @@
                 background-color: var(
                     --ffe-color-component-form-input-fill-default
                 );
-                outline: var(--ffe-g-outline-width) solid
-                    var(--ffe-color-border-interactive-focus);
-                outline-offset: var(--ffe-g-outline-offset);
             }
         }
     }

--- a/packages/ffe-form-react/src/Input.mdx
+++ b/packages/ffe-form-react/src/Input.mdx
@@ -26,3 +26,10 @@ Sender man inn en string eller et `<ErrorFieldMessage>`-element til `fieldMessag
 
 <Canvas of={InputStories.FieldMessage} />
 <Controls of={InputStories.FieldMessage} />
+
+## Med affikser
+
+Affikser i inputfeltet kan sendes inn med propene `prefix` eller `suffix` på `<Input>`.
+
+<Canvas of={InputStories.WithAffixes} />
+<Controls of={InputStories.WithAffixes} />

--- a/packages/ffe-form-react/src/Input.spec.tsx
+++ b/packages/ffe-form-react/src/Input.spec.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Input, InputProps } from './Input';
 import { render, screen } from '@testing-library/react';
 
+const TEST_ID = 'input-test-id';
 const renderInput = (props?: Partial<InputProps>) =>
     render(<Input {...props} />);
 
@@ -24,13 +25,12 @@ describe('<Input />', () => {
     });
 
     it('sets the correct class for inline-modifer', () => {
-        const { rerender } = render(<Input />);
-        const input = screen.getByRole('textbox');
-        expect(input.classList.contains('ffe-input-field--inline')).toBeFalsy();
+        const { rerender } = render(<Input data-testid={TEST_ID} />);
+        const input = screen.getByTestId(TEST_ID);
+        const wrapper = input.parentElement;
+        expect(wrapper && wrapper.classList.contains('ffe-input-field__wrapper--inline')).toBeFalsy();
         rerender(<Input inline={true} />);
-        expect(
-            input.classList.contains('ffe-input-field--inline'),
-        ).toBeTruthy();
+        expect(wrapper && wrapper.classList.contains('ffe-input-field__wrapper--inline')).toBeTruthy();
     });
 
     it('sets the correct class for textRightAlign', () => {

--- a/packages/ffe-form-react/src/Input.spec.tsx
+++ b/packages/ffe-form-react/src/Input.spec.tsx
@@ -19,8 +19,9 @@ describe('<Input />', () => {
             className: 'app-input',
         });
         const input = screen.getByRole('textbox');
+        const wrapper = input.parentElement;
         expect(input.getAttribute('autoComplete')).toBe('off');
-        expect(input.classList.contains('app-input')).toBeTruthy();
+        expect(wrapper && wrapper.classList.contains('app-input')).toBeTruthy();
         expect(input.classList.contains('ffe-input-field')).toBeTruthy();
     });
 

--- a/packages/ffe-form-react/src/Input.stories.tsx
+++ b/packages/ffe-form-react/src/Input.stories.tsx
@@ -24,6 +24,20 @@ export const Standard: Story = {
     ),
 };
 
+export const WithAffixes: Story = {
+    args: {
+        inline: false,
+        textRightAlign: false,
+        prefix: 'Prefix',
+        suffix: 'Suffix',
+    },
+    render: args => (
+        <InputGroup label="Navn">
+            <Input {...args} />
+        </InputGroup>
+    ),
+};
+
 export const FieldMessage: Story = {
     args: {
         ...Standard.args,

--- a/packages/ffe-form-react/src/Input.tsx
+++ b/packages/ffe-form-react/src/Input.tsx
@@ -17,6 +17,7 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
                 'ffe-input-field__wrapper',
                 'ffe-default-mode',
                 { 'ffe-input-field__wrapper--inline': inline },
+                className,
             )}>
                 {prefix && (
                     <div className="ffe-input-field__prefix">
@@ -28,7 +29,6 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
                         'ffe-input-field',
                         'ffe-default-mode',
                         { 'ffe-input-field--text-right-align': textRightAlign },
-                        className,
                     )}
                     ref={ref}
                     {...rest}

--- a/packages/ffe-form-react/src/Input.tsx
+++ b/packages/ffe-form-react/src/Input.tsx
@@ -6,22 +6,40 @@ export interface InputProps extends React.ComponentPropsWithoutRef<'input'> {
     inline?: boolean;
     /** Make the text right aligned */
     textRightAlign?: boolean;
+    prefix?: string;
+    suffix?: string;
 }
 
 export const Input = React.forwardRef<HTMLInputElement, InputProps>(
-    ({ className, inline, textRightAlign, ...rest }, ref) => {
+    ({ className, inline, textRightAlign, prefix, suffix, ...rest }, ref) => {
         return (
-            <input
-                className={classNames(
-                    'ffe-input-field',
-                    'ffe-default-mode',
-                    { 'ffe-input-field--inline': inline },
-                    { 'ffe-input-field--text-right-align': textRightAlign },
-                    className,
+            <div className={classNames(
+                'ffe-input-field__wrapper',
+                'ffe-default-mode',
+                { 'ffe-input-field__wrapper--inline': inline },
+            )}>
+                {prefix && (
+                    <div className="ffe-input-field__prefix">
+                        {prefix}
+                    </div>
                 )}
-                ref={ref}
-                {...rest}
-            />
+                <input
+                    className={classNames(
+                        'ffe-input-field',
+                        'ffe-default-mode',
+                        { 'ffe-input-field--text-right-align': textRightAlign },
+                        className,
+                    )}
+                    ref={ref}
+                    {...rest}
+                />
+                {suffix && (
+                    <div className="ffe-input-field__suffix">
+                        {suffix}
+                    </div>
+                )}
+                <div className="ffe-input-field__backdrop" />
+            </div>
         );
     },
 );

--- a/packages/ffe-form-react/src/PhoneNumber.tsx
+++ b/packages/ffe-form-react/src/PhoneNumber.tsx
@@ -128,32 +128,38 @@ export const PhoneNumber = React.forwardRef<
                             >
                                 +
                             </span>
-                            <input
-                                ref={countryRef}
-                                id={countryCodeId}
-                                value={countryCodeInputProps?.value ?? '47'}
-                                className={classNames(
-                                    'ffe-input-field',
-                                    'ffe-phone-number__country-code-input',
-                                    'ffe-default-mode',
-                                )}
-                                type="tel"
-                                aria-invalid={
-                                    !!(
-                                        countryCodeFieldMessage ||
-                                        countryCodeAndNumberFieldMessage
-                                    )
-                                }
-                                aria-describedby={
-                                    !!(
-                                        countryCodeFieldMessage ||
-                                        countryCodeAndNumberFieldMessage
-                                    )
-                                        ? fieldMessageId
-                                        : undefined
-                                }
-                                {...countryCodeInputProps}
-                            />
+                            <div className={classNames(
+                                'ffe-input-field__wrapper',
+                                'ffe-phone-number__country-code-input',
+                                'ffe-default-mode',
+                            )}>
+                                <input
+                                    ref={countryRef}
+                                    id={countryCodeId}
+                                    value={countryCodeInputProps?.value ?? '47'}
+                                    className={classNames(
+                                        'ffe-input-field',
+                                        'ffe-default-mode',
+                                    )}
+                                    type="tel"
+                                    aria-invalid={
+                                        !!(
+                                            countryCodeFieldMessage ||
+                                            countryCodeAndNumberFieldMessage
+                                        )
+                                    }
+                                    aria-describedby={
+                                        !!(
+                                            countryCodeFieldMessage ||
+                                            countryCodeAndNumberFieldMessage
+                                        )
+                                            ? fieldMessageId
+                                            : undefined
+                                    }
+                                    {...countryCodeInputProps}
+                                />
+                                 <div className="ffe-input-field__backdrop" />
+                            </div>
                         </div>
                     </div>
                     <div className="ffe-phone-number__number">
@@ -162,31 +168,37 @@ export const PhoneNumber = React.forwardRef<
                                 ? text.MOBILE_NUMBER
                                 : text.PHONE_NUMBER}
                         </label>
-                        <input
-                            ref={numberRef}
-                            id={numberId}
-                            type="tel"
-                            className={classNames(
-                                'ffe-input-field',
-                                'ffe-phone-number__phone-input',
-                                'ffe-default-mode',
-                            )}
-                            aria-invalid={
-                                !!(
-                                    numberFieldMessage ||
-                                    countryCodeAndNumberFieldMessage
-                                )
-                            }
-                            aria-describedby={
-                                !!(
-                                    numberFieldMessage ||
-                                    countryCodeAndNumberFieldMessage
-                                )
-                                    ? fieldMessageId
-                                    : undefined
-                            }
-                            {...numberInputProps}
-                        />
+                        <div className={classNames(
+                            'ffe-input-field__wrapper',
+                            'ffe-default-mode',
+                        )}>
+                            <input
+                                ref={numberRef}
+                                id={numberId}
+                                type="tel"
+                                className={classNames(
+                                    'ffe-input-field',
+                                    'ffe-phone-number__phone-input',
+                                    'ffe-default-mode',
+                                )}
+                                aria-invalid={
+                                    !!(
+                                        numberFieldMessage ||
+                                        countryCodeAndNumberFieldMessage
+                                    )
+                                }
+                                aria-describedby={
+                                    !!(
+                                        numberFieldMessage ||
+                                        countryCodeAndNumberFieldMessage
+                                    )
+                                        ? fieldMessageId
+                                        : undefined
+                                }
+                                {...numberInputProps}
+                            />
+                            <div className="ffe-input-field__backdrop" />
+                        </div>
                     </div>
                 </div>
                 {typeof fieldMessage === 'string' && (

--- a/packages/ffe-form/less/checkbox.less
+++ b/packages/ffe-form/less/checkbox.less
@@ -9,7 +9,9 @@
     grid-column-gap: var(--ffe-spacing-xs);
     align-items: center;
     cursor: pointer;
-    transition: width var(--ffe-transition-duration) var(--ffe-ease);
+    transition:
+        width var(--ffe-transition-duration) var(--ffe-ease),
+        outline var(--ffe-transition-duration) var(--ffe-ease);
     font-family: var(--ffe-g-font);
     font-variant-numeric: tabular-nums;
     text-align: left;

--- a/packages/ffe-form/less/checkbox.less
+++ b/packages/ffe-form/less/checkbox.less
@@ -88,11 +88,14 @@
         outline: none;
     }
 
-    &:focus-visible + .ffe-checkbox {
-        outline: var(--ffe-g-outline-width) solid
-            var(--ffe-color-border-interactive-focus);
+    + .ffe-checkbox {
+        outline: var(--ffe-g-outline-width) solid transparent;
         outline-offset: var(--ffe-g-outline-offset);
         border-radius: var(--ffe-g-outline-border-radius);
+    }
+
+    &:focus-visible + .ffe-checkbox {
+        outline-color: var(--ffe-color-border-interactive-focus);
     }
 
     @media (hover: hover) and (pointer: fine) {

--- a/packages/ffe-form/less/checkbox.less
+++ b/packages/ffe-form/less/checkbox.less
@@ -9,9 +9,7 @@
     grid-column-gap: var(--ffe-spacing-xs);
     align-items: center;
     cursor: pointer;
-    transition:
-        width var(--ffe-transition-duration) var(--ffe-ease),
-        outline var(--ffe-transition-duration) var(--ffe-ease);
+    transition: all var(--ffe-transition-duration) var(--ffe-ease);
     font-family: var(--ffe-g-font);
     font-variant-numeric: tabular-nums;
     text-align: left;

--- a/packages/ffe-form/less/dropdown.less
+++ b/packages/ffe-form/less/dropdown.less
@@ -10,7 +10,8 @@
     background-size: 24px 24px;
     background-repeat: no-repeat;
     background-position: calc(100% - 6px) 50%;
-    border: var(--ffe-g-border-width) solid var(--ffe-color-border-primary-default);
+    border: var(--ffe-g-border-width) solid
+        var(--ffe-color-border-primary-default);
     border-radius: var(--ffe-g-border-radius);
     color: var(--ffe-color-component-form-input-foreground-default);
     display: block;
@@ -22,7 +23,8 @@
         color var(--ffe-transition-duration) var(--ffe-ease),
         border var(--ffe-transition-duration) var(--ffe-ease),
         box-shadow var(--ffe-transition-duration) var(--ffe-ease),
-        background-color var(--ffe-transition-duration) var(--ffe-ease);
+        background-color var(--ffe-transition-duration) var(--ffe-ease),
+        outline var(--ffe-transition-duration) var(--ffe-ease);
     width: 100%;
     font-size: var(--ffe-fontsize-form-dropdown);
     .chevron(@ffe-color-chevron-light-default);
@@ -40,23 +42,27 @@
     @media (hover: hover) and (pointer: fine) {
         &:hover {
             border-color: var(--ffe-color-border-primary-default-hover);
-            box-shadow: var(--ffe-g-border-focus-box-shadow) var(--ffe-color-border-primary-default-hover);
+            box-shadow: var(--ffe-g-border-focus-box-shadow)
+                var(--ffe-color-border-primary-default-hover);
         }
     }
 
     &:focus-within {
-        outline: var(--ffe-g-outline-width) solid var(--ffe-color-border-interactive-focus);
+        outline: var(--ffe-g-outline-width) solid
+            var(--ffe-color-border-interactive-focus);
         outline-offset: var(--ffe-g-outline-offset);
     }
 
     &:focus {
         border-color: var(--ffe-color-component-form-input-border-active);
-        box-shadow: var(--ffe-g-border-focus-box-shadow) var(--ffe-color-component-form-input-border-active);
+        box-shadow: var(--ffe-g-border-focus-box-shadow)
+            var(--ffe-color-component-form-input-border-active);
     }
 
     &:active {
         border-color: var(--ffe-color-component-form-input-border-active);
-        box-shadow: var(--ffe-g-border-focus-box-shadow) var(--ffe-color-component-form-input-border-active);
+        box-shadow: var(--ffe-g-border-focus-box-shadow)
+            var(--ffe-color-component-form-input-border-active);
     }
 
     &--inline {
@@ -71,16 +77,19 @@
 
     &[aria-invalid='true'] {
         color: var(--ffe-color-foreground-feedback-critical);
-        border: var(--ffe-g-border-width) solid var(--ffe-color-border-feedback-critical);
-        box-shadow: var(--ffe-g-border-focus-box-shadow) var(--ffe-color-border-feedback-critical);
+        border: var(--ffe-g-border-width) solid
+            var(--ffe-color-border-feedback-critical);
+        box-shadow: var(--ffe-g-border-focus-box-shadow)
+            var(--ffe-color-border-feedback-critical);
         background-color: var(--ffe-color-surface-feedback-critical);
 
         @media (hover: hover) and (pointer: fine) {
-
             &:hover,
             &:focus {
-                border: var(--ffe-g-border-width) solid var(--ffe-color-border-feedback-critical);
-                box-shadow: var(--ffe-g-border-focus-box-shadow) var(--ffe-color-border-feedback-critical);
+                border: var(--ffe-g-border-width) solid
+                    var(--ffe-color-border-feedback-critical);
+                box-shadow: var(--ffe-g-border-focus-box-shadow)
+                    var(--ffe-color-border-feedback-critical);
                 background-color: var(--ffe-color-surface-primary-default);
             }
         }

--- a/packages/ffe-form/less/dropdown.less
+++ b/packages/ffe-form/less/dropdown.less
@@ -27,6 +27,8 @@
         outline var(--ffe-transition-duration) var(--ffe-ease);
     width: 100%;
     font-size: var(--ffe-fontsize-form-dropdown);
+    outline: var(--ffe-g-outline-width) solid transparent;
+    outline-offset: var(--ffe-g-outline-offset);
     .chevron(@ffe-color-chevron-light-default);
 
     &.ffe-default-mode {
@@ -48,9 +50,7 @@
     }
 
     &:focus-within {
-        outline: var(--ffe-g-outline-width) solid
-            var(--ffe-color-border-interactive-focus);
-        outline-offset: var(--ffe-g-outline-offset);
+        outline-color: var(--ffe-color-border-interactive-focus);
     }
 
     &:focus {

--- a/packages/ffe-form/less/dropdown.less
+++ b/packages/ffe-form/less/dropdown.less
@@ -19,12 +19,7 @@
     font-variant-numeric: tabular-nums;
     height: 2.8125rem;
     padding: 0 var(--ffe-spacing-lg) 0 var(--ffe-spacing-sm);
-    transition:
-        color var(--ffe-transition-duration) var(--ffe-ease),
-        border var(--ffe-transition-duration) var(--ffe-ease),
-        box-shadow var(--ffe-transition-duration) var(--ffe-ease),
-        background-color var(--ffe-transition-duration) var(--ffe-ease),
-        outline var(--ffe-transition-duration) var(--ffe-ease);
+    transition: all var(--ffe-transition-duration) var(--ffe-ease);
     width: 100%;
     font-size: var(--ffe-fontsize-form-dropdown);
     outline: var(--ffe-g-outline-width) solid transparent;

--- a/packages/ffe-form/less/input-field.less
+++ b/packages/ffe-form/less/input-field.less
@@ -1,19 +1,14 @@
 .ffe-input-field {
     display: block;
+    position: relative;
+    z-index: 1;
     height: 2.8125rem;
-    padding: var(--ffe-spacing-2xs) var(--ffe-spacing-sm); /* Increased horizontal padding */
+    padding: var(--ffe-spacing-2xs) var(--ffe-spacing-sm);
     font-family: var(--ffe-g-font);
     font-variant-numeric: tabular-nums;
-    background-color: var(--ffe-color-surface-primary-default);
+    background: transparent;
+    border: none;
     color: var(--ffe-color-foreground-default);
-    border-radius: var(--ffe-g-border-radius);
-    border: var(--ffe-g-border-width) solid
-        var(--ffe-color-border-primary-default);
-    transition:
-        color var(--ffe-transition-duration) var(--ffe-ease),
-        border var(--ffe-transition-duration) var(--ffe-ease),
-        box-shadow var(--ffe-transition-duration) var(--ffe-ease),
-        background-color var(--ffe-transition-duration) var(--ffe-ease);
     width: 100%;
     font-size: var(--ffe-fontsize-form-input);
 
@@ -26,15 +21,58 @@
         text-align: left;
     }
 
-    @media (hover: hover) and (pointer: fine) {
-        &:hover {
+    &__backdrop {
+        position: absolute;
+        z-index: 0;
+        inset: 0;
+        background-color: var(--ffe-color-surface-primary-default);
+        border-radius: var(--ffe-g-border-radius);
+        border: var(--ffe-g-border-width) solid
+            var(--ffe-color-border-primary-default);
+        transition: all var(--ffe-transition-duration) var(--ffe-ease);
+
+        .ffe-input-field__wrapper:hover & {
             border-color: var(--ffe-color-border-primary-default-hover);
             box-shadow: var(--ffe-g-border-focus-box-shadow)
                 var(--ffe-color-border-primary-default-hover);
         }
     }
 
-    &:focus {
+    &__wrapper {
+        position: relative;
+        display: flex;
+        align-items: center;
+        width: 100%;
+        margin: 0;
+        padding: 0;
+        z-index: 1;
+
+        &--inline {
+            display: inline-flex;
+            width: auto;
+        }
+    }
+
+    &__suffix,
+    &__prefix {
+        color: var(--ffe-color-foreground-subtle);
+        display: inline-flex;
+        align-items: center;
+        z-index: 1;
+        white-space: nowrap;
+        padding: 0;
+    }
+
+    &__suffix {
+        margin: 0 var(--ffe-spacing-xs) 0 0;
+    }
+
+    &__prefix {
+        margin: 0 0 0 var(--ffe-spacing-xs);
+    }
+
+    &:focus ~ &__backdrop,
+    &:focus-within ~ &__backdrop {
         border: var(--ffe-g-border-width) solid
             var(--ffe-color-fill-primary-selected-default);
         box-shadow: var(--ffe-g-border-focus-box-shadow)
@@ -44,9 +82,10 @@
         outline-offset: var(--ffe-g-outline-offset);
     }
 
-    &--inline {
-        display: inline-block;
-        width: auto;
+    &:focus,
+    &:focus-within {
+        border: none;
+        outline: none;
     }
 
     &--text-right-align {
@@ -69,7 +108,8 @@
             color var(--ffe-transition-duration) var(--ffe-ease),
             border var(--ffe-transition-duration) var(--ffe-ease),
             box-shadow var(--ffe-transition-duration) var(--ffe-ease),
-            background-color var(--ffe-transition-duration) var(--ffe-ease);
+            background-color var(--ffe-transition-duration) var(--ffe-ease),
+            outline var(--ffe-transition-duration) var(--ffe-ease);
         background-color: transparent;
         border-radius: 2px;
 
@@ -82,6 +122,9 @@
 
         &:focus-visible {
             border-color: var(--ffe-color-border-interactive-selected);
+            outline: var(--ffe-g-outline-width) solid
+                var(--ffe-color-border-interactive-focus);
+            outline-offset: var(--ffe-g-outline-offset);
         }
 
         &[aria-invalid='true'] {
@@ -110,31 +153,24 @@
 }
 
 .ffe-input-field--invalid,
-:where(input).ffe-input-field:not(
-        .ffe-input-field--text-like
-    )[aria-invalid='true'] {
-    color: var(--ffe-color-foreground-feedback-critical);
-    border: var(--ffe-g-border-width) solid
-        var(--ffe-color-border-feedback-critical);
-    box-shadow: var(--ffe-g-border-focus-box-shadow)
-        var(--ffe-color-border-feedback-critical);
-    background-color: var(--ffe-color-surface-feedback-critical);
-
-    &:focus {
+.ffe-input-field[aria-invalid='true'],
+.ffe-input-field:not(.ffe-input-field--text-like)[aria-invalid='true'] {
+    ~ .ffe-input-field__backdrop {
+        color: var(--ffe-color-foreground-feedback-critical);
         border: var(--ffe-g-border-width) solid
             var(--ffe-color-border-feedback-critical);
         box-shadow: var(--ffe-g-border-focus-box-shadow)
             var(--ffe-color-border-feedback-critical);
+        background-color: var(--ffe-color-surface-feedback-critical);
     }
 
-    @media (hover: hover) and (pointer: fine) {
-        &:hover,
-        &:focus {
-            border: var(--ffe-g-border-width) solid
-                var(--ffe-color-border-feedback-critical);
-            box-shadow: var(--ffe-g-border-focus-box-shadow)
-                var(--ffe-color-border-feedback-critical);
-            background-color: var(--ffe-color-surface-primary-default);
-        }
+    &:focus ~ .ffe-input-field__backdrop,
+    &:focus-within ~ .ffe-input-field__backdrop,
+    &:hover ~ .ffe-input-field__backdrop {
+        border: var(--ffe-g-border-width) solid
+            var(--ffe-color-border-feedback-critical);
+        box-shadow: var(--ffe-g-border-focus-box-shadow)
+            var(--ffe-color-border-feedback-critical);
+        background-color: var(--ffe-color-component-form-input-fill-default);
     }
 }

--- a/packages/ffe-form/less/input-field.less
+++ b/packages/ffe-form/less/input-field.less
@@ -1,19 +1,14 @@
 .ffe-input-field {
     display: block;
+    position: relative;
+    z-index: 1;
     height: 2.8125rem;
-    padding: var(--ffe-spacing-2xs) var(--ffe-spacing-sm); /* Increased horizontal padding */
+    padding: var(--ffe-spacing-2xs) var(--ffe-spacing-sm);
     font-family: var(--ffe-g-font);
     font-variant-numeric: tabular-nums;
-    background-color: var(--ffe-color-surface-primary-default);
+    background: transparent;
+    border: none;
     color: var(--ffe-color-foreground-default);
-    border-radius: var(--ffe-g-border-radius);
-    border: var(--ffe-g-border-width) solid
-        var(--ffe-color-border-primary-default);
-    transition:
-        color var(--ffe-transition-duration) var(--ffe-ease),
-        border var(--ffe-transition-duration) var(--ffe-ease),
-        box-shadow var(--ffe-transition-duration) var(--ffe-ease),
-        background-color var(--ffe-transition-duration) var(--ffe-ease);
     width: 100%;
     font-size: var(--ffe-fontsize-form-input);
 
@@ -26,15 +21,57 @@
         text-align: left;
     }
 
-    @media (hover: hover) and (pointer: fine) {
-        &:hover {
+    &__backdrop {
+        position: absolute;
+        z-index: 0;
+        inset: 0;
+        background-color: var(--ffe-color-surface-primary-default);
+        border-radius: var(--ffe-g-border-radius);
+        border: var(--ffe-g-border-width) solid
+            var(--ffe-color-border-primary-default);
+        transition: all var(--ffe-transition-duration) var(--ffe-ease);
+
+        .ffe-input-field__wrapper:hover & {
             border-color: var(--ffe-color-border-primary-default-hover);
             box-shadow: var(--ffe-g-border-focus-box-shadow)
                 var(--ffe-color-border-primary-default-hover);
         }
     }
 
-    &:focus {
+    &__wrapper {
+        position: relative;
+        display: flex;
+        align-items: center;
+        width: 100%;
+        margin: 0;
+        padding: 0;
+
+        &--inline {
+            display: inline-flex;
+            width: auto;
+        }
+    }
+
+    &__suffix,
+    &__prefix {
+        color: var(--ffe-color-foreground-subtle);
+        display: inline-flex;
+        align-items: center;
+        z-index: 1;
+        white-space: nowrap;
+        padding: 0;
+    }
+
+    &__suffix {
+        margin: 0 var(--ffe-spacing-xs) 0 0;
+    }
+
+    &__prefix {
+        margin: 0 0 0 var(--ffe-spacing-xs);
+    }
+
+    &:focus ~ &__backdrop,
+    &:focus-within ~ &__backdrop {
         border: var(--ffe-g-border-width) solid
             var(--ffe-color-fill-primary-selected-default);
         box-shadow: var(--ffe-g-border-focus-box-shadow)
@@ -44,9 +81,10 @@
         outline-offset: var(--ffe-g-outline-offset);
     }
 
-    &--inline {
-        display: inline-block;
-        width: auto;
+    &:focus,
+    &:focus-within {
+        border: none;
+        outline: none;
     }
 
     &--text-right-align {
@@ -69,7 +107,8 @@
             color var(--ffe-transition-duration) var(--ffe-ease),
             border var(--ffe-transition-duration) var(--ffe-ease),
             box-shadow var(--ffe-transition-duration) var(--ffe-ease),
-            background-color var(--ffe-transition-duration) var(--ffe-ease);
+            background-color var(--ffe-transition-duration) var(--ffe-ease),
+            outline var(--ffe-transition-duration) var(--ffe-ease);
         background-color: transparent;
         border-radius: 2px;
 
@@ -82,6 +121,9 @@
 
         &:focus-visible {
             border-color: var(--ffe-color-border-interactive-selected);
+            outline: var(--ffe-g-outline-width) solid
+                var(--ffe-color-border-interactive-focus);
+            outline-offset: var(--ffe-g-outline-offset);
         }
 
         &[aria-invalid='true'] {
@@ -110,31 +152,24 @@
 }
 
 .ffe-input-field--invalid,
-:where(input).ffe-input-field:not(
-        .ffe-input-field--text-like
-    )[aria-invalid='true'] {
-    color: var(--ffe-color-foreground-feedback-critical);
-    border: var(--ffe-g-border-width) solid
-        var(--ffe-color-border-feedback-critical);
-    box-shadow: var(--ffe-g-border-focus-box-shadow)
-        var(--ffe-color-border-feedback-critical);
-    background-color: var(--ffe-color-surface-feedback-critical);
-
-    &:focus {
+.ffe-input-field[aria-invalid='true'],
+.ffe-input-field:not(.ffe-input-field--text-like)[aria-invalid='true'] {
+    ~ .ffe-input-field__backdrop {
+        color: var(--ffe-color-foreground-feedback-critical);
         border: var(--ffe-g-border-width) solid
             var(--ffe-color-border-feedback-critical);
         box-shadow: var(--ffe-g-border-focus-box-shadow)
             var(--ffe-color-border-feedback-critical);
+        background-color: var(--ffe-color-surface-feedback-critical);
     }
 
-    @media (hover: hover) and (pointer: fine) {
-        &:hover,
-        &:focus {
-            border: var(--ffe-g-border-width) solid
-                var(--ffe-color-border-feedback-critical);
-            box-shadow: var(--ffe-g-border-focus-box-shadow)
-                var(--ffe-color-border-feedback-critical);
-            background-color: var(--ffe-color-surface-primary-default);
-        }
+    &:focus ~ .ffe-input-field__backdrop,
+    &:focus-within ~ .ffe-input-field__backdrop,
+    &:hover ~ .ffe-input-field__backdrop {
+        border: var(--ffe-g-border-width) solid
+            var(--ffe-color-border-feedback-critical);
+        box-shadow: var(--ffe-g-border-focus-box-shadow)
+            var(--ffe-color-border-feedback-critical);
+        background-color: var(--ffe-color-component-form-input-fill-default);
     }
 }

--- a/packages/ffe-form/less/input-field.less
+++ b/packages/ffe-form/less/input-field.less
@@ -45,7 +45,6 @@
         width: 100%;
         margin: 0;
         padding: 0;
-        z-index: 1;
 
         &--inline {
             display: inline-flex;

--- a/packages/ffe-form/less/input-field.less
+++ b/packages/ffe-form/less/input-field.less
@@ -45,6 +45,7 @@
         width: 100%;
         margin: 0;
         padding: 0;
+        z-index: 1;
 
         &--inline {
             display: inline-flex;

--- a/packages/ffe-form/less/input-field.less
+++ b/packages/ffe-form/less/input-field.less
@@ -30,6 +30,8 @@
         border: var(--ffe-g-border-width) solid
             var(--ffe-color-border-primary-default);
         transition: all var(--ffe-transition-duration) var(--ffe-ease);
+        outline: var(--ffe-g-outline-width) solid transparent;
+        outline-offset: var(--ffe-g-outline-offset);
 
         .ffe-input-field__wrapper:hover & {
             border-color: var(--ffe-color-border-primary-default-hover);
@@ -76,9 +78,7 @@
             var(--ffe-color-fill-primary-selected-default);
         box-shadow: var(--ffe-g-border-focus-box-shadow)
             var(--ffe-color-fill-primary-selected-default);
-        outline: var(--ffe-g-outline-width) solid
-            var(--ffe-color-border-interactive-focus);
-        outline-offset: var(--ffe-g-outline-offset);
+        outline-color: var(--ffe-color-border-interactive-focus);
     }
 
     &:focus,

--- a/packages/ffe-form/less/input-group.less
+++ b/packages/ffe-form/less/input-group.less
@@ -43,4 +43,18 @@
             transform: translateY(var(--ffe-spacing-2xs));
         }
     }
+
+    &__body {
+        margin: 0;
+        padding: 0;
+        display: flex;
+        align-items: center;
+    }
+
+    &__suffix,
+    &__prefix {
+        color: var(--ffe-color-foreground-subtle);
+        display: inline-flex;
+        align-items: center;
+    }
 }

--- a/packages/ffe-form/less/phone-number.less
+++ b/packages/ffe-form/less/phone-number.less
@@ -28,10 +28,12 @@
         }
     }
 
-    &__country-code-input {
+    &__country-code-input .ffe-input-field__backdrop {
         border-top-left-radius: 0;
         border-bottom-left-radius: 0;
+    }
 
+    &__country-code-input {
         @media (min-width: @breakpoint-sm) {
             max-width: 4rem;
             margin-right: var(--ffe-spacing-sm);

--- a/packages/ffe-form/less/radio-block.less
+++ b/packages/ffe-form/less/radio-block.less
@@ -33,6 +33,9 @@
         border: var(--ffe-g-border-width) solid var(--outer-border-color);
         border-radius: var(--ffe-g-border-radius);
         overflow: hidden;
+        transition: all var(--ffe-transition-duration) var(--ffe-ease);
+        outline: var(--ffe-g-outline-width) solid transparent;
+        outline-offset: var(--ffe-g-outline-offset);
 
         &::before {
             place-self: center;
@@ -129,7 +132,6 @@
     &:focus + .ffe-radio-block__content {
         --outer-border-color: var(--ffe-color-border-interactive-selected);
 
-        outline: none;
         box-shadow: var(--ffe-g-border-focus-box-shadow)
             var(--ffe-color-border-interactive-selected);
     }
@@ -139,9 +141,7 @@
     }
 
     &:focus-visible + .ffe-radio-block__content {
-        outline: var(--ffe-g-outline-width) solid
-            var(--ffe-color-border-interactive-focus);
-        outline-offset: var(--ffe-g-outline-offset);
+        outline-color: var(--ffe-color-border-interactive-focus);
     }
 
     &:disabled + .ffe-radio-block__content {

--- a/packages/ffe-form/less/radio-block.less
+++ b/packages/ffe-form/less/radio-block.less
@@ -14,12 +14,7 @@
     &__content,
     &__header {
         cursor: pointer;
-        transition:
-            color var(--ffe-transition-duration) var(--ffe-ease),
-            border var(--ffe-transition-duration) var(--ffe-ease),
-            box-shadow var(--ffe-transition-duration) var(--ffe-ease),
-            background-color var(--ffe-transition-duration) var(--ffe-ease),
-            outline var(--ffe-transition-duration) var(--ffe-ease);
+        transition: all var(--ffe-transition-duration) var(--ffe-ease);
     }
 
     &__content {

--- a/packages/ffe-form/less/radio-block.less
+++ b/packages/ffe-form/less/radio-block.less
@@ -18,7 +18,8 @@
             color var(--ffe-transition-duration) var(--ffe-ease),
             border var(--ffe-transition-duration) var(--ffe-ease),
             box-shadow var(--ffe-transition-duration) var(--ffe-ease),
-            background-color var(--ffe-transition-duration) var(--ffe-ease);
+            background-color var(--ffe-transition-duration) var(--ffe-ease),
+            outline var(--ffe-transition-duration) var(--ffe-ease);
     }
 
     &__content {

--- a/packages/ffe-form/less/radio-button.less
+++ b/packages/ffe-form/less/radio-button.less
@@ -14,7 +14,9 @@
     align-items: center;
     position: relative;
     cursor: pointer;
-    transition: width var(--ffe-transition-duration) var(--ffe-ease-in-out-back);
+    transition:
+        width var(--ffe-transition-duration) var(--ffe-ease-in-out-back),
+        outline var(--ffe-transition-duration) var(--ffe-ease);
     text-align: left;
     padding-left: 0;
     padding-top: 1px;

--- a/packages/ffe-form/less/radio-button.less
+++ b/packages/ffe-form/less/radio-button.less
@@ -14,6 +14,8 @@
     align-items: center;
     position: relative;
     cursor: pointer;
+    outline: var(--ffe-g-outline-width) solid transparent;
+    outline-offset: var(--ffe-g-outline-offset);
     transition:
         width var(--ffe-transition-duration) var(--ffe-ease-in-out-back),
         outline var(--ffe-transition-duration) var(--ffe-ease);
@@ -118,9 +120,7 @@
     }
 
     &:focus-visible + .ffe-radio-button {
-        outline: var(--ffe-g-outline-width) solid
-            var(--ffe-color-border-interactive-focus);
-        outline-offset: var(--ffe-g-outline-offset);
+        outline-color: var(--ffe-color-border-interactive-focus);
     }
 
     &:disabled + .ffe-radio-button {

--- a/packages/ffe-form/less/radio-button.less
+++ b/packages/ffe-form/less/radio-button.less
@@ -16,9 +16,7 @@
     cursor: pointer;
     outline: var(--ffe-g-outline-width) solid transparent;
     outline-offset: var(--ffe-g-outline-offset);
-    transition:
-        width var(--ffe-transition-duration) var(--ffe-ease-in-out-back),
-        outline var(--ffe-transition-duration) var(--ffe-ease);
+    transition: all var(--ffe-transition-duration) var(--ffe-ease);
     text-align: left;
     padding-left: 0;
     padding-top: 1px;

--- a/packages/ffe-form/less/radio-switch.less
+++ b/packages/ffe-form/less/radio-switch.less
@@ -17,6 +17,8 @@
     text-align: left;
     font-family: var(--ffe-g-font);
     font-variant-numeric: tabular-nums;
+    outline: var(--ffe-g-outline-width) solid transparent;
+    outline-offset: var(--ffe-g-outline-offset);
     cursor: pointer;
     transition:
         color var(--ffe-transition-duration) var(--ffe-ease),
@@ -117,9 +119,7 @@
     }
 
     &:focus-visible + .ffe-radio-switch {
-        outline: var(--ffe-g-outline-width) solid
-            var(--ffe-color-border-interactive-focus);
-        outline-offset: var(--ffe-g-outline-offset);
+        outline-color: var(--ffe-color-border-interactive-focus);
     }
 
     &:disabled + .ffe-radio-switch {

--- a/packages/ffe-form/less/radio-switch.less
+++ b/packages/ffe-form/less/radio-switch.less
@@ -20,12 +20,7 @@
     outline: var(--ffe-g-outline-width) solid transparent;
     outline-offset: var(--ffe-g-outline-offset);
     cursor: pointer;
-    transition:
-        color var(--ffe-transition-duration) var(--ffe-ease),
-        border var(--ffe-transition-duration) var(--ffe-ease),
-        box-shadow var(--ffe-transition-duration) var(--ffe-ease),
-        background-color var(--ffe-transition-duration) var(--ffe-ease),
-        outline var(--ffe-transition-duration) var(--ffe-ease);
+    transition: all var(--ffe-transition-duration) var(--ffe-ease);
     margin-bottom: var(--ffe-spacing-2xs);
     margin-top: var(--ffe-spacing-sm);
     line-height: 1.5;

--- a/packages/ffe-form/less/radio-switch.less
+++ b/packages/ffe-form/less/radio-switch.less
@@ -4,7 +4,8 @@
     --radio-switch-background: var(--ffe-color-surface-primary-default);
 
     color: var(--ffe-color-foreground-default);
-    padding: var(--ffe-spacing-xs) var(--ffe-spacing-md) var(--ffe-spacing-xs) var(--ffe-spacing-xs);
+    padding: var(--ffe-spacing-xs) var(--ffe-spacing-md) var(--ffe-spacing-xs)
+        var(--ffe-spacing-xs);
     grid-template-columns: auto 1fr;
     grid-column-gap: var(--ffe-spacing-xs);
     position: relative;
@@ -21,7 +22,8 @@
         color var(--ffe-transition-duration) var(--ffe-ease),
         border var(--ffe-transition-duration) var(--ffe-ease),
         box-shadow var(--ffe-transition-duration) var(--ffe-ease),
-        background-color var(--ffe-transition-duration) var(--ffe-ease);
+        background-color var(--ffe-transition-duration) var(--ffe-ease),
+        outline var(--ffe-transition-duration) var(--ffe-ease);
     margin-bottom: var(--ffe-spacing-2xs);
     margin-top: var(--ffe-spacing-sm);
     line-height: 1.5;
@@ -47,14 +49,16 @@
 
             background-color: var(--ffe-color-surface-primary-default-hover);
             border-color: var(--ffe-color-border-primary-default-hover);
-            box-shadow: var(--ffe-g-border-focus-box-shadow) var(--ffe-color-border-primary-default-hover);
+            box-shadow: var(--ffe-g-border-focus-box-shadow)
+                var(--ffe-color-border-primary-default-hover);
         }
     }
 
     &:active {
         background-color: var(--ffe-color-surface-primary-default-pressed);
         border-color: var(--ffe-color-border-primary-default-pressed);
-        box-shadow: var(--ffe-g-border-focus-box-shadow) var(--ffe-color-border-primary-default-pressed);
+        box-shadow: var(--ffe-g-border-focus-box-shadow)
+            var(--ffe-color-border-primary-default-pressed);
     }
 
     @media (min-width: @breakpoint-sm) {
@@ -71,22 +75,27 @@
 }
 
 .ffe-radio-input {
-    &:where(:checked, :focus, :active, :hover)+.ffe-radio-switch::before {
+    &:where(:checked, :focus, :active, :hover) + .ffe-radio-switch::before {
         outline: none;
     }
 
     @media (hover: hover) and (pointer: fine) {
-        &:hover+.ffe-radio-switch {
-            --radio-switch-background: var(--ffe-color-surface-primary-default-hover);
+        &:hover + .ffe-radio-switch {
+            --radio-switch-background: var(
+                --ffe-color-surface-primary-default-hover
+            );
         }
     }
 
-    &:checked+.ffe-radio-switch {
+    &:checked + .ffe-radio-switch {
         --inner-circle-color: var(--ffe-color-fill-primary-default-pressed);
         --radio-switch-background: var(--ffe-color-surface-primary-default);
-        --radio-switch-border-color: var(--ffe-color-border-interactive-selected);
+        --radio-switch-border-color: var(
+            --ffe-color-border-interactive-selected
+        );
 
-        box-shadow: var(--ffe-g-border-focus-box-shadow) var(--radio-switch-border-color);
+        box-shadow: var(--ffe-g-border-focus-box-shadow)
+            var(--radio-switch-border-color);
 
         &::before {
             border: 5px solid var(--ffe-color-surface-primary-default);
@@ -96,7 +105,9 @@
 
         @media (hover: hover) and (pointer: fine) {
             &:hover {
-                background-color: var(--ffe-color-surface-primary-default-hover);
+                background-color: var(
+                    --ffe-color-surface-primary-default-hover
+                );
             }
         }
 
@@ -105,12 +116,13 @@
         }
     }
 
-    &:focus-visible+.ffe-radio-switch {
-        outline: var(--ffe-g-outline-width) solid var(--ffe-color-border-interactive-focus);
+    &:focus-visible + .ffe-radio-switch {
+        outline: var(--ffe-g-outline-width) solid
+            var(--ffe-color-border-interactive-focus);
         outline-offset: var(--ffe-g-outline-offset);
     }
 
-    &:disabled+.ffe-radio-switch {
+    &:disabled + .ffe-radio-switch {
         --radio-switch-border-color: var(--ffe-color-border-primary-subtle);
         --radio-switch-background: var(--ffe-color-surface-primary-default);
 
@@ -118,15 +130,17 @@
         color: var(--ffe-color-foreground-subtle);
     }
 
-    &[aria-invalid='true']+.ffe-radio-switch {
+    &[aria-invalid='true'] + .ffe-radio-switch {
         --radio-switch-border-color: var(--ffe-color-border-feedback-critical);
         --radio-switch-background: var(--ffe-color-surface-feedback-critical);
         --inner-circle-color: var(--ffe-color-surface-primary-default);
 
-        box-shadow: var(--ffe-g-border-focus-box-shadow) var(--ffe-color-border-feedback-critical);
+        box-shadow: var(--ffe-g-border-focus-box-shadow)
+            var(--ffe-color-border-feedback-critical);
 
         &::before {
-            box-shadow: var(--ffe-g-border-focus-box-shadow) var(--ffe-color-border-feedback-critical);
+            box-shadow: var(--ffe-g-border-focus-box-shadow)
+                var(--ffe-color-border-feedback-critical);
         }
 
         @media (hover: hover) and (pointer: fine) {

--- a/packages/ffe-form/less/textarea.less
+++ b/packages/ffe-form/less/textarea.less
@@ -11,12 +11,7 @@
     color: var(--ffe-color-foreground-default);
     outline: var(--ffe-g-outline-width) solid transparent;
     outline-offset: var(--ffe-g-outline-offset);
-    transition:
-        color var(--ffe-transition-duration) var(--ffe-ease),
-        border var(--ffe-transition-duration) var(--ffe-ease),
-        box-shadow var(--ffe-transition-duration) var(--ffe-ease),
-        background-color var(--ffe-transition-duration) var(--ffe-ease),
-        outline var(--ffe-transition-duration) var(--ffe-ease);
+    transition: all var(--ffe-transition-duration) var(--ffe-ease);
     font-size: var(--ffe-fontsize-form-input);
 
     @media (hover: hover) and (pointer: fine) {

--- a/packages/ffe-form/less/textarea.less
+++ b/packages/ffe-form/less/textarea.less
@@ -9,6 +9,8 @@
         var(--ffe-color-border-primary-default);
     background-color: var(--ffe-color-surface-primary-default);
     color: var(--ffe-color-foreground-default);
+    outline: var(--ffe-g-outline-width) solid transparent;
+    outline-offset: var(--ffe-g-outline-offset);
     transition:
         color var(--ffe-transition-duration) var(--ffe-ease),
         border var(--ffe-transition-duration) var(--ffe-ease),
@@ -31,9 +33,7 @@
             var(--ffe-color-component-form-input-border-active);
         box-shadow: var(--ffe-g-border-focus-box-shadow)
             var(--ffe-color-component-form-input-border-active);
-        outline: var(--ffe-g-outline-width) solid
-            var(--ffe-color-border-interactive-focus);
-        outline-offset: var(--ffe-g-outline-offset);
+        outline-color: var(--ffe-color-border-interactive-focus);
     }
 
     &::placeholder {

--- a/packages/ffe-form/less/textarea.less
+++ b/packages/ffe-form/less/textarea.less
@@ -13,7 +13,8 @@
         color var(--ffe-transition-duration) var(--ffe-ease),
         border var(--ffe-transition-duration) var(--ffe-ease),
         box-shadow var(--ffe-transition-duration) var(--ffe-ease),
-        background-color var(--ffe-transition-duration) var(--ffe-ease);
+        background-color var(--ffe-transition-duration) var(--ffe-ease),
+        outline var(--ffe-transition-duration) var(--ffe-ease);
     font-size: var(--ffe-fontsize-form-input);
 
     @media (hover: hover) and (pointer: fine) {

--- a/packages/ffe-searchable-dropdown-react/less/searchable-dropdown.less
+++ b/packages/ffe-searchable-dropdown-react/less/searchable-dropdown.less
@@ -2,7 +2,9 @@
     --button-width: 40px;
     --border-width: var(--ffe-g-border-width);
     --border-color: var(--ffe-color-border-primary-default);
-    --detail-text-color: var(--ffe-color-component-form-input-foreground-subtle);
+    --detail-text-color: var(
+        --ffe-color-component-form-input-foreground-subtle
+    );
     --selected-icon-color: var(--ffe-color-fill-primary-selected-default);
     --text-color: var(--ffe-color-foreground-default);
 
@@ -15,6 +17,8 @@
     border-radius: var(--ffe-g-border-radius);
     color: var(--text-color);
     border: var(--border-width) solid var(--border-color);
+    outline: var(--ffe-g-outline-width) solid transparent;
+    outline-offset: var(--ffe-g-outline-offset);
     transition: all var(--ffe-transition-duration) var(--ffe-ease);
 
     :where(.ffe-searchable-dropdown__button) {
@@ -32,14 +36,13 @@
     &:active,
     &:focus-within {
         border-color: var(--ffe-color-component-form-input-border-active);
-        box-shadow: var(--ffe-g-border-focus-box-shadow) var(--ffe-color-component-form-input-border-active);
+        box-shadow: var(--ffe-g-border-focus-box-shadow)
+            var(--ffe-color-component-form-input-border-active);
     }
 
     &:focus-within {
-        outline: var(--ffe-g-outline-width) solid var(--ffe-color-border-interactive-focus);
-        outline-offset: var(--ffe-g-outline-offset);
+        outline-color: var(--ffe-color-border-interactive-focus);
     }
-
 
     &__input {
         display: grid;
@@ -48,7 +51,7 @@
         border-right: none;
 
         @media (hover: hover) and (pointer: fine) {
-            &:hover+.ffe-searchable-dropdown__button {
+            &:hover + .ffe-searchable-dropdown__button {
                 --border-color: var(--ffe-color-border-primary-default-hover);
             }
         }
@@ -69,7 +72,8 @@
         &-icon {
             transition:
                 color var(--ffe-transition-duration) var(--ffe-ease),
-                transform var(--ffe-transition-duration) var(--ffe-ease-in-out-back);
+                transform var(--ffe-transition-duration)
+                    var(--ffe-ease-in-out-back);
         }
 
         &--flip {
@@ -124,7 +128,7 @@
     &__no-match {
         padding: var(--ffe-spacing-xs) var(--ffe-spacing-sm);
 
-        &+.ffe-searchable-dropdown__list-item-container {
+        & + .ffe-searchable-dropdown__list-item-container {
             border-top: 1px solid var(--ffe-color-border-primary-default);
         }
 
@@ -147,7 +151,6 @@
         color: var(--text-color);
 
         @media (hover: hover) and (pointer: fine) {
-
             &:hover,
             &--highlighted:hover {
                 background: var(--ffe-color-surface-primary-default-hover);
@@ -175,16 +178,19 @@
 
     &:has(input[aria-invalid='true']) {
         color: var(--ffe-color-foreground-feedback-critical);
-        border: var(--ffe-g-border-width) solid var(--ffe-color-border-feedback-critical);
-        box-shadow: var(--ffe-g-border-focus-box-shadow) var(--ffe-color-border-feedback-critical);
+        border: var(--ffe-g-border-width) solid
+            var(--ffe-color-border-feedback-critical);
+        box-shadow: var(--ffe-g-border-focus-box-shadow)
+            var(--ffe-color-border-feedback-critical);
         background-color: var(--ffe-color-surface-feedback-critical);
 
         @media (hover: hover) and (pointer: fine) {
-
             &:hover,
             &:focus {
-                border: var(--ffe-g-border-width) solid var(--ffe-color-border-feedback-critical);
-                box-shadow: var(--ffe-g-border-focus-box-shadow) var(--ffe-color-border-feedback-critical);
+                border: var(--ffe-g-border-width) solid
+                    var(--ffe-color-border-feedback-critical);
+                box-shadow: var(--ffe-g-border-focus-box-shadow)
+                    var(--ffe-color-border-feedback-critical);
                 background-color: var(--ffe-color-surface-primary-default);
             }
         }


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse

* Legger til støtte for `prefix` og `suffix` i `<Input/>`. Dette innebærer at markup-strukturen er noe endret. Tidligere lå all styling direkte på `input`-elementet, mens nå består komponenten i tillegg av en wrapper og en backdrop. Backdrop-elementet håndterer mesteparten av utseendet og "rammer inn" `input`. Denne endringen var nødvendig fordi det gjør det mulig for andre elementer å ta opp plass "inni" `input`.
* `className` er flyttet fra input-elementet til wrapperen
* Fjernet en del duplikat styling fra ffe-datepicker, som bruker i utgangspunktet bruker ffe-input, men bare delvis.
* Lagt til transition på outline i en rekke komponenter der det manglet i etterkant av at fokus-stylingen ble ble flyttet fra border/box-shadow.
* Fikset en bug som gjorde transition på outline hakkete i mange forskjellige komponenter

## Motivasjon og kontekst

En rekke team har etterspurt støtte for `prefix` og `suffix` i `Input`.

## Testing

Testet i Storybook
