### PR TITLE
feat(ffe-core): legg til generator for tailwind 4 css farge variabler

### DIFF
--- a/packages/ffe-core/documentation/Colors.mdx
+++ b/packages/ffe-core/documentation/Colors.mdx
@@ -18,23 +18,6 @@ Dark mode aktiveres automatisk basert på brukerens systeminnstillinger.
 Accent mode aktiveres med å legge klassen `ffe-accent-mode` på elementet eller på
 containeren til elementet. Se mer om accent mode på [siden om accent mode](./?path=/docs/design-farger-accent--docs) WIP
 
-## Tailwind
-
-For å bruke semantiske farger i Tailwind importerer en `@sb1/ffe-core/lib/semanticColorsTailwind`.
-
-```tsx
-import * as colors from '@sb1/ffe-core/lib/semanticColorsTailwind';
-module.exports = {
-    theme: {
-        colors: {
-            ...colors,
-        },
-    },
-};
-```
-
-Da blir fargene tilgjengelige i kebab-case uten `--ffe-color`. Feks `--ffe-color-background-default` -> `background-default`
-
 ## Liste over de semantiske fargene
 
 <table class="ffe-color-table">

--- a/packages/ffe-core/documentation/Tailwind.mdx
+++ b/packages/ffe-core/documentation/Tailwind.mdx
@@ -1,0 +1,36 @@
+import { Meta } from '@storybook/blocks';
+
+<Meta title="Design/Farger/Tailwind" />
+
+# Tailwind
+
+Vi anbefaler ikke å bruke Tailwind, men vet det er mange som gjør det.
+Vi tilbyr derfor farge tokens for Tailwind også.
+
+## Versjon 4
+
+Tailwind versjon 4 bruker css layers per default. På grunn av hvilke [nettleserversjoner](https://design.sparebank1.no/grunnleggende/nettleserversjoner/) vi må støtte i dag (sept 2025) støtter vi ikke CSS layers. Vi anbefaler å bruke Tailwind 4 med en måte som importerer fargene uten CSS layers, som du kan lese mer om her: [tailwindlabs/tailwindcss#13188](https://github.com/tailwindlabs/tailwindcss/discussions/13188)
+Importer følgende css fil for å få semantiske farger i Tailwind versjon 4:
+
+```css
+@import '@sb1/ffe-core/css/colors-semantic-tailwind-4.css';
+```
+
+## Versjon 3
+
+For å bruke semantiske farger med Tailwind Versjon 3 kan du importere fargene fra `@sb1/ffe-core/lib/semanticColorsTailwind`.
+
+Her et eksempel på hvordan et utsnitt av din `tailwind.config.js` kan se ut for å sette opp til bruk av de semantske fagene
+
+```tsx
+import * as colors from '@sb1/ffe-core/lib/semanticColorsTailwind';
+module.exports = {
+    theme: {
+        colors: {
+            ...colors,
+        },
+    },
+};
+```
+
+Da blir fargene tilgjengelige i kebab-case uten `--ffe-color`. Feks `--ffe-color-background-default` -> `background-default`

--- a/packages/ffe-core/scripts/build-colors/web/tailwind4.cjs
+++ b/packages/ffe-core/scripts/build-colors/web/tailwind4.cjs
@@ -1,0 +1,24 @@
+#!/usr/bin/env node
+const { writeToFile } = require('../../utils.cjs');
+
+function transformToTW4CssProperty(name, value) {
+    return `--${name.replaceAll('.', '-')}: var(--ffe-${name.replaceAll('.', '-')});`;
+}
+
+function generateTailwind4CssColorFileContent(colors) {
+    return `@theme inline {
+\t${Object.entries(colors.light)
+        .map(([name]) => transformToTW4CssProperty(name))
+        .join('\n\t')}
+}
+`;
+}
+
+function buildTailwind4CssColors(paths, colors) {
+    paths.forEach(path => {
+        const content = generateTailwind4CssColorFileContent(colors);
+        writeToFile(path + 'css/colors-semantic-tailwind-4.css')(content);
+    });
+}
+
+module.exports = { buildTailwind4CssColors };

--- a/packages/ffe-core/scripts/build-colors/web/web.cjs
+++ b/packages/ffe-core/scripts/build-colors/web/web.cjs
@@ -4,6 +4,7 @@ const { buildCssColors } = require('./css.cjs');
 const { buildJsColors } = require('./js.cjs');
 const { buildColorsNames } = require('./color-names.cjs');
 const { buildTailwindJsColors } = require('./tailwind.cjs');
+const { buildTailwind4CssColors } = require('./tailwind4.cjs');
 
 function buildWebColors(paths, colors) {
     buildCssColors(paths, colors);
@@ -11,6 +12,7 @@ function buildWebColors(paths, colors) {
     buildChevronCssColors(paths, colors);
     buildColorsNames(paths, colors);
     buildTailwindJsColors(paths, colors);
+    buildTailwind4CssColors(paths, colors);
 }
 
 module.exports = { buildWebColors };


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse

fixes [#3029](https://github.com/SpareBank1/designsystem/issues/3029)

Legger til støtte for Tailwind 4 css custom properties.

TW4 kan brukes uten layers så da gir det mening å støtte det og med generatoren er det en liten jobb.

Genererer fila:

`colors-semantic-tailwind-4.css`
```css
@theme {
	--color-background-default: var(--ffe-color-background-default);
	--color-background-subtle: var(--ffe-color-background-subtle);
	--color-surface-primary-default: var(--ffe-color-surface-primary-default);
...
	--color-border-feedback-info: var(--ffe-color-border-feedback-info);
	--color-border-feedback-success: var(--ffe-color-border-feedback-success);
	--color-border-feedback-warning: var(--ffe-color-border-feedback-warning);
	--color-border-feedback-critical: var(--ffe-color-border-feedback-critical);
	--color-border-feedback-tip: var(--ffe-color-border-feedback-tip);
	--color-border-interactive-focus: var(--ffe-color-border-interactive-focus);
	--color-border-interactive-selected: var(--ffe-color-border-interactive-selected);
}
```

Får tilbakemelding fra Marius som tester fila i prosjektet sitt.