### PR TITLE
Fokus bare ved tab

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "lerna": "lerna",
     "prepare": "husky",
     "storybook:build": "node scripts/generate-dependency-graph.js && node scripts/update-ffe-dependency-lists.js && storybook build",
-    "storybook": "node scripts/generate-dependency-graph.js && node scripts/update-ffe-dependency-lists.js && node count-stories.js && echo \"💡[INFO] If Storybook fails, try building the design system first with: npm run build\" && storybook dev -p 6006",
+    "storybook": "node scripts/generate-dependency-graph.js && node scripts/update-ffe-dependency-lists.js && echo \"💡[INFO] If Storybook fails, try building the design system first with: npm run build\" && storybook dev -p 6006",
     "build-storybook": "run-s build storybook:build",
     "sync-figma-to-tokens": "tsx packages/ffe-core/scripts/figma-api/sync_figma_to_tokens.ts",
     "count": "node count-stories.js",

--- a/packages/ffe-accordion-react/src/Accordion.spec.tsx
+++ b/packages/ffe-accordion-react/src/Accordion.spec.tsx
@@ -96,4 +96,30 @@ describe('<Accordion />', () => {
         const accordionBody = content.closest('.ffe-accordion-item__body');
         expect(accordionBody).toHaveClass('ffe-accordion-item__body--no-padding');
     });
+
+    it('should set focus class only when tab key is used to focus', () => {
+        render(
+            <Accordion headingLevel={3}>
+                <AccordionItem heading="heading1">
+                    <span data-testid="content1">content1</span>
+                </AccordionItem>
+            </Accordion>,
+        );
+
+        const button = screen.getByRole('button', { name: /heading1/i });
+        const accordionItem = button.closest('.ffe-accordion-item');
+
+        fireEvent.focus(button);
+        expect(accordionItem).not.toHaveClass('ffe-accordion-item--focus');
+
+        fireEvent.blur(button);
+        expect(accordionItem).not.toHaveClass('ffe-accordion-item--focus');
+
+        fireEvent.keyDown(document, { key: 'Tab', code: 'Tab' });
+        fireEvent.focus(button);
+        expect(accordionItem).toHaveClass('ffe-accordion-item--focus');
+
+        fireEvent.blur(button);
+        expect(accordionItem).not.toHaveClass('ffe-accordion-item--focus');
+    });
 });

--- a/packages/ffe-accordion-react/src/AccordionItem.tsx
+++ b/packages/ffe-accordion-react/src/AccordionItem.tsx
@@ -3,6 +3,7 @@ import { Icon } from '@sb1/ffe-icons-react';
 import { Collapse } from '@sb1/ffe-collapse-react';
 import classNames from 'classnames';
 import { AccordionContext } from './AccordionContext';
+import { useTabPressed } from './useTabPressed';
 
 export interface AccordionItemProps
     extends React.ComponentPropsWithoutRef<'div'> {
@@ -33,6 +34,7 @@ export const AccordionItem: React.FC<AccordionItemProps> = ({
     noPadding = false,
     ...rest
 }) => {
+    const tabPressed = useTabPressed();
     const [isExpanded, setIsExpanded] = useState(defaultOpen);
     const [isAnimating, setIsAnimating] = useState(false);
     const [isFocused, setFocus] = useState(false);
@@ -85,7 +87,7 @@ export const AccordionItem: React.FC<AccordionItemProps> = ({
                         },
                     )}
                     onClick={handleOnClick}
-                    onFocus={() => setFocus(true)}
+                    onFocus={() => setFocus(tabPressed)}
                     onBlur={() => setFocus(false)}
                 >
                     <span className="ffe-accordion-item__heading-button-content">
@@ -108,11 +110,13 @@ export const AccordionItem: React.FC<AccordionItemProps> = ({
                 role="region"
             >
                 {!collapseHidden && (
-                    <div className={
-                        classNames("ffe-accordion-item__body", {
-                            "ffe-accordion-item__body--no-padding": noPadding,
-                        })
-                    }>{children}</div>
+                    <div
+                        className={classNames('ffe-accordion-item__body', {
+                            'ffe-accordion-item__body--no-padding': noPadding,
+                        })}
+                    >
+                        {children}
+                    </div>
                 )}
             </Collapse>
         </div>

--- a/packages/ffe-accordion-react/src/useTabPressed.ts
+++ b/packages/ffe-accordion-react/src/useTabPressed.ts
@@ -1,0 +1,26 @@
+import { useEffect, useState } from 'react';
+
+export function useTabPressed(): boolean {
+    const [tabPressed, setTabPressed] = useState(false);
+
+    useEffect(() => {
+        const handleKeyDown = (e: KeyboardEvent) => {
+            if (e.key === 'Tab') {
+                setTabPressed(true);
+            }
+        };
+        const handleKeyUp = (e: KeyboardEvent) => {
+            if (e.key === 'Tab') {
+                setTabPressed(false);
+            }
+        };
+        window.addEventListener('keydown', handleKeyDown);
+        window.addEventListener('keyup', handleKeyUp);
+        return () => {
+            window.removeEventListener('keydown', handleKeyDown);
+            window.removeEventListener('keyup', handleKeyUp);
+        };
+    }, []);
+
+    return tabPressed;
+}

--- a/packages/ffe-accordion/less/ffe-accordion.less
+++ b/packages/ffe-accordion/less/ffe-accordion.less
@@ -1,7 +1,5 @@
 .ffe-accordion {
-    --ffe-v-accordion-hover-color: var(
-        --ffe-color-surface-primary-default-hover
-    );
+    --ffe-v-accordion-hover-color: var(--ffe-color-surface-primary-default-hover);
     --ffe-v-accordion-border-color: var(--ffe-color-border-primary-subtle);
     --ffe-v-accordion-header-text-color: var(--ffe-color-foreground-emphasis);
     --ffe-v-accordion-body-text-color: var(--ffe-color-foreground-default);
@@ -18,14 +16,11 @@
         background-color: var(--ffe-color-surface-primary-default);
         color: var(--ffe-v-accordion-body-text-color);
         margin-bottom: var(--ffe-spacing-xs);
-        transition:
-            color var(--ffe-transition-duration) var(--ffe-ease),
-            border var(--ffe-transition-duration) var(--ffe-ease),
-            box-shadow var(--ffe-transition-duration) var(--ffe-ease),
-            background-color var(--ffe-transition-duration) var(--ffe-ease);
+        transition: all var(--ffe-transition-duration) var(--ffe-ease);
         border-radius: var(--ffe-g-border-radius-lg);
-        border: var(--ffe-g-border-width) solid
-            var(--ffe-v-accordion-border-color);
+        border: var(--ffe-g-border-width) solid var(--ffe-v-accordion-border-color);
+        outline: var(--ffe-g-outline-width) solid transparent;
+        outline-offset: var(--ffe-g-outline-offset);
 
         @media (hover: hover) and (pointer: fine) {
             &:hover {
@@ -33,15 +28,19 @@
             }
         }
 
-        &:focus-within {
+        &--focus {
             box-shadow: 0 0 0 1px var(--ffe-color-border-primary-default-hover);
         }
 
         @media (pointer: fine) {
-            &:focus-within {
-                outline: var(--ffe-g-outline-width) solid
-                    var(--ffe-color-border-interactive-focus);
-                outline-offset: var(--ffe-g-outline-offset);
+            &--focus {
+                outline-color: var(--ffe-color-border-interactive-focus);
+
+                @media (hover: hover) {
+                    &:hover {
+                        border-color: var(--ffe-v-accordion-border-color);
+                    }
+                }
             }
         }
 
@@ -61,8 +60,7 @@
             outline: none;
             color: var(--ffe-v-accordion-header-text-color);
             border-radius: 16px;
-            transition: background-color var(--ffe-transition-duration)
-                var(--ffe-ease);
+            transition: background-color var(--ffe-transition-duration) var(--ffe-ease);
 
             &--open {
                 border-radius: 16px 16px 0 0;
@@ -93,14 +91,12 @@
             flex: 0 0 auto;
             color: var(--ffe-v-accordion-header-text-color);
             transition:
-                transform var(--ffe-transition-duration)
-                    var(--ffe-ease-in-out-back),
+                transform var(--ffe-transition-duration) var(--ffe-ease-in-out-back),
                 color var(--ffe-transition-duration) var(--ffe-ease);
         }
 
         &__body {
-            padding: var(--ffe-spacing-xs) var(--ffe-spacing-sm)
-                var(--ffe-spacing-md);
+            padding: var(--ffe-spacing-xs) var(--ffe-spacing-sm) var(--ffe-spacing-md);
             color: var(--ffe-v-accordion-body-text-color);
 
             &--no-padding {
@@ -111,14 +107,6 @@
         &--open {
             .ffe-accordion-item__heading-icon {
                 transform: rotateZ(180deg);
-            }
-        }
-
-        &--focus {
-            @media (hover: hover) and (pointer: fine) {
-                &:hover {
-                    border-color: var(--ffe-v-accordion-border-color);
-                }
             }
         }
     }


### PR DESCRIPTION
## Beskrivelse

fixes #3013

I dag er det outline-fokus på accordion også ved klikk. Det er fordi vi ikke fikk til å løse det med css. Denne løsningen fjerner outline-fargen ved musepeker, og viser den kun ved tastaturnavigasjon

I dag (ved klikk) :
<img width="761" height="288" alt="image" src="https://github.com/user-attachments/assets/06a4a76e-011c-4f1e-95cc-a9f697bd6111" />

Ny løsning: 
<img width="922" height="264" alt="image" src="https://github.com/user-attachments/assets/a959d5c5-ec4d-43e9-b6d1-874c29b2b64e" />

Ny løsning ved tab: 
<img width="956" height="277" alt="image" src="https://github.com/user-attachments/assets/3867d0b3-006a-4d3c-bb20-0b9ee88ed546" />


(oppdatert av Tuva)
