### PR TITLE
docs(ffe-core): Legger til bakgrunnsfarge på fargeeksemplene i Farger…

### DIFF
--- a/packages/ffe-core/documentation/Colors.mdx
+++ b/packages/ffe-core/documentation/Colors.mdx
@@ -36,6 +36,8 @@ module.exports = {
 Da blir fargene tilgjengelige i kebab-case uten `--ffe-color`. Feks `--ffe-color-background-default` -> `background-default`
 
 ## Liste over de semantiske fargene
+Noen av fargene har gjennomsiktighet, og dette kan påvirke hvordan de vises på forskjellige bakgrunner. 
+I eksemplene under er bakgrunnen satt til `--ffe-color-background-default` for å illustrere effekten i de forskjellige modusene og kontekstene.
 
 <table class="ffe-color-table">
     <thead>
@@ -51,19 +53,64 @@ Da blir fargene tilgjengelige i kebab-case uten `--ffe-color`. Feks `--ffe-color
         {colors.map(color => (
             <tr key={color}>
                 <td>{color}</td>
-                <td style={{ backgroundColor: `var(${color})` }}></td>
+                <td
+                    style={{ 
+                        backgroundColor: `var(--ffe-color-background-default)`,
+                        padding: '0',
+                        border: '1px solid #dfe6eb'
+                    }}
+                >
+                    <span
+                        style={{ 
+                            backgroundColor: `var(${color})`, 
+                            display: 'block',
+                            height: '40px'
+                        }}></span>
+                </td>
                 <td
                     class="ffe-accent-mode"
-                    style={{ backgroundColor: `var(${color})` }}
-                ></td>
+                    style={{ 
+                        backgroundColor: `var(--ffe-color-background-default)`,
+                        padding: '0',
+                        border: '1px solid #dfe6eb'
+                    }}
+                >
+                    <span
+                        style={{ 
+                            backgroundColor: `var(${color})`, 
+                            display: 'block',
+                            height: '40px'
+                        }}></span>
+                </td>
                 <td
                     class="dark-mode"
-                    style={{ backgroundColor: `var(${color})` }}
-                ></td>
+                    style={{ 
+                        backgroundColor: `var(--ffe-color-background-default)`,
+                        padding: '0',
+                        border: '1px solid #dfe6eb'
+                    }}
+                >
+                    <span
+                        style={{ 
+                            backgroundColor: `var(${color})`, 
+                            display: 'block',
+                            height: '40px'
+                        }}></span>
+                </td>
                 <td
                     class="dark-mode ffe-accent-mode"
-                    style={{ backgroundColor: `var(${color})` }}
-                ></td>
+                    style={{ 
+                        backgroundColor: `var(--ffe-color-background-default)`,
+                        padding: '0',
+                        border: '1px solid #dfe6eb'
+                     }}
+                >
+                    <span
+                        style={{ 
+                            backgroundColor: `var(${color})`, 
+                            display: 'block',
+                            height: '40px'
+                        }}></span></td>
             </tr>
         ))}
     </tbody>


### PR DESCRIPTION
fixes #3020 

Vi har fått inn noen farger med gjennomsiktighet og det har kommet inn innspill på at dokumentasjonen ikke reflekterer det godt nok. Har lagt til bakgrunnsfarge bak alle `td` og lagt inn en span med fargen. 

Måtte legge til en annen border-farge på tabellen fordi den hadde gjennomsiktighet. Hvis jeg ikke gjorde det ville borderen få bakgrunnsfargen til cellen.

Før: 
<img width="840" height="813" alt="image" src="https://github.com/user-attachments/assets/7a568857-4204-450d-83f5-c9138a0c0939" />
Nå: 
<img width="846" height="838" alt="image" src="https://github.com/user-attachments/assets/a8fd909c-0d2b-4e1f-99e2-453656665128" />

Gjelder f.eks border-fargene, de har gjennomsiktighet. 
Før:
<img width="841" height="529" alt="image" src="https://github.com/user-attachments/assets/d5e68d62-aac9-407e-801b-74f7b1de4c79" />
Nå:
<img width="836" height="584" alt="image" src="https://github.com/user-attachments/assets/50938d6a-c385-4107-b1fa-0ccf1503441d" />
