### PR TITLE
fix(ffe-searchable-dropdown-react): Do not run open or close callbacks on mount

### DIFF
--- a/packages/ffe-searchable-dropdown-react/src/multi/SearchableDropdownMultiSelect.spec.tsx
+++ b/packages/ffe-searchable-dropdown-react/src/multi/SearchableDropdownMultiSelect.spec.tsx
@@ -583,4 +583,62 @@ describe('SearchableDropdownMultiSelect', () => {
         await user.click(screen.getByTestId('change-multiselect-input'));
         expect(screen.queryByText(companies[0].organizationName)).toBeNull();
     });
+
+    it('does not run onOpen or onClose on mount', async () => {
+        const onChange = jest.fn();
+        const onOpen = jest.fn();
+        const onClose = jest.fn();
+
+        render(
+            <SearchableDropdownMultiSelectButton
+                id="id"
+                labelledById="labelId"
+                dropdownAttributes={['organizationName', 'organizationNumber']}
+                dropdownList={companies}
+                onChange={onChange}
+                onOpen={onOpen}
+                onClose={onClose}
+                searchAttributes={['organizationName', 'organizationNumber']}
+                locale="nb"
+            />,
+        );
+
+        expect(onOpen).not.toHaveBeenCalled();
+        expect(onClose).not.toHaveBeenCalled();
+    });
+
+    it('runs onOpen when opening dropdown and onClose when closing dropdown', async () => {
+        const onChange = jest.fn();
+        const onOpen = jest.fn();
+        const onClose = jest.fn();
+        const user = userEvent.setup();
+
+        render(
+            <>
+                <button>Knapp</button>
+                <SearchableDropdownMultiSelectButton
+                    id="id"
+                    labelledById="labelId"
+                    dropdownAttributes={['organizationName', 'organizationNumber']}
+                    dropdownList={companies}
+                    onChange={onChange}
+                    onOpen={onOpen}
+                    onClose={onClose}
+                    searchAttributes={['organizationName', 'organizationNumber']}
+                    locale="nb"
+                />
+            </>,
+        );
+
+        const input = screen.getByRole('combobox');
+        const button = screen.getByText('Knapp');
+
+        // Focus combobox to open dropdown
+        await user.click(input);
+        expect(onOpen).toHaveBeenCalledTimes(1);
+
+        // Unfocus combobox to close dropdown
+        await user.click(button);
+        expect(onClose).toHaveBeenCalledTimes(1);
+    });
 });

--- a/packages/ffe-searchable-dropdown-react/src/single/SearchableDropdown.spec.tsx
+++ b/packages/ffe-searchable-dropdown-react/src/single/SearchableDropdown.spec.tsx
@@ -1062,4 +1062,66 @@ describe('SearchableDropdown', () => {
         expect(onChange).toHaveBeenCalledWith(companies[2]);
         expect(input.getAttribute('value')).toEqual('812602552');
     });
+
+    it('runs onOpen callback when opening dropdown and onClose when closing dropdown', async () => {
+        const onOpen = jest.fn();
+        const onClose = jest.fn();
+
+        render(
+            <SearchableDropdown
+                id="id"
+                labelledById="labelId"
+                dropdownAttributes={['organizationName', 'organizationNumber']}
+                displayAttribute={'organizationNumber'}
+                dropdownList={companies}
+                onOpen={onOpen}
+                onClose={onClose}
+                searchAttributes={['organizationName', 'organizationNumber']}
+                locale="nb"
+            />,
+        );
+
+        expect(onOpen).not.toHaveBeenCalled();
+        expect(onClose).not.toHaveBeenCalled();
+    });
+
+    it('runs onOpen when opening dropdown and onClose when closing dropdown', async () => {
+        const onOpen = jest.fn();
+        const onClose = jest.fn();
+        const user = userEvent.setup();
+
+        render(
+            <>
+                <button>Knapp</button>
+                <SearchableDropdown
+                    id="id"
+                    labelledById="labelId"
+                    dropdownAttributes={[
+                        'organizationName',
+                        'organizationNumber',
+                    ]}
+                    displayAttribute={'organizationNumber'}
+                    dropdownList={companies}
+                    onOpen={onOpen}
+                    onClose={onClose}
+                    searchAttributes={[
+                        'organizationName',
+                        'organizationNumber',
+                    ]}
+                    locale="nb"
+                />
+            </>,
+        );
+
+        const input = screen.getByRole('combobox');
+        const button = screen.getByText('Knapp');
+
+        // Focus combobox to open dropdown
+        await user.click(input);
+        expect(onOpen).toHaveBeenCalledTimes(1);
+
+        // Unfocus combobox to close dropdown
+        await user.click(button);
+        expect(onClose).toHaveBeenCalledTimes(1);
+    });
 });

--- a/packages/ffe-searchable-dropdown-react/src/useIsExpandedCallbacks.ts
+++ b/packages/ffe-searchable-dropdown-react/src/useIsExpandedCallbacks.ts
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 
 interface Params {
     isExpanded: boolean;
@@ -11,8 +11,10 @@ export const useIsExpandedCallbacks = ({
     onOpen,
     onClose,
 }: Params) => {
+    const [isInitialRender, setIsInitialRender] = useState(true);
     useEffect(() => {
         const cb = isExpanded ? onOpen : onClose;
-        cb?.();
+        if (!isInitialRender) { cb?.() }
+        setIsInitialRender(false);
     }, [isExpanded, onOpen, onClose]);
 };


### PR DESCRIPTION
## Beskrivelse
I dag kjøres `onClose`-callbacks ved mount av SearchableDropdown og SearchableDropdownMultiSelect. Som navnet på callbacks tilsier bør denne kun kjøre ved åpning/lukking av dropdown, ikke ved mount.

## Motivasjon og kontekst
Endringen gjør at `onClose`-callbacket ikke kjøres ved første render.

## Testing
Har lagt ved komponenttester som tester at callbacket ikke kjøres ved mount.