### PR TITLE
docs: Legge til alternativt løsningsforslag for blå ikoner.

### DIFF
--- a/packages/ffe-icons-react/src/Icon.mdx
+++ b/packages/ffe-icons-react/src/Icon.mdx
@@ -43,9 +43,14 @@ ikonene til et passende format, for eksempel [base64](https://developer.mozilla.
 ### Ikonet vises ikke?
 
 Hvis ikonet ikke vises, men i stedet blir en firkantet boks etter deploy, kan det skyldes at SVG-filen ikke blir 
-riktig håndtert av byggeverktøyet. Prøv å legge til `build.assetsInlineLimit: 0` i `vite.config.ts` 
-for å sikre at SVG-ikonene ikke blir inlinet som data-URL-er.
+riktig håndtert av byggeverktøyet. To mulige løsninger er: 
+1. Legg til `build.assetsInlineLimit: 0` i `vite.config.ts` for å sikre at SVG-ikonene ikke blir inlinet som data-URL-er.  
+Merk at dette vil stoppe alt av assetinlining som Vite kan gjøre under bygg.
+2. Eller, legg til `?no-inline` på slutten av importsti for hvert ikon du importerer, eksempelvis vil import se slik ut:
 
+```
+import stacksIcon from "@sb1/ffe-icons/icons/open/500/sm/stacks.svg?no-inline"
+```
 
 ## Figma
 


### PR DESCRIPTION
## Beskrivelse

Oppdaterte docs med alternativt løsningsforslag som sørger for at ikoner blir importert på en slik måte at ffe-icons-react kan bruke dem.

## Motivasjon og kontekst

<!-- Hvorfor trengs denne endringen, og hva løser den? -->
`build.assetsInlineLimit: 0` vil skru av Vite sin mulighet til å inline assets i den produserte javascriptbundelen. Hvis en er spesifikk med `?no-inline` for de import'ene hvor det trengs så vil det gi muligheten til å fortsatt bruke ffe-icons-react, samtidig som en kan la Vite inline der den kan og dermed redusere nettverkskall for bruker.

## Testing

Ikke relevant? 😅 
