### PR TITLE
Datepicker fixes

### DIFF
--- a/packages/ffe-datepicker-react/src/calendar/Calendar.spec.tsx
+++ b/packages/ffe-datepicker-react/src/calendar/Calendar.spec.tsx
@@ -22,87 +22,159 @@ describe('Calendar', () => {
 
     it('renders standard calendar with correct header and days', () => {
         render(<Calendar {...defaultProps} />);
-        
+
         // Verify calendar structure
         expect(screen.getByRole('dialog')).toBeInTheDocument();
-        
+
         // Verify navigation buttons
-        expect(screen.getByRole('button', { name: /forrige måned/i })).toBeInTheDocument();
-        expect(screen.getByRole('button', { name: /neste måned/i })).toBeInTheDocument();
-        
+        expect(
+            screen.getByRole('button', { name: /forrige måned/i }),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole('button', { name: /neste måned/i }),
+        ).toBeInTheDocument();
+
         // Verify some days are present (15th is the selected date)
-        const dayButtons = screen.getAllByRole('button', { name: /\d+\. mai 2025/ });
+        const dayButtons = screen.getAllByRole('button', {
+            name: /\d+\. mai 2025/,
+        });
         expect(dayButtons.length).toBeGreaterThan(0);
     });
 
     it('renders calendar with dropdown caption when dropdownCaption is true', () => {
         render(<Calendar {...defaultProps} dropdownCaption={true} />);
-        
+
         // There should be dropdown selects for month and year
         const selects = screen.getAllByRole('combobox');
         expect(selects.length).toBe(2);
-        
+
         // Check for Dropdown elements
-        const monthDropdown = selects.find(select => 
-            select.closest('.ffe-calendar__month-select')
+        const monthDropdown = selects.find(select =>
+            select.closest('.ffe-calendar__month-select'),
         ) as HTMLSelectElement;
-        const yearDropdown = selects.find(select => 
-            select.closest('.ffe-calendar__year-select')
+        const yearDropdown = selects.find(select =>
+            select.closest('.ffe-calendar__year-select'),
         ) as HTMLSelectElement;
-        
+
         expect(monthDropdown).toBeInTheDocument();
         expect(yearDropdown).toBeInTheDocument();
-        
+
         // Verify the month dropdown shows current month (May = 5)
         expect(monthDropdown.value).toBe('5');
-        
+
         // Verify the year dropdown shows current year
         expect(yearDropdown.value).toBe('2025');
     });
-    
+
     it('navigates to a specific month and year when using dropdowns', async () => {
         const user = userEvent.setup();
         render(<Calendar {...defaultProps} dropdownCaption={true} />);
-        
+
         // Get the month dropdown by finding select in month-select container
-        const monthDropdown = screen.getAllByRole('combobox').find(select => 
-            select.closest('.ffe-calendar__month-select')
-        );
+        const monthDropdown = screen
+            .getAllByRole('combobox')
+            .find(select => select.closest('.ffe-calendar__month-select'));
         expect(monthDropdown).toBeInTheDocument();
-        
+
         // Change to December (month 12)
         await user.selectOptions(monthDropdown!, '12');
-        
+
         // Verify days have updated to December
-        const decemberDays = await screen.findAllByRole('button', { name: /\d+\. desember 2025/ });
+        const decemberDays = await screen.findAllByRole('button', {
+            name: /\d+\. desember 2025/,
+        });
         expect(decemberDays.length).toBeGreaterThan(0);
     });
-    
+
     it('allows selecting a date after navigation', async () => {
         const user = userEvent.setup();
         render(<Calendar {...defaultProps} dropdownCaption={true} />);
-        
+
         // Get the month dropdown
-        const monthDropdown = screen.getAllByRole('combobox').find(select => 
-            select.closest('.ffe-calendar__month-select')
-        );
+        const monthDropdown = screen
+            .getAllByRole('combobox')
+            .find(select => select.closest('.ffe-calendar__month-select'));
         expect(monthDropdown).toBeInTheDocument();
-        
+
         // Change to June (month 6)
         await user.selectOptions(monthDropdown!, '6');
-        
+
         // Wait for the June days to appear
-        const juneDays = await screen.findAllByRole('button', { name: /\d+\. juni 2025/ });
+        const juneDays = await screen.findAllByRole('button', {
+            name: /\d+\. juni 2025/,
+        });
         expect(juneDays.length).toBeGreaterThan(0);
-        
+
         // Find the day 10 button
-        const day10 = juneDays.find(button => button.textContent?.includes('10'));
+        const day10 = juneDays.find(button =>
+            button.textContent?.includes('10'),
+        );
         expect(day10).toBeInTheDocument();
-        
+
         // Click on day 10
         await user.click(day10!);
-        
+
         // Verify the date picker was called with the correct date
         expect(mockDatePicked).toHaveBeenCalledWith('10.06.2025');
+    });
+
+    it('disables dates before minDate', () => {
+        render(
+            <Calendar
+                {...defaultProps}
+                minDate="03.01.2025"
+                selectedDate="10.01.2025"
+            />,
+        );
+
+        const beforeMin = screen.getByRole('button', {
+            name: '2. januar 2025',
+        });
+        expect(beforeMin).toHaveAttribute('aria-disabled', 'true');
+
+        const inRange = screen.getByRole('button', { name: '10. januar 2025' });
+        expect(inRange).toHaveAttribute('aria-disabled', 'false');
+    });
+
+    it('disables dates after maxDate', () => {
+        render(
+            <Calendar
+                {...defaultProps}
+                maxDate="03.01.2025"
+                selectedDate="02.01.2025"
+            />,
+        );
+
+        const afterMax = screen.getByRole('button', {
+            name: '4. januar 2025',
+        });
+        expect(afterMax).toHaveAttribute('aria-disabled', 'true');
+
+        const inRange = screen.getByRole('button', { name: '2. januar 2025' });
+        expect(inRange).toHaveAttribute('aria-disabled', 'false');
+    });
+
+    it('disables dates outside of minDate and MaxDate', () => {
+        render(
+            <Calendar
+                {...defaultProps}
+                minDate="10.01.2025"
+                maxDate="15.01.2025"
+                selectedDate="12.01.2025"
+            />,
+        );
+
+        const beforeMin = screen.getByRole('button', {
+            name: '9. januar 2025',
+        });
+        expect(beforeMin).toHaveAttribute('aria-disabled', 'true');
+
+        const afterMax = screen.getByRole('button', {
+            name: '16. januar 2025',
+        });
+        expect(afterMax).toHaveAttribute('aria-disabled', 'true');
+
+        const inRange = screen.getByRole('button', { name: '12. januar 2025' });
+        expect(inRange).toHaveAttribute('aria-disabled', 'false');
     });
 });

--- a/packages/ffe-datepicker-react/src/calendar/Calendar.stories.tsx
+++ b/packages/ffe-datepicker-react/src/calendar/Calendar.stories.tsx
@@ -18,8 +18,8 @@ export const Standard: Story = {
         onDatePicked: (date: string) => null,
         selectedDate: '17.12.2024',
         focusOnMount: false,
-        minDate: '01.01.2020',
-        maxDate: '31.12.2030',
+        minDate: '10.01.2025',
+        maxDate: '15.01.2025',
     },
     render: function Render(args) {
         const [selectedDate, setSelectedDate] = useState<

--- a/packages/ffe-datepicker-react/src/calendar/Calendar.tsx
+++ b/packages/ffe-datepicker-react/src/calendar/Calendar.tsx
@@ -39,6 +39,8 @@ export class Calendar extends Component<CalendarProps, State> {
         this.state = {
             calendar: new SimpleCalendar(
                 getSimpleDateFromString(props?.selectedDate),
+                props.minDate,
+                props.maxDate,
                 props.locale,
             ),
             isFocusingHeader: false,
@@ -68,6 +70,8 @@ export class Calendar extends Component<CalendarProps, State> {
                 {
                     calendar: new SimpleCalendar(
                         getSimpleDateFromString(this.props.selectedDate),
+                        this.props.minDate,
+                        this.props.maxDate,
                         this.props.locale,
                     ),
                 },
@@ -264,10 +268,10 @@ export class Calendar extends Component<CalendarProps, State> {
         const { calendar } = this.state;
         let currentMonth = calendar.focusedDate.month + 1; // 1-indexed month
         let currentYear = calendar.focusedYear;
-        
+
         // Calculate how many months to move based on current and target date
         const monthsDiff = (year - currentYear) * 12 + (month - currentMonth);
-        
+
         if (monthsDiff < 0) {
             // Go backward
             for (let i = 0; i > monthsDiff; i--) {
@@ -279,7 +283,7 @@ export class Calendar extends Component<CalendarProps, State> {
                 calendar.nextMonth();
             }
         }
-        
+
         this.forceUpdate();
     }
 

--- a/packages/ffe-datepicker-react/src/datelogic/simplecalendar.ts
+++ b/packages/ffe-datepicker-react/src/datelogic/simplecalendar.ts
@@ -37,14 +37,29 @@ function firstDayOfMonth(simpledate: SimpleDate) {
     return clone.day;
 }
 
+function isDateWithinMinMax(
+    date: SimpleDate,
+    minDate: SimpleDate | null,
+    maxDate: SimpleDate | null,
+) {
+    if (minDate && date.isBefore(minDate)) {
+        return false;
+    }
+    return !(maxDate && date.isAfter(maxDate));
+}
+
 export class SimpleCalendar {
     locale: Locale;
     focusedDate: SimpleDate;
     selectedDate?: SimpleDate | null;
     firstDay: number;
+    minDate: SimpleDate | null;
+    maxDate: SimpleDate | null;
 
     constructor(
         initialDate?: SimpleDate | null,
+        minDate?: string | null,
+        maxDate?: string | null,
         locale: Locale = 'nb',
     ) {
         this.locale = locale;
@@ -52,6 +67,8 @@ export class SimpleCalendar {
             ? initialDate.clone()
             : getSimpleDateToday();
         this.selectedDate = initialDate ? initialDate.clone() : initialDate;
+        this.minDate = minDate ? getSimpleDateFromString(minDate) : null;
+        this.maxDate = maxDate ? getSimpleDateFromString(maxDate) : null;
 
         // Settings
         this.firstDay = i18n[locale].FIRST_DAY_OF_WEEK;
@@ -132,7 +149,7 @@ export class SimpleCalendar {
     }
 
     public isDateWithinDateRange(date: SimpleDate) {
-        return true; // Always allow all dates
+        return isDateWithinMinMax(date, this.minDate, this.maxDate);
     }
 
     public selectTimestamp(timestamp: number) {
@@ -189,7 +206,11 @@ export class SimpleCalendar {
                     isSelected:
                         !!this.selectedDate &&
                         currentDate.equal(this.selectedDate),
-                    isEnabled: true, // Always enable all dates
+                    isEnabled: isDateWithinMinMax(
+                        currentDate,
+                        this.minDate,
+                        this.maxDate,
+                    ),
                 };
                 week.dates.push(date);
                 currentDate.adjust({ period: 'D', offset: 1 });

--- a/packages/ffe-datepicker-react/src/datepicker/Datepicker.stories.tsx
+++ b/packages/ffe-datepicker-react/src/datepicker/Datepicker.stories.tsx
@@ -7,6 +7,10 @@ import { Datepicker, DatepickerProps } from './Datepicker';
 const meta: Meta<typeof Datepicker> = {
     title: 'Komponenter/Datepicker/Datepicker',
     component: Datepicker,
+    argTypes: {
+        minDate: { control: 'text' },
+        maxDate: { control: 'text' },
+    }
 };
 export default meta;
 

--- a/packages/ffe-datepicker/less/calendar.less
+++ b/packages/ffe-datepicker/less/calendar.less
@@ -152,7 +152,9 @@
         }
 
         &:active {
-            background: var(--ffe-color-component-form-input-fill-default-pressed);
+            background: var(
+                --ffe-color-component-form-input-fill-default-pressed
+            );
             color: var(--ffe-color-component-form-input-foreground-default);
         }
 
@@ -188,13 +190,13 @@
 
             @media (hover: hover) and (pointer: fine) {
                 &:hover {
-                    background: var(--ffe-color-fill-tertiary-subtle);
-                    color: var(--ffe-color-foreground-subtle);
-                }
-            }
+                    background: none;
+                    color: var(
+                        --ffe-color-component-form-input-foreground-disabled
+                    );
 
-            &-focus {
-                border-color: var(--ffe-color-foreground-subtle);
+                    cursor: not-allowed;
+                }
             }
         }
     }


### PR DESCRIPTION
(oppdatert av Tuva) 
fixes #2951 og #2960 

Legger tilbake min og maxDate, det var en bug at det ikke fungerte. 
Nå fungerer det også å sende inn min/maxDate til datepicker som bruker `dropdownCaption`, har testet det i DSBanken. 

Har gjort om så storybook skjønner at det er en streng som skal sendes inn, men storybook er ganske flaky om det fungerer ikke. Den får i alle fall riktig verdi, men jeg opplever at det ikke er mulig å endre verdien i storybook (den bare hopper tilbake til den verdien den var). Jeg undersøkte om det var fordi args ikke var sendt direkte (det har vært en feil tidligere, at man ikke bruker (args) => <Comp {...args}/>, da vil man ikke kunne justere controls i storybook), men det så ikke ut til å fikse feilen, så jeg droppet å gjøre den endringen i eksemplene. 

<img width="421" height="127" alt="image" src="https://github.com/user-attachments/assets/aad6c33c-ae18-4d49-8673-7bbaf68c8d2b" />

Vi har også lagt til disabled-styling 
<img width="368" height="469" alt="image" src="https://github.com/user-attachments/assets/615c5413-794b-412e-b004-2d29821c8a60" />
Kjent "feil": Hvis en dato er disabled OG Selected så er hover-effekten litt rar. Men er så knot å fikse og et veldig lite sannsynlig scenario, så tenker det går fint. Selected og disabled ser slik ut 
<img width="392" height="525" alt="image" src="https://github.com/user-attachments/assets/440029fd-5ccc-4f3e-9c05-42e4f71695fd" />

