### PR TITLE
Chip selectable fix

### DIFF
--- a/packages/ffe-chips-react/src/ChipSelectable.stories.tsx
+++ b/packages/ffe-chips-react/src/ChipSelectable.stories.tsx
@@ -18,9 +18,11 @@ export const Standard: Story = {
     render: args => {
         const [chip1Selected, setChip1Selected] = React.useState(false);
         const [chip2Selected, setChip2Selected] = React.useState(true);
+        const [chip3Selected, setChip3Selected] = React.useState(false);
+        const [chip4Selected, setChip4Selected] = React.useState(true);
 
         return (
-            <div className="storybook-button-display-group">
+            <div style={{display: 'flex', gap: '8px', flexWrap: 'wrap'}}>
                 <ChipSelectable
                     {...args}
                     isSelected={chip1Selected}
@@ -34,6 +36,20 @@ export const Standard: Story = {
                     onClick={() => setChip2Selected(!chip2Selected)}
                 >
                     Selected Chip
+                </ChipSelectable>
+                <ChipSelectable
+                    {...args}
+                    isSelected={chip3Selected}
+                    onClick={() => setChip3Selected(!chip3Selected)}
+                >
+                    Chip
+                </ChipSelectable>
+                <ChipSelectable
+                    {...args}
+                    isSelected={chip4Selected}
+                    onClick={() => setChip4Selected(!chip4Selected)}
+                >
+                    Chip
                 </ChipSelectable>
             </div>
         );

--- a/packages/ffe-chips-react/src/ChipSelectable.tsx
+++ b/packages/ffe-chips-react/src/ChipSelectable.tsx
@@ -23,9 +23,12 @@ function ChipSelectableForwardRef<As extends ElementType>(
         <Chip
             ref={ref}
             leftIcon={<Icon size="sm" fileUrl={checkOpen400Sm} />}
-            className={classNames(className, {
-                'ffe-chip--selected': isSelected,
-            })}
+            className={classNames(className,
+                {
+                    'ffe-chip--selectable': !isSelected,
+                    'ffe-chip--selected': isSelected,
+                }
+            )}
             {...rest}
         />
     );

--- a/packages/ffe-chips/less/chip.less
+++ b/packages/ffe-chips/less/chip.less
@@ -56,6 +56,10 @@
         transform: scale(0.97);
     }
 
+    &--selectable .ffe-icons {
+        display: none;
+    }
+
     &--selected {
         --background-color: var(--ffe-color-fill-primary-selected-default);
         --border-color: var(--ffe-color-border-interactive-selected);


### PR DESCRIPTION
fixes #3057 

Skjuler check-ikonet når `ChipSelectable` ikke er valgt. 
I dag var check-ikonet synlig uansett om chip var selected eller ikke, det kunne være forvirrende for brukeren. 

<img width="361" height="58" alt="image" src="https://github.com/user-attachments/assets/5545ca00-0dac-48f7-b720-f2f372caeda3" />

Nå er denne fjernet. Ulempen er at flere chips på rad som skal velges vil hoppe siden bredden på chippen vil variere. Vi har vurdert det som en bedre brukeropplevelse enn at brukeren kanskje tar feil. Vi ser på en forbedret versjon senere. 

Testet i DSBanken også
<img width="624" height="108" alt="image" src="https://github.com/user-attachments/assets/b8b3b9af-2df5-4323-ab8c-5def9e040d70" />
