### PR TITLE
fix(ffe-core): fiks slik at script for å bygge farger til native blir publisert

### DIFF
--- a/packages/ffe-core/package.json
+++ b/packages/ffe-core/package.json
@@ -9,7 +9,9 @@
         "lib",
         "es",
         "less",
-        "css"
+        "css",
+        "scripts",
+        "tokens"
     ],
     "main": "lib/index.js",
     "module": "es/index.js",


### PR DESCRIPTION
Scriptene build colors kom ikke med i tidligere versjoner av ffe core