### PR TITLE
Fiks at border-radius på heading-button på accordion-items hopper mellom 16px og 0 uten animasjon

### DIFF
--- a/packages/ffe-accordion/less/ffe-accordion.less
+++ b/packages/ffe-accordion/less/ffe-accordion.less
@@ -21,6 +21,7 @@
         border: var(--ffe-g-border-width) solid var(--ffe-v-accordion-border-color);
         outline: var(--ffe-g-outline-width) solid transparent;
         outline-offset: var(--ffe-g-outline-offset);
+        overflow: hidden;
 
         @media (hover: hover) and (pointer: fine) {
             &:hover {
@@ -59,12 +60,7 @@
             cursor: pointer;
             outline: none;
             color: var(--ffe-v-accordion-header-text-color);
-            border-radius: 16px;
             transition: background-color var(--ffe-transition-duration) var(--ffe-ease);
-
-            &--open {
-                border-radius: 16px 16px 0 0;
-            }
 
             @media (hover: hover) and (pointer: fine) {
                 &:hover {


### PR DESCRIPTION
## Beskrivelse

Gir .ffe-accordion-item overflow hidden slik at dens border radius vil skjule innhold, og fjerner spesifisert border radius fra .ffe-accordion-item__heading-button

Før:
[Screencast_20250910_091400.webm](https://github.com/user-attachments/assets/ce582d7f-9e76-44ec-a159-2a497f39e7db)

Etter:
[Screencast_20250918_100021.webm](https://github.com/user-attachments/assets/f5f339b2-4087-4675-a52c-d85d9df3e95d)

## Motivasjon og kontekst

Denne endringen trengs for å gjøre åpningen av accordions jevnere og med færre "hopp" i synlige egenskaper. Innholdet i en accordion forsvinner fortsatt i samme øyeblikk accordionen lukkes, men dette kan fikses i en senere PR.

## Testing

Har kjørt `npm test` og sjekket i Storybooken at komponenten ser ut som tiltenkt ved åpning og lukking i light, accent og dark mode.
