### PR TITLE
Ny komponent - TextField

### DIFF
--- a/documentation/Changelog.mdx
+++ b/documentation/Changelog.mdx
@@ -8,6 +8,10 @@ Denne siden lister breaking changes og større endringer i designsystemet. For a
 
 F.eks: https://github.com/SpareBank1/designsystem/blob/develop/packages/ffe-core/CHANGELOG.md
 
+## 2025 - September - Ny komponent: TextField
+
+Vi har laget en ny komponent, `<TextField>`. Dette er en avart av `<Input>`, som er laget for å støtte affikser (prefix og suffix) i input-feltet - funksjonalitet som har vært etterspurt av flere team. Dette er ikke er mulig å legge til i dagens implementasjon av `<Input>` uten en større omskrivning med breaking changes, noe som i tillegg ville påvirket andre komponenter som avhenger av `<Input>`.
+
 ## 2025 - September - Ett versjonsnummer for alle pakker og justering av darkmode bakgrunnsfarger
 Fra og med denne versjonen (100.0.0) vil alle pakker i designsystemet ha samme versjonsnummer.
 Dette er et mellomsteg før vi går over til én pakke for hele designsystemet.
@@ -24,7 +28,6 @@ Det er ikke gjort noen endringer i koden eller på variabelnavn, det er kun farg
     src="./images/background-colors.png"
     style={{ maxHeight: '400px', marginBottom: '50px' }}
 />
-
 
 ## 2025 - Juli - Oppdatering av semantiske farger
 
@@ -54,23 +57,23 @@ Disse må skiftes ut med farger fra context laget som dere finner på [siden om 
 
 #### Foreground
 
-`--ffe-color-foreground-on-fill-default` erstattes med `--ffe-color-foreground-inverse` <br/>
+`--ffe-color-foreground-on-fill-default` erstattes med `--ffe-color-foreground-inverse`
 `--ffe-color-foreground-on-fill-inverse` erstattes med `--ffe-color-foreground-default`
 
 #### Fill
 
-`--ffe-color-fill-primary-hover` erstattes med `--ffe-color-fill-primary-default-hover` <br/>
+`--ffe-color-fill-primary-hover` erstattes med `--ffe-color-fill-primary-default-hover`
 `--ffe-color-fill-primary-pressed` erstattes med `--ffe-color-fill-primary-default-pressed`
 
 #### Border
 
-Fjernet: <br/>
-`--ffe-color-border-secondary-*` <br/>
+Fjernet: 
+`--ffe-color-border-secondary-*` 
 `--ffe-color-border-tertiary-*`
 
-bruk <br/>
-`--ffe-color-border-primary-default` <br/>
-`--ffe-color-border-primary-subtle` <br/>
+bruk 
+`--ffe-color-border-primary-default` 
+`--ffe-color-border-primary-subtle` 
 `--ffe-color-border-primary-emphasis`
 i stedet
 
@@ -78,10 +81,10 @@ i stedet
 
 Alle skjemaelementer har nå fått en gul focus-border. Komponentene blir nå lettere å se for brukere med nedsatt synsevne, og fokus-stilen fungerer på både hvit og blå bakgrunn (accent context).
 
-Alle skjemaelementer bruker også nå egne input-farger <br />
-`--ffe-color-component-form-input-fill-default` <br />
-`--ffe-color-component-form-input-foreground-default` <br />
-`--ffe-color-component-form-input-foreground-subtle` <br />
+Alle skjemaelementer bruker også nå egne input-farger
+`--ffe-color-component-form-input-fill-default`
+`--ffe-color-component-form-input-foreground-default`
+`--ffe-color-component-form-input-foreground-subtle`
 `--ffe-color-component-form-input-border-active`
 
 Checkbox (Ved keyboard focus)
@@ -166,7 +169,7 @@ Tooltip (ny farge)
 />
 
 
-Obs: `--ffe-color-border-interactive-focus` får ny farge, og kan ikke brukes til active-states lenger.  <br/>
+Obs: `--ffe-color-border-interactive-focus` får ny farge, og kan ikke brukes til active-states lenger. 
 `component-input-border-active` kan brukes til det.
 
 
@@ -184,24 +187,24 @@ Obs: `--ffe-color-border-interactive-focus` får ny farge, og kan ikke brukes ti
     alt="image"
     src="https://github.com/user-attachments/assets/c1b8ef7e-da7e-440a-b87f-b8509a4dfb2e"
 />
-<br/>
-<br/>
+
+
 
 ### Nye fargevariabler
-Vi har også lagt til flere farger. Det har blitt flere neutral-varianter:  <br/>
-`--ffe-color-surface-neutral-*` <br/>
-`--ffe-color-fill-neutral-default-*`  <br/>
-`--ffe-color-fill-neutral-subtle-*`  <br/>
-`--ffe-color-fill-neutral-extra-subtle-*`  <br/>
+Vi har også lagt til flere farger. Det har blitt flere neutral-varianter:  
+`--ffe-color-surface-neutral-*` 
+`--ffe-color-fill-neutral-default-*`  
+`--ffe-color-fill-neutral-subtle-*`  
+`--ffe-color-fill-neutral-extra-subtle-*`  
 i tillegg til input-variabler som nevnt over. 
- <br/>
+ 
 
  ## 2025 - Mars - Bølgen trukket ut i egen pakke
  Bølgen, `Wave`, som tidligere har ligget i `ffe-core-react` er nå deprecated fra core 
  og flyttet ut i egne pakker - `ffe-shapes-react` og `ffe-shapes`.
  Dette gjør det lettere å vedlikeholde og oppdatere komponenten. 
  Den har også fått noen nye endringer i forbindelse med oppdatering av de semantiske fargene: 
- <br/>
+ 
  Ikke lenger tilgjengelig: 
 - `color`
 - `darkModeColor`

--- a/packages/ffe-chips/less/chip.less
+++ b/packages/ffe-chips/less/chip.less
@@ -18,9 +18,9 @@
     background: var(--background-color);
     color: var(--text-color);
     border-radius: var(--border-radius);
-    transition-property: background-color, transform, border-color, color;
-    transition-duration: var(--ffe-transition-duration);
-    transition-timing-function: var(--ffe-ease);
+    transition: all var(--ffe-transition-duration) var(--ffe-ease);
+    outline: var(--ffe-g-outline-width) solid transparent;
+    outline-offset: var(--ffe-g-outline-offset);
     cursor: pointer;
 
     .ffe-icons,
@@ -45,8 +45,7 @@
     }
 
     &:focus-visible {
-        outline: 2px solid var(--ffe-color-border-interactive-focus);
-        outline-offset: 3px;
+        outline-color: var(--ffe-color-border-interactive-focus);
     }
 
     &:active {

--- a/packages/ffe-datepicker/less/dateinput.less
+++ b/packages/ffe-datepicker/less/dateinput.less
@@ -11,11 +11,14 @@
     border: var(--ffe-g-border-width) solid
         var(--ffe-color-border-primary-default);
     border-radius: var(--ffe-g-border-radius);
+    outline-offset: var(--ffe-g-outline-offset);
+    outline: var(--ffe-g-outline-width) solid transparent;
     transition:
         color var(--ffe-transition-duration) var(--ffe-ease),
         border var(--ffe-transition-duration) var(--ffe-ease),
         box-shadow var(--ffe-transition-duration) var(--ffe-ease),
-        background-color var(--ffe-transition-duration) var(--ffe-ease);
+        background-color var(--ffe-transition-duration) var(--ffe-ease),
+        outline var(--ffe-transition-duration) var(--ffe-ease);
     &--full-width {
         width: 100%;
     }
@@ -47,7 +50,6 @@
 
     &:focus-within,
     &:has(&__button:focus) .ffe-input-field:hover {
-        outline: none;
         box-shadow: var(--ffe-g-border-focus-box-shadow)
             var(--ffe-color-component-form-input-border-active);
         border-color: var(--ffe-color-component-form-input-border-active);
@@ -55,9 +57,7 @@
 
     @media (pointer: fine) {
         &:focus-within {
-            outline: var(--ffe-g-outline-width) solid
-                var(--ffe-color-border-interactive-focus);
-            outline-offset: var(--ffe-g-outline-offset);
+            outline-color: var(--ffe-color-border-interactive-focus);
         }
     }
 

--- a/packages/ffe-form-react/src/TextField.mdx
+++ b/packages/ffe-form-react/src/TextField.mdx
@@ -1,0 +1,27 @@
+import { Canvas, Meta, Controls } from '@storybook/blocks';
+import * as TextFieldStories from './TextField.stories.tsx';
+
+<Meta of={TextFieldStories} />
+
+# TextField
+
+`<TextField>` er en avart av [Input](.?path=/docs/komponenter-form-input--docs), der stylingen i stor grad er lagt på en wrapper i stedet for på selve input-feltet. Dette gjør det blant annet mulig å legge til støtte for affikser. Visuelt er `<TextField>` og `<Input>` identiske.
+
+## Forhåndsvisning
+
+<Canvas of={TextFieldStories.Standard} />
+<Controls of={TextFieldStories.Standard} />
+
+## Med affikser
+
+Affikser i inputfeltet kan sendes inn med propene `prefix` eller `suffix` på `<TextField>`.
+
+<Canvas of={TextFieldStories.WithAffixes} />
+<Controls of={TextFieldStories.WithAffixes} />
+
+## Med feilmelding
+
+Sender man inn en string eller et `<ErrorFieldMessage>`-element til `fieldMessage` på `<InputGroup>` vil input-feltet rendres med `aria-invalid` og en feilmelding.
+
+<Canvas of={TextFieldStories.FieldMessage} />
+<Controls of={TextFieldStories.FieldMessage} />

--- a/packages/ffe-form-react/src/TextField.spec.tsx
+++ b/packages/ffe-form-react/src/TextField.spec.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { TextField, TextFieldProps } from './TextField';
+import { render, screen } from '@testing-library/react';
+
+const TEST_ID = 'textfield-test-id';
+const renderTextField = (props?: Partial<TextFieldProps>) =>
+    render(<TextField {...props} />);
+
+describe('<TextField />', () => {
+    it('renders an input element', () => {
+        renderTextField();
+        const textfield = screen.getByRole('textbox');
+        expect(textfield.classList.contains('ffe-text-field')).toBeTruthy();
+    });
+
+    it('renders affixes', () => {
+        renderTextField({ prefix: 'Prefix', suffix: 'Suffix' });
+        const textfield = screen.getByRole('textbox');
+        const wrapper = textfield.parentElement;
+        expect(wrapper && wrapper.querySelector('.ffe-text-field__prefix')).toBeTruthy();
+        expect(wrapper && wrapper.querySelector('.ffe-text-field__suffix')).toBeTruthy();
+    });
+
+    it('passes props', () => {
+        renderTextField({
+            autoComplete: 'off',
+            className: 'app-textfield',
+        });
+        const textfield = screen.getByRole('textbox');
+        const wrapper = textfield.parentElement;
+        expect(textfield.getAttribute('autoComplete')).toBe('off');
+        expect(wrapper && wrapper.classList.contains('app-textfield')).toBeTruthy();
+        expect(textfield.classList.contains('ffe-text-field')).toBeTruthy();
+    });
+
+    it('sets the correct class for inline-modifer', () => {
+        const { rerender } = render(<TextField data-testid={TEST_ID} />);
+        const textfield = screen.getByTestId(TEST_ID);
+        const wrapper = textfield.parentElement;
+        expect(wrapper && wrapper.classList.contains('ffe-text-field__wrapper--inline')).toBeFalsy();
+        rerender(<TextField inline={true} />);
+        expect(wrapper && wrapper.classList.contains('ffe-text-field__wrapper--inline')).toBeTruthy();
+    });
+
+    it('sets the correct class for textRightAlign', () => {
+        const { rerender } = render(<TextField />);
+        const textfield = screen.getByRole('textbox');
+        expect(
+            textfield.classList.contains('ffe-text-field--text-right-align'),
+        ).toBeFalsy();
+        rerender(<TextField textRightAlign={true} />);
+        expect(
+            textfield.classList.contains('ffe-text-field--text-right-align'),
+        ).toBeTruthy();
+    });
+});

--- a/packages/ffe-form-react/src/TextField.stories.tsx
+++ b/packages/ffe-form-react/src/TextField.stories.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { TextField } from './TextField';
+import { InputGroup } from './InputGroup';
+import type { StoryObj, Meta } from '@storybook/react';
+import { ErrorFieldMessage } from './message';
+
+const meta: Meta<typeof TextField> = {
+    title: 'Komponenter/Form/TextField',
+    component: TextField,
+};
+export default meta;
+
+type Story = StoryObj<typeof TextField>;
+
+export const Standard: Story = {
+    args: {
+        inline: false,
+        textRightAlign: false,
+    },
+    render: args => (
+        <InputGroup label="Navn">
+            <TextField {...args} />
+        </InputGroup>
+    ),
+};
+
+export const WithAffixes: Story = {
+    args: {
+        inline: false,
+        textRightAlign: false,
+        prefix: 'Prefix',
+        suffix: 'Suffix',
+    },
+    render: args => (
+        <InputGroup label="Navn">
+            <TextField {...args} />
+        </InputGroup>
+    ),
+};
+
+export const FieldMessage: Story = {
+    args: {
+        ...Standard.args,
+    },
+    render: args => (
+        <InputGroup
+            fieldMessage={<ErrorFieldMessage>Feilmelding</ErrorFieldMessage>}
+        >
+            <TextField {...args} />
+        </InputGroup>
+    ),
+};

--- a/packages/ffe-form-react/src/TextField.tsx
+++ b/packages/ffe-form-react/src/TextField.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import classNames from 'classnames';
+
+export interface TextFieldProps extends React.ComponentPropsWithoutRef<'input'> {
+    /** Text fields default to `display: block;`. Set this to `true` to apply the inline modifier. */
+    inline?: boolean;
+    /** Make the text right aligned */
+    textRightAlign?: boolean;
+    /** Add a prefix inside the input */
+    prefix?: string;
+    /** Add a suffix inside the input */
+    suffix?: string;
+}
+
+export const TextField = React.forwardRef<HTMLInputElement, TextFieldProps>(
+    ({ className, inline, textRightAlign, prefix, suffix, ...rest }, ref) => {
+        return (
+            <div className={classNames(
+                'ffe-text-field__wrapper',
+                'ffe-default-mode',
+                { 'ffe-text-field__wrapper--inline': inline },
+                className,
+            )}>
+                {prefix && (
+                    <div className="ffe-text-field__prefix">
+                        {prefix}
+                    </div>
+                )}
+                <input
+                    className={classNames(
+                        'ffe-text-field',
+                        'ffe-default-mode',
+                        { 'ffe-text-field--text-right-align': textRightAlign },
+                    )}
+                    ref={ref}
+                    {...rest}
+                />
+                {suffix && (
+                    <div className="ffe-text-field__suffix">
+                        {suffix}
+                    </div>
+                )}
+            </div>
+        );
+    },
+);

--- a/packages/ffe-form-react/src/index.ts
+++ b/packages/ffe-form-react/src/index.ts
@@ -24,5 +24,6 @@ export {
 } from './RadioButtonInputGroup';
 export { RadioSwitch, RadioSwitchProps } from './RadioSwitch';
 export { TextArea, TextAreaProps } from './TextArea';
+export { TextField, TextFieldProps } from './TextField';
 export { Tooltip, TooltipProps } from './Tooltip';
 export { ToggleSwitch, ToggleSwitchProps } from './ToggleSwitch';

--- a/packages/ffe-form/less/checkbox.less
+++ b/packages/ffe-form/less/checkbox.less
@@ -9,7 +9,7 @@
     grid-column-gap: var(--ffe-spacing-xs);
     align-items: center;
     cursor: pointer;
-    transition: width var(--ffe-transition-duration) var(--ffe-ease);
+    transition: all var(--ffe-transition-duration) var(--ffe-ease);
     font-family: var(--ffe-g-font);
     font-variant-numeric: tabular-nums;
     text-align: left;
@@ -86,11 +86,14 @@
         outline: none;
     }
 
-    &:focus-visible + .ffe-checkbox {
-        outline: var(--ffe-g-outline-width) solid
-            var(--ffe-color-border-interactive-focus);
+    + .ffe-checkbox {
+        outline: var(--ffe-g-outline-width) solid transparent;
         outline-offset: var(--ffe-g-outline-offset);
         border-radius: var(--ffe-g-outline-border-radius);
+    }
+
+    &:focus-visible + .ffe-checkbox {
+        outline-color: var(--ffe-color-border-interactive-focus);
     }
 
     @media (hover: hover) and (pointer: fine) {

--- a/packages/ffe-form/less/dropdown.less
+++ b/packages/ffe-form/less/dropdown.less
@@ -10,7 +10,8 @@
     background-size: 24px 24px;
     background-repeat: no-repeat;
     background-position: calc(100% - 6px) 50%;
-    border: var(--ffe-g-border-width) solid var(--ffe-color-border-primary-default);
+    border: var(--ffe-g-border-width) solid
+        var(--ffe-color-border-primary-default);
     border-radius: var(--ffe-g-border-radius);
     color: var(--ffe-color-component-form-input-foreground-default);
     display: block;
@@ -18,13 +19,11 @@
     font-variant-numeric: tabular-nums;
     height: 2.8125rem;
     padding: 0 var(--ffe-spacing-lg) 0 var(--ffe-spacing-sm);
-    transition:
-        color var(--ffe-transition-duration) var(--ffe-ease),
-        border var(--ffe-transition-duration) var(--ffe-ease),
-        box-shadow var(--ffe-transition-duration) var(--ffe-ease),
-        background-color var(--ffe-transition-duration) var(--ffe-ease);
+    transition: all var(--ffe-transition-duration) var(--ffe-ease);
     width: 100%;
     font-size: var(--ffe-fontsize-form-dropdown);
+    outline: var(--ffe-g-outline-width) solid transparent;
+    outline-offset: var(--ffe-g-outline-offset);
     .chevron(@ffe-color-chevron-light-default);
 
     &.ffe-default-mode {
@@ -40,23 +39,25 @@
     @media (hover: hover) and (pointer: fine) {
         &:hover {
             border-color: var(--ffe-color-border-primary-default-hover);
-            box-shadow: var(--ffe-g-border-focus-box-shadow) var(--ffe-color-border-primary-default-hover);
+            box-shadow: var(--ffe-g-border-focus-box-shadow)
+                var(--ffe-color-border-primary-default-hover);
         }
     }
 
     &:focus-within {
-        outline: var(--ffe-g-outline-width) solid var(--ffe-color-border-interactive-focus);
-        outline-offset: var(--ffe-g-outline-offset);
+        outline-color: var(--ffe-color-border-interactive-focus);
     }
 
     &:focus {
         border-color: var(--ffe-color-component-form-input-border-active);
-        box-shadow: var(--ffe-g-border-focus-box-shadow) var(--ffe-color-component-form-input-border-active);
+        box-shadow: var(--ffe-g-border-focus-box-shadow)
+            var(--ffe-color-component-form-input-border-active);
     }
 
     &:active {
         border-color: var(--ffe-color-component-form-input-border-active);
-        box-shadow: var(--ffe-g-border-focus-box-shadow) var(--ffe-color-component-form-input-border-active);
+        box-shadow: var(--ffe-g-border-focus-box-shadow)
+            var(--ffe-color-component-form-input-border-active);
     }
 
     &--inline {
@@ -71,16 +72,19 @@
 
     &[aria-invalid='true'] {
         color: var(--ffe-color-foreground-feedback-critical);
-        border: var(--ffe-g-border-width) solid var(--ffe-color-border-feedback-critical);
-        box-shadow: var(--ffe-g-border-focus-box-shadow) var(--ffe-color-border-feedback-critical);
+        border: var(--ffe-g-border-width) solid
+            var(--ffe-color-border-feedback-critical);
+        box-shadow: var(--ffe-g-border-focus-box-shadow)
+            var(--ffe-color-border-feedback-critical);
         background-color: var(--ffe-color-surface-feedback-critical);
 
         @media (hover: hover) and (pointer: fine) {
-
             &:hover,
             &:focus {
-                border: var(--ffe-g-border-width) solid var(--ffe-color-border-feedback-critical);
-                box-shadow: var(--ffe-g-border-focus-box-shadow) var(--ffe-color-border-feedback-critical);
+                border: var(--ffe-g-border-width) solid
+                    var(--ffe-color-border-feedback-critical);
+                box-shadow: var(--ffe-g-border-focus-box-shadow)
+                    var(--ffe-color-border-feedback-critical);
                 background-color: var(--ffe-color-surface-primary-default);
             }
         }

--- a/packages/ffe-form/less/form.less
+++ b/packages/ffe-form/less/form.less
@@ -8,6 +8,7 @@
 @import 'radio-switch';
 @import 'radio-block';
 @import 'phone-number';
+@import 'text-field';
 @import 'toggle-switch';
 
 /* Form Layout */

--- a/packages/ffe-form/less/input-field.less
+++ b/packages/ffe-form/less/input-field.less
@@ -9,11 +9,9 @@
     border-radius: var(--ffe-g-border-radius);
     border: var(--ffe-g-border-width) solid
         var(--ffe-color-border-primary-default);
-    transition:
-        color var(--ffe-transition-duration) var(--ffe-ease),
-        border var(--ffe-transition-duration) var(--ffe-ease),
-        box-shadow var(--ffe-transition-duration) var(--ffe-ease),
-        background-color var(--ffe-transition-duration) var(--ffe-ease);
+    transition: all var(--ffe-transition-duration) var(--ffe-ease);
+    outline: var(--ffe-g-outline-width) solid transparent;
+    outline-offset: var(--ffe-g-outline-offset);
     width: 100%;
     font-size: var(--ffe-fontsize-form-input);
 
@@ -39,9 +37,7 @@
             var(--ffe-color-fill-primary-selected-default);
         box-shadow: var(--ffe-g-border-focus-box-shadow)
             var(--ffe-color-fill-primary-selected-default);
-        outline: var(--ffe-g-outline-width) solid
-            var(--ffe-color-border-interactive-focus);
-        outline-offset: var(--ffe-g-outline-offset);
+        outline-color: var(--ffe-color-border-interactive-focus);
     }
 
     &--inline {
@@ -65,11 +61,7 @@
         padding: 0;
         display: inline-block;
         height: 2em;
-        transition:
-            color var(--ffe-transition-duration) var(--ffe-ease),
-            border var(--ffe-transition-duration) var(--ffe-ease),
-            box-shadow var(--ffe-transition-duration) var(--ffe-ease),
-            background-color var(--ffe-transition-duration) var(--ffe-ease);
+        transition: all var(--ffe-transition-duration) var(--ffe-ease);
         background-color: transparent;
         border-radius: 2px;
 

--- a/packages/ffe-form/less/radio-block.less
+++ b/packages/ffe-form/less/radio-block.less
@@ -14,11 +14,7 @@
     &__content,
     &__header {
         cursor: pointer;
-        transition:
-            color var(--ffe-transition-duration) var(--ffe-ease),
-            border var(--ffe-transition-duration) var(--ffe-ease),
-            box-shadow var(--ffe-transition-duration) var(--ffe-ease),
-            background-color var(--ffe-transition-duration) var(--ffe-ease);
+        transition: all var(--ffe-transition-duration) var(--ffe-ease);
     }
 
     &__content {
@@ -32,6 +28,9 @@
         border: var(--ffe-g-border-width) solid var(--outer-border-color);
         border-radius: var(--ffe-g-border-radius);
         overflow: hidden;
+        transition: all var(--ffe-transition-duration) var(--ffe-ease);
+        outline: var(--ffe-g-outline-width) solid transparent;
+        outline-offset: var(--ffe-g-outline-offset);
 
         &::before {
             place-self: center;
@@ -128,7 +127,6 @@
     &:focus + .ffe-radio-block__content {
         --outer-border-color: var(--ffe-color-border-interactive-selected);
 
-        outline: none;
         box-shadow: var(--ffe-g-border-focus-box-shadow)
             var(--ffe-color-border-interactive-selected);
     }
@@ -138,9 +136,7 @@
     }
 
     &:focus-visible + .ffe-radio-block__content {
-        outline: var(--ffe-g-outline-width) solid
-            var(--ffe-color-border-interactive-focus);
-        outline-offset: var(--ffe-g-outline-offset);
+        outline-color: var(--ffe-color-border-interactive-focus);
     }
 
     &:disabled + .ffe-radio-block__content {

--- a/packages/ffe-form/less/radio-button.less
+++ b/packages/ffe-form/less/radio-button.less
@@ -14,7 +14,9 @@
     align-items: center;
     position: relative;
     cursor: pointer;
-    transition: width var(--ffe-transition-duration) var(--ffe-ease-in-out-back);
+    outline: var(--ffe-g-outline-width) solid transparent;
+    outline-offset: var(--ffe-g-outline-offset);
+    transition: all var(--ffe-transition-duration) var(--ffe-ease);
     text-align: left;
     padding-left: 0;
     padding-top: 1px;
@@ -116,9 +118,7 @@
     }
 
     &:focus-visible + .ffe-radio-button {
-        outline: var(--ffe-g-outline-width) solid
-            var(--ffe-color-border-interactive-focus);
-        outline-offset: var(--ffe-g-outline-offset);
+        outline-color: var(--ffe-color-border-interactive-focus);
     }
 
     &:disabled + .ffe-radio-button {

--- a/packages/ffe-form/less/radio-switch.less
+++ b/packages/ffe-form/less/radio-switch.less
@@ -4,7 +4,8 @@
     --radio-switch-background: var(--ffe-color-surface-primary-default);
 
     color: var(--ffe-color-foreground-default);
-    padding: var(--ffe-spacing-xs) var(--ffe-spacing-md) var(--ffe-spacing-xs) var(--ffe-spacing-xs);
+    padding: var(--ffe-spacing-xs) var(--ffe-spacing-md) var(--ffe-spacing-xs)
+        var(--ffe-spacing-xs);
     grid-template-columns: auto 1fr;
     grid-column-gap: var(--ffe-spacing-xs);
     position: relative;
@@ -16,12 +17,10 @@
     text-align: left;
     font-family: var(--ffe-g-font);
     font-variant-numeric: tabular-nums;
+    outline: var(--ffe-g-outline-width) solid transparent;
+    outline-offset: var(--ffe-g-outline-offset);
     cursor: pointer;
-    transition:
-        color var(--ffe-transition-duration) var(--ffe-ease),
-        border var(--ffe-transition-duration) var(--ffe-ease),
-        box-shadow var(--ffe-transition-duration) var(--ffe-ease),
-        background-color var(--ffe-transition-duration) var(--ffe-ease);
+    transition: all var(--ffe-transition-duration) var(--ffe-ease);
     margin-bottom: var(--ffe-spacing-2xs);
     margin-top: var(--ffe-spacing-sm);
     line-height: 1.5;
@@ -47,14 +46,16 @@
 
             background-color: var(--ffe-color-surface-primary-default-hover);
             border-color: var(--ffe-color-border-primary-default-hover);
-            box-shadow: var(--ffe-g-border-focus-box-shadow) var(--ffe-color-border-primary-default-hover);
+            box-shadow: var(--ffe-g-border-focus-box-shadow)
+                var(--ffe-color-border-primary-default-hover);
         }
     }
 
     &:active {
         background-color: var(--ffe-color-surface-primary-default-pressed);
         border-color: var(--ffe-color-border-primary-default-pressed);
-        box-shadow: var(--ffe-g-border-focus-box-shadow) var(--ffe-color-border-primary-default-pressed);
+        box-shadow: var(--ffe-g-border-focus-box-shadow)
+            var(--ffe-color-border-primary-default-pressed);
     }
 
     @media (min-width: @breakpoint-sm) {
@@ -71,22 +72,27 @@
 }
 
 .ffe-radio-input {
-    &:where(:checked, :focus, :active, :hover)+.ffe-radio-switch::before {
+    &:where(:checked, :focus, :active, :hover) + .ffe-radio-switch::before {
         outline: none;
     }
 
     @media (hover: hover) and (pointer: fine) {
-        &:hover+.ffe-radio-switch {
-            --radio-switch-background: var(--ffe-color-surface-primary-default-hover);
+        &:hover + .ffe-radio-switch {
+            --radio-switch-background: var(
+                --ffe-color-surface-primary-default-hover
+            );
         }
     }
 
-    &:checked+.ffe-radio-switch {
+    &:checked + .ffe-radio-switch {
         --inner-circle-color: var(--ffe-color-fill-primary-default-pressed);
         --radio-switch-background: var(--ffe-color-surface-primary-default);
-        --radio-switch-border-color: var(--ffe-color-border-interactive-selected);
+        --radio-switch-border-color: var(
+            --ffe-color-border-interactive-selected
+        );
 
-        box-shadow: var(--ffe-g-border-focus-box-shadow) var(--radio-switch-border-color);
+        box-shadow: var(--ffe-g-border-focus-box-shadow)
+            var(--radio-switch-border-color);
 
         &::before {
             border: 5px solid var(--ffe-color-surface-primary-default);
@@ -96,7 +102,9 @@
 
         @media (hover: hover) and (pointer: fine) {
             &:hover {
-                background-color: var(--ffe-color-surface-primary-default-hover);
+                background-color: var(
+                    --ffe-color-surface-primary-default-hover
+                );
             }
         }
 
@@ -105,12 +113,11 @@
         }
     }
 
-    &:focus-visible+.ffe-radio-switch {
-        outline: var(--ffe-g-outline-width) solid var(--ffe-color-border-interactive-focus);
-        outline-offset: var(--ffe-g-outline-offset);
+    &:focus-visible + .ffe-radio-switch {
+        outline-color: var(--ffe-color-border-interactive-focus);
     }
 
-    &:disabled+.ffe-radio-switch {
+    &:disabled + .ffe-radio-switch {
         --radio-switch-border-color: var(--ffe-color-border-primary-subtle);
         --radio-switch-background: var(--ffe-color-surface-primary-default);
 
@@ -118,15 +125,17 @@
         color: var(--ffe-color-foreground-subtle);
     }
 
-    &[aria-invalid='true']+.ffe-radio-switch {
+    &[aria-invalid='true'] + .ffe-radio-switch {
         --radio-switch-border-color: var(--ffe-color-border-feedback-critical);
         --radio-switch-background: var(--ffe-color-surface-feedback-critical);
         --inner-circle-color: var(--ffe-color-surface-primary-default);
 
-        box-shadow: var(--ffe-g-border-focus-box-shadow) var(--ffe-color-border-feedback-critical);
+        box-shadow: var(--ffe-g-border-focus-box-shadow)
+            var(--ffe-color-border-feedback-critical);
 
         &::before {
-            box-shadow: var(--ffe-g-border-focus-box-shadow) var(--ffe-color-border-feedback-critical);
+            box-shadow: var(--ffe-g-border-focus-box-shadow)
+                var(--ffe-color-border-feedback-critical);
         }
 
         @media (hover: hover) and (pointer: fine) {

--- a/packages/ffe-form/less/text-field.less
+++ b/packages/ffe-form/less/text-field.less
@@ -1,0 +1,116 @@
+.ffe-text-field {
+    display: block;
+    padding: var(--ffe-spacing-2xs) var(--ffe-spacing-sm);
+    font-family: var(--ffe-g-font);
+    font-variant-numeric: tabular-nums;
+    background: transparent;
+    border: none;
+    color: var(--ffe-color-foreground-default);
+    width: 100%;
+    height: 100%;
+    font-size: var(--ffe-fontsize-form-input);
+
+    &[type='date'] {
+        display: flex;
+        padding-left: var(--ffe-spacing-xs);
+    }
+
+    &::-webkit-date-and-time-value {
+        text-align: left;
+    }
+
+    &__wrapper {
+        display: flex;
+        align-items: center;
+        width: 100%;
+        height: 2.8125rem;
+        margin: 0;
+        padding: 0;
+        background-color: var(--ffe-color-surface-primary-default);
+        border-radius: var(--ffe-g-border-radius);
+        border: var(--ffe-g-border-width) solid
+            var(--ffe-color-border-primary-default);
+        transition: all var(--ffe-transition-duration) var(--ffe-ease);
+        outline: var(--ffe-g-outline-width) solid transparent;
+        outline-offset: var(--ffe-g-outline-offset);
+
+        &:hover {
+            border-color: var(--ffe-color-border-primary-default-hover);
+            box-shadow: var(--ffe-g-border-focus-box-shadow)
+                var(--ffe-color-border-primary-default-hover);
+        }
+
+        &--inline {
+            display: inline-flex;
+            width: auto;
+        }
+
+        &:focus-within {
+            border: var(--ffe-g-border-width) solid
+                var(--ffe-color-fill-primary-selected-default);
+            box-shadow: var(--ffe-g-border-focus-box-shadow)
+                var(--ffe-color-fill-primary-selected-default);
+            outline-color: var(--ffe-color-border-interactive-focus);
+        }
+    }
+
+    &:focus,
+    &:focus-within {
+        border: none;
+        outline: none;
+    }
+
+    &__suffix,
+    &__prefix {
+        color: var(--ffe-color-component-form-input-foreground-subtle);
+        display: inline-flex;
+        align-items: center;
+        white-space: nowrap;
+        padding: 0;
+    }
+
+    &__suffix {
+        margin: 0 var(--ffe-spacing-xs) 0 0;
+    }
+
+    &__prefix {
+        margin: 0 0 0 var(--ffe-spacing-xs);
+    }
+
+    &--text-right-align {
+        text-align: right;
+    }
+
+    &::-ms-clear {
+        display: none;
+    }
+
+    &::placeholder {
+        color: var(--ffe-color-foreground-subtle);
+        opacity: 1;
+    }
+}
+
+.ffe-text-field--invalid,
+.ffe-text-field[aria-invalid='true'] {
+    color: var(--ffe-color-foreground-feedback-critical);
+}
+
+.ffe-text-field__wrapper:has(.ffe-text-field--invalid),
+.ffe-text-field__wrapper:has([aria-invalid='true']) {
+    border: var(--ffe-g-border-width) solid
+        var(--ffe-color-border-feedback-critical);
+    box-shadow: var(--ffe-g-border-focus-box-shadow)
+        var(--ffe-color-border-feedback-critical);
+    background-color: var(--ffe-color-surface-feedback-critical);
+
+    &:focus,
+    &:focus-within,
+    &:hover {
+        border: var(--ffe-g-border-width) solid
+            var(--ffe-color-border-feedback-critical);
+        box-shadow: var(--ffe-g-border-focus-box-shadow)
+            var(--ffe-color-border-feedback-critical);
+        background-color: var(--ffe-color-component-form-input-fill-default);
+    }
+}

--- a/packages/ffe-form/less/textarea.less
+++ b/packages/ffe-form/less/textarea.less
@@ -9,11 +9,9 @@
         var(--ffe-color-border-primary-default);
     background-color: var(--ffe-color-surface-primary-default);
     color: var(--ffe-color-foreground-default);
-    transition:
-        color var(--ffe-transition-duration) var(--ffe-ease),
-        border var(--ffe-transition-duration) var(--ffe-ease),
-        box-shadow var(--ffe-transition-duration) var(--ffe-ease),
-        background-color var(--ffe-transition-duration) var(--ffe-ease);
+    outline: var(--ffe-g-outline-width) solid transparent;
+    outline-offset: var(--ffe-g-outline-offset);
+    transition: all var(--ffe-transition-duration) var(--ffe-ease);
     font-size: var(--ffe-fontsize-form-input);
 
     @media (hover: hover) and (pointer: fine) {
@@ -30,9 +28,7 @@
             var(--ffe-color-component-form-input-border-active);
         box-shadow: var(--ffe-g-border-focus-box-shadow)
             var(--ffe-color-component-form-input-border-active);
-        outline: var(--ffe-g-outline-width) solid
-            var(--ffe-color-border-interactive-focus);
-        outline-offset: var(--ffe-g-outline-offset);
+        outline-color: var(--ffe-color-border-interactive-focus);
     }
 
     &::placeholder {

--- a/packages/ffe-searchable-dropdown-react/less/searchable-dropdown.less
+++ b/packages/ffe-searchable-dropdown-react/less/searchable-dropdown.less
@@ -2,7 +2,9 @@
     --button-width: 40px;
     --border-width: var(--ffe-g-border-width);
     --border-color: var(--ffe-color-border-primary-default);
-    --detail-text-color: var(--ffe-color-component-form-input-foreground-subtle);
+    --detail-text-color: var(
+        --ffe-color-component-form-input-foreground-subtle
+    );
     --selected-icon-color: var(--ffe-color-fill-primary-selected-default);
     --text-color: var(--ffe-color-foreground-default);
 
@@ -15,6 +17,8 @@
     border-radius: var(--ffe-g-border-radius);
     color: var(--text-color);
     border: var(--border-width) solid var(--border-color);
+    outline: var(--ffe-g-outline-width) solid transparent;
+    outline-offset: var(--ffe-g-outline-offset);
     transition: all var(--ffe-transition-duration) var(--ffe-ease);
 
     :where(.ffe-searchable-dropdown__button) {
@@ -32,14 +36,13 @@
     &:active,
     &:focus-within {
         border-color: var(--ffe-color-component-form-input-border-active);
-        box-shadow: var(--ffe-g-border-focus-box-shadow) var(--ffe-color-component-form-input-border-active);
+        box-shadow: var(--ffe-g-border-focus-box-shadow)
+            var(--ffe-color-component-form-input-border-active);
     }
 
     &:focus-within {
-        outline: var(--ffe-g-outline-width) solid var(--ffe-color-border-interactive-focus);
-        outline-offset: var(--ffe-g-outline-offset);
+        outline-color: var(--ffe-color-border-interactive-focus);
     }
-
 
     &__input {
         display: grid;
@@ -48,7 +51,7 @@
         border-right: none;
 
         @media (hover: hover) and (pointer: fine) {
-            &:hover+.ffe-searchable-dropdown__button {
+            &:hover + .ffe-searchable-dropdown__button {
                 --border-color: var(--ffe-color-border-primary-default-hover);
             }
         }
@@ -69,7 +72,8 @@
         &-icon {
             transition:
                 color var(--ffe-transition-duration) var(--ffe-ease),
-                transform var(--ffe-transition-duration) var(--ffe-ease-in-out-back);
+                transform var(--ffe-transition-duration)
+                    var(--ffe-ease-in-out-back);
         }
 
         &--flip {
@@ -124,7 +128,7 @@
     &__no-match {
         padding: var(--ffe-spacing-xs) var(--ffe-spacing-sm);
 
-        &+.ffe-searchable-dropdown__list-item-container {
+        & + .ffe-searchable-dropdown__list-item-container {
             border-top: 1px solid var(--ffe-color-border-primary-default);
         }
 
@@ -147,7 +151,6 @@
         color: var(--text-color);
 
         @media (hover: hover) and (pointer: fine) {
-
             &:hover,
             &--highlighted:hover {
                 background: var(--ffe-color-surface-primary-default-hover);
@@ -175,16 +178,19 @@
 
     &:has(input[aria-invalid='true']) {
         color: var(--ffe-color-foreground-feedback-critical);
-        border: var(--ffe-g-border-width) solid var(--ffe-color-border-feedback-critical);
-        box-shadow: var(--ffe-g-border-focus-box-shadow) var(--ffe-color-border-feedback-critical);
+        border: var(--ffe-g-border-width) solid
+            var(--ffe-color-border-feedback-critical);
+        box-shadow: var(--ffe-g-border-focus-box-shadow)
+            var(--ffe-color-border-feedback-critical);
         background-color: var(--ffe-color-surface-feedback-critical);
 
         @media (hover: hover) and (pointer: fine) {
-
             &:hover,
             &:focus {
-                border: var(--ffe-g-border-width) solid var(--ffe-color-border-feedback-critical);
-                box-shadow: var(--ffe-g-border-focus-box-shadow) var(--ffe-color-border-feedback-critical);
+                border: var(--ffe-g-border-width) solid
+                    var(--ffe-color-border-feedback-critical);
+                box-shadow: var(--ffe-g-border-focus-box-shadow)
+                    var(--ffe-color-border-feedback-critical);
                 background-color: var(--ffe-color-surface-primary-default);
             }
         }


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse

`<TextField>` er en avart av `<Input>`, der stylingen i stor grad er lagt på en wrapper i stedet for på selve input-feltet. Dette gjør det blant annet mulig å legge til støtte for affikser.

Visuelt er `<TextField>` og `<Input>` identiske. Grunnen til at en ny komponent er lagt til i stedet for å endre på den gamle er at en rekke andre komponenter har avhengigheter til `<Input>` - både styling og markupstruktur. Større endringer i den gamle komponenten ville medført breaking changes på flere forskjellige steder, noe som gjør det unødvendig komplisert å oppgradere. Større refaktoreringer ligger i horisonten.

Har i tillegg:
* Lagt til transition på outline i en rekke komponenter der det manglet i etterkant av at fokus-stylingen ble ble flyttet fra border/box-shadow.
* Fikset en bug som gjorde transition på outline hakkete i mange forskjellige komponenter

## Motivasjon og kontekst

En rekke team har etterspurt støtte for `prefix` og `suffix` i `Input`.

## Testing

Testet lokalt med Storybook
