### PR TITLE
chore: Legg til manglende styling definisjon for progressbar

### DIFF
--- a/documentation/components/InstallImport.tsx
+++ b/documentation/components/InstallImport.tsx
@@ -77,6 +77,9 @@ const packageStyles = {
     '@sb1/ffe-tags': {
         less: '@sb1/ffe-tags/less/tag',
     },
+    '@sb1/ffe-progressbar': {
+        less: '@sb1/ffe-progressbar/less/progressbar',
+    },
 };
 
 type Props = {


### PR DESCRIPTION
Vet ikke hvor å dokumentere det. Men en må legge til styling definisjonene i InstallImport komponenten for at den skal vises. Er noe som må gjøres når en lager nye komponenter. Greit å vite om, usikker på om det gir mening å bruke tid på det nå.

Denne legger til manglende definisjon.