### PR TITLE
docs(ffe-modals-react): legger til dokumentasjon om darkmode i modalen

### DIFF
--- a/packages/ffe-modals-react/src/Modal.mdx
+++ b/packages/ffe-modals-react/src/Modal.mdx
@@ -1,7 +1,7 @@
-import { Canvas, Meta, Controls } from '@storybook/blocks';
-import * as ModalStories from './Modal.stories.tsx';
+import { Canvas, Controls, Meta } from '@storybook/blocks';
 import { InstallImport } from '../../../documentation/components/InstallImport';
 import dependencies from '../ffe-dependencies';
+import * as ModalStories from './Modal.stories.tsx';
 
 <Meta of={ModalStories} />
 
@@ -29,15 +29,26 @@ For å lukke eller åpne en modal brukes `ModalHandle`. Innhold kan plasseres i 
 <Canvas of={ModalStories.Standard} />
 <Controls of={ModalStories.Standard} />
 
-## Tilpasset bakgrunn
+## Dark mode
 
-<Canvas of={ModalStories.Custom} />
+Modalen legger seg utenfor resten av sidens innhold og må derfor håndteres separat om man ønsker å støtte dark mode.
+Legg til classen `regard-color-scheme-preference` i `className` på `<Modal/>` der du ønsker at modalen skal følge brukerens fargepreferanse.
 
-## Utsene i dark modalen
-
-Modalen følger css classen `regard-color-scheme-preference` og vil se slik ut i dark mode.
+``` 
+<Modal
+    ariaLabelledby="modal-heading"
+    className="regard-color-scheme-preference"
+>
+...
+</Modal>
+```
 
 <Canvas of={ModalStories.DarkMode} />
+
+## Tilpasset bakgrunn
+Her er et eksempel på en modal med en egen bakgrunnsfarge.
+
+<Canvas of={ModalStories.Custom} />
 
 ## Veiledning for bruk
 

--- a/packages/ffe-modals-react/src/Modal.stories.tsx
+++ b/packages/ffe-modals-react/src/Modal.stories.tsx
@@ -1,13 +1,13 @@
-import React, { useRef } from 'react';
-import { Modal, type ModalHandle } from './Modal';
-import { ModalBlock } from './ModalBlock';
-import type { StoryObj, Meta } from '@storybook/react';
 import {
     ActionButton,
     ButtonGroup,
     SecondaryButton,
 } from '@sb1/ffe-buttons-react';
 import { Heading2, Paragraph } from '@sb1/ffe-core-react';
+import type { Meta, StoryObj } from '@storybook/react';
+import React, { useRef } from 'react';
+import { Modal, type ModalHandle } from './Modal';
+import { ModalBlock } from './ModalBlock';
 
 const meta: Meta<typeof Modal> = {
     title: 'Komponenter/Modals/Modal',
@@ -93,7 +93,7 @@ export const Custom: Story = {
                         style={{
                             height: 150,
                             width: '100%',
-                            background: '#d8e9f2',
+                            background: 'var(--ffe-color-surface-secondary-default)',
                         }}
                     />
                     <ModalBlock>


### PR DESCRIPTION
Modalen følger ikke darkmode `regard-color-scheme-preferences`. 
Vi kommer ikke til å fikse dette i ffe, men legger til bedre dokumentasjon om hvordan det kan fikses på hvert enkelt team. 

fixes #3035 