### PR TITLE
Chip fix

### DIFF
--- a/packages/ffe-chips-react/src/Chip.tsx
+++ b/packages/ffe-chips-react/src/Chip.tsx
@@ -45,7 +45,7 @@ function ChipWithForwardRef<As extends ElementType>(
         <span
             className={classNames(
                 'ffe-chip__label',
-                size === 'sm' ? 'ffe-small-text' : 'ffe-body-paragraph',
+                size === 'sm' && 'ffe-chip__label--sm',
             )}
         >
             {children}

--- a/packages/ffe-chips/less/chip.less
+++ b/packages/ffe-chips/less/chip.less
@@ -35,6 +35,11 @@
     &__label {
         margin: 0;
         grid-area: 2 e('/') 2 e('/') span 1 e('/') span 1;
+
+        &--sm {
+            font-size: var(--ffe-fontsize-small-text);
+            line-height: 1.25;
+        }
     }
 
     @media (hover: hover) and (pointer: fine) {


### PR DESCRIPTION
fixes #3067 

Fjerner bruken av ffe-small-text og ffe-body-paragraph klassene slik at fargene ikke blir overstyrt om man har chip.less importert før ffe.less. Litt usikker på hva dette gjør ifht. breaking-oppførsel, de hadde begge overflow-wrap: anywhere; og ffe-body-paragraph hadde `text-wrap: pretty;`. Usikker på hva som er ønsket der. 