### PR TITLE
feat(ffe-feedback-react): new callback: onFinish

### DIFF
--- a/packages/ffe-feedback-react/src/Feedback.spec.tsx
+++ b/packages/ffe-feedback-react/src/Feedback.spec.tsx
@@ -143,6 +143,27 @@ describe('Feedback Component', () => {
         expect(onFeedbackSendMock).toHaveBeenCalledWith('Test feedback', true);
     });
 
+    it('should trigger onFinish if no text', () => {
+        const onFeedbackSendMock = jest.fn();
+        const onFinishMock = jest.fn();
+        render(
+            <Feedback
+                onThumbClick={() => {}}
+                onFeedbackSend={onFeedbackSendMock}
+                onFinish={onFinishMock}
+            />,
+        );
+
+        const thumbButton = screen.getByLabelText('Gi tommel opp');
+        fireEvent.click(thumbButton);
+
+        const finishButton = screen.getByText('Avslutt');
+        fireEvent.click(finishButton);
+
+        expect(onFeedbackSendMock).not.toHaveBeenCalled();
+        expect(onFinishMock).toHaveBeenCalled()
+    });
+
     it('should render with custom heading', () => {
         render(
             <Feedback

--- a/packages/ffe-feedback-react/src/Feedback.tsx
+++ b/packages/ffe-feedback-react/src/Feedback.tsx
@@ -15,6 +15,7 @@ export interface FeedbackProps {
     locale?: Locale;
     onThumbClick: (thumb: Thumb) => void;
     onFeedbackSend: (feedbackText: string, consent?: boolean) => void;
+    onFinish?: () => void;
     bgColor?: BgColor;
     contactLink?: FeedbackExpandedProps['contactLink'];
     texts?: {
@@ -30,6 +31,7 @@ export const Feedback = ({
     locale = 'nb',
     onThumbClick,
     onFeedbackSend,
+    onFinish,
     bgColor,
     contactLink,
     texts,
@@ -68,6 +70,8 @@ export const Feedback = ({
         feedbackSentRef.current?.focus();
         if (feedbackText && feedbackText.length > 0) {
             onFeedbackSend(feedbackText, consentGiven);
+        } else if (onFinish) {
+            onFinish();
         }
     };
 


### PR DESCRIPTION
## Beskrivelse

Ny callback som kalles når brukeren klikker "Avslutt"

## Motivasjon og kontekst

Gjør det mulig å lagre tommel og tekst (med onFeedbackSend), 
eller bare tommel hvis brukeren klikker "Avslutt" (med onFinish)