### PR TITLE
feat(ffe-tables-react): expandContent kan sendes inn som en funksjon som får tilgang til setIsOpen fra TableRowExpandable

### DIFF
--- a/packages/ffe-tables-react/src/Table.stories.tsx
+++ b/packages/ffe-tables-react/src/Table.stories.tsx
@@ -10,7 +10,8 @@ import { TableCaption } from './TableCaption';
 import { TableFoot } from './TableFoot';
 import { TableRowExpandable } from './TableRowExpandable';
 import { formatNumber } from '@sb1/ffe-formatters';
-import { TertiaryButton } from '@sb1/ffe-buttons-react';
+import { SecondaryButton, TertiaryButton } from '@sb1/ffe-buttons-react';
+import { Paragraph } from '@sb1/ffe-core-react';
 
 const meta: Meta<typeof Table> = {
     title: 'Komponenter/Table/Table',
@@ -135,6 +136,68 @@ export const Expandable: Story = {
                                 isDefaultOpen={index === 1}
                                 key={it.email}
                                 expandContent={it.expand}
+                            >
+                                <TableDataCell columnHeader={navnHeader}>
+                                    {it.name}
+                                </TableDataCell>
+                                <TableDataCell columnHeader={epostHeader}>
+                                    {it.email}
+                                </TableDataCell>
+                            </TableRowExpandable>
+                        ))}
+                    </TableBody>
+                </Table>
+            </div>
+        );
+    },
+};
+
+export const ExpandableAndClosable: Story = {
+    args: {},
+    render: (args) => {
+        const data = [
+            {
+                name: 'Ola Normann',
+                email: 'ola@normann.no',
+                expand: 'Info: mer spennende info om Ola',
+            },
+            {
+                name: 'Sivert Svensk',
+                email: 'sivert@svenska.se',
+                expand: 'Info: mer spennende info om Sivert',
+            },
+            {
+                name: 'Daniel Dansk',
+                email: 'daniel@dansk.dk',
+                expand: 'Info: mer spennende info om Daniel',
+            },
+        ];
+        const navnHeader = 'Navn';
+        const epostHeader = 'E-post';
+        return (
+            <div style={{ overflowX: 'auto' }}>
+                <Table {...args}>
+                    <TableCaption>Tabel utvidbare rader</TableCaption>
+                    <TableHead>
+                        <TableRow>
+                            <TableHeaderCell scope="col">
+                                {navnHeader}
+                            </TableHeaderCell>
+                            <TableHeaderCell scope="col">
+                                {epostHeader}
+                            </TableHeaderCell>
+                        </TableRow>
+                    </TableHead>
+                    <TableBody>
+                        {data.map((it, index) => (
+                            <TableRowExpandable
+                                isDefaultOpen={index === 1}
+                                key={it.email}
+                                expandContent={(setIsOpen) => (
+                                    <div>
+                                        <Paragraph>{it.expand}</Paragraph>
+                                        <SecondaryButton onClick={() => setIsOpen(false)}>Lukk</SecondaryButton>
+                                    </div>)}
                             >
                                 <TableDataCell columnHeader={navnHeader}>
                                     {it.name}

--- a/packages/ffe-tables-react/src/TableRowExpandable.spec.tsx
+++ b/packages/ffe-tables-react/src/TableRowExpandable.spec.tsx
@@ -83,4 +83,34 @@ describe('<TableRowExpandable />', () => {
         expect(onClick).toHaveBeenCalledTimes(1);
         jest.useRealTimers();
     });
+
+    it('should set open from parent', async () => {
+        const onClick = jest.fn();
+        const user = userEvent.setup({ delay: null });
+        jest.useFakeTimers();
+
+        const expandContent = (setIsOpen : React.Dispatch<React.SetStateAction<boolean>> ) => {
+            return <div>expand - <button onClick={() => setIsOpen(false)}>close</button></div>;
+        }
+
+        render(
+            <table>
+                <tbody>
+                <TableRowExpandable
+                    onClick={onClick}
+                    expandContent={(setIsOpen) => expandContent(setIsOpen)}
+                    isDefaultOpen={true}
+                />
+                </tbody>
+            </table>
+        );
+
+        const expandButton = screen.getByRole('button', { name: 'Vis mindre' });
+        expect(expandButton.getAttribute('aria-expanded')).toBe('true');
+
+        await user.click(screen.getByRole('button', { name: 'close' }));
+
+        expect(expandButton.getAttribute('aria-expanded')).toBe('false');
+        jest.useRealTimers();
+    });
 });

--- a/packages/ffe-tables-react/src/TableRowExpandable.tsx
+++ b/packages/ffe-tables-react/src/TableRowExpandable.tsx
@@ -7,7 +7,7 @@ import { CellContent } from './CellContent';
 
 export interface TableRowExpandableProps
     extends Omit<React.ComponentPropsWithoutRef<'tr'>, 'onClick'> {
-    expandContent: React.ReactNode;
+    expandContent: React.ReactNode | ((setIsOpen: React.Dispatch<React.SetStateAction<boolean>>) => React.ReactNode);
     locale?: 'nb' | 'nn' | 'en';
     isDefaultOpen?: boolean;
     onClick?: React.MouseEventHandler<HTMLButtonElement>;
@@ -104,7 +104,7 @@ export const TableRowExpandable = React.forwardRef<
                             onRest={() => setIsAnimating(false)}
                         >
                             <CellContent className="ffe-table__expand-content">
-                                {!expandIdHidden && expandContent}
+                                {!expandIdHidden && (typeof expandContent === "function" ? expandContent(setIsOpen) : expandContent)}
                             </CellContent>
                         </Collapse>
                     </td>


### PR DESCRIPTION
## Beskrivelse

Det er per nå ikke mulig å lukke TableRowExpandable uten at brukeren trykker på "Vis mindre"-knappen

## Motivasjon og kontekst

Endringen gjør det mulig for en knapp inne i TableRowExpandable å lukke TableRowExpandable

## Testing

Jeg har lagt til tester og eksempel i storybook

