### PR TITLE
Fiks at className ikke ble brukt i AccountSelectorMulti

### DIFF
--- a/packages/ffe-account-selector-react/src/account-selector-multi/AccountSelectorMulti.tsx
+++ b/packages/ffe-account-selector-react/src/account-selector-multi/AccountSelectorMulti.tsx
@@ -95,6 +95,7 @@ export const AccountSelectorMulti = <T extends Account = Account>({
         <SearchableDropdownMultiSelect<T>
             id={id}
             labelledById={labelledById}
+            className={className}
             inputProps={inputProps}
             dropdownAttributes={
                 showBalance


### PR DESCRIPTION
## Beskrivelse

Bruker className fra props på underliggende SearchableDropdownMultiSelect.

## Motivasjon og kontekst

Denne endringen trengs når avhengere (dependants) har behov for å endre aspekter ved komponentens styling, oftest å fjerne outer margin.

## Testing

Har kjørt testene med npm test og sjekket at AccountSelectorMulti får valgt klasse i Storybook.
