### PR TITLE
feat(account-selector-multi): Legg til showNumberSelectedAfter

### DIFF
--- a/packages/ffe-account-selector-react/src/account-selector-multi/AccountSelectorMulti.tsx
+++ b/packages/ffe-account-selector-react/src/account-selector-multi/AccountSelectorMulti.tsx
@@ -64,6 +64,12 @@ export interface AccountSelectorMultiProps<T extends Account = Account> {
      * Use the `ffe-accent-color` class on the component or on the container of the component instead
      * [Read more in the upgrade guide](https://sparebank1.github.io/designsystem/?path=/docs/introduksjon-changelog--docs#2025---februar---semantiske-farger) */
     onColoredBg?: never;
+    /**
+     * Using this will give a text "X selected" instead of chips,
+     * after a certain number of selected items.
+     * If you always want "X selected" showing, pass in 0
+     */
+    showNumberSelectedAfter?: number;
 }
 
 export const AccountSelectorMulti = <T extends Account = Account>({
@@ -85,6 +91,7 @@ export const AccountSelectorMulti = <T extends Account = Account>({
     onOpen,
     onClose,
     maxRenderedDropdownElements,
+    showNumberSelectedAfter,
     ...rest
 }: AccountSelectorMultiProps<T>) => {
     const formatter = formatAccountNumber
@@ -134,6 +141,7 @@ export const AccountSelectorMulti = <T extends Account = Account>({
             onOpen={onOpen}
             onClose={onClose}
             maxRenderedDropdownElements={maxRenderedDropdownElements}
+            showNumberSelectedAfter={showNumberSelectedAfter}
             isEqual={(accountA, accountB) =>
                 accountA.accountNumber === accountB.accountNumber
             }


### PR DESCRIPTION
## Beskrivelse

Eksponerer funksjonaliteten til underliggende SearchableDropdownMultiSelect slik at  chips som viser valgte verdier kan forkortes etter n valgte verdier.

<img width="1020" height="582" alt="image" src="https://github.com/user-attachments/assets/23f25925-7b6e-4b9a-9745-10ef5a23347a" />

## Motivasjon og kontekst

Dette trengs av samme årsak til at showNumberSelectedAfter finnes på SearchableDropdownMultiSelect, nemlig å unngå at dropdownen eser ut ved valg av mange verdier.

## Testing

Har kjørt npm test og sjekket i Storybook at propen applikeres og fungerer som tiltenkt.
