### PR TITLE
Semantiske farger oppdatering

### DIFF
--- a/documentation/Changelog.mdx
+++ b/documentation/Changelog.mdx
@@ -8,6 +8,84 @@ Denne siden lister breaking changes og større endringer i designsystemet. For a
 
 F.eks: https://github.com/SpareBank1/designsystem/blob/develop/packages/ffe-core/CHANGELOG.md
 
+## 2025 - Oktober - Justeringer i noen farger (liten endring) - 100.4.1
+Vi har gjort noen justeringer i fargene for å bedre kontrasten i enkelte tilfeller. I fargesystemet nå har vi et primitivt lag, et semantisk lag og et kontekstlag. 
+Det er fargene i kontekstlaget som brukes i komponentene og som dere har tilgang til. 
+
+Fargeendringene som er gjort i det semantiske laget (se nederst) får følger for disse variablene i kontekstlaget: 
+`--ffe-color-fill-secondary-subtle` og `--ffe-color-fill-tertiary-subtle`
+
+I tillegg er det gjort justeringer på disse fargene i kontekst-laget: 
+
+<table>
+<thead>
+<tr>
+<th>Variabel</th>
+<th>Endret fra</th>
+<th>Endret til</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>--ffe-color-fill-feedback-info-subtle</code></td>
+<td><code>default-feedback-info-subtlest</code></td>
+<td><code>-subtler</code></td>
+</tr>
+<tr>
+<td><code>--ffe-color-fill-feedback-success-subtle</code></td>
+<td><code>default-feedback-success-subtlest</code></td>
+<td><code>-subtler</code></td>
+</tr>
+<tr>
+<td><code>--ffe-color-fill-warning-info-subtle</code></td>
+<td><code>default-warning-info-subtlest</code></td>
+<td><code>-subtler</code></td>
+</tr>
+<tr>
+<td><code>--ffe-color-fill-critical-success-subtle</code></td>
+<td><code>default-feedback-critical-subtlest</code></td>
+<td><code>-subtler</code></td>
+</tr>
+<tr>
+<td><code>--ffe-color-fill-tip-success-subtle</code></td>
+<td><code>default-feedback-tip-subtlest</code></td>
+<td><code>-subtler</code></td>
+</tr>
+<tr>
+<td><code>ffe-color-fill-primary-subtle</code></td>
+<td><code>default-brand-primary-subtlest</code></td>
+<td><code>-subtler</code></td>
+</tr>
+<tr>
+<td><code>ffe-color-fill-primary-subtle-hover</code></td>
+<td><code>default-brand-primary-subtler</code></td>
+<td><code>-subtle</code></td>
+</tr>
+<tr>
+<td><code>ffe-color-fill-primary-subtle-pressed</code></td>
+<td><code>default-brand-primary-subtle</code></td>
+<td><code>-default</code></td>
+</tr>
+</tbody>
+</table>
+
+Dette får en veldig liten justering i disse komponentene:
+- Chips hover og pressed
+- Tabs hover og pressed
+- Spinner bakgrunnsfarge
+- Progressbar bar
+- Tags subtle
+- Datepicker bakgrunnsfarge på dato i inputfeltet
+- Tooltip bakgrunnsfarge
+
+Fargeendringene som er gjort i det semantsike laget er gjort på:
+- `ffe-color-default-brand-secondary-subtlest`
+- `ffe-color-default-brand-secondary-subtler`
+- `ffe-color-default-brand-tertiary-subtlest`
+- `ffe-color-default-brand-tertiary-subtler`
+
+Alle verdiene er veldig små justeringer, stort sett endret 25 hakk opp eller ned på en skala fra 0-1000.
+
 ## 2025 - September - Ny komponent: TextField
 
 Vi har laget en ny komponent, `<TextField>`. Dette er en avart av `<Input>`, som er laget for å støtte affikser (prefix og suffix) i input-feltet - funksjonalitet som har vært etterspurt av flere team. Dette er ikke er mulig å legge til i dagens implementasjon av `<Input>` uten en større omskrivning med breaking changes, noe som i tillegg ville påvirket andre komponenter som avhenger av `<Input>`.

--- a/packages/ffe-core/tokens/01 Primitive.value.json
+++ b/packages/ffe-core/tokens/01 Primitive.value.json
@@ -3886,9 +3886,7 @@
         "$extensions": {
           "com.figma": {
             "hiddenFromPublishing": true,
-            "scopes": [
-              "ALL_FILLS"
-            ],
+            "scopes": [],
             "codeSyntax": {}
           }
         }
@@ -3900,9 +3898,7 @@
         "$extensions": {
           "com.figma": {
             "hiddenFromPublishing": true,
-            "scopes": [
-              "ALL_FILLS"
-            ],
+            "scopes": [],
             "codeSyntax": {}
           }
         }
@@ -3914,9 +3910,7 @@
         "$extensions": {
           "com.figma": {
             "hiddenFromPublishing": true,
-            "scopes": [
-              "ALL_FILLS"
-            ],
+            "scopes": [],
             "codeSyntax": {}
           }
         }

--- a/packages/ffe-core/tokens/02 Semantic.Light.json
+++ b/packages/ffe-core/tokens/02 Semantic.Light.json
@@ -103,7 +103,7 @@
         "secondary": {
           "subtlest": {
             "$type": "color",
-            "$value": "{color.frost.25}",
+            "$value": "{color.frost.50}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -115,7 +115,7 @@
           },
           "subtler": {
             "$type": "color",
-            "$value": "{color.frost.50}",
+            "$value": "{color.frost.75}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -201,7 +201,7 @@
         "tertiary": {
           "subtlest": {
             "$type": "color",
-            "$value": "{color.syrin.25}",
+            "$value": "{color.syrin.50}",
             "$description": "",
             "$extensions": {
               "com.figma": {
@@ -213,7 +213,7 @@
           },
           "subtler": {
             "$type": "color",
-            "$value": "{color.syrin.50}",
+            "$value": "{color.syrin.75}",
             "$description": "",
             "$extensions": {
               "com.figma": {

--- a/packages/ffe-core/tokens/03 Context.Default.json
+++ b/packages/ffe-core/tokens/03 Context.Default.json
@@ -399,7 +399,7 @@
         },
         "subtle": {
           "$type": "color",
-          "$value": "{color.default.brand.primary.subtlest}",
+          "$value": "{color.default.brand.primary.subtler}",
           "$description": "",
           "$extensions": {
             "com.figma": {
@@ -414,7 +414,7 @@
         },
         "subtle-hover": {
           "$type": "color",
-          "$value": "{color.default.brand.primary.subtler}",
+          "$value": "{color.default.brand.primary.subtle}",
           "$description": "",
           "$extensions": {
             "com.figma": {
@@ -429,7 +429,7 @@
         },
         "subtle-pressed": {
           "$type": "color",
-          "$value": "{color.default.brand.primary.subtle}",
+          "$value": "{color.default.brand.primary.default}",
           "$description": "",
           "$extensions": {
             "com.figma": {
@@ -797,7 +797,7 @@
         },
         "info-subtle": {
           "$type": "color",
-          "$value": "{color.default.feedback.info.subtlest}",
+          "$value": "{color.default.feedback.info.subtler}",
           "$description": "",
           "$extensions": {
             "com.figma": {
@@ -827,7 +827,7 @@
         },
         "success-subtle": {
           "$type": "color",
-          "$value": "{color.default.feedback.success.subtlest}",
+          "$value": "{color.default.feedback.success.subtler}",
           "$description": "",
           "$extensions": {
             "com.figma": {
@@ -857,7 +857,7 @@
         },
         "warning-subtle": {
           "$type": "color",
-          "$value": "{color.default.feedback.warning.subtlest}",
+          "$value": "{color.default.feedback.warning.subtler}",
           "$description": "",
           "$extensions": {
             "com.figma": {
@@ -887,7 +887,7 @@
         },
         "critical-subtle": {
           "$type": "color",
-          "$value": "{color.default.feedback.critical.subtlest}",
+          "$value": "{color.default.feedback.critical.subtler}",
           "$description": "",
           "$extensions": {
             "com.figma": {
@@ -917,7 +917,7 @@
         },
         "tip-subtle": {
           "$type": "color",
-          "$value": "{color.default.feedback.tip.sublest}",
+          "$value": "{color.default.feedback.tip.subtler}",
           "$description": "",
           "$extensions": {
             "com.figma": {

--- a/packages/ffe-datepicker/less/calendar.less
+++ b/packages/ffe-datepicker/less/calendar.less
@@ -184,7 +184,7 @@
             color: var(--ffe-color-component-form-input-foreground-disabled);
 
             &.ffe-calendar__date--selected {
-                background: var(--ffe-color-fill-tertiary-subtle);
+                background: var(--ffe-color-component-form-input-fill-disabled);
                 color: var(--ffe-color-foreground-subtle);
             }
 


### PR DESCRIPTION
Løser: 
Fill-subtle fargene var ikke synlige oppå surface-fargene. 


Liten justering av noen farger. Oversikt: 
Det er gjort noen justeringer på farger i det semantiske laget: 
`ffe-color-default-brand-secondary-subtlest` 
`ffe-color-default-brand-secondary-subtler` 
`ffe-color-default-brand-tertiary-subtlest` 
`ffe-color-default-brand-tertiary-subtler`

I kontekst-laget får det følger for 
`--ffe-color-fill-secondary-subtle`
`--ffe-color-fill-tertiary-subtle`

Det er også gjort endringer i kontekst-laget:

`--ffe-color-fill-feedback-info-subtle` 
(Endret fra `default-feedback-info-subtlest` til **subtler**)
`--ffe-color-fill-feedback-success-subtle`
(Endret fra `default-feedback-success-subtlest` til **subtler**)
`--ffe-color-fill-warning-info-subtle` 
(Endret fra `default-warning-info-subtlest` til **subtler**)
`--ffe-color-fill-critical-success-subtle`
(Endret fra `default-feedback-critical-subtlest` til **subtler**)
`--ffe-color-fill-tip-success-subtle`
(Endret fra `default-feedback-tip-subtlest` til **subtler**)

`ffe-color-fill-primary-subtle`
(Endret fra `default-brand-primary-subtlest` til **subtler**)
`ffe-color-fill-primary-subtle-hover`
(Endret fra `default-brand-primary-subtler` til **subtle**)
`ffe-color-fill-primary-subtle-pressed`
(Endret fra `default-brand-primary-subtle` til **default**)

Fra: 
<img width="512" height="41" alt="image" src="https://github.com/user-attachments/assets/1ea1d1d5-c144-486e-95dc-453134bf4b31" />
<img width="507" height="41" alt="image" src="https://github.com/user-attachments/assets/4f59de6c-4a5c-48dd-8007-b8df0db95467" />
<img width="537" height="411" alt="image" src="https://github.com/user-attachments/assets/9776fe81-fd96-4f20-ba80-4e7a7f46a476" />


Til: 

<img width="512" height="43" alt="image" src="https://github.com/user-attachments/assets/9e1ec58e-86c7-4745-a998-df6d7a00bfe0" />

<img width="508" height="41" alt="image" src="https://github.com/user-attachments/assets/61f89882-f104-40a5-889d-23f4c82f0eca" />
<img width="536" height="412" alt="image" src="https://github.com/user-attachments/assets/88bbf294-16be-4c6e-b28e-edc057bf2911" />


Dette får effekt i Progressbar og Tags subtle

Og:
- Chips hover og pressed
- Tabs hover og pressed
- Spinner bakgrunnsfarge
- Progressbar bar fargen
- Datepicker fokus på tall farge
- Tooltip bakgrunnsfarge

Eneste endringen som er gjort i komponenter er datepicker selected disabled state. 
