### PR TITLE
chore: fjerner npm token

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -53,7 +53,6 @@ jobs:
               if: ${{ steps.lerna-changed.outputs.CHANGED_COUNT > 0 }}
               run: lerna publish --yes --no-verify-access --force-git-tag --create-release github --force-publish
               env:
-                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
                   GH_TOKEN: ${{ secrets.GH_USER_PAT }}
 
             - name: Merge back changes to development branch


### PR DESCRIPTION
Fjerner npm token som har vært brukt til autentisering mot npmjs ved publisering av pakker. Autentisering skjer nå med trusted publishing etter #3091 