### PR TITLE
feat: Tilbakemeldingskomponent godtar headingLookLike

### DIFF
--- a/packages/ffe-feedback-react/src/Feedback.tsx
+++ b/packages/ffe-feedback-react/src/Feedback.tsx
@@ -12,6 +12,7 @@ type BgColor = 'primary' | 'secondary' | 'tertiary';
 
 export interface FeedbackProps {
     headingLevel?: HeadingLevel;
+    headingLookLike?: HeadingLevel;
     locale?: Locale;
     onThumbClick: (thumb: Thumb) => void;
     onFeedbackSend: (feedbackText: string, consent?: boolean) => void;
@@ -28,6 +29,7 @@ export interface FeedbackProps {
 
 export const Feedback = ({
     headingLevel = 4,
+    headingLookLike,
     locale = 'nb',
     onThumbClick,
     onFeedbackSend,
@@ -83,13 +85,14 @@ export const Feedback = ({
             tabIndex?: number;
             id?: string;
             textCenter?: boolean;
+            lookLike?: HeadingLevel;
         },
     ) => {
         const { ref, tabIndex, id, textCenter } = options || {};
 
         const headingClassName = classNames(
-            `ffe-h${level}`,
-            { [`ffe-h${level}--text-center`]: textCenter },
+            `ffe-h${options?.lookLike ?? level}`,
+            { [`ffe-h${options?.lookLike ?? level}--text-center`]: textCenter },
             'ffe-feedback__heading',
         );
 
@@ -112,7 +115,11 @@ export const Feedback = ({
                     {renderHeading(
                         headingLevel,
                         txt[locale].FEEDBACK_SENT_HEADING,
-                        { ref: feedbackSentRef, tabIndex: -1 },
+                        {
+                            ref: feedbackSentRef,
+                            tabIndex: -1,
+                            lookLike: headingLookLike,
+                        },
                     )}
                     <HighFive />
                 </div>
@@ -127,7 +134,11 @@ export const Feedback = ({
                     {renderHeading(
                         headingLevel,
                         txt[locale].FEEDBACK_SENT_HEADING,
-                        { ref: expandedRef, tabIndex: -1 },
+                        {
+                            ref: expandedRef,
+                            tabIndex: -1,
+                            lookLike: headingLookLike,
+                        },
                     )}
                     <FeedbackExpanded
                         locale={locale}
@@ -147,7 +158,11 @@ export const Feedback = ({
                     headingLevel,
                     texts?.feedbackNotSentHeading ??
                         txt[locale].FEEDBACK_NOT_SENT_HEADING,
-                    { id: headingId, textCenter: true },
+                    {
+                        id: headingId,
+                        textCenter: true,
+                        lookLike: headingLookLike,
+                    },
                 )}
                 <FeedbackThumbs
                     onClick={handleThumbClicked}


### PR DESCRIPTION
# Styr visningsnivået på overskriften i tilbakemeldingskomponenten

<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse

Tilbakemeldingskomponenten lar nå brukeren spesifisere både hvilket semantisk nivå overskriften skal ha (`headingLevel`), samt hvilket nivå overskriften skal *vises* med, gjennom den nye _prop_-en `headingLookLike`.

<!-- Detaljert beskrivelse av endringene dine. Skjermskudd er lov. -->

## Motivasjon og kontekst

Den semantiske verdien (`<h1>`, `<h2>`) som er riktig å sette på tilbakemeldingskomponenten, der den hører hjemme i DOM-en, samsvarer ikke nødvendigvis med hvordan overskriften skal vises rent visuelt.

<!-- Hvorfor trengs denne endringen, og hva løser den? -->

## Testing

Verifisert gjennom Storybook, hvor _prop_-en `headingLookLike` vellykket kan settes for å styre visningsnivået uten å endre den semantiske HTML-tagen.

<!-- Hvordan har du har testet endringene dine? Ta gjerne med systeminfo o.l -->

<!--

Helt til slutt, har du ..

.. lest retningslinjene våre for bidrag?
.. tatt en siste sjekk for kode og skrivefeil, debug informasjon o.l?
.. kjørt og eventuelt oppdatert testene?
.. kommentert og dokumentert det som trengs?
.. knyttet denne opp til relaterte issues?

-->
