### PR TITLE
Fix on header tabs when clicked

### DIFF
--- a/packages/ffe-header/less/ffe-header.less
+++ b/packages/ffe-header/less/ffe-header.less
@@ -74,7 +74,7 @@
             left: 0;
         }
 
-        &--active:focus::after {
+        &--active:focus-visible::after {
             border-bottom: 0;
         }
 


### PR DESCRIPTION
## Beskrivelse

fix so that the line under menu items in header is visible when clicked (not after clicking somewhere else on the page), but not visible when tabbing (as probably intended).

## Motivasjon og kontekst

Denne endringen løser (det vi mistenker er) en bug når man klikker på en tab i headeren så kommer ikke streken under før man har klikket et annet vilkårlig sted på siden.

hvordan det er on focus i dagens løsning
<img width="128" height="66" alt="Screenshot 2025-12-08 at 13 00 51" src="https://github.com/user-attachments/assets/f35950a5-07ce-4174-ae8f-0c2e59c24a69" />


hvordan det er etter fiksen on focus
<img width="127" height="70" alt="Screenshot 2025-12-08 at 13 01 18" src="https://github.com/user-attachments/assets/fd4db9b6-ec6d-4f98-b7ac-5ca8938626ee" />

## Testing

Testet lokalt i kodebasen vår, funker som det skal nå

<!--

Helt til slutt, har du ..

.. lest retningslinjene våre for bidrag?
.. tatt en siste sjekk for kode og skrivefeil, debug informasjon o.l?
.. kjørt og eventuelt oppdatert testene?
.. kommentert og dokumentert det som trengs?
.. knyttet denne opp til relaterte issues?

-->


