### PR TITLE
feat(ffe-form-react): Allow InputGroup description to be a ReactElement

### DIFF
--- a/packages/ffe-form-react/src/InputGroup.tsx
+++ b/packages/ffe-form-react/src/InputGroup.tsx
@@ -38,7 +38,7 @@ export interface InputGroupProps
           }>
         | null;
     /** To just render a static, always visible tooltip, use this. */
-    description?: string;
+    description?: string | React.ReactElement;
     /** Use the Label component if you need more flexibility in how the content is rendered. */
     label?:
         | string


### PR DESCRIPTION
## Beskrivelse

Gjør det mulig å sende inn et ReactElement som description på InputGroup.

Dette er kun endring i typen.

## Motivasjon og kontekst

Det blir mulig å fremheve eller på annet vis formatere deler av beskrivelsen. Her er et eksempel:

<img width="608" height="138" alt="Screenshot 2025-12-19 at 10-39-51 Meldinger" src="https://github.com/user-attachments/assets/15c82e43-5425-4d55-a480-c8b4e2f38569" />

Det er mulig å trikse litt for å sende inn ReactElement i dag ved å bruke `as unknown as string`, men det hadde vært bedre å få oppdatert typen i komponenten.

## Testing

<!-- Hvordan har du har testet endringene dine? Ta gjerne med systeminfo o.l -->

<!--

Helt til slutt, har du ..

.. lest retningslinjene våre for bidrag?
.. tatt en siste sjekk for kode og skrivefeil, debug informasjon o.l?
.. kjørt og eventuelt oppdatert testene?
.. kommentert og dokumentert det som trengs?
.. knyttet denne opp til relaterte issues?

-->
