### PR TITLE
Radio block z index fix

### DIFF
--- a/packages/ffe-form/less/radio-block.less
+++ b/packages/ffe-form/less/radio-block.less
@@ -38,7 +38,6 @@
             grid-row: 1 e('/') 2;
             content: '';
             left: var(--ffe-spacing-sm);
-            z-index: 1;
             background-color: var(--ffe-color-surface-primary-default);
             border: var(--ffe-g-border-width) solid var(--outer-border-color);
             width: 20px;


### PR DESCRIPTION
Ref [slack-tråden](https://sb1-utvikling.slack.com/archives/CNS68BM1B/p1768227405821799).

Klassen `.ffe-radio-block__content::before` hadde z-index satt. Klarer ikke se en grunn til at den er der. 

Har testet: 
- Chrome
- Safari
- Accent context
- I DSBanken
- Dark mode/light mode
- Focus
- zoom og større font-størrelse
- Ugyldig state

<img width="693" height="651" alt="image" src="https://github.com/user-attachments/assets/76882a91-8ac3-4a17-ae4c-bcbe7acee1dc" />
<img width="710" height="605" alt="image" src="https://github.com/user-attachments/assets/3f68b4ee-8e4d-4ca2-b00c-8eac5172b98d" />


