### PR TITLE
Spesifiserer font i datepicker

### DIFF
--- a/packages/ffe-datepicker/less/dateinput.less
+++ b/packages/ffe-datepicker/less/dateinput.less
@@ -1,4 +1,5 @@
 .ffe-datepicker {
+    font-family: var(--ffe-g-font);
     position: relative;
     height: 2.8125rem; //Etterlikner ffe-input-field
     display: grid;


### PR DESCRIPTION
Det kom inn en bug på at fonten i datepicker ikke blir riktig når den er i modal. Det skyldes nok to ting: 
1. Modal som dialog havner kanskje utenfor body og dermed utenfor `ffe-body`, som er det som setter font-family som fallback 
2. Datepicker mangler spesifisering av font. 

Fiksen er det siste, legger bare til fonten i datepicker. Ser ut til å løse problemet. Man kunne kanskje sett på å forbedre modalen sånn at det samme ikke skjer på liknende komponenter, men det er jo fint å ha spesifiseringen i komponenten, og heller bedre å ta høyde for det senere hvis det skulle dukke opp som et problem på flere komponenter. 

Testet i storybook chrome. 