### PR TITLE
feat(ffe-tables): update background color on expand content

### DIFF
--- a/packages/ffe-tables/less/tables.less
+++ b/packages/ffe-tables/less/tables.less
@@ -94,7 +94,7 @@
     }
 
     &__expand-content {
-        background: var(--ffe-color-surface-primary-default-pressed);
+        background: var(--ffe-color-surface-neutral-default);
     }
 
     &__th,


### PR DESCRIPTION
Oppdaterte bakgrunnsfargen i expandable row i table slik at det blir likt med figma (#f0f0f0 / color/surface/neutral/default)

## Beskrivelse
<img width="1175" height="132" alt="Skjermbilde 2026-02-10 kl  16 47 33" src="https://github.com/user-attachments/assets/b08eacb1-efea-43f7-a5e4-b8180a46180c" />

## Motivasjon og kontekst
Vil at storybook og figma skal være så likt som mulig.

## Testing
Kjørt opp lokalt og sjekket at det stemmer

Helt til slutt, har du ..

.. lest retningslinjene våre for bidrag?
.. tatt en siste sjekk for kode og skrivefeil, debug informasjon o.l?
.. kjørt og eventuelt oppdatert testene?
.. kommentert og dokumentert det som trengs?
.. knyttet denne opp til relaterte issues?

-->
