### PR TITLE
fix(ffe-form): endret div til legend for label i RadioButtonInputGroup

### DIFF
--- a/packages/ffe-form-react/src/RadioButtonInputGroup.tsx
+++ b/packages/ffe-form-react/src/RadioButtonInputGroup.tsx
@@ -107,7 +107,7 @@ export const RadioButtonInputGroup: React.FC<RadioButtonInputGroupProps> = ({
             {...rest}
         >
             {label && (
-                <div
+                <legend
                     id={id}
                     className={classNames(
                         'ffe-form-label',
@@ -119,7 +119,7 @@ export const RadioButtonInputGroup: React.FC<RadioButtonInputGroupProps> = ({
                         <Tooltip>{tooltip}</Tooltip>
                     )}
                     {React.isValidElement(tooltip) && tooltip}
-                </div>
+                </legend>
             )}
 
             {description && (


### PR DESCRIPTION
## Beskrivelse

Labelen i RadioButtonInputGroup var wrappet med en `div`, men det burde være en `legend`. Grunnen er måten disabled fungerer på [fieldset](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/fieldset#attributes) som gjør at klikkeventer ikke fungerer med mindre man bruker `legend`

## Motivasjon og kontekst

Denne endringen løser https://github.com/SpareBank1/designsystem/issues/3136

## Testing

Jeg har bare testet det i nettlesere jeg har tilgang til på min Mac: Safari, Firefox og Chrome

En codepen som kan brukes til å teste: https://codepen.io/lars-sb1u/pen/qEaWKmJ