### PR TITLE
fix(ffe-datepicker-react): fiks bug hvor en ikke kan bruke dateinput hvis en har voiceover aktivert i safari

### DIFF
--- a/packages/ffe-datepicker-react/src/input/DateInput.spec.tsx
+++ b/packages/ffe-datepicker-react/src/input/DateInput.spec.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { DateInput, DateInputProps } from './DateInput';
 import { render, screen } from '@testing-library/react';
+import * as isIOSSafariUtil from '../util/isIOSSafari';
 
 const noop = () => {};
 
@@ -18,50 +19,55 @@ const defaultProps = {
 const renderInput = (props?: Partial<DateInputProps>) =>
     render(<DateInput {...defaultProps} {...props} />);
 
+const getInput = () => screen.getByDisplayValue('2016-03-07');
+
 describe('<Input />', () => {
     describe('nested input field', () => {
         it('should be a single input field', () => {
             renderInput();
-            expect(screen.getByRole('textbox')).toBeInTheDocument();
+            expect(getInput()).toBeInTheDocument();
         });
 
         it('should have BEM element class name', () => {
             renderInput();
             expect(
-                screen
-                    .getByRole('textbox')
-                    .classList.contains('ffe-dateinput__field'),
+                getInput().classList.contains('ffe-dateinput__field'),
             ).toBeTruthy();
         });
 
         it('should have given value', () => {
             renderInput();
-            expect(screen.getByRole('textbox').getAttribute('value')).toBe(
-                '2016-03-07',
-            );
-        });
-
-        it('should have property from input props', () => {
-            renderInput();
-            expect(
-                screen.getByRole('textbox').getAttribute('placeholder'),
-            ).toBe('Given placeholder');
+            expect(getInput().getAttribute('value')).toBe('2016-03-07');
         });
 
         it('should have given aria-invalid', () => {
             renderInput();
-            expect(
-                screen.getByRole('textbox').getAttribute('aria-invalid'),
-            ).toBe('false');
+            expect(getInput().getAttribute('aria-invalid')).toBe('false');
         });
 
         it('should have class name from input props', () => {
             renderInput();
             expect(
-                screen
-                    .getByRole('textbox')
-                    .classList.contains('given-class-name'),
+                getInput().classList.contains('given-class-name'),
             ).toBeTruthy();
+        });
+    });
+
+    describe('iOS Safari VoiceOver workaround', () => {
+        afterEach(() => {
+            jest.restoreAllMocks();
+        });
+
+        it('should add role="textbox" on iOS Safari', () => {
+            jest.spyOn(isIOSSafariUtil, 'isIOSSafari').mockReturnValue(true);
+            renderInput();
+            expect(getInput().getAttribute('role')).toBe('textbox');
+        });
+
+        it('should not add role attribute on other platforms', () => {
+            jest.spyOn(isIOSSafariUtil, 'isIOSSafari').mockReturnValue(false);
+            renderInput();
+            expect(getInput().hasAttribute('role')).toBe(false);
         });
     });
 });

--- a/packages/ffe-datepicker-react/src/input/DateInput.stories.tsx
+++ b/packages/ffe-datepicker-react/src/input/DateInput.stories.tsx
@@ -1,0 +1,75 @@
+import { InputGroup } from '@sb1/ffe-form-react';
+import type { Meta, StoryObj } from '@storybook/react';
+import React, { useState } from 'react';
+import { DateInput, DateInputProps } from './DateInput';
+import { BodyText } from '@sb1/ffe-core-react';
+
+const meta: Meta<typeof DateInput> = {
+    title: 'Komponenter/Datepicker/DateInput',
+    component: DateInput,
+    parameters: {
+        docs: {
+            description: {
+                component:
+                    'DateInput er et enkelt tekstfelt for datoinntasting. Skal kun brukes på mobile enheter som et alternativ til Datepicker, da det gir bedre UX — brukeren taster inn dato direkte i stedet for å navigere en kalender på liten skjerm. På desktop skal Datepicker brukes.',
+            },
+        },
+    },
+};
+export default meta;
+
+type Story = StoryObj<typeof DateInput>;
+
+export const Standard: Story = {
+    args: {
+        locale: 'nb',
+        ariaInvalid: 'false',
+    },
+    render: function Render({ value, onChange, ...args }: DateInputProps) {
+        const [date, setDate] = useState('01.12.2024');
+
+        return (
+            <>
+                <BodyText>
+                    Skal kun brukes på mobile enheter som et alternativ til
+                    Datepicker, da det gir bedre UX. På desktop skal Datepicker
+                    brukes.
+                </BodyText>
+                <InputGroup label="Dato" labelId="dateinput-label">
+                    <DateInput
+                        id="dateinput-label"
+                        value={date}
+                        onChange={e => setDate(e.target.value)}
+                        {...args}
+                    />
+                </InputGroup>
+            </>
+        );
+    },
+};
+
+export const AriaInvalid: Story = {
+    args: {
+        ...Standard.args,
+        ariaInvalid: 'true',
+    },
+    render: function Render({ value, onChange, ...args }: DateInputProps) {
+        const [date, setDate] = useState('foobar');
+
+        return (
+            <InputGroup
+                label="Dato"
+                labelId="dateinput-label"
+                aria-invalid={true}
+                fieldMessage="Ugyldig dato"
+            >
+                <DateInput
+                    id="dateinput-label"
+                    value={date}
+                    onChange={e => setDate(e.target.value)}
+                    {...args}
+                />
+            </InputGroup>
+        );
+    },
+};

--- a/packages/ffe-datepicker-react/src/input/DateInput.tsx
+++ b/packages/ffe-datepicker-react/src/input/DateInput.tsx
@@ -1,6 +1,7 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import classNames from 'classnames';
 import i18n from '../i18n/i18n';
+import { isIOSSafari } from '../util/isIOSSafari';
 
 export interface DateInputProps extends React.ComponentPropsWithRef<'input'> {
     ariaInvalid: string;
@@ -10,9 +11,15 @@ export interface DateInputProps extends React.ComponentPropsWithRef<'input'> {
 
 export const DateInput = React.forwardRef<HTMLInputElement, DateInputProps>(
     ({ ariaInvalid, value, className, locale = 'nb', ...rest }, ref) => {
+        // VoiceOver on iOS Safari blocks interaction with date-related inputs.
+        // Using role="textbox" as a workaround on that platform.
+        // https://dev.to/mfranzke/voiceover-bug-on-ios-safari-blocks-date-time-related-inputs-especially-in-react-4f61
+        const role = useMemo(() => (isIOSSafari() ? 'textbox' : undefined), []);
+
         return (
             <input
-                {...rest}
+                type="date"
+                role={role}
                 aria-invalid={
                     ariaInvalid as unknown as React.ComponentPropsWithRef<'input'>['aria-invalid']
                 }
@@ -24,6 +31,7 @@ export const DateInput = React.forwardRef<HTMLInputElement, DateInputProps>(
                     'ffe-input-field ffe-dateinput__field',
                     className,
                 )}
+                {...rest}
             />
         );
     },

--- a/packages/ffe-datepicker-react/src/util/isIOSSafari.spec.ts
+++ b/packages/ffe-datepicker-react/src/util/isIOSSafari.spec.ts
@@ -1,0 +1,58 @@
+import { isIOSSafari } from './isIOSSafari';
+
+const mockNavigator = (userAgent: string, maxTouchPoints = 0) => {
+    Object.defineProperty(window, 'navigator', {
+        value: { userAgent, maxTouchPoints },
+        writable: true,
+        configurable: true,
+    });
+};
+
+describe('isIOSSafari', () => {
+    const originalNavigator = window.navigator;
+
+    afterEach(() => {
+        Object.defineProperty(window, 'navigator', {
+            value: originalNavigator,
+            writable: true,
+            configurable: true,
+        });
+    });
+
+    it('should return true for Safari on iPhone', () => {
+        mockNavigator(
+            'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1',
+        );
+        expect(isIOSSafari()).toBe(true);
+    });
+
+    it('should return true for Safari on iPadOS 13+ in desktop mode', () => {
+        mockNavigator(
+            'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/604.1',
+            5,
+        );
+        expect(isIOSSafari()).toBe(true);
+    });
+
+    it('should return false for Safari on macOS (no touch points)', () => {
+        mockNavigator(
+            'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/604.1',
+            0,
+        );
+        expect(isIOSSafari()).toBe(false);
+    });
+
+    it('should return false for Chrome on iPhone', () => {
+        mockNavigator(
+            'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/118.0.5993.69 Mobile/15E148 Safari/604.1',
+        );
+        expect(isIOSSafari()).toBe(false);
+    });
+
+    it('should return false for Chrome on desktop', () => {
+        mockNavigator(
+            'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/118.0.0.0 Safari/537.36',
+        );
+        expect(isIOSSafari()).toBe(false);
+    });
+});

--- a/packages/ffe-datepicker-react/src/util/isIOSSafari.ts
+++ b/packages/ffe-datepicker-react/src/util/isIOSSafari.ts
@@ -1,0 +1,24 @@
+/**
+ * Detects iOS/iPadOS Safari to work around a VoiceOver bug that blocks
+ * interaction with date-related inputs.
+ * @see https://dev.to/mfranzke/voiceover-bug-on-ios-safari-blocks-date-time-related-inputs-especially-in-react-4f61
+ *
+ * Known limitations:
+ * - iOS WebViews (in-app browsers like Instagram, Facebook) use WebKit and may
+ *   be affected by the same bug, but are not detected here since they don't
+ *   include "Safari" in the user agent string.
+ */
+export const isIOSSafari = (): boolean => {
+    if (typeof navigator === 'undefined') {
+        return false;
+    }
+    const ua = navigator.userAgent;
+    // iPadOS 13+ in desktop mode reports as Macintosh, but can be identified
+    // by having touch points (real Macs have maxTouchPoints === 0).
+    const isIOS =
+        /iP(ad|hone|od)/.test(ua) ||
+        (/Macintosh/.test(ua) && navigator.maxTouchPoints > 1);
+    const isSafari =
+        !!ua.match(/Safari/) && !ua.match(/CriOS|FxiOS|OPiOS|EdgiOS/);
+    return isIOS && isSafari;
+};


### PR DESCRIPTION
Skal en teste det kan en kanskje gjøre det på en iphone i storybook. sjekke om den ikke funker i dag men fungerer i storybook i denne PRen