### PR TITLE
Fikser bug som gjør at noMatch teksten vises selv om den ikke burde

### DIFF
--- a/packages/ffe-searchable-dropdown-react/src/getListToRender.spec.ts
+++ b/packages/ffe-searchable-dropdown-react/src/getListToRender.spec.ts
@@ -1,0 +1,112 @@
+import { getListToRender } from './getListToRender';
+
+interface Item {
+    name: string;
+    value: string;
+}
+
+const items: Item[] = [
+    { name: 'Apple', value: 'apple' },
+    { name: 'Banana', value: 'banana' },
+    { name: 'Cherry', value: 'cherry' },
+];
+
+const defaultParams = {
+    inputValue: '',
+    searchAttributes: ['name'] as Array<keyof Item>,
+    maxRenderedDropdownElements: 10,
+    dropdownList: items,
+    noMatchDropdownList: undefined,
+    showAllItemsInDropdown: false,
+};
+
+describe('getListToRender', () => {
+    it('should return all items when input is empty', () => {
+        const result = getListToRender(defaultParams);
+        expect(result.listToRender).toEqual(items);
+        expect(result.noMatch).toBe(false);
+    });
+
+    it('should filter items based on input value', () => {
+        const result = getListToRender({
+            ...defaultParams,
+            inputValue: 'App',
+        });
+        expect(result.listToRender).toEqual([items[0]]);
+        expect(result.noMatch).toBe(false);
+    });
+
+    it('should set noMatch to true when no items match', () => {
+        const result = getListToRender({
+            ...defaultParams,
+            inputValue: 'xyz',
+        });
+        expect(result.listToRender).toEqual([]);
+        expect(result.noMatch).toBe(true);
+    });
+
+    it('should return noMatchDropdownList when provided and no items match', () => {
+        const noMatchItems = [{ name: 'No results', value: 'none' }];
+        const result = getListToRender({
+            ...defaultParams,
+            inputValue: 'xyz',
+            noMatchDropdownList: noMatchItems,
+        });
+        expect(result.listToRender).toEqual(noMatchItems);
+        expect(result.noMatch).toBe(true);
+    });
+
+    it('should return all items when showAllItemsInDropdown is true', () => {
+        const result = getListToRender({
+            ...defaultParams,
+            inputValue: 'xyz',
+            showAllItemsInDropdown: true,
+        });
+        expect(result.listToRender).toEqual(items);
+    });
+
+    it('should set noMatch to false when showAllItemsInDropdown is true even if filter has no matches', () => {
+        const result = getListToRender({
+            ...defaultParams,
+            inputValue: 'xyz',
+            showAllItemsInDropdown: true,
+        });
+        expect(result.noMatch).toBe(false);
+    });
+
+    it('should respect maxRenderedDropdownElements', () => {
+        const result = getListToRender({
+            ...defaultParams,
+            maxRenderedDropdownElements: 2,
+        });
+        expect(result.listToRender).toHaveLength(2);
+    });
+
+    it('should trim input value before filtering', () => {
+        const result = getListToRender({
+            ...defaultParams,
+            inputValue: '  App  ',
+        });
+        expect(result.listToRender).toEqual([items[0]]);
+    });
+
+    it('should be case-insensitive when filtering', () => {
+        const result = getListToRender({
+            ...defaultParams,
+            inputValue: 'apple',
+        });
+        expect(result.listToRender).toEqual([items[0]]);
+    });
+
+    it('should use custom searchMatcher when provided', () => {
+        const searchMatcher = (inputValue: string) => (item: Item) =>
+            item.value === inputValue;
+
+        const result = getListToRender({
+            ...defaultParams,
+            inputValue: 'banana',
+            searchMatcher,
+        });
+        expect(result.listToRender).toEqual([items[1]]);
+    });
+});

--- a/packages/ffe-searchable-dropdown-react/src/getListToRender.ts
+++ b/packages/ffe-searchable-dropdown-react/src/getListToRender.ts
@@ -61,6 +61,6 @@ export const getListToRender = <Item extends Record<string, any>>({
 
     return {
         listToRender: listToRender(),
-        noMatch: !dropdownListFiltered?.length,
+        noMatch: !showAllItemsInDropdown && !dropdownListFiltered?.length,
     };
 };


### PR DESCRIPTION
## Beskrivelse
<img width="648" height="352" alt="image" src="https://github.com/user-attachments/assets/af5cfb54-b7b0-4ffd-ab8d-46040e833bba" />

Hvis man skriver inn noe som ikke gir noen treff, og så trykker på søkefeltet vil den vise hele listen og meldingen om at den ikke fant noe

## Motivasjon og kontekst

Snubla på denne feilen når jeg tok den i bruk og tenkte den kunne fikses

## Testing

Testet manuelt, og verifisert at testene tryner uten fiksen.

Helt til slutt, har du ..

.. lest retningslinjene våre for bidrag?
.. tatt en siste sjekk for kode og skrivefeil, debug informasjon o.l?
.. kjørt og eventuelt oppdatert testene?
.. kommentert og dokumentert det som trengs?
.. knyttet denne opp til relaterte issues?

-->
