### PR TITLE
feat(ffe-tables): oppdaterer farger i expandable og sortable

### DIFF
--- a/packages/ffe-tables/less/tables.less
+++ b/packages/ffe-tables/less/tables.less
@@ -94,7 +94,7 @@
     }
 
     &__expand-content {
-        background: var(--ffe-color-surface-neutral-default);
+        background: var(--ffe-color-fill-primary-subtle);
     }
 
     &__th,
@@ -124,23 +124,6 @@
 
         &:active {
             background: var(--ffe-color-surface-primary-default-pressed);
-        }
-
-        &-ascending,
-        &-descending {
-            background: var(--ffe-color-fill-primary-selected-default);
-            color: var(--ffe-color-foreground-inverse);
-
-            @media (hover: hover) and (pointer: fine) {
-                &:hover {
-                    background: var(--ffe-color-fill-primary-selected-hover);
-                    color: var(--ffe-color-foreground-inverse);
-                }
-            }
-
-            &:active {
-                background: var(--ffe-color-fill-primary-selected-pressed);
-            }
         }
 
         @media (hover: hover) and (pointer: fine) {
@@ -175,19 +158,10 @@
     }
 
     &__tr--expand-open {
-        background: var(--ffe-color-fill-primary-selected-default);
-
-        .ffe-table__cell-content {
-            color: var(--ffe-color-foreground-inverse);
-        }
-
-        .ffe-table__expand-button .ffe-icons {
-            color: var(--ffe-color-foreground-inverse);
-        }
-
+        background: var(--ffe-color-fill-primary-default);
         @media (hover: hover) and (pointer: fine) {
             &:hover {
-                background: var(--ffe-color-fill-primary-selected-default);
+                background: var(--ffe-color-fill-primary-default-hover);
             }
         }
     }


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse

* Endrer farger i expandable table for mer forutsigbare kontraster, etter en bugrapport
* Fjerner bakgrunnsfarge på table-headere i sortable table

### Expandable før:

<img width="892" height="278" alt="image" src="https://github.com/user-attachments/assets/554532e0-4254-4f8c-a45b-8109234845ed" />

#### Expandable etter:

<img width="892" height="278" alt="image" src="https://github.com/user-attachments/assets/4bbba9dd-1ed3-4c7c-9b2e-5bbe27a335e1" />

### Sortable før:

<img width="892" height="196" alt="image" src="https://github.com/user-attachments/assets/575e87fa-18a4-49c2-860e-0c4de4b83d2d" />

#### Sortable etter:

<img width="892" height="196" alt="image" src="https://github.com/user-attachments/assets/d9d9ef89-17fd-4f99-8462-563b293913fd" />
