### PR TITLE
fix(ffe-datepicker-react): fikser bug i tastaturnavigasjon med dropdown caption

### DIFF
--- a/packages/ffe-datepicker-react/src/calendar/Calendar.tsx
+++ b/packages/ffe-datepicker-react/src/calendar/Calendar.tsx
@@ -65,6 +65,8 @@ export class Calendar extends Component<CalendarProps, State> {
     clickableDateRef = React.createRef<HTMLTableCellElement>();
     prevMonthButtonElementRef = React.createRef<HTMLButtonElement>();
     nextMonthButtonElementRef = React.createRef<HTMLButtonElement>();
+    monthSelectRef = React.createRef<HTMLSelectElement>();
+    yearSelectRef = React.createRef<HTMLSelectElement>();
 
     /* eslint-disable react/no-did-update-set-state */
     componentDidUpdate(prevProps: CalendarProps) {
@@ -243,15 +245,23 @@ export class Calendar extends Component<CalendarProps, State> {
 
         if (event.key === 'Tab') {
             event.preventDefault();
+            const { dropdownCaption } = this.props;
+
             if (event.shiftKey) {
                 if (activeElement === this.clickableDateRef.current) {
                     this.nextMonthButtonElementRef.current?.focus();
                     this.setState({ isFocusingHeader: true });
-                }
-                if (activeElement === this.nextMonthButtonElementRef.current) {
+                } else if (activeElement === this.nextMonthButtonElementRef.current) {
+                    if (dropdownCaption) {
+                        this.yearSelectRef.current?.focus();
+                    } else {
+                        this.prevMonthButtonElementRef.current?.focus();
+                    }
+                } else if (dropdownCaption && activeElement === this.yearSelectRef.current) {
+                    this.monthSelectRef.current?.focus();
+                } else if (dropdownCaption && activeElement === this.monthSelectRef.current) {
                     this.prevMonthButtonElementRef.current?.focus();
-                }
-                if (activeElement === this.prevMonthButtonElementRef.current) {
+                } else if (activeElement === this.prevMonthButtonElementRef.current) {
                     this.clickableDateRef.current?.focus();
                     this.setState({ isFocusingHeader: false });
                     this.forceUpdate();
@@ -260,11 +270,17 @@ export class Calendar extends Component<CalendarProps, State> {
                 if (activeElement === this.clickableDateRef.current) {
                     this.prevMonthButtonElementRef.current?.focus();
                     this.setState({ isFocusingHeader: true });
-                }
-                if (activeElement === this.prevMonthButtonElementRef.current) {
+                } else if (activeElement === this.prevMonthButtonElementRef.current) {
+                    if (dropdownCaption) {
+                        this.monthSelectRef.current?.focus();
+                    } else {
+                        this.nextMonthButtonElementRef.current?.focus();
+                    }
+                } else if (dropdownCaption && activeElement === this.monthSelectRef.current) {
+                    this.yearSelectRef.current?.focus();
+                } else if (dropdownCaption && activeElement === this.yearSelectRef.current) {
                     this.nextMonthButtonElementRef.current?.focus();
-                }
-                if (activeElement === this.nextMonthButtonElementRef.current) {
+                } else if (activeElement === this.nextMonthButtonElementRef.current) {
                     this.clickableDateRef.current?.focus();
                     this.setState({ isFocusingHeader: false });
                     this.forceUpdate();
@@ -333,6 +349,8 @@ export class Calendar extends Component<CalendarProps, State> {
                         }
                         minDate={this.props.minDate}
                         maxDate={this.props.maxDate}
+                        monthSelectRef={this.monthSelectRef}
+                        yearSelectRef={this.yearSelectRef}
                     />
                     <table
                         className="ffe-calendar__grid"

--- a/packages/ffe-datepicker-react/src/calendar/Header.tsx
+++ b/packages/ffe-datepicker-react/src/calendar/Header.tsx
@@ -14,6 +14,8 @@ interface HeaderProps {
     year: number;
     prevMonthButtonElement: React.RefObject<HTMLButtonElement>;
     nextMonthButtonElement: React.RefObject<HTMLButtonElement>;
+    monthSelectRef?: React.RefObject<HTMLSelectElement>;
+    yearSelectRef?: React.RefObject<HTMLSelectElement>;
     /** Nåværende månedsnummer (1-12) */
     monthNumber: number;
     /** Om måned- og år-dropdown skal vises i kalenderen */
@@ -44,6 +46,8 @@ export const Header: React.FC<HeaderProps> = ({
     onMonthYearChange,
     minDate,
     maxDate,
+    monthSelectRef,
+    yearSelectRef,
 }) => {
     const arrowBackIosIcon =
         'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGhlaWdodD0iMjQiIHZpZXdCb3g9IjAgLTk2MCA5NjAgOTYwIiB3aWR0aD0iMjQiPjxwYXRoIGQ9Im0zNjcuMzg0LTQ4MCAzMDEuMzA4IDMwMS4zMDhxMTEuOTIzIDExLjkyMyAxMS42MTUgMjguMDc3LS4zMDggMTYuMTUzLTEyLjIzMSAyOC4wNzZxLTExLjkyMiAxMS45MjMtMjguMDc2IDExLjkyM3QtMjguMDc2LTExLjkyM0wzMDUuMDc4LTQyOC43N3EtMTAuODQ3LTEwLjg0Ni0xNi4wNzctMjQuMzA3LTUuMjMxLTEzLjQ2Mi01LjIzMS0yNi45MjMgMC0xMy40NjEgNS4yMzEtMjYuOTIzIDUuMjMtMTMuNDYxIDE2LjA3Ny0yNC4zMDdsMzA2Ljg0Ni0zMDYuODQ2cTExLjkyMi0xMS45MjMgMjguMzg0LTExLjYxNiAxNi40NjEuMzA4IDI4LjM4NCAxMi4yMzEgMTEuOTIzIDExLjkyMyAxMS45MjMgMjguMDc2IDAgMTYuMTU0LTExLjkyMyAyOC4wNzdMMzY3LjM4NC00ODBaIi8+PC9zdmc+';
@@ -106,6 +110,7 @@ export const Header: React.FC<HeaderProps> = ({
                                     aria-label={`${month} ${year}`}
                                     onClick={handleDropdownClick}
                                     onFocus={handleDropdownFocus}
+                                    ref={monthSelectRef}
                                 >
                                     {monthOptions.map(option => (
                                         <option key={option.value} value={option.value}>
@@ -123,6 +128,7 @@ export const Header: React.FC<HeaderProps> = ({
                                     aria-label={`${year}`}
                                     onClick={handleDropdownClick}
                                     onFocus={handleDropdownFocus}
+                                    ref={yearSelectRef}
                                 >
                                     {yearOptions.map(option => (
                                         <option key={option.value} value={option.value}>


### PR DESCRIPTION
## Beskrivelse

Tastaturnavigasjon i datepicker med dropdown caption har en bug som gjør at focus kan sette seg fast i dropdown, se #3146 for eksempel. I tillegg er det ikke mulig for focus å nå dropdown-menyene før man først har valgt en dato og deretter startet navigeringen på nytt. Dette skyldes tilsynlatende at focus er hardkodet til prev/next og ikke inkluderer dropdown-menyene når `dropdownCaption` er aktiv.

## Motivasjon og kontekst

Fixes #3146 

## Testing

Testet med Storybook