### PR TITLE
fix(ffe-form-react): allow ReactNode for TextField prefix and suffix

### DIFF
--- a/packages/ffe-form-react/src/TextField.tsx
+++ b/packages/ffe-form-react/src/TextField.tsx
@@ -1,15 +1,15 @@
 import React from 'react';
 import classNames from 'classnames';
 
-export interface TextFieldProps extends React.ComponentPropsWithoutRef<'input'> {
+export interface TextFieldProps extends Omit<React.ComponentPropsWithoutRef<'input'>, 'prefix' | 'suffix'> {
     /** Text fields default to `display: block;`. Set this to `true` to apply the inline modifier. */
     inline?: boolean;
     /** Make the text right aligned */
     textRightAlign?: boolean;
     /** Add a prefix inside the input */
-    prefix?: string;
+    prefix?: React.ReactNode;
     /** Add a suffix inside the input */
-    suffix?: string;
+    suffix?: React.ReactNode;
 }
 
 export const TextField = React.forwardRef<HTMLInputElement, TextFieldProps>(


### PR DESCRIPTION
Widen prefix and suffix props from string to React.ReactNode and use Omit to prevent conflicts with the native input element's own prefix and suffix attributes.

The native prefix attribute on `<input>` is a legacy/non-standard attribute. it has no meaningful effect in modern browsers.
It was part of an older XForms spec and is essentially unused today.

