### PR TITLE
fix(ffe-datepicker): visuell indikator for focus i kalenderknappen

### DIFF
--- a/packages/ffe-datepicker/less/dateinput.less
+++ b/packages/ffe-datepicker/less/dateinput.less
@@ -30,6 +30,7 @@
     }
 
     &__button {
+        height: calc(2.8125rem - var(--ffe-g-border-width) * 2);
         background: transparent;
         border: none;
         grid-column: 2 e('/') 3;
@@ -40,6 +41,10 @@
         width: 56px;
         cursor: pointer;
         isolation: isolate;
+
+        &:focus-visible {
+            background-color: var(--ffe-color-fill-primary-subtle);
+        }
     }
 
     .ffe-input-field:focus {


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse

Legger til manglende visuell indikator for fokus når man navigerer til kalenderknappen i datepicker med tastatur.

Før:
<img width="242" height="95" alt="image" src="https://github.com/user-attachments/assets/ae44ed9f-9306-4257-95c8-5ddf6f73d9ca" />


Etter:
<img width="242" height="95" alt="image" src="https://github.com/user-attachments/assets/fff02e73-e687-4201-933f-aeca03528e78" />


## Motivasjon og kontekst

Fixes #3158 

## Testing

Testet med storybook