### PR TITLE
fix(ffe-datepicker-react): allow key events to bubble from SpinButton input fields

### DIFF
--- a/packages/ffe-datepicker-react/src/datepicker/SpinButton.tsx
+++ b/packages/ffe-datepicker-react/src/datepicker/SpinButton.tsx
@@ -32,8 +32,6 @@ export const SpinButton = React.forwardRef<HTMLSpanElement, SpinButtonProps>(
         const history = useRef<number[]>([]);
 
         const handleKeyDown = (evt: React.KeyboardEvent) => {
-            evt.stopPropagation();
-
             if (/\d/.test(evt.key)) {
                 history.current =
                     history.current.length === maxLength


### PR DESCRIPTION
## Summary

- Removes `stopPropagation()` from `SpinButton`'s `handleKeyDown` handler so key events bubble from the input fields consistently with how they behave when the calendar is open
- Keys that need to be consumed for UX purposes (arrow keys) still call `preventDefault()` to prevent scroll/browser defaults

## Test plan

- [ ] Open the Datepicker story in Storybook and verify typing/navigating in the input fields works as expected
- [ ] Verify key events bubble to parent components (e.g. wrapping a datepicker in a keydown listener should now receive events from the input fields)
- [ ] All 99 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)