### PR TITLE
Fikser bugs i datepicker-tastaturnavigering

### DIFF
--- a/packages/ffe-datepicker-react/src/calendar/Calendar.tsx
+++ b/packages/ffe-datepicker-react/src/calendar/Calendar.tsx
@@ -14,7 +14,7 @@ export interface CalendarProps {
     calendarClassName?: string;
     escKeyHandler?: React.KeyboardEventHandler<HTMLDivElement>;
     locale: 'nb' | 'nn' | 'en';
-    onDatePicked: (date: string) => void;
+    onDatePicked: (date: string, keepOpen?: boolean) => void;
     selectedDate?: string | null;
     focusOnMount?: boolean;
     /** Om måned- og år-dropdown skal vises i kalenderen */
@@ -102,6 +102,7 @@ export class Calendar extends Component<CalendarProps, State> {
             'ArrowUp',
             'ArrowRight',
             'ArrowDown',
+            ' ',
         ] as const;
         if (scrollableEvents.includes(event.key)) {
             event.preventDefault();
@@ -109,14 +110,18 @@ export class Calendar extends Component<CalendarProps, State> {
 
         switch (event.key) {
             case 'Enter':
+            case ' ':
                 if (
                     calendar.isDateWithinDateRange(calendar.focusedDate) &&
-                    this.props.disabledDates?.includes(
+                    !this.props.disabledDates?.includes(
                         calendar.focusedDate.toString(),
-                    ) === false
+                    )
                 ) {
                     calendar.selectFocusedDate();
-                    this.props.onDatePicked(calendar.selected());
+                    this.props.onDatePicked(
+                        calendar.selected(),
+                        event.key === ' ',
+                    );
                 }
                 event.preventDefault();
                 break;
@@ -178,13 +183,13 @@ export class Calendar extends Component<CalendarProps, State> {
     nextMonth(evt: React.MouseEvent<HTMLButtonElement>) {
         evt.preventDefault();
         this.state.calendar.nextMonth();
-        this.forceUpdate();
+        this.forceUpdate(() => this.nextMonthButtonElementRef.current?.focus());
     }
 
     previousMonth(evt: React.MouseEvent<HTMLButtonElement>) {
         evt.preventDefault();
         this.state.calendar.previousMonth();
-        this.forceUpdate();
+        this.forceUpdate(() => this.prevMonthButtonElementRef.current?.focus());
     }
 
     renderDate(calendarButtonState: CalendarButtonState, index: number) {

--- a/packages/ffe-datepicker-react/src/datepicker/DatepickerComp.tsx
+++ b/packages/ffe-datepicker-react/src/datepicker/DatepickerComp.tsx
@@ -242,15 +242,17 @@ export const DatepickerComp: React.FC<DatepickerCompProps> = ({
         }
     };
 
-    const datePickedHandler = (date: string) => {
+    const datePickedHandler = (date: string, keepOpen?: boolean) => {
         const simpleDate = getSimpleDateFromString(date);
         if (simpleDate) {
             setDay([simpleDate.date]);
             setMonth([simpleDate.month + 1]);
             setYear([simpleDate.year]);
-            setDisplayDatePicker(false);
             setCalendarActiveDate(date);
-            buttonRef.current?.focus();
+            if (!keepOpen) {
+                setDisplayDatePicker(false);
+                buttonRef.current?.focus();
+            }
         }
     };
 

--- a/packages/ffe-datepicker/less/calendar.less
+++ b/packages/ffe-datepicker/less/calendar.less
@@ -37,6 +37,7 @@
     }
 
     &__month,
+    &__year,
     &__title {
         padding-right: var(--ffe-spacing-xs);
         color: var(--ffe-color-foreground-emphasis);


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse

Fikser diverse bugs i datepicker:

* Misalignment mellom måned og år i kalender-header er rettet opp
* Når man bytter måned med pilene i kalender-header flyttes ikke fokus lenger tilbake til datoen i input-feltet, noe som gjør det noen hakk mer smidig å navigere med tastatur
* Fikset bug som gjorde at det ikke var mulig å velge dato i kalenderen med tastatur. Nå fungerer det som ønsket i #3163 

## Motivasjon og kontekst

Fixes #3101 
Fixes #3163 
Fixes #3164 

## Testing

Testet i Storybook