### PR TITLE
fix(ffe-badge-react): gjør Badge children optional

### DIFF
--- a/packages/ffe-account-selector-react/package.json
+++ b/packages/ffe-account-selector-react/package.json
@@ -32,7 +32,7 @@
     "dependencies": {
         "@sb1/ffe-formatters": "^101.0.1",
         "@sb1/ffe-icons-react": "^101.0.1",
-        "@sb1/ffe-searchable-dropdown-react": "^100.12.4",
+        "@sb1/ffe-searchable-dropdown-react": "^101.0.1",
         "classnames": "^2.5.1"
     },
     "devDependencies": {

--- a/packages/ffe-badge-react/src/Badge.tsx
+++ b/packages/ffe-badge-react/src/Badge.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 
 export type BadgeProps = {
     className?: string;
-    children: React.ReactNode;
+    children?: React.ReactNode;
 };
 
 export function Badge({ className, children, ...rest }: BadgeProps) {


### PR DESCRIPTION
Gjør Badge children optional og fikser avhengighetversjon til avhengighet som ble nedgradert ved en feil i en rebase.