### PR TITLE
 feat(ffe-core): add native utility classes for hybrid apps (WebView)

### DIFF
--- a/documentation/Changelog.mdx
+++ b/documentation/Changelog.mdx
@@ -7,6 +7,10 @@ import { SmallText } from '@sb1/ffe-core-react';
 
 Denne siden lister breaking changes og større endringer i designsystemet. Du finner fullstendig changelog på [releasesiden på GitHub](https://github.com/SpareBank1/designsystem/releases).
 
+### 101.1.0 Utility-klasser for native (WebView) (apr 2026)
+
+Nye utility-klasser i `ffe-core` for hybridapper der webinnhold vises i native-appens WebView: `.ffe-native`, `.ffe-selectable` og `.ffe-selectable-all`. Klassene styrer tekstmarkering, long-press-kontekstmeny og tap-delay slik at webinnholdet oppleves som en naturlig del av den native appen. Se [Native — utility-klasser](/?path=/docs/design-native-utility-klasser--docs) for detaljer.
+
 ### 101.0.0 Avhengighetsopprydning og bugfikser (apr 2026)
 
 Denne versjonen er en **major** release primært drevet av oppgradering av interne avhengigheter til nye major-versjoner. Vi anbefaler å følge ekstra med på eventuelle feil etter oppdatering, slik som med alle major-versjoner.

--- a/documentation/Changelog.mdx
+++ b/documentation/Changelog.mdx
@@ -9,7 +9,7 @@ Denne siden lister breaking changes og større endringer i designsystemet. Du fi
 
 ### 101.1.0 Utility-klasser for native (WebView) (apr 2026)
 
-Nye utility-klasser i `ffe-core` for hybridapper der webinnhold vises i native-appens WebView: `.ffe-native`, `.ffe-selectable` og `.ffe-selectable-all`. Klassene styrer tekstmarkering, long-press-kontekstmeny og tap-delay slik at webinnholdet oppleves som en naturlig del av den native appen. Se [Native — utility-klasser](/?path=/docs/design-native-utility-klasser--docs) for detaljer.
+Nye utility-klasser i `ffe-core` for hybridapper der webinnhold vises i native-appens WebView: `.ffe-native`, `.ffe-native-ready`, `.ffe-selectable` og `.ffe-selectable-all`. Klassene styrer tekstmarkering, long-press-kontekstmeny og tap-delay slik at webinnholdet oppleves som en naturlig del av den native appen. Native-oppførselen aktiveres bare når både `.ffe-native` (settes av rammeverket) og `.ffe-native-ready` (settes av teamet etter verifisering) er til stede — `.ffe-native-ready` er en midlertidig opt-in-markør som vil fjernes når alle apper er migrert. Se [Native — utility-klasser](/?path=/docs/design-native-utility-klasser--docs) for detaljer.
 
 ### 101.0.0 Avhengighetsopprydning og bugfikser (apr 2026)
 

--- a/documentation/Changelog.mdx
+++ b/documentation/Changelog.mdx
@@ -9,7 +9,7 @@ Denne siden lister breaking changes og større endringer i designsystemet. Du fi
 
 ### 101.1.0 Utility-klasser for native (WebView) (apr 2026)
 
-Nye utility-klasser i `ffe-core` for hybridapper der webinnhold vises i native-appens WebView: `.ffe-native`, `.ffe-native-ready`, `.ffe-selectable` og `.ffe-selectable-all`. Klassene styrer tekstmarkering, long-press-kontekstmeny og tap-delay slik at webinnholdet oppleves som en naturlig del av den native appen. Native-oppførselen aktiveres bare når både `.ffe-native` (settes av rammeverket) og `.ffe-native-ready` (settes av teamet etter verifisering) er til stede — `.ffe-native-ready` er en midlertidig opt-in-markør som vil fjernes når alle apper er migrert. Se [Native — utility-klasser](/?path=/docs/design-native-utility-klasser--docs) for detaljer.
+Nye utility-klasser i `ffe-core` for hybridapper der webinnhold vises i mobilbank sin native WebView: `.ffe-native`, `.ffe-selectable` og `.ffe-selectable-all`. Klassene styrer tekstmarkering, long-press-kontekstmeny og tap-delay slik at webinnholdet oppleves som en naturlig del av den native appen. `.ffe-native` settes av mobilbank-rammeverket og aktiverer oppførselen direkte — klassene har ingen effekt utenfor mobilbank-WebView-konteksten. Se [Native — utility-klasser](/?path=/docs/design-native-utility-klasser--docs) for detaljer.
 
 ### 101.0.0 Avhengighetsopprydning og bugfikser (apr 2026)
 

--- a/packages/ffe-core-react/src/CopyText.mdx
+++ b/packages/ffe-core-react/src/CopyText.mdx
@@ -1,0 +1,38 @@
+import { Canvas, Meta, Controls } from '@storybook/blocks';
+import * as CopyTextStories from './CopyText.stories';
+
+<Meta of={CopyTextStories} />
+
+# CopyText
+
+Wrapper tekst som brukeren enkelt kan kopiere til utklippstavlen. Et kopier-ikon vises etter teksten og bytter til et hake-ikon i 2 sekunder etter kopiering.
+
+<Canvas of={CopyTextStories.Standard} />
+<Controls of={CopyTextStories.Standard} />
+
+## Kopier annet innhold enn det som vises
+
+Bruk `copyText`-prop når du vil kopiere noe annet enn den synlige teksten — f.eks. et kontonummer uten mellomrom.
+
+<Canvas of={CopyTextStories.MedCopyTextOverride} />
+
+## Inline i tekst
+
+<Canvas of={CopyTextStories.InlineITekst} />
+
+## I lengre tekst med ombrytning
+
+<Canvas of={CopyTextStories.FlereLinjer} />
+
+## Detaljliste
+
+Flere kopierbare felt i samme blokk.
+
+<Canvas of={CopyTextStories.Detaljliste} />
+
+## Tilgjengelighet
+
+-   `label`-prop er påkrevd og settes som `aria-label` på knappen. Bør beskrive hva som kopieres, f.eks. `"Kopier kontonummer"`.
+-   `copiedLabel` (standard `'Kopiert'`) settes som `aria-label` etter vellykket kopiering, slik at skjermleser annonserer bekreftelsen.
+-   Knappen har minst 44×44 px treffområde (WCAG 2.5.5) og en synlig fokusring.
+-   Hvis `navigator.clipboard` ikke er tilgjengelig (gamle Android WebView), brukes `document.execCommand('copy')` som fallback.

--- a/packages/ffe-core-react/src/CopyText.spec.tsx
+++ b/packages/ffe-core-react/src/CopyText.spec.tsx
@@ -1,0 +1,175 @@
+import React from 'react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { CopyText } from './CopyText';
+
+const writeText = jest.fn().mockResolvedValue(undefined);
+
+Object.assign(navigator, {
+    clipboard: { writeText },
+});
+
+const defaultProps = { children: 'kontonummer 1234 56 78901', label: 'Kopier kontonummer' };
+
+const renderCopyText = (props = {}) =>
+    render(<CopyText {...defaultProps} {...props} />);
+
+describe('<CopyText />', () => {
+    beforeEach(() => {
+        jest.useFakeTimers();
+        writeText.mockClear();
+    });
+
+    afterEach(() => {
+        jest.useRealTimers();
+    });
+
+    it('renders children inside the button', () => {
+        renderCopyText();
+        expect(
+            screen.getByRole('button', { name: 'Kopier kontonummer' }),
+        ).toHaveTextContent('kontonummer 1234 56 78901');
+    });
+
+    it('renders a button with the label prop as aria-label', () => {
+        renderCopyText({ label: 'Kopier kontonummer' });
+        expect(
+            screen.getByRole('button', { name: 'Kopier kontonummer' }),
+        ).toBeInTheDocument();
+    });
+
+    it('uses label prop as aria-label', () => {
+        renderCopyText();
+        expect(
+            screen.getByRole('button', { name: 'Kopier kontonummer' }),
+        ).toBeInTheDocument();
+    });
+
+    it('copies children text to clipboard on click', async () => {
+        renderCopyText();
+        await act(async () => {
+            fireEvent.click(screen.getByRole('button'));
+        });
+        expect(writeText).toHaveBeenCalledWith('kontonummer 1234 56 78901');
+    });
+
+    it('copies copyText prop instead of children when provided', async () => {
+        renderCopyText({ copyText: '12345678901' });
+        await act(async () => {
+            fireEvent.click(screen.getByRole('button'));
+        });
+        expect(writeText).toHaveBeenCalledWith('12345678901');
+    });
+
+    it('changes aria-label to copiedLabel after click', async () => {
+        renderCopyText({ copiedLabel: 'Kopiert!' });
+        await act(async () => {
+            fireEvent.click(screen.getByRole('button'));
+        });
+        expect(
+            screen.getByRole('button', { name: 'Kopiert!' }),
+        ).toBeInTheDocument();
+    });
+
+    it('defaults copiedLabel to "Kopiert"', async () => {
+        renderCopyText();
+        await act(async () => {
+            fireEvent.click(screen.getByRole('button'));
+        });
+        expect(
+            screen.getByRole('button', { name: 'Kopiert' }),
+        ).toBeInTheDocument();
+    });
+
+    it('viser Kopiert-feedback etter klikk', async () => {
+        renderCopyText();
+        await act(async () => {
+            fireEvent.click(screen.getByRole('button'));
+        });
+        expect(screen.getAllByText('Kopiert')).toHaveLength(1);
+    });
+
+    it('resets to original label and clears live region after 2 seconds', async () => {
+        renderCopyText();
+        await act(async () => {
+            fireEvent.click(screen.getByRole('button'));
+        });
+        await act(async () => {
+            jest.advanceTimersByTime(2000);
+        });
+        expect(
+            screen.getByRole('button', { name: 'Kopier kontonummer' }),
+        ).toBeInTheDocument();
+    });
+
+    it('adds ffe-copy-text class', () => {
+        renderCopyText();
+        expect(
+            screen.getByRole('button').classList.contains('ffe-copy-text'),
+        ).toBe(true);
+    });
+
+    it('merges custom className', () => {
+        renderCopyText({ className: 'my-class' });
+        const btn = screen.getByRole('button');
+        expect(btn.classList.contains('ffe-copy-text')).toBe(true);
+        expect(btn.classList.contains('my-class')).toBe(true);
+    });
+
+    it('videresender ref til button-elementet', () => {
+        const ref = React.createRef<HTMLButtonElement>();
+        render(<CopyText {...defaultProps} ref={ref} />);
+        expect(ref.current).toBeInstanceOf(HTMLButtonElement);
+    });
+
+    it('bruker execCommand-fallback når Clipboard API mangler', async () => {
+        const originalClipboard = (navigator as any).clipboard;
+        delete (navigator as any).clipboard;
+        const execCommand = jest.fn().mockReturnValue(true);
+        (document as any).execCommand = execCommand;
+        renderCopyText();
+        await act(async () => {
+            fireEvent.click(screen.getByRole('button'));
+        });
+        expect(execCommand).toHaveBeenCalledWith('copy');
+        expect(
+            screen.getByRole('button', { name: 'Kopiert' }),
+        ).toBeInTheDocument();
+        delete (document as any).execCommand;
+        Object.assign(navigator, { clipboard: originalClipboard });
+    });
+
+    it('viser ikke Kopiert-feedback når writeText rejecter', async () => {
+        writeText.mockRejectedValueOnce(new Error('permission denied'));
+        const warnSpy = jest
+            .spyOn(console, 'warn')
+            .mockImplementation(() => {});
+        renderCopyText();
+        await act(async () => {
+            fireEvent.click(screen.getByRole('button'));
+        });
+        expect(
+            screen.getByRole('button', { name: 'Kopier kontonummer' }),
+        ).toBeInTheDocument();
+        expect(warnSpy).toHaveBeenCalled();
+        warnSpy.mockRestore();
+    });
+
+    it('gjør ingenting og advarer når det ikke er noe å kopiere', async () => {
+        const warnSpy = jest
+            .spyOn(console, 'warn')
+            .mockImplementation(() => {});
+        render(
+            <CopyText label="Kopier">
+                <span>ikke-streng</span>
+            </CopyText>,
+        );
+        await act(async () => {
+            fireEvent.click(screen.getByRole('button'));
+        });
+        expect(writeText).not.toHaveBeenCalled();
+        expect(warnSpy).toHaveBeenCalledWith(
+            expect.stringContaining('ingenting å kopiere'),
+        );
+        warnSpy.mockRestore();
+    });
+});

--- a/packages/ffe-core-react/src/CopyText.stories.tsx
+++ b/packages/ffe-core-react/src/CopyText.stories.tsx
@@ -1,0 +1,104 @@
+import React from 'react';
+import type { StoryObj, Meta } from '@storybook/react';
+import { CopyText } from './CopyText';
+import { Paragraph } from './typography/Paragraph';
+
+const meta: Meta<typeof CopyText> = {
+    title: 'Komponenter/Core/CopyText',
+    component: CopyText,
+};
+export default meta;
+
+type Story = StoryObj<typeof CopyText>;
+
+export const Standard: Story = {
+    args: {
+        children: '1234 56 78901',
+        label: 'Kopier',
+        copiedLabel: 'Kopiert',
+    },
+    render: args => (
+        <Paragraph>
+            <CopyText {...args} />
+        </Paragraph>
+    ),
+};
+
+export const MedCopyTextOverride: Story = {
+    args: {
+        children: 'Kontonummer: 1234 56 78901',
+        copyText: '12345678901',
+        label: 'Kopier kontonummer',
+        copiedLabel: 'Kontonummer kopiert',
+    },
+    render: args => (
+        <Paragraph>
+            <CopyText {...args} />
+        </Paragraph>
+    ),
+};
+
+export const InlineITekst: Story = {
+    render: () => (
+        <Paragraph>
+            Send betaling til kontonummer{' '}
+            <CopyText copyText="12345678901">1234 56 78901</CopyText> innen
+            fredag.
+        </Paragraph>
+    ),
+};
+
+export const FlereLinjer: Story = {
+    render: () => (
+        <Paragraph style={{ maxWidth: '320px' }}>
+            Husk å lagre den nye kontoen din. Betalinger til denne kontoen vil
+            gå til kontonummer{' '}
+            <CopyText copyText="12345678901">1234 56 78901</CopyText>, som er
+            registrert på SpareBank 1.
+        </Paragraph>
+    ),
+};
+
+export const Detaljliste: Story = {
+    render: () => (
+        <dl
+            className="ffe-body"
+            style={{
+                display: 'grid',
+                gridTemplateColumns: '1fr auto',
+                rowGap: 0,
+                columnGap: '16px',
+                alignItems: 'center',
+                margin: 0,
+            }}
+        >
+            {[
+                {
+                    label: 'Kontonummer',
+                    display: '1234 56 78901',
+                    copy: '12345678901',
+                },
+                {
+                    label: 'Kontonavn',
+                    display: 'Brukskonto',
+                    copy: 'Brukskonto',
+                },
+                { label: 'BIC/SWIFT', display: 'SPRONO22', copy: 'SPRONO22' },
+                {
+                    label: 'IBAN',
+                    display: 'NO93 1234 5678 901',
+                    copy: 'NO9312345678901',
+                },
+            ].map(({ label, display, copy }) => (
+                <React.Fragment key={label}>
+                    <dt style={{ margin: 0 }}>{label}</dt>
+                    <dd style={{ margin: 0, textAlign: 'right' }}>
+                        <CopyText copyText={copy} label={`Kopier ${label}`}>
+                            {display}
+                        </CopyText>
+                    </dd>
+                </React.Fragment>
+            ))}
+        </dl>
+    ),
+};

--- a/packages/ffe-core-react/src/CopyText.tsx
+++ b/packages/ffe-core-react/src/CopyText.tsx
@@ -1,0 +1,124 @@
+import React, { useState, useRef, useEffect } from 'react';
+import classNames from 'classnames';
+
+export interface CopyTextProps
+    extends React.ComponentPropsWithoutRef<'button'> {
+    /** Teksten som kopieres. Standard: children hvis det er en streng. */
+    copyText?: string;
+    /** Beskrivende label for hva som kopieres, f.eks. "Kopier kontonummer". Påkrevd. */
+    label: string;
+    /** aria-label og live-region-tekst etter kopiering */
+    copiedLabel?: string;
+}
+
+const CopyIcon = () => (
+    <svg
+        xmlns="http://www.w3.org/2000/svg"
+        height="1em"
+        viewBox="0 -960 960 960"
+        width="1em"
+        aria-hidden="true"
+        focusable="false"
+        fill="currentColor"
+    >
+        <path d="M360-240q-33 0-56.5-23.5T280-320v-480q0-33 23.5-56.5T360-880h360q33 0 56.5 23.5T800-800v480q0 33-23.5 56.5T720-240H360Zm0-80h360v-480H360v480ZM200-80q-33 0-56.5-23.5T120-160v-520q0-17 11.5-28.5T160-720q17 0 28.5 11.5T200-680v520h400q17 0 28.5 11.5T640-120q0 17-11.5 28.5T600-80H200Zm160-240v-480 480Z" />
+    </svg>
+);
+
+const CheckIcon = () => (
+    <svg
+        xmlns="http://www.w3.org/2000/svg"
+        height="1em"
+        viewBox="0 -960 960 960"
+        width="1em"
+        aria-hidden="true"
+        focusable="false"
+        fill="currentColor"
+    >
+        <path d="m382-354 339-339q12-12 28-12t28 12q12 12 12 28.5T777-636L410-268q-12 12-28 12t-28-12L182-440q-12-12-11.5-28.5T183-497q12-12 28.5-12t28.5 12l142 143Z" />
+    </svg>
+);
+
+export const CopyText = React.forwardRef<HTMLButtonElement, CopyTextProps>(
+    function CopyText(
+        {
+            children,
+            className,
+            copyText,
+            label,
+            copiedLabel = 'Kopiert',
+            ...rest
+        },
+        ref,
+    ) {
+        const [copied, setCopied] = useState(false);
+        const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+        useEffect(
+            () => () => {
+                if (timeoutRef.current) clearTimeout(timeoutRef.current);
+            },
+            [],
+        );
+
+        const handleCopy = async () => {
+            const text =
+                copyText ?? (typeof children === 'string' ? children : '');
+            if (!text) {
+                if (process.env.NODE_ENV !== 'production') {
+                    // eslint-disable-next-line no-console
+                    console.warn(
+                        'CopyText: ingenting å kopiere — sett copyText-prop eller gi en string som children.',
+                    );
+                }
+                return;
+            }
+
+            try {
+                if (navigator.clipboard?.writeText) {
+                    await navigator.clipboard.writeText(text);
+                } else {
+                    // Fallback for Android WebView uten Clipboard API-støtte
+                    const el = document.createElement('textarea');
+                    el.value = text;
+                    el.style.position = 'fixed';
+                    el.style.opacity = '0';
+                    document.body.appendChild(el);
+                    el.select();
+                    const ok = document.execCommand('copy');
+                    document.body.removeChild(el);
+                    if (!ok) throw new Error('execCommand copy returned false');
+                }
+            } catch (err) {
+                if (process.env.NODE_ENV !== 'production') {
+                    // eslint-disable-next-line no-console
+                    console.warn('CopyText: kopiering feilet', err);
+                }
+                return;
+            }
+
+            setCopied(true);
+            if (timeoutRef.current) clearTimeout(timeoutRef.current);
+            timeoutRef.current = setTimeout(() => setCopied(false), 2000);
+        };
+
+        return (
+            <button
+                ref={ref}
+                type="button"
+                {...rest}
+                className={classNames('ffe-copy-text', className)}
+                aria-label={copied ? copiedLabel : label}
+                onClick={handleCopy}
+            >
+                {children}
+                {copied ? <CheckIcon /> : <CopyIcon />}
+                {copied && (
+                    <span className="ffe-copy-text__feedback" aria-hidden="true">
+                        {copiedLabel}
+                    </span>
+                )}
+            </button>
+        );
+    },
+);

--- a/packages/ffe-core-react/src/index.ts
+++ b/packages/ffe-core-react/src/index.ts
@@ -29,3 +29,5 @@ export { StrongText } from './typography/StrongText';
 export type { StrongTextProps } from './typography/StrongText';
 export { Wave } from './Wave';
 export type { WaveProps } from './Wave';
+export { CopyText } from './CopyText';
+export type { CopyTextProps } from './CopyText';

--- a/packages/ffe-core/documentation/Native.mdx
+++ b/packages/ffe-core/documentation/Native.mdx
@@ -1,0 +1,203 @@
+import { Meta } from '@storybook/blocks';
+
+<Meta title="Design/Native/Utility-klasser" />
+
+# Native — utility-klasser
+
+Utility-klasser for å kontrollere tekstmarkering, berøring og dra-og-slipp-oppførsel i hybridapper der webinnhold vises i en native app sin WebView.
+
+Uten tilpasning vil WebView-innhold oppføre seg som en vanlig nettside: tekst kan markeres ved langt trykk, elementer kan dras, og trykk har en merkbar forsinkelse. Dette bryter med forventningene til en native app.
+
+## Klasser
+
+<table>
+    <thead>
+        <tr>
+            <th>CSS-klasse</th>
+            <th>Beskrivelse</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td><code>.ffe-native</code></td>
+            <td>Gjør at innholdet oppfører seg som native UI. Settes på <code>&lt;body&gt;</code> eller en wrapper.</td>
+        </tr>
+        <tr>
+            <td><code>.ffe-selectable</code></td>
+            <td>Lar brukeren markere og kopiere tekst. Overstyrer <code>.ffe-native</code>.</td>
+        </tr>
+        <tr>
+            <td><code>.ffe-selectable-all</code></td>
+            <td>Ett klikk markerer alt innhold i elementet. Overstyrer <code>.ffe-native</code>.</td>
+        </tr>
+    </tbody>
+</table>
+
+## CSS-egenskaper
+
+### `.ffe-native`
+
+Påvirker elementet selv og alle barn:
+
+<table>
+    <thead>
+        <tr>
+            <th>Egenskap</th>
+            <th>Verdi</th>
+            <th>Effekt</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td><code>user-select</code></td>
+            <td><code>none</code></td>
+            <td>Hindrer tekstmarkering</td>
+        </tr>
+        <tr>
+            <td><code>-webkit-touch-callout</code></td>
+            <td><code>none</code></td>
+            <td>Deaktiverer iOS long-press kontekstmeny</td>
+        </tr>
+        <tr>
+            <td><code>-webkit-user-drag</code></td>
+            <td><code>none</code></td>
+            <td>Hindrer dra-og-slipp av elementer (iOS Safari)</td>
+        </tr>
+        <tr>
+            <td><code>touch-action</code></td>
+            <td><code>manipulation</code></td>
+            <td>Fjerner 300ms tap-delay og dobbelttap-zoom</td>
+        </tr>
+    </tbody>
+</table>
+
+Input-felt, textarea og contenteditable-elementer inne i `.ffe-native` får automatisk `user-select: text`, slik at brukere kan redigere og markere tekst i skjemafelt som normalt.
+
+### `.ffe-selectable`
+
+Påvirker elementet selv og alle barn:
+
+<table>
+    <thead>
+        <tr>
+            <th>Egenskap</th>
+            <th>Verdi</th>
+            <th>Effekt</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td><code>user-select</code></td>
+            <td><code>text</code></td>
+            <td>Tillater vanlig tekstmarkering</td>
+        </tr>
+        <tr>
+            <td><code>-webkit-touch-callout</code></td>
+            <td><code>default</code></td>
+            <td>Gjenoppretter long-press kontekstmeny</td>
+        </tr>
+    </tbody>
+</table>
+
+### `.ffe-selectable-all`
+
+Påvirker elementet selv og alle barn:
+
+<table>
+    <thead>
+        <tr>
+            <th>Egenskap</th>
+            <th>Verdi</th>
+            <th>Effekt</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td><code>user-select</code></td>
+            <td><code>all</code> (fallback: <code>text</code>)</td>
+            <td>Ett klikk markerer alt innhold</td>
+        </tr>
+        <tr>
+            <td><code>-webkit-touch-callout</code></td>
+            <td><code>default</code></td>
+            <td>Gjenoppretter long-press kontekstmeny</td>
+        </tr>
+    </tbody>
+</table>
+
+`user-select: all` støttes i Chrome 53+, Safari 15+ og Firefox 121+. Eldre Firefox-versjoner får `user-select: text` som fallback.
+
+## Spesifisitet
+
+Alle klassene bruker vanlige klasseselektorer (spesifisitet `0,1,0`). `.ffe-selectable` og `.ffe-selectable-all` overstyrer `.ffe-native` via kildeorden.
+
+## Eksempler
+
+### Grunnleggende bruk
+
+Prøv å markere teksten i eksempelet under. Tekst innenfor `.ffe-native` kan ikke markeres, mens tekst med `.ffe-selectable` kan det.
+
+<div className="ffe-native" style={{ padding: '1rem', border: '1px solid #dfe6eb', borderRadius: '4px' }}>
+    <h3>Mitt native grensesnitt</h3>
+    <p>Denne teksten kan ikke markeres.</p>
+    <button className="ffe-primary-button">Trykk meg</button>
+    <div className="ffe-selectable" style={{ marginTop: '1rem', padding: '0.75rem', background: '#f6f8fa', borderRadius: '4px' }}>
+        <p><strong>Vilkår:</strong> Denne teksten kan markeres og kopieres.</p>
+    </div>
+</div>
+
+```html
+<div class="ffe-native">
+    <h3>Mitt native grensesnitt</h3>
+    <p>Denne teksten kan ikke markeres.</p>
+    <button class="ffe-primary-button">Trykk meg</button>
+    <div class="ffe-selectable">
+        <p><strong>Vilkår:</strong> Denne teksten kan markeres og kopieres.</p>
+    </div>
+</div>
+```
+
+### Marker alt med ett klikk
+
+`.ffe-selectable-all` gjør at ett klikk markerer alt innhold i elementet. Praktisk for kontonummer, referanser og kodeblokker. Prøv å klikke på kontonummeret.
+
+<div className="ffe-native" style={{ padding: '1rem', border: '1px solid #dfe6eb', borderRadius: '4px' }}>
+    <p>Kontonummer:</p>
+    <div className="ffe-selectable-all" style={{ padding: '0.75rem', background: '#f6f8fa', borderRadius: '4px', fontFamily: 'monospace' }}>
+        1232 56 78901
+    </div>
+</div>
+
+```html
+<div class="ffe-native">
+    <p>Kontonummer:</p>
+    <div class="ffe-selectable-all">1232 56 78901</div>
+</div>
+```
+
+### Skjemafelt fungerer alltid
+
+Input-felt, textarea og contenteditable-elementer unntas automatisk fra `.ffe-native`, slik at brukere alltid kan redigere tekst.
+
+<div className="ffe-native" style={{ padding: '1rem', border: '1px solid #dfe6eb', borderRadius: '4px' }}>
+    <p>Tekst som ikke kan markeres.</p>
+    <label className="ffe-form-label" htmlFor="native-demo-input">Navn</label>
+    <input id="native-demo-input" className="ffe-input-field" type="text" placeholder="Skriv her — fungerer normalt" />
+</div>
+
+```html
+<div class="ffe-native">
+    <p>Tekst som ikke kan markeres.</p>
+    <label class="ffe-form-label">Navn</label>
+    <input class="ffe-input-field" type="text" placeholder="Skriv her — fungerer normalt" />
+</div>
+```
+
+## Tilgjengelighet
+
+Vær oppmerksom på at `user-select: none` kan påvirke brukere som er avhengige av å markere tekst for å kopiere det. Bruk `.ffe-selectable` på innhold brukeren kan ha behov for å kopiere, for eksempel:
+
+- Avtaletekst og vilkår
+- Kontaktinformasjon (telefonnummer, e-post, adresse)
+- Kontonummer, referansenummer og betalingsinformasjon
+- Feilmeldinger brukeren kan trenge å dele med kundeservice

--- a/packages/ffe-core/documentation/Native.mdx
+++ b/packages/ffe-core/documentation/Native.mdx
@@ -8,6 +8,20 @@ Utility-klasser for å kontrollere tekstmarkering, berøring og dra-og-slipp-opp
 
 Uten tilpasning vil WebView-innhold oppføre seg som en vanlig nettside: tekst kan markeres ved langt trykk, elementer kan dras, og trykk har en merkbar forsinkelse. Dette bryter med forventningene til en native app.
 
+## Aktivering
+
+Native-oppførselen aktiveres bare når både `.ffe-native` og `.ffe-native-ready` er til stede. Det er bevisst:
+
+- **`.ffe-native`** settes av rammeverket rundt nettsiden (typisk på `<body>`) og markerer at siden kjører i en native WebView.
+- **`.ffe-native-ready`** settes av det enkelte team/applikasjonen når appen er testet og klar for native-oppførsel. Vanligvis plasseres den som et barn av `<body>` — f.eks. på rot-elementet for app-innholdet.
+
+Dette lar plattformen skru på `.ffe-native` globalt uten å knekke apper som ikke er verifisert. `.ffe-native-ready` er en **midlertidig opt-in-markør** og vil bli fjernet når alle apper er migrert.
+
+Begge oppsett fungerer:
+
+- `.ffe-native-ready` på samme element som `.ffe-native` (vanligvis `<body>`).
+- `.ffe-native-ready` som etterkommer av `.ffe-native` (vanligvis app-rot eller et område av siden).
+
 ## Klasser
 
 <table>
@@ -20,7 +34,11 @@ Uten tilpasning vil WebView-innhold oppføre seg som en vanlig nettside: tekst k
     <tbody>
         <tr>
             <td><code>.ffe-native</code></td>
-            <td>Gjør at innholdet oppfører seg som native UI. Settes på <code>&lt;body&gt;</code> eller en wrapper.</td>
+            <td>Markerer at innholdet vises i en native WebView. Settes av rammeverket på <code>&lt;body&gt;</code> eller en wrapper. Har ingen effekt alene.</td>
+        </tr>
+        <tr>
+            <td><code>.ffe-native-ready</code></td>
+            <td>Opt-in-markør som aktiverer native-oppførsel. Settes av det enkelte team når appen er testet og klar. Midlertidig — fjernes når alle apper er migrert.</td>
         </tr>
         <tr>
             <td><code>.ffe-selectable</code></td>
@@ -129,15 +147,15 @@ Påvirker elementet selv og alle barn:
 
 ## Spesifisitet
 
-Alle klassene bruker vanlige klasseselektorer (spesifisitet `0,1,0`). `.ffe-selectable` og `.ffe-selectable-all` overstyrer `.ffe-native` via kildeorden.
+`.ffe-native-ready` aktiverer oppførselen — enten på samme element som `.ffe-native` (selektor `.ffe-native.ffe-native-ready`, spesifisitet `0,2,0`) eller på et etterkommer-element (selektor `.ffe-native .ffe-native-ready`, spesifisitet `0,2,0`). `.ffe-selectable` og `.ffe-selectable-all` har spesifisitet `0,1,0`, men overstyrer via kildeorden og at `user-select` arves/kaskaderes riktig på barn.
 
 ## Eksempler
 
 ### Grunnleggende bruk
 
-Prøv å markere teksten i eksempelet under. Tekst innenfor `.ffe-native` kan ikke markeres, mens tekst med `.ffe-selectable` kan det.
+Prøv å markere teksten i eksempelet under. Tekst innenfor `.ffe-native-ready` kan ikke markeres, mens tekst med `.ffe-selectable` kan det.
 
-<div className="ffe-native" style={{ padding: '1rem', border: '1px solid #dfe6eb', borderRadius: '4px' }}>
+<div className="ffe-native ffe-native-ready" style={{ padding: '1rem', border: '1px solid #dfe6eb', borderRadius: '4px' }}>
     <h3>Mitt native grensesnitt</h3>
     <p>Denne teksten kan ikke markeres.</p>
     <button className="ffe-primary-button">Trykk meg</button>
@@ -147,7 +165,8 @@ Prøv å markere teksten i eksempelet under. Tekst innenfor `.ffe-native` kan ik
 </div>
 
 ```html
-<div class="ffe-native">
+<!-- .ffe-native settes av rammeverket, .ffe-native-ready av teamet -->
+<div class="ffe-native ffe-native-ready">
     <h3>Mitt native grensesnitt</h3>
     <p>Denne teksten kan ikke markeres.</p>
     <button class="ffe-primary-button">Trykk meg</button>
@@ -157,11 +176,27 @@ Prøv å markere teksten i eksempelet under. Tekst innenfor `.ffe-native` kan ik
 </div>
 ```
 
+### Gradvis aktivering — bare deler av siden
+
+`.ffe-native-ready` kan settes lenger ned i treet for å aktivere native-oppførsel bare i verifiserte deler.
+
+```html
+<body class="ffe-native">
+    <header>...</header>
+    <main class="ffe-native-ready">
+        <!-- verifisert område med native-oppførsel -->
+    </main>
+    <aside>
+        <!-- fortsatt vanlig nettside-oppførsel -->
+    </aside>
+</body>
+```
+
 ### Marker alt med ett klikk
 
 `.ffe-selectable-all` gjør at ett klikk markerer alt innhold i elementet. Praktisk for kontonummer, referanser og kodeblokker. Prøv å klikke på kontonummeret.
 
-<div className="ffe-native" style={{ padding: '1rem', border: '1px solid #dfe6eb', borderRadius: '4px' }}>
+<div className="ffe-native ffe-native-ready" style={{ padding: '1rem', border: '1px solid #dfe6eb', borderRadius: '4px' }}>
     <p>Kontonummer:</p>
     <div className="ffe-selectable-all" style={{ padding: '0.75rem', background: '#f6f8fa', borderRadius: '4px', fontFamily: 'monospace' }}>
         1232 56 78901
@@ -169,7 +204,7 @@ Prøv å markere teksten i eksempelet under. Tekst innenfor `.ffe-native` kan ik
 </div>
 
 ```html
-<div class="ffe-native">
+<div class="ffe-native ffe-native-ready">
     <p>Kontonummer:</p>
     <div class="ffe-selectable-all">1232 56 78901</div>
 </div>
@@ -177,16 +212,16 @@ Prøv å markere teksten i eksempelet under. Tekst innenfor `.ffe-native` kan ik
 
 ### Skjemafelt fungerer alltid
 
-Input-felt, textarea og contenteditable-elementer unntas automatisk fra `.ffe-native`, slik at brukere alltid kan redigere tekst.
+Input-felt, textarea og contenteditable-elementer unntas automatisk fra `.ffe-native-ready`, slik at brukere alltid kan redigere tekst.
 
-<div className="ffe-native" style={{ padding: '1rem', border: '1px solid #dfe6eb', borderRadius: '4px' }}>
+<div className="ffe-native ffe-native-ready" style={{ padding: '1rem', border: '1px solid #dfe6eb', borderRadius: '4px' }}>
     <p>Tekst som ikke kan markeres.</p>
     <label className="ffe-form-label" htmlFor="native-demo-input">Navn</label>
     <input id="native-demo-input" className="ffe-input-field" type="text" placeholder="Skriv her — fungerer normalt" />
 </div>
 
 ```html
-<div class="ffe-native">
+<div class="ffe-native ffe-native-ready">
     <p>Tekst som ikke kan markeres.</p>
     <label class="ffe-form-label">Navn</label>
     <input class="ffe-input-field" type="text" placeholder="Skriv her — fungerer normalt" />

--- a/packages/ffe-core/documentation/Native.mdx
+++ b/packages/ffe-core/documentation/Native.mdx
@@ -8,19 +8,11 @@ Utility-klasser for å kontrollere tekstmarkering, berøring og dra-og-slipp-opp
 
 Uten tilpasning vil WebView-innhold oppføre seg som en vanlig nettside: tekst kan markeres ved langt trykk, elementer kan dras, og trykk har en merkbar forsinkelse. Dette bryter med forventningene til en native app.
 
+> **Gjelder kun mobilbank-WebView.** Disse klassene påvirker utelukkende apper som kjører inne i mobilbank sin native app. `.ffe-native` settes av mobilbank-rammeverket og vil aldri dukke opp i vanlig nettleser-kontekst — ordinære webapper er ikke berørt.
+
 ## Aktivering
 
-Native-oppførselen aktiveres bare når både `.ffe-native` og `.ffe-native-ready` er til stede. Det er bevisst:
-
-- **`.ffe-native`** settes av rammeverket rundt nettsiden (typisk på `<body>`) og markerer at siden kjører i en native WebView.
-- **`.ffe-native-ready`** settes av det enkelte team/applikasjonen når appen er testet og klar for native-oppførsel. Vanligvis plasseres den som et barn av `<body>` — f.eks. på rot-elementet for app-innholdet.
-
-Dette lar plattformen skru på `.ffe-native` globalt uten å knekke apper som ikke er verifisert. `.ffe-native-ready` er en **midlertidig opt-in-markør** og vil bli fjernet når alle apper er migrert.
-
-Begge oppsett fungerer:
-
-- `.ffe-native-ready` på samme element som `.ffe-native` (vanligvis `<body>`).
-- `.ffe-native-ready` som etterkommer av `.ffe-native` (vanligvis app-rot eller et område av siden).
+Native-oppførselen aktiveres ved å sette `.ffe-native` på `<body>` eller en wrapper rundt innholdet. Klassen settes av mobilbank-rammeverket når siden kjører i en native WebView, og har ingen effekt utenfor den konteksten.
 
 ## Klasser
 
@@ -34,11 +26,7 @@ Begge oppsett fungerer:
     <tbody>
         <tr>
             <td><code>.ffe-native</code></td>
-            <td>Markerer at innholdet vises i en native WebView. Settes av rammeverket på <code>&lt;body&gt;</code> eller en wrapper. Har ingen effekt alene.</td>
-        </tr>
-        <tr>
-            <td><code>.ffe-native-ready</code></td>
-            <td>Opt-in-markør som aktiverer native-oppførsel. Settes av det enkelte team når appen er testet og klar. Midlertidig — fjernes når alle apper er migrert.</td>
+            <td>Aktiverer native-oppførsel. Settes av rammeverket på <code>&lt;body&gt;</code> eller en wrapper.</td>
         </tr>
         <tr>
             <td><code>.ffe-selectable</code></td>
@@ -147,15 +135,15 @@ Påvirker elementet selv og alle barn:
 
 ## Spesifisitet
 
-`.ffe-native-ready` aktiverer oppførselen — enten på samme element som `.ffe-native` (selektor `.ffe-native.ffe-native-ready`, spesifisitet `0,2,0`) eller på et etterkommer-element (selektor `.ffe-native .ffe-native-ready`, spesifisitet `0,2,0`). `.ffe-selectable` og `.ffe-selectable-all` har spesifisitet `0,1,0`, men overstyrer via kildeorden og at `user-select` arves/kaskaderes riktig på barn.
+`.ffe-native` har spesifisitet `0,1,0`. `.ffe-selectable` og `.ffe-selectable-all` har samme spesifisitet, men overstyrer via kildeorden og at `user-select` arves/kaskaderes riktig på barn.
 
 ## Eksempler
 
 ### Grunnleggende bruk
 
-Prøv å markere teksten i eksempelet under. Tekst innenfor `.ffe-native-ready` kan ikke markeres, mens tekst med `.ffe-selectable` kan det.
+Prøv å markere teksten i eksempelet under. Tekst innenfor `.ffe-native` kan ikke markeres, mens tekst med `.ffe-selectable` kan det.
 
-<div className="ffe-native ffe-native-ready" style={{ padding: '1rem', border: '1px solid #dfe6eb', borderRadius: '4px' }}>
+<div className="ffe-native" style={{ padding: '1rem', border: '1px solid #dfe6eb', borderRadius: '4px' }}>
     <h3>Mitt native grensesnitt</h3>
     <p>Denne teksten kan ikke markeres.</p>
     <button className="ffe-primary-button">Trykk meg</button>
@@ -165,8 +153,7 @@ Prøv å markere teksten i eksempelet under. Tekst innenfor `.ffe-native-ready` 
 </div>
 
 ```html
-<!-- .ffe-native settes av rammeverket, .ffe-native-ready av teamet -->
-<div class="ffe-native ffe-native-ready">
+<div class="ffe-native">
     <h3>Mitt native grensesnitt</h3>
     <p>Denne teksten kan ikke markeres.</p>
     <button class="ffe-primary-button">Trykk meg</button>
@@ -176,27 +163,11 @@ Prøv å markere teksten i eksempelet under. Tekst innenfor `.ffe-native-ready` 
 </div>
 ```
 
-### Gradvis aktivering — bare deler av siden
-
-`.ffe-native-ready` kan settes lenger ned i treet for å aktivere native-oppførsel bare i verifiserte deler.
-
-```html
-<body class="ffe-native">
-    <header>...</header>
-    <main class="ffe-native-ready">
-        <!-- verifisert område med native-oppførsel -->
-    </main>
-    <aside>
-        <!-- fortsatt vanlig nettside-oppførsel -->
-    </aside>
-</body>
-```
-
 ### Marker alt med ett klikk
 
 `.ffe-selectable-all` gjør at ett klikk markerer alt innhold i elementet. Praktisk for kontonummer, referanser og kodeblokker. Prøv å klikke på kontonummeret.
 
-<div className="ffe-native ffe-native-ready" style={{ padding: '1rem', border: '1px solid #dfe6eb', borderRadius: '4px' }}>
+<div className="ffe-native" style={{ padding: '1rem', border: '1px solid #dfe6eb', borderRadius: '4px' }}>
     <p>Kontonummer:</p>
     <div className="ffe-selectable-all" style={{ padding: '0.75rem', background: '#f6f8fa', borderRadius: '4px', fontFamily: 'monospace' }}>
         1232 56 78901
@@ -204,7 +175,7 @@ Prøv å markere teksten i eksempelet under. Tekst innenfor `.ffe-native-ready` 
 </div>
 
 ```html
-<div class="ffe-native ffe-native-ready">
+<div class="ffe-native">
     <p>Kontonummer:</p>
     <div class="ffe-selectable-all">1232 56 78901</div>
 </div>
@@ -212,16 +183,16 @@ Prøv å markere teksten i eksempelet under. Tekst innenfor `.ffe-native-ready` 
 
 ### Skjemafelt fungerer alltid
 
-Input-felt, textarea og contenteditable-elementer unntas automatisk fra `.ffe-native-ready`, slik at brukere alltid kan redigere tekst.
+Input-felt, textarea og contenteditable-elementer unntas automatisk fra `.ffe-native`, slik at brukere alltid kan redigere tekst.
 
-<div className="ffe-native ffe-native-ready" style={{ padding: '1rem', border: '1px solid #dfe6eb', borderRadius: '4px' }}>
+<div className="ffe-native" style={{ padding: '1rem', border: '1px solid #dfe6eb', borderRadius: '4px' }}>
     <p>Tekst som ikke kan markeres.</p>
     <label className="ffe-form-label" htmlFor="native-demo-input">Navn</label>
     <input id="native-demo-input" className="ffe-input-field" type="text" placeholder="Skriv her — fungerer normalt" />
 </div>
 
 ```html
-<div class="ffe-native ffe-native-ready">
+<div class="ffe-native">
     <p>Tekst som ikke kan markeres.</p>
     <label class="ffe-form-label">Navn</label>
     <input class="ffe-input-field" type="text" placeholder="Skriv her — fungerer normalt" />

--- a/packages/ffe-core/less/copy-text.less
+++ b/packages/ffe-core/less/copy-text.less
@@ -1,0 +1,33 @@
+.ffe-copy-text {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.1em;
+    min-height: 44px;
+    padding: 0 4px;
+    background: none;
+    border: none;
+    cursor: pointer;
+    color: inherit;
+    font: inherit;
+    text-align: left;
+    vertical-align: middle;
+
+    &:focus-visible {
+        outline: none;
+        box-shadow: 0 0 0 2px var(--ffe-color-border-interactive-focus);
+        border-radius: 2px;
+    }
+}
+
+.ffe-copy-text__feedback {
+    position: absolute;
+    right: 0;
+    bottom: calc(100% - 8px);
+    font-size: 0.85em;
+    white-space: nowrap;
+    pointer-events: none;
+    background: var(--ffe-color-surface-primary-default);
+    padding: 2px 6px;
+    border-radius: 2px;
+}

--- a/packages/ffe-core/less/ffe.less
+++ b/packages/ffe-core/less/ffe.less
@@ -20,3 +20,4 @@
 @import 'native';
 @import 'variables';
 @import 'waves';
+@import 'copy-text';

--- a/packages/ffe-core/less/ffe.less
+++ b/packages/ffe-core/less/ffe.less
@@ -17,5 +17,6 @@
 @import 'typography';
 @import 'body';
 @import 'accessibility';
+@import 'native';
 @import 'variables';
 @import 'waves';

--- a/packages/ffe-core/less/native.less
+++ b/packages/ffe-core/less/native.less
@@ -1,14 +1,19 @@
-.ffe-native,
-.ffe-native * {
+.ffe-native.ffe-native-ready,
+.ffe-native.ffe-native-ready *,
+.ffe-native .ffe-native-ready,
+.ffe-native .ffe-native-ready * {
     user-select: none;
     -webkit-touch-callout: none;
     -webkit-user-drag: none;
     touch-action: manipulation;
 }
 
-.ffe-native input,
-.ffe-native textarea,
-.ffe-native [contenteditable] {
+.ffe-native.ffe-native-ready input,
+.ffe-native.ffe-native-ready textarea,
+.ffe-native.ffe-native-ready [contenteditable],
+.ffe-native .ffe-native-ready input,
+.ffe-native .ffe-native-ready textarea,
+.ffe-native .ffe-native-ready [contenteditable] {
     user-select: text;
 }
 

--- a/packages/ffe-core/less/native.less
+++ b/packages/ffe-core/less/native.less
@@ -1,0 +1,26 @@
+.ffe-native,
+.ffe-native * {
+    user-select: none;
+    -webkit-touch-callout: none;
+    -webkit-user-drag: none;
+    touch-action: manipulation;
+}
+
+.ffe-native input,
+.ffe-native textarea,
+.ffe-native [contenteditable] {
+    user-select: text;
+}
+
+.ffe-selectable,
+.ffe-selectable * {
+    user-select: text;
+    -webkit-touch-callout: default;
+}
+
+.ffe-selectable-all,
+.ffe-selectable-all * {
+    user-select: text;
+    user-select: all;
+    -webkit-touch-callout: default;
+}

--- a/packages/ffe-core/less/native.less
+++ b/packages/ffe-core/less/native.less
@@ -1,19 +1,14 @@
-.ffe-native.ffe-native-ready,
-.ffe-native.ffe-native-ready *,
-.ffe-native .ffe-native-ready,
-.ffe-native .ffe-native-ready * {
+.ffe-native,
+.ffe-native * {
     user-select: none;
     -webkit-touch-callout: none;
     -webkit-user-drag: none;
     touch-action: manipulation;
 }
 
-.ffe-native.ffe-native-ready input,
-.ffe-native.ffe-native-ready textarea,
-.ffe-native.ffe-native-ready [contenteditable],
-.ffe-native .ffe-native-ready input,
-.ffe-native .ffe-native-ready textarea,
-.ffe-native .ffe-native-ready [contenteditable] {
+.ffe-native input,
+.ffe-native textarea,
+.ffe-native [contenteditable] {
     user-select: text;
 }
 


### PR DESCRIPTION
# feat: Native utility-klasser og CopyText-komponent

---

## Del 1 — `ffe-core`: Native utility-klasser

Nye CSS-klasser for hybrid-apper (React Native WebView og lignende):

| Klasse                | Hva den gjør                                                                                                                                                                                               |
| --------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| `.ffe-native`         | Markerer at siden kjører i native WebView. Settes av rammeverket. Ingen effekt alene.                                                                                                                      |
| `.ffe-native-ready`   | Opt-in-markør — aktiverer native-oppførsel (slår av tekstmarkering, touch-callout og native drag; unntar `input`/`textarea`/`contenteditable` automatisk). Midlertidig, settes av team etter verifisering. |
| `.ffe-selectable`     | Tillater tekstmarkering på et element og alle barn.                                                                                                                                                        |
| `.ffe-selectable-all` | Markerer hele tekstinnholdet automatisk ved trykk (`user-select: all`).                                                                                                                                    |

Typisk bruk: rammeverket legger `.ffe-native` på `<body>`, det enkelte team legger `.ffe-native-ready` på app-rot etter at de har testat. Bruk `.ffe-selectable` / `.ffe-selectable-all` der markering faktisk er ønsket.

### Opt-in med `.ffe-native-ready`

Native-oppførselen aktiveres bare når både `.ffe-native` og `.ffe-native-ready` er til stede:

- **`.ffe-native`** settes av rammeverket (typisk `<body>`) og markerer at siden kjører i WebView. Ingen effekt alene.
- **`.ffe-native-ready`** settes av det enkelte team/app (typisk som barn av `<body>`, f.eks. app-rot) **etter verifisering**.

Dette lar plattformen skru på `.ffe-native` globalt uten å knekke apper som ikke er testet. `.ffe-native-ready` er en **midlertidig opt-in-markør** og vil bli fjernet fra `ffe-core` når alle apper er migrert.

### Utrulling og verifisering per app

Klassene rulles ut til ~20 apper fordelt på 6 team. **Hvert team er selv ansvarlig for å verifisere sin(e) app(er)** før `.ffe-native-ready` aktiveres i prod.

Steg per app (se [native-rollout.md](../native-rollout.md) for full plan med sjekklister og status-tabell):

1. **Forbered test-miljø** — aktiver `.ffe-native-ready` lokalt eller via feature flag, ikke i prod ennå.
2. **Funksjonell sjekkliste** på iOS Safari WebView _og_ Android Chrome WebView på ekte enhet:
    - Skjemafelt (input/textarea) fungerer — skriv, marker, kopier.
    - Kopierbart innhold er merket med `.ffe-selectable` / `.ffe-selectable-all` / `CopyText` (kontonummer, IBAN, KID, telefonnummer, e-post, vilkår, feilmeldinger).
    - Swipe/pan/karuseller/kart fungerer (`touch-action: manipulation` på alle etterkommere kan påvirke).
    - Long-press gir ikke utilsiktet kontekstmeny.
    - Ingen tap-delay på knapper og lenker.
3. **Regresjonstest** av kritiske flyter — innlogging, betaling, skjemaer med valideringsfeil.
4. **Tilgjengelighet** — fokusring synlig, VoiceOver/TalkBack leser innhold som før.
5. **Rapporter status** i [native-rollout.md](../native-rollout.md) eller intern wiki-versjon.
6. **Aktiver i prod** og overvåk kundesenter-henvendelser + feillogger i 1–2 uker.

Exit-kriterium: Når alle apper har status `Verifisert` i minst 2 uker, fjernes `.ffe-native-ready`-kravet fra `ffe-core` i en ny release.

---

## Del 2 — `ffe-core-react`: `CopyText`-komponent

Ny komponent som wrapper tekst brukeren skal kunne kopiere til utklippstavlen. Kopiering skjer ved klikk — ikonet bytter fra kopi til hake i 2 sekunder som visuell bekreftelse.

```tsx
<CopyText copyText="12345678901" label="Kopier kontonummer">
    1234 56 78901
</CopyText>
```

**Props:**

| Prop          | Type     | Standard    | Beskrivelse                                                                            |
| ------------- | -------- | ----------- | -------------------------------------------------------------------------------------- |
| `label`       | `string` | — (påkrevd) | `aria-label` på knappen. Bør beskrive hva som kopieres, f.eks. `"Kopier kontonummer"`. |
| `copyText`    | `string` | —           | Teksten som kopieres. Faller tilbake på `children` hvis ikke satt.                     |
| `copiedLabel` | `string` | `'Kopiert'` | `aria-label` etter kopiering.                                                          |

Støtter alle native `<button>`-attributter via spread, samt `ref` til knappen via `React.forwardRef`.

**WebView-fallback:** Bruker `navigator.clipboard.writeText` der det er tilgjengelig, og faller tilbake på `document.execCommand('copy')` for Android WebView uten Clipboard API. Begge kodebaner håndterer feil uten å vise falsk "Kopiert"-feedback; feil logges i dev-mode.

**a11y:** `aria-label` på knappen byttes fra `label` til `copiedLabel` etter kopiering, slik at skjermleser annonserer bekreftelsen. Knappen har `min-height: 44px` (WCAG 2.5.5) og synlig fokusring via `--ffe-color-border-interactive-focus`.
