### PR TITLE
fix(ffe-buttons-react): Ikon i knapp matcher knapp størrelse

### DIFF
--- a/packages/ffe-buttons-react/src/BaseButton.tsx
+++ b/packages/ffe-buttons-react/src/BaseButton.tsx
@@ -70,13 +70,13 @@ function BaseButtonWithForwardRef<As extends ElementType>(
                 {leftIcon &&
                     React.cloneElement(leftIcon, {
                         className: 'ffe-button__icon ffe-button__icon--left',
-                        size: 'md',
+                        size: size,
                     })}
                 {children}
                 {rightIcon &&
                     React.cloneElement(rightIcon, {
                         className: 'ffe-button__icon ffe-button__icon--right',
-                        size: 'md',
+                        size: size,
                     })}
             </span>
             {supportsSpinner && isLoading && (

--- a/packages/ffe-buttons-react/src/BaseButton.tsx
+++ b/packages/ffe-buttons-react/src/BaseButton.tsx
@@ -70,13 +70,13 @@ function BaseButtonWithForwardRef<As extends ElementType>(
                 {leftIcon &&
                     React.cloneElement(leftIcon, {
                         className: 'ffe-button__icon ffe-button__icon--left',
-                        size: size,
+                        size: leftIcon.props.size ?? size,
                     })}
                 {children}
                 {rightIcon &&
                     React.cloneElement(rightIcon, {
                         className: 'ffe-button__icon ffe-button__icon--right',
-                        size: size,
+                        size: rightIcon.props.size ?? size,
                     })}
             </span>
             {supportsSpinner && isLoading && (


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse
Setter ikonet i knappene til å matche `size`-prop på på selve knappen.
`size`-prop er `md` når den ikke er satt, så ingen endring for de som ikke har endret størrelsen.
<!-- Detaljert beskrivelse av endringene dine. Skjermskudd er lov. -->

## Motivasjon og kontekst
Var rapportert som en feil i support kanalen, der man lurte på hvorfor ikonet alltid hadde størrelse md når knappen var satt til noe annet. 
<!-- Hvorfor trengs denne endringen, og hva løser den? -->

## Testing

<!-- Hvordan har du har testet endringene dine? Ta gjerne med systeminfo o.l -->

<!--

Helt til slutt, har du ..

.. lest retningslinjene våre for bidrag?
.. tatt en siste sjekk for kode og skrivefeil, debug informasjon o.l?
.. kjørt og eventuelt oppdatert testene?
.. kommentert og dokumentert det som trengs?
.. knyttet denne opp til relaterte issues?

-->
