### PR TITLE
fix(ffe-datepicker-react): tillat brukere å skrive dato med tastatur

### DIFF
--- a/packages/ffe-datepicker-react/src/datepicker/DatepickerComp.tsx
+++ b/packages/ffe-datepicker-react/src/datepicker/DatepickerComp.tsx
@@ -356,7 +356,7 @@ export const DatepickerComp: React.FC<DatepickerCompProps> = ({
                     aria-describedby={ariaDescribedby()}
                     aria-labelledby={labelId}
                 >
-                    {day ? padZero(day) : 'dd'}
+                    {day != null ? padZero(day) : 'dd'}
                 </SpinButton>
                 .
                 <SpinButton
@@ -390,7 +390,7 @@ export const DatepickerComp: React.FC<DatepickerCompProps> = ({
                     aria-describedby={ariaDescribedby()}
                     aria-labelledby={labelId}
                 >
-                    {month ? padZero(month) : 'mm'}
+                    {month != null ? padZero(month) : 'mm'}
                 </SpinButton>
                 .
                 <SpinButton
@@ -412,7 +412,7 @@ export const DatepickerComp: React.FC<DatepickerCompProps> = ({
                     aria-describedby={ariaDescribedby()}
                     aria-labelledby={labelId}
                 >
-                    {year ? year : 'yyyy'}
+                    {year != null ? year : 'yyyy'}
                 </SpinButton>
             </div>
             <Button

--- a/packages/ffe-datepicker-react/src/datepicker/DatepickerContext.tsx
+++ b/packages/ffe-datepicker-react/src/datepicker/DatepickerContext.tsx
@@ -80,34 +80,35 @@ export const DatepickerProvider: React.FC<Props> = ({
                 month,
                 year,
                 setDay: (newValue, focusNext = undefined) => {
-                    const numbers = newValue.slice(-2);
-                    const [first, second] = numbers;
-                    const total = toNumber(numbers);
+                    const digits = newValue.slice(-2);
+                    const [first, second] = digits;
+                    const total = toNumber(digits);
+                    const isSingleDigit = second === undefined;
                     if (total > MAX_DAYS) {
                         focusNext?.();
-                    } else if (first > 3) {
+                    } else if (isSingleDigit && first >= 4) {
                         setDay(total);
                         focusNext?.();
                     } else {
                         setDay(total);
-                        if (second !== undefined) {
+                        if (!isSingleDigit) {
                             focusNext?.();
                         }
                     }
                 },
                 setMonth: (newValue, focusNext = undefined) => {
-                    const numbers = newValue.slice(-2);
-                    const [first, second] = numbers;
-                    const total = toNumber(numbers);
-
+                    const digits = newValue.slice(-2);
+                    const [first, second] = digits;
+                    const total = toNumber(digits);
+                    const isSingleDigit = second === undefined;
                     if (total > MONTHS_PER_YEAR) {
                         focusNext?.();
-                    } else if (first > 1) {
+                    } else if (isSingleDigit && first >= 2) {
                         setMonth(total);
                         focusNext?.();
                     } else {
                         setMonth(total);
-                        if (second !== undefined) {
+                        if (!isSingleDigit) {
                             focusNext?.();
                         }
                     }

--- a/packages/ffe-datepicker-react/src/datepicker/SpinButton.tsx
+++ b/packages/ffe-datepicker-react/src/datepicker/SpinButton.tsx
@@ -33,31 +33,36 @@ export const SpinButton = React.forwardRef<HTMLSpanElement, SpinButtonProps>(
 
         const handleKeyDown = (evt: React.KeyboardEvent) => {
             if (/\d/.test(evt.key)) {
+                evt.preventDefault();
+                evt.nativeEvent.stopImmediatePropagation();
+                const digit = parseInt(evt.key);
                 history.current =
-                    history.current.length === maxLength
-                        ? (history.current = [parseInt(evt.key)])
-                        : history.current.concat(parseInt(evt.key));
+                    history.current.length >= maxLength
+                        ? [digit]
+                        : history.current.concat(digit);
                 onSpinButtonChange(history.current);
             } else if (evt.key === 'Backspace' || evt.key === 'Delete') {
-                history.current = [];
                 if (value === 0) {
+                    history.current = [];
                     prevSpinButton?.current?.focus();
                     return;
                 }
-                const newValue = value?.toString().slice(0, -1);
-                history.current = newValue
-                    ? newValue.split('').map(Number)
+                const truncated = value?.toString().slice(0, -1);
+                history.current = truncated
+                    ? truncated.split('').map(Number)
                     : [];
                 onSpinButtonChange(history.current);
             } else if (evt.key === 'ArrowUp') {
                 evt.preventDefault();
+                history.current = [];
                 let newValue = (value ?? 0) + 1;
-                if (newValue && newValue !== null && newValue > max) {
+                if (newValue > max) {
                     newValue = min;
                 }
                 onSpinButtonChange([newValue], false);
             } else if (evt.key === 'ArrowDown') {
                 evt.preventDefault();
+                history.current = [];
                 let newValue = (value ?? 0) - 1;
                 if (newValue < min) {
                     newValue = max;
@@ -85,8 +90,14 @@ export const SpinButton = React.forwardRef<HTMLSpanElement, SpinButtonProps>(
                 aria-valuemax={max}
                 aria-valuenow={value}
                 ref={ref}
-                onKeyDown={handleKeyDown}
                 {...rest}
+                onKeyDown={handleKeyDown}
+                onKeyUp={evt => {
+                    if (/\d/.test(evt.key)) {
+                        evt.preventDefault();
+                        evt.nativeEvent.stopImmediatePropagation();
+                    }
+                }}
             >
                 {children}
             </span>


### PR DESCRIPTION
<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse

Fikser et par forskjellige bugs i tastaturnavigeringen i datepicker, som i sum gjorde det umulig å manuelt skrive inn dato. Fokus hoppet ut av datepickeren og det var ikke mulig å skrive en fullstendig verdi i feltene for dag eller måned.

## Motivasjon og kontekst

Fixes #3173 

## Testing

Testet i Storybook
