### PR TITLE
fix(ffe-datepicker-react): rett opp getDatepickerByLabelText som returnerte undefined

### DIFF
--- a/packages/ffe-datepicker-react/src/datepicker/DatepickerInContext.spec.tsx
+++ b/packages/ffe-datepicker-react/src/datepicker/DatepickerInContext.spec.tsx
@@ -1,6 +1,6 @@
 import { render } from '@testing-library/react';
 import React from 'react';
-import { InputGroup } from '../../../ffe-form-react/src/InputGroup';
+import { InputGroup, Label } from '../../../ffe-form-react/src';
 import { Datepicker, DatepickerProps } from './Datepicker';
 import { getDatepickerByLabelText } from './testHelper';
 
@@ -20,6 +20,25 @@ const renderDatePicker = (props?: Partial<DatepickerProps>) =>
     );
 
 describe('<InputGroup><Datepicker /></InputGroup>', () => {
+    it('getDatepickerByLabelText fungerer når label-elementet har child-elementer', async () => {
+        render(
+            <InputGroup
+                label={
+                    <Label>
+                        Datovelger <span aria-hidden="true">*</span>
+                    </Label>
+                }
+            >
+                <Datepicker {...defaultProps} />
+            </InputGroup>,
+        );
+
+        const datepicker = await getDatepickerByLabelText('Datovelger *');
+        expect(
+            datepicker.element.classList.contains('ffe-datepicker'),
+        ).toBeTruthy();
+    });
+
     it('empty datepicker returns <empty string> from testing functions', async () => {
         renderDatePicker();
 

--- a/packages/ffe-datepicker-react/src/datepicker/testHelper.ts
+++ b/packages/ffe-datepicker-react/src/datepicker/testHelper.ts
@@ -62,29 +62,69 @@ export type DatepickerTestHelper = {
     setValue: (value: string) => Promise<void>;
 };
 
+function findDatepickerElement(
+    label: string,
+    index: number,
+): HTMLElement | undefined {
+    const labelElements = Array.from(
+        document.querySelectorAll<HTMLLabelElement>('label'),
+    ).filter(el => el.textContent?.trim() === label);
+
+    const elements = labelElements
+        .map(el => {
+            const forAttr = el.htmlFor;
+            if (forAttr) {
+                const labeled = document.getElementById(forAttr);
+                if (labeled) {
+                    if (labeled.classList.contains('ffe-datepicker')) {
+                        return labeled;
+                    }
+                    return labeled.querySelector<HTMLElement>('.ffe-datepicker');
+                }
+            }
+            return (
+                el.parentElement?.querySelector<HTMLElement>(
+                    '.ffe-datepicker',
+                ) ??
+                el.parentElement?.parentElement?.querySelector<HTMLElement>(
+                    '.ffe-datepicker',
+                ) ??
+                null
+            );
+        })
+        .filter((el): el is HTMLElement => el !== null && el !== undefined);
+
+    return elements[index];
+}
+
 /**
  * Get a datepicker with helper functions by label
  *
  * @param label label of the datepicker element you want to get
  * @param index if there are multiple datepicker elements with the same label, you can specify which one you want to get
+ * @param timeout how long to wait for the element to appear (ms), default 3000
  * @returns DatepickerTestHelper
  */
 export async function getDatepickerByLabelText(
     label: string,
     index = 0,
+    timeout = 3000,
 ): Promise<DatepickerTestHelper> {
-    const elements = Array.from(document.querySelectorAll<HTMLElement>('*'))
-        .filter(
-            el =>
-                el.children.length === 0 &&
-                el.textContent?.trim() === label,
-        )
-        .map(el =>
-            el.parentElement?.parentElement?.querySelector<HTMLElement>(
-                '.ffe-datepicker',
-            ),
-        )
-        .filter((el): el is HTMLElement => el !== null && el !== undefined);
+    const deadline = Date.now() + timeout;
+    let datepickerElement: HTMLElement | undefined;
+
+    while (true) {
+        datepickerElement = findDatepickerElement(label, index);
+        if (datepickerElement) break;
+        if (Date.now() >= deadline) {
+            throw new Error(
+                `getDatepickerByLabelText: datepicker with label "${label}" (index ${index}) not found within ${timeout}ms`,
+            );
+        }
+        await new Promise<void>(resolve => setTimeout(resolve, 50));
+    }
+
+    const element = datepickerElement;
 
     function getValue(element: Element): string {
         const [dayElement, monthElement, yearElement] = Array.from(
@@ -122,8 +162,8 @@ export async function getDatepickerByLabelText(
     }
 
     return {
-        element: elements[index],
-        getValue: () => getValue(elements[index]),
-        setValue: (value: string) => setValue(elements[index], value),
+        element,
+        getValue: () => getValue(element),
+        setValue: (value: string) => setValue(element, value),
     };
 }


### PR DESCRIPTION
  DOM-søket brukte children.length === 0 og fast dybde-traversering for å finne
  .ffe-datepicker fra en label. Dette feilet i konsumentapper med ekstra wrapper-div-er,
  og når getDatepickerByLabelText ble kalt rett etter render() før React hadde montert
  komponenten.

  Endringer:
  - Bruker nå label[htmlFor] → getElementById for å finne datepickeren direkte, uavhengig av DOM-struktur
  - Legger til polling-løkke (50ms intervall, 3s timeout) slik at funksjonen venter til elementet er synlig i DOM
  - Kaster en tydelig feilmelding ved timeout i stedet for å returnere undefined

Teste ved å bygge og pakke pakken logalt, innstalere den i repo som feilet og verifisere at testene kjørte fint med den nye pakken.
