### PR TITLE
chore: Ikke kjør deploy på dependabot PR

### DIFF
--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -37,7 +37,7 @@ jobs:
               env:
                   GH_PUBLIC_URL: /
             - name: Build and deploy preview
-              if: ${{ !github.event.pull_request.head.repo.fork }}
+              if: ${{ !github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]' }}
               uses: Azure/static-web-apps-deploy@1a947af9992250f3bc2e68ad0754c0b0c11566c9 # v1
               with:
                   azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_BLACK_BEACH_0D62D0D03 }}


### PR DESCRIPTION
Dependabot PR feiler siden den prøver å kjøre deploy uten tokens. Trenger ikke deploye, bare bygge for å verifisere.