### PR TITLE
feat(ffe-buttons): add progress and pulse to buttons

### DIFF
--- a/packages/ffe-buttons-react/src/BaseButton.spec.tsx
+++ b/packages/ffe-buttons-react/src/BaseButton.spec.tsx
@@ -66,4 +66,79 @@ describe('<BaseButton />', () => {
             expect(button.getAttribute('aria-disabled')).toBe('false');
         });
     });
+
+    describe('when showing progress', () => {
+        it('sets the correct class and fill width', () => {
+            renderBaseButton({ progress: 40 });
+            const button = screen.getByRole('progressbar');
+            expect(
+                button.classList.contains('ffe-button--progress'),
+            ).toBeTruthy();
+            expect(button.style.getPropertyValue('--progress-fill-width')).toBe(
+                '40%',
+            );
+        });
+
+        it('sets progressbar aria attributes', () => {
+            renderBaseButton({ progress: 40 });
+            const button = screen.getByRole('progressbar');
+            expect(button.getAttribute('aria-valuenow')).toBe('40');
+            expect(button.getAttribute('aria-valuemin')).toBe('0');
+            expect(button.getAttribute('aria-valuemax')).toBe('100');
+            expect(button.getAttribute('aria-busy')).toBe('true');
+        });
+
+        it('clamps the value to the 0–100 range', () => {
+            renderBaseButton({ progress: 140 });
+            const button = screen.getByRole('progressbar');
+            expect(button.getAttribute('aria-valuenow')).toBe('100');
+            expect(button.style.getPropertyValue('--progress-fill-width')).toBe(
+                '100%',
+            );
+        });
+
+        it('does nothing for unsupported button type', () => {
+            renderBaseButton({ progress: 40, buttonType: 'shortcut' });
+            const button = screen.getByRole('button');
+            expect(
+                button.classList.contains('ffe-button--progress'),
+            ).toBeFalsy();
+            expect(screen.queryByRole('progressbar')).toBeNull();
+        });
+    });
+
+    describe('when pulsing', () => {
+        it('renders the pulse element when pulseKey is set', () => {
+            renderBaseButton({ pulseKey: 1 });
+            const button = screen.getByRole('button');
+            expect(button.querySelector('.ffe-button__pulse')).toBeTruthy();
+        });
+
+        it('does not render the pulse element without pulseKey', () => {
+            renderBaseButton();
+            const button = screen.getByRole('button');
+            expect(button.querySelector('.ffe-button__pulse')).toBeFalsy();
+        });
+
+        it('remounts the pulse element when pulseKey changes', () => {
+            const { rerender } = render(
+                <BaseButton {...defaultProps} pulseKey={1} />,
+            );
+            const first = screen
+                .getByRole('button')
+                .querySelector('.ffe-button__pulse');
+            rerender(<BaseButton {...defaultProps} pulseKey={2} />);
+            const second = screen
+                .getByRole('button')
+                .querySelector('.ffe-button__pulse');
+            expect(second).toBeTruthy();
+            expect(second).not.toBe(first);
+        });
+
+        it('does nothing for unsupported button type', () => {
+            renderBaseButton({ pulseKey: 1, buttonType: 'shortcut' });
+            const button = screen.getByRole('button');
+            expect(button.querySelector('.ffe-button__pulse')).toBeFalsy();
+        });
+    });
 });

--- a/packages/ffe-buttons-react/src/BaseButton.tsx
+++ b/packages/ffe-buttons-react/src/BaseButton.tsx
@@ -15,6 +15,10 @@ export type BaseButtonProps<As extends ElementType = 'button'> =
         size?: 'sm' | 'md' | 'lg';
         /** Using only an icon, no label */
         iconOnly?: boolean;
+        /** Determinate progress as a percentage (0–100), shown as a fill bar. Use `isLoading` for unknown durations. No effect on shortcut/task. */
+        progress?: number;
+        /** Plays a single sweep each time the value changes, e.g. on a received poll. No effect on shortcut/task. */
+        pulseKey?: string | number;
     };
 /**
  * Internal component
@@ -36,27 +40,54 @@ function BaseButtonWithForwardRef<As extends ElementType>(
         size = 'md',
         iconOnly = false,
         ariaLoadingMessage,
+        progress,
+        pulseKey,
+        style,
         children,
         ...rest
     } = props;
+    // The filled/spinner variants share the same set of button types.
     const supportsSpinner = ['action', 'primary', 'secondary'].includes(
         buttonType,
     );
+    const hasProgress = supportsSpinner && progress !== undefined;
+    const clampedProgress =
+        progress !== undefined
+            ? Math.min(100, Math.max(0, progress))
+            : undefined;
+    const hasPulse = supportsSpinner && pulseKey !== undefined;
 
     return (
         <Comp
-            aria-busy={isLoading && supportsSpinner}
+            aria-busy={(isLoading && supportsSpinner) || hasProgress}
             aria-disabled={isDisabled || (isLoading && supportsSpinner)}
+            {...(hasProgress
+                ? {
+                      role: 'progressbar',
+                      'aria-valuenow': Math.round(clampedProgress as number),
+                      'aria-valuemin': 0,
+                      'aria-valuemax': 100,
+                  }
+                : {})}
+            style={
+                hasProgress
+                    ? ({
+                          ...(style as React.CSSProperties),
+                          '--progress-fill-width': `${clampedProgress}%`,
+                      } as React.CSSProperties)
+                    : style
+            }
             className={classNames(
                 'ffe-button',
                 `ffe-button--${buttonType}`,
                 `ffe-button--${size}`,
                 { 'ffe-button--icon-only': iconOnly },
                 { 'ffe-button--loading': isLoading && supportsSpinner },
+                { 'ffe-button--progress': hasProgress },
                 className,
             )}
             onClick={(event: React.MouseEvent) => {
-                if (isLoading && supportsSpinner) {
+                if ((isLoading && supportsSpinner) || hasProgress) {
                     event.preventDefault();
                     event.stopPropagation();
                 } else if (onClick) {
@@ -84,6 +115,14 @@ function BaseButtonWithForwardRef<As extends ElementType>(
                     aria-label={ariaLoadingMessage}
                     role="img"
                     className="ffe-button__spinner"
+                />
+            )}
+            {hasPulse && (
+                // Remount on key change restarts the sweep animation.
+                <span
+                    key={pulseKey}
+                    className="ffe-button__pulse"
+                    aria-hidden="true"
                 />
             )}
         </Comp>

--- a/packages/ffe-buttons-react/src/SecondaryButton.mdx
+++ b/packages/ffe-buttons-react/src/SecondaryButton.mdx
@@ -21,6 +21,24 @@ sette `size`-propen til en av disse verdiene, altså `size="sm"`. Hvis du ikke s
 
 <Canvas of={SecondaryButtonStories.DifferentSizes} />
 
+## Fremdrift
+
+Når en handling har en kjent eller estimert varighet, kan du vise fremdrift direkte i knappen med `progress`-propen (0–100).
+Knappen tegner da en fyll-bar som vokser fra venstre, og får `role="progressbar"` med riktige `aria-value*`-attributter.
+Mens `progress` er satt er knappen ikke klikkbar.
+Bruk `isLoading` i stedet når varigheten er ukjent (da vises en spinner). `progress` støttes på `ActionButton`, `PrimaryButton` og `SecondaryButton`.
+
+<Canvas of={SecondaryButtonStories.Progress} />
+<Controls of={SecondaryButtonStories.Progress} />
+
+### Puls ved hendelser
+
+Skal du i tillegg signalisere en diskret hendelse mens fremdriften vises – for eksempel at en ny poll/heartbeat kom inn fra serveren –
+kan du sende inn `pulseKey`. Hver gang verdien endrer seg, spilles én feiing («sweep») over knappen. Send gjerne inn et tidsstempel eller en teller.
+Animasjonen respekterer `prefers-reduced-motion`.
+
+<Canvas of={SecondaryButtonStories.Pulse} />
+
 ## Ikon i stedet for tekst
 
 Hvis du kun vil bruke ikon på knappen, og ikke tekst, kan du sende inn `iconOnly="true"`. Det gjelder for alle størrelser,

--- a/packages/ffe-buttons-react/src/SecondaryButton.stories.tsx
+++ b/packages/ffe-buttons-react/src/SecondaryButton.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { SecondaryButton } from './SecondaryButton';
 import type { StoryObj, Meta } from '@storybook/react';
 import { Icon } from '@sb1/ffe-icons-react';
@@ -65,6 +65,42 @@ export const DifferentSizes: Story = {
             </SecondaryButton>
         </div>
     ),
+};
+
+export const Progress: Story = {
+    args: {
+        progress: 40,
+    },
+    argTypes: {
+        progress: {
+            control: { type: 'range', min: 0, max: 100, step: 1 },
+            description:
+                'Determinate fremdrift i prosent (0–100). Viser en fyll-bar som vokser over knappen.',
+        },
+    },
+    render: args => <SecondaryButton {...args}>Lagrer …</SecondaryButton>,
+};
+
+export const Pulse: Story = {
+    render: function Render() {
+        const [progress, setProgress] = useState(0);
+        const [pulseKey, setPulseKey] = useState(0);
+        // Simulate polling: a tick every second advances progress and pulses.
+        useEffect(() => {
+            const id = setInterval(() => {
+                setProgress(p => (p >= 90 ? 0 : p + 15));
+                setPulseKey(k => k + 1);
+            }, 1000);
+            return () => clearInterval(id);
+        }, []);
+        return (
+            <div className="storybook-button-display-group">
+                <SecondaryButton progress={progress} pulseKey={pulseKey}>
+                    Henter status …
+                </SecondaryButton>
+            </div>
+        );
+    },
 };
 
 export const IconOnly: Story = {

--- a/packages/ffe-buttons/less/base-button.less
+++ b/packages/ffe-buttons/less/base-button.less
@@ -390,11 +390,89 @@
         }
     }
 
+    &--progress {
+        pointer-events: none;
+        isolation: isolate;
+
+        // Fill colour per variant: light tint under the dark secondary label,
+        // a darker shade under the white primary/action label. Keeps contrast
+        // in both light and dark mode.
+        --progress-fill-color: var(--ffe-color-fill-primary-subtle);
+
+        &.ffe-button--primary {
+            --progress-fill-color: var(
+                --ffe-color-component-button-primary-fill-pressed
+            );
+        }
+
+        &.ffe-button--action {
+            --progress-fill-color: var(
+                --ffe-color-component-button-action-fill-pressed
+            );
+        }
+
+        // Determinate fill bar. The width is driven by the
+        // --progress-fill-width custom property, set inline by the React
+        // component (a clamped 0%–100% value).
+        &::before {
+            content: '';
+            position: absolute;
+            inset: 0 auto 0 0;
+            width: var(--progress-fill-width, 0%);
+            background-color: var(--progress-fill-color);
+            z-index: 0;
+            pointer-events: none;
+            will-change: width;
+            transition: width var(--ffe-transition-duration) var(--ffe-ease);
+        }
+
+        .ffe-button__label {
+            position: relative;
+            z-index: 1;
+        }
+
+        @media (prefers-reduced-motion: reduce) {
+            &::before {
+                transition: none;
+            }
+        }
+    }
+
     &__label {
         align-items: center;
         display: flex;
         transition: transform var(--ffe-transition-duration) var(--ffe-ease);
         gap: var(--ffe-spacing-xs);
+    }
+
+    &__pulse {
+        position: absolute;
+        top: 0;
+        bottom: 0;
+        left: -20%;
+        width: 20%;
+        z-index: 2;
+        pointer-events: none;
+        opacity: 0.5;
+        background: linear-gradient(
+            90deg,
+            transparent 0%,
+            var(--progress-fill-color, var(--ffe-color-fill-primary-subtle)) 50%,
+            transparent 100%
+        );
+
+        @media (prefers-reduced-motion: no-preference) {
+            animation: button-pulse-sweep 600ms ease-out forwards;
+        }
+
+        @keyframes button-pulse-sweep {
+            from {
+                transform: translateX(0%);
+            }
+            to {
+                transform: translateX(600%);
+            }
+        }
     }
 
     &__spinner {


### PR DESCRIPTION
## Hva

Legger til to nye, komplementære states på knappene i `ffe-buttons`/`ffe-buttons-react`:

- **`progress` (0–100)** – en determinate fyll-bar som vokser over knappen. For handlinger med kjent/estimert varighet. Utfyller eksisterende `isLoading` (indeterminate spinner).
- **`pulseKey`** – spiller én sweep-animasjon hver gang verdien endrer seg. For å signalisere en diskret hendelse (f.eks. en mottatt poll/heartbeat) mens fremdrift vises.

Begge støttes på `ActionButton`, `PrimaryButton` og `SecondaryButton` (samme sett som spinner). Ingen effekt på `shortcut`/`task`.

## Detaljer

- `BaseButton` får `role="progressbar"` + `aria-valuenow/min/max` og `aria-busy` når `progress` er satt; verdien klampes til 0–100. Knappen blokkerer klikk mens den vises (som `isLoading`).
- Fyllfargen velges **per variant** for å holde tekstkontrast i både light og dark mode: lys tint (`--ffe-color-fill-primary-subtle`) under den mørke secondary-teksten, og en mørkere shade (`*-fill-pressed`) under den hvite primary/action-teksten.
- `pulseKey` remounter et `.ffe-button__pulse`-element (via React `key`) for å restarte CSS-animasjonen. Respekterer `prefers-reduced-motion`.

## Tester / verifisering

- Nye spec-tester i `BaseButton.spec.tsx` (progress: klasse/fyllbredde, aria, klamping, no-op for ustøttet variant; pulse: render, remount-on-key, no-op).
- `npm test -w @sb1/ffe-buttons-react`: 58/58 grønn.
- Prettier, oxlint og stylelint: 0 errors.
- Nye stories (`Progress`, `Pulse`) + mdx-dokumentasjon på SecondaryButton.