### PR TITLE
fix(ffe-header): begge media queries aktiv på @breakpoint-md

### DIFF
--- a/packages/ffe-header/less/ffe-header.less
+++ b/packages/ffe-header/less/ffe-header.less
@@ -425,7 +425,7 @@
     // === End override styles for new header ===
 }
 
-@media (max-width: (@breakpoint-md)) {
+@media not (min-width: @breakpoint-md) {
     .ffe-header {
         &__border {
             &:last-child {


### PR DESCRIPTION
Header stylingen har to media queries:

1. `@media (min-width: @breakpoint-md)`
2. `@media (max-width: (@breakpoint-md))`

Hvis skjermen er nøyaktig på `@breakpoint-md` (768px), er begge media queriene aktiv samtidig, noe som ikke virker bevisst.

## Beskrivelse

For å sørge for at de 2 media queriene ikke kan være aktiv samtidig, er media query nr. 2 endret til å bli media query nr. 1 prefikset med `not`, som vil si at de alltid har motsatt verdi.

## Motivasjon og kontekst

Hvis man resizer viduet gradvis, er det nokså tydelig at headeren ikke ser ut som den skal midt i overgangen rundt 768px. Bildet under viser hvordan den nåværende headeren ser ut på 768px i storybook:

<img width="882" height="408" alt="image" src="https://github.com/user-attachments/assets/5be2939e-3773-4148-8a6d-ab887f436acb" />

## Testing

Har kjørt storybook lokalt, resizet vinduet og sjekket at kun en av media queriene er aktiv på 768px.
