### PR TITLE
fix(ffe-buttons-react): Ikon i inline knapp matcher knapp størrelse

### DIFF
--- a/packages/ffe-buttons-react/src/InlineBaseButton.tsx
+++ b/packages/ffe-buttons-react/src/InlineBaseButton.tsx
@@ -56,14 +56,14 @@ function InlineBaseButtonWithForwardRef<As extends ElementType>(
                 React.cloneElement(leftIcon, {
                     className:
                         'ffe-inline-button__icon ffe-inline-button__icon--left',
-                    size: 'md',
+                    size: leftIcon.props.size ?? size,
                 })}
             <span className="ffe-inline-button__label">{children}</span>
             {rightIcon &&
                 React.cloneElement(rightIcon, {
                     className:
                         'ffe-inline-button__icon ffe-inline-button__icon--right',
-                    size: 'md',
+                    size: rightIcon.props.size ?? size,
                 })}
         </Comp>
     );


### PR DESCRIPTION
## Beskrivelse

<!-- Detaljert beskrivelse av endringene dine. Skjermskudd er lov. -->

Endrer ikoner i inline knapper til å bruke ikonets `size` prop med fallback til knappens størrelse i stedet for å alltid ha `size="md"`.

## Motivasjon og kontekst

<!-- Hvorfor trengs denne endringen, og hva løser den? -->

Jeg prøvde å lage en `<TertiaryButton size="sm">` med et ikon og fant ut at ikonet alltid fikk `size="md"`. Det endte opp med at jeg måtte overskrive størrelsen med CSS, noe som ikke var en pen løsning.

Jeg ser at #3170 hadde en identisk fiks for `BaseButton.tsx`. Denne PR-en gjør de samme endringene på `InlineBaseButton.tsx` også.
