### PR TITLE
fix(ffe-collapse-react): min-width på grid-item

### DIFF
--- a/packages/ffe-collapse-react/less/collapse.less
+++ b/packages/ffe-collapse-react/less/collapse.less
@@ -15,6 +15,7 @@
 
 .ffe-collapse__inner {
     overflow: hidden;
+    min-width: 0;
 }
 
 .ffe-collapse__inner.ffe-collapse__inner--visible {


### PR DESCRIPTION
endrer min-width fra auto til 0 for å unngå grid blowout

<!-- Gi saken en oppsummerende tittel ovenfor. -->

## Beskrivelse

Grid-items har `min-width: auto` som default verdi. `auto` beregnes ut fra innholdet, noe som fører til at visse typer innhold presser bredden utover grid-itemets opprinnelig verdi i stedet for å krympe for å passe griden. Dette løses med `min-width: 0` som default.

Problemstillingen er beskrevet her:
https://css-tricks.com/preventing-a-grid-blowout/

## Motivasjon og kontekst

Fikset etter bug-rapport

## Testing

Testet i storybook