### PR TITLE
feat(ffe-feedback-react): isNative gir tekster som omtaler appen i stedet for siden

### DIFF
--- a/packages/ffe-feedback-react/src/Feedback.mdx
+++ b/packages/ffe-feedback-react/src/Feedback.mdx
@@ -24,6 +24,30 @@ Du kan endre lenken i teksten ved å sende med `contactLink`-prop og element som
 Ved å bare sende inn `onClick` kan du overskrive hva som skjer når lenken blir trykket på.
 Hvis du vil sende med din egen tekst kan du legge til `linkText`.
 
+## isNative
+
+Standardtekstene spør hva du synes om «denne siden», noe som ikke passer inne i en hybrid app.
+Sender du med `isNative` bytter komponenten til tekster som omtaler appen i stedet:
+
+| `isNative={false}` (default)                                            | `isNative={true}`                                                 |
+| ----------------------------------------------------------------------- | ----------------------------------------------------------------- |
+| Hva synes du om denne siden?                                            | Hva synes du om denne delen av appen?                             |
+| Svaret ditt blir brukt til å forbedre denne siden og blir ikke besvart. | Svaret ditt blir brukt til å forbedre appen og blir ikke besvart. |
+
+Kjører appen din både i nettleser og i mobilbanken, kan du bruke `checks.isNative()` fra
+Mobilbank Communication til å finne ut hvilken av dem det er. Se
+[dokumentasjonen for `checks.isNative`](https://www.test.sparebank1.no/test/mbc-demo/static/docs/functions/checks.isNative.html).
+
+```jsx
+<Feedback
+    isNative={checks.isNative()}
+    onThumbClick={onThumbClick}
+    onFeedbackSend={onFeedbackSend}
+/>
+```
+
+Sender du inn `texts.feedbackNotSentHeading` vinner den fortsatt over begge variantene.
+
 ## Forhåndsvisning
 
 <Canvas of={FeedbackStories.Standard} />

--- a/packages/ffe-feedback-react/src/Feedback.spec.tsx
+++ b/packages/ffe-feedback-react/src/Feedback.spec.tsx
@@ -161,7 +161,7 @@ describe('Feedback Component', () => {
         fireEvent.click(finishButton);
 
         expect(onFeedbackSendMock).not.toHaveBeenCalled();
-        expect(onFinishMock).toHaveBeenCalled()
+        expect(onFinishMock).toHaveBeenCalled();
     });
 
     it('should render with custom heading', () => {
@@ -237,5 +237,55 @@ describe('Feedback Component', () => {
 
         const heading = screen.getByText('What do you think of this page?');
         expect(heading).toBeInTheDocument();
+    });
+
+    it('should render texts about the page by default', () => {
+        render(<Feedback onThumbClick={() => {}} onFeedbackSend={() => {}} />);
+
+        expect(
+            screen.getByText('Hva synes du om denne siden?'),
+        ).toBeInTheDocument();
+
+        fireEvent.click(screen.getByLabelText('Gi tommel opp'));
+
+        expect(
+            screen.getByText(
+                'Svaret ditt blir brukt til å forbedre denne siden og blir ikke besvart.',
+            ),
+        ).toBeInTheDocument();
+    });
+
+    describe('with isNative', () => {
+        it('should render heading about the app instead of the page', () => {
+            render(
+                <Feedback
+                    onThumbClick={() => {}}
+                    onFeedbackSend={() => {}}
+                    isNative={true}
+                />,
+            );
+
+            expect(
+                screen.getByText('Hva synes du om denne delen av appen?'),
+            ).toBeInTheDocument();
+        });
+
+        it('should render feedback text about the app instead of the page', () => {
+            render(
+                <Feedback
+                    onThumbClick={() => {}}
+                    onFeedbackSend={() => {}}
+                    isNative={true}
+                />,
+            );
+
+            fireEvent.click(screen.getByLabelText('Gi tommel opp'));
+
+            expect(
+                screen.getByText(
+                    'Svaret ditt blir brukt til å forbedre appen og blir ikke besvart.',
+                ),
+            ).toBeInTheDocument();
+        });
     });
 });

--- a/packages/ffe-feedback-react/src/Feedback.tsx
+++ b/packages/ffe-feedback-react/src/Feedback.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useRef, useId } from 'react';
 import { flushSync } from 'react-dom';
-import { txt } from './i18n/texts';
+import { getLocaleTexts } from './i18n/getLocaleTexts';
 import { FeedbackThumbs, Thumb } from './FeedbackThumbs';
 import classNames from 'classnames';
 import { FeedbackExpanded, FeedbackExpandedProps } from './FeedbackExpanded';
@@ -25,6 +25,11 @@ export interface FeedbackProps {
     };
     className?: string;
     includeConsent?: boolean;
+    /**
+     * Bruk tekster som omtaler appen i stedet for siden. Settes når komponenten
+     * vises inne i en hybrid app.
+     */
+    isNative?: boolean;
 }
 
 export const Feedback = ({
@@ -39,7 +44,9 @@ export const Feedback = ({
     texts,
     className,
     includeConsent = false,
+    isNative = false,
 }: FeedbackProps) => {
+    const localeTexts = getLocaleTexts(locale, isNative);
     const feedbackSentRef = useRef<HTMLHeadingElement>(null);
     const expandedRef = useRef<HTMLHeadingElement>(null);
     const [expanded, setExpanded] = useState(false);
@@ -114,7 +121,7 @@ export const Feedback = ({
                 <div className="ffe-feedback__content">
                     {renderHeading(
                         headingLevel,
-                        txt[locale].FEEDBACK_SENT_HEADING,
+                        localeTexts.FEEDBACK_SENT_HEADING,
                         {
                             ref: feedbackSentRef,
                             tabIndex: -1,
@@ -133,7 +140,7 @@ export const Feedback = ({
                 <div className="ffe-feedback__expanded">
                     {renderHeading(
                         headingLevel,
-                        txt[locale].FEEDBACK_SENT_HEADING,
+                        localeTexts.FEEDBACK_SENT_HEADING,
                         {
                             ref: expandedRef,
                             tabIndex: -1,
@@ -145,6 +152,7 @@ export const Feedback = ({
                         handleFeedback={handleFeedbackSent}
                         contactLink={contactLink}
                         includeConsent={includeConsent}
+                        isNative={isNative}
                     />
                 </div>
             </div>
@@ -157,7 +165,7 @@ export const Feedback = ({
                 {renderHeading(
                     headingLevel,
                     texts?.feedbackNotSentHeading ??
-                        txt[locale].FEEDBACK_NOT_SENT_HEADING,
+                        localeTexts.FEEDBACK_NOT_SENT_HEADING,
                     {
                         id: headingId,
                         textCenter: true,

--- a/packages/ffe-feedback-react/src/FeedbackExpanded.tsx
+++ b/packages/ffe-feedback-react/src/FeedbackExpanded.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { LinkText, Paragraph } from '@sb1/ffe-core-react';
-import { txt } from './i18n/texts';
+import { getLocaleTexts } from './i18n/getLocaleTexts';
 import { InputGroup, TextArea, Checkbox } from '@sb1/ffe-form-react';
 import {
     ActionButton,
@@ -17,6 +17,7 @@ export interface FeedbackExpandedProps {
         linkText?: string;
     };
     includeConsent?: boolean;
+    isNative?: boolean;
 }
 
 export const FeedbackExpanded: React.FC<FeedbackExpandedProps> = ({
@@ -24,7 +25,9 @@ export const FeedbackExpanded: React.FC<FeedbackExpandedProps> = ({
     handleFeedback,
     contactLink,
     includeConsent = false,
+    isNative = false,
 }) => {
+    const localeTexts = getLocaleTexts(locale, isNative);
     const [feedbackText, setFeedbackText] = useState<string>();
     const [consentGiven, setConsentGiven] = useState<boolean>(false);
 
@@ -34,21 +37,23 @@ export const FeedbackExpanded: React.FC<FeedbackExpandedProps> = ({
             className="ffe-feedback__link-button"
             onClick={contactLink?.onClick}
         >
-            {contactLink.linkText ?? txt[locale].FEEDBACK_LINK_TEXT}
+            {contactLink.linkText ?? localeTexts.FEEDBACK_LINK_TEXT}
         </LinkText>
     ) : null;
 
     return (
         <>
             <Paragraph>
-                {includeConsent ? txt[locale].FEEDBACK_ANSWER_INCLUDE_CONSENT : txt[locale].FEEDBACK_ANSWER}
-                {contactLinkElement && txt[locale].QUESTIONS}
+                {includeConsent
+                    ? localeTexts.FEEDBACK_ANSWER_INCLUDE_CONSENT
+                    : localeTexts.FEEDBACK_ANSWER}
+                {contactLinkElement && localeTexts.QUESTIONS}
                 {contactLinkElement}
             </Paragraph>
             <InputGroup
                 className="ffe-feedback__textarea-container"
-                label={txt[locale].FEEDBACK_IMPROVE}
-                description={txt[locale].FEEDBACK_SENSITIVE}
+                label={localeTexts.FEEDBACK_IMPROVE}
+                description={localeTexts.FEEDBACK_SENSITIVE}
             >
                 <TextArea
                     data-testid="feedbackTextArea"
@@ -67,14 +72,14 @@ export const FeedbackExpanded: React.FC<FeedbackExpandedProps> = ({
                             setConsentGiven(event.target.checked)
                         }
                     >
-                        {txt[locale].FEEDBACK_CONSENT}
+                        {localeTexts.FEEDBACK_CONSENT}
                     </Checkbox>
                 </div>
             )}
 
             <ButtonGroup
                 className="ffe-feedback__button-group"
-                ariaLabel={txt[locale].FEEDBACK_BUTTON_GROUP}
+                ariaLabel={localeTexts.FEEDBACK_BUTTON_GROUP}
                 thin={true}
             >
                 <ActionButton
@@ -87,10 +92,10 @@ export const FeedbackExpanded: React.FC<FeedbackExpandedProps> = ({
                         }
                     }}
                 >
-                    {txt[locale].FEEDBACK_BUTTON_SEND}
+                    {localeTexts.FEEDBACK_BUTTON_SEND}
                 </ActionButton>
                 <TertiaryButton onClick={() => handleFeedback()}>
-                    {txt[locale].FEEDBACK_BUTTON_CANCEL}
+                    {localeTexts.FEEDBACK_BUTTON_CANCEL}
                 </TertiaryButton>
             </ButtonGroup>
         </>

--- a/packages/ffe-feedback-react/src/i18n/en.ts
+++ b/packages/ffe-feedback-react/src/i18n/en.ts
@@ -2,6 +2,8 @@ export const en = {
     ARIA_LABEL_THUMB_UP: 'Give thumbs up',
     ARIA_LABEL_THUMB_DOWN: 'Give thumbs down',
     FEEDBACK_NOT_SENT_HEADING: 'What do you think of this page? ',
+    FEEDBACK_NOT_SENT_HEADING_NATIVE:
+        'What do you think of this part of the app? ',
     FEEDBACK_SENT_HEADING: 'Thank you!',
     FEEDBACK_BUTTON_SEND: 'Send feedback',
     FEEDBACK_BUTTON_CANCEL: 'Finish',
@@ -9,8 +11,12 @@ export const en = {
     FEEDBACK_IMPROVE: 'Do you have anything else on your mind?',
     FEEDBACK_ANSWER:
         'Your feedback will be used to improve this site and will not be answered.',
+    FEEDBACK_ANSWER_NATIVE:
+        'Your feedback will be used to improve the app and will not be answered.',
     FEEDBACK_ANSWER_INCLUDE_CONSENT:
         'Your feedback will be used to improve this site and will not be answered without consent.',
+    FEEDBACK_ANSWER_INCLUDE_CONSENT_NATIVE:
+        'Your feedback will be used to improve the app and will not be answered without consent.',
     FEEDBACK_CONSENT: 'I consent to be contacted regarding my feedback.',
     QUESTIONS: ' If you have questions, ',
     FEEDBACK_LINK_TEXT: 'contact customer services.',

--- a/packages/ffe-feedback-react/src/i18n/getLocaleTexts.ts
+++ b/packages/ffe-feedback-react/src/i18n/getLocaleTexts.ts
@@ -1,0 +1,23 @@
+import { txt } from './texts';
+
+type Locale = keyof typeof txt;
+
+/**
+ * Inne i en hybrid app passer ikke ordet «side», så da bytter vi til tekstene
+ * som omtaler appen i stedet.
+ */
+export const getLocaleTexts = (locale: Locale, isNative: boolean) => {
+    const texts = txt[locale];
+
+    if (!isNative) {
+        return texts;
+    }
+
+    return {
+        ...texts,
+        FEEDBACK_NOT_SENT_HEADING: texts.FEEDBACK_NOT_SENT_HEADING_NATIVE,
+        FEEDBACK_ANSWER: texts.FEEDBACK_ANSWER_NATIVE,
+        FEEDBACK_ANSWER_INCLUDE_CONSENT:
+            texts.FEEDBACK_ANSWER_INCLUDE_CONSENT_NATIVE,
+    };
+};

--- a/packages/ffe-feedback-react/src/i18n/nb.ts
+++ b/packages/ffe-feedback-react/src/i18n/nb.ts
@@ -2,6 +2,7 @@ export const nb = {
     ARIA_LABEL_THUMB_UP: 'Gi tommel opp',
     ARIA_LABEL_THUMB_DOWN: 'Gi tommel ned',
     FEEDBACK_NOT_SENT_HEADING: 'Hva synes du om denne siden? ',
+    FEEDBACK_NOT_SENT_HEADING_NATIVE: 'Hva synes du om denne delen av appen? ',
     FEEDBACK_SENT_HEADING: 'Takk for tilbakemeldingen!',
     FEEDBACK_BUTTON_SEND: 'Send tilbakemelding',
     FEEDBACK_BUTTON_CANCEL: 'Avslutt',
@@ -9,8 +10,12 @@ export const nb = {
     FEEDBACK_IMPROVE: 'Har du noe mer på hjertet? (valgfritt)',
     FEEDBACK_ANSWER:
         'Svaret ditt blir brukt til å forbedre denne siden og blir ikke besvart.',
+    FEEDBACK_ANSWER_NATIVE:
+        'Svaret ditt blir brukt til å forbedre appen og blir ikke besvart.',
     FEEDBACK_ANSWER_INCLUDE_CONSENT:
         'Svaret ditt blir brukt til å forbedre denne siden og blir ikke besvart uten samtykke.',
+    FEEDBACK_ANSWER_INCLUDE_CONSENT_NATIVE:
+        'Svaret ditt blir brukt til å forbedre appen og blir ikke besvart uten samtykke.',
     FEEDBACK_CONSENT:
         'Jeg samtykker til at jeg kan bli kontaktet angående tilbakemeldingen min.',
     QUESTIONS: ' Har du spørsmål, ',

--- a/packages/ffe-feedback-react/src/i18n/nn.ts
+++ b/packages/ffe-feedback-react/src/i18n/nn.ts
@@ -2,6 +2,7 @@ export const nn = {
     ARIA_LABEL_THUMB_UP: 'Gje tommel opp',
     ARIA_LABEL_THUMB_DOWN: 'Gje tommel ned',
     FEEDBACK_NOT_SENT_HEADING: 'Kva synest du om denne sida? ',
+    FEEDBACK_NOT_SENT_HEADING_NATIVE: 'Kva synest du om denne delen av appen? ',
     FEEDBACK_SENT_HEADING: 'Takk for tilbakemeldinga!',
     FEEDBACK_BUTTON_SEND: 'Send tilbakemelding',
     FEEDBACK_BUTTON_CANCEL: 'Avslutt',
@@ -9,8 +10,12 @@ export const nn = {
     FEEDBACK_IMPROVE: 'Har du noko meir på hjartet? (valfritt)',
     FEEDBACK_ANSWER:
         'Svaret ditt vert brukt til å betre denne sida og vert ikkje svart på.',
+    FEEDBACK_ANSWER_NATIVE:
+        'Svaret ditt vert brukt til å betre appen og vert ikkje svart på.',
     FEEDBACK_ANSWER_INCLUDE_CONSENT:
         'Svaret ditt vert brukt til å betre denne sida og vert ikkje svart på utan samtykke.',
+    FEEDBACK_ANSWER_INCLUDE_CONSENT_NATIVE:
+        'Svaret ditt vert brukt til å betre appen og vert ikkje svart på utan samtykke.',
     FEEDBACK_CONSENT:
         'Eg samtykkjer til at eg kan bli kontakta angåande tilbakemeldinga mi.',
     QUESTIONS: ' Har du spørsmål, ',


### PR DESCRIPTION
## Hva

`Feedback` spør «Hva synes du om denne siden?». Inne i en hybrid app passer ikke ordet «side».
Denne PR-en legger til en `isNative`-prop som bytter til tekster som omtaler appen i stedet.

Default er `false`, altså dagens oppførsel i nettleser. Ingen breaking change.

| `isNative={false}` (default) | `isNative={true}` |
| --- | --- |
| Hva synes du om denne siden? | Hva synes du om denne delen av appen? |
| Svaret ditt blir brukt til å forbedre denne siden og blir ikke besvart. | Svaret ditt blir brukt til å forbedre appen og blir ikke besvart. |

Tre nøkler er berørt i alle tre språk (`nb`, `nn`, `en`):

- `FEEDBACK_NOT_SENT_HEADING`
- `FEEDBACK_ANSWER`
- `FEEDBACK_ANSWER_INCLUDE_CONSENT`

Sender du inn `texts.feedbackNotSentHeading` vinner den fortsatt over begge variantene.

## Hvordan bruke den

Teams som kjører både i nettleser og i mobilbanken kan bruke [`checks.isNative()`](https://www.test.sparebank1.no/test/mbc-demo/static/docs/functions/checks.isNative.html) fra Mobilbank Communication:

```jsx
<Feedback
    isNative={checks.isNative()}
    onThumbClick={onThumbClick}
    onFeedbackSend={onFeedbackSend}
/>
```

## Endringer

- Ny `src/i18n/getLocaleTexts.ts` som velger variant ut fra `isNative`
- `*_NATIVE`-nøkler i `i18n/nb.ts`, `i18n/nn.ts` og `i18n/en.ts`
- `isNative`-prop på `Feedback` og `FeedbackExpanded`
- `Feedback.mdx`: ny `## isNative`-seksjon. Proppen dukker også opp i `<Controls>`-tabellen i Storybook
- `Feedback.spec.tsx`: tester for både default og `isNative={true}`

`FeedbackThumbs` er urørt. Den bruker bare aria-labelene på tommelknappene, som ikke trenger en variant.

## Testet

`npm test` i `packages/ffe-feedback-react`: 16 av 16 tester passerer. `npm run build`, oxlint og prettier er også kjørt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)